### PR TITLE
feat: Add x402 donation tools and payment endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # TheologAI — Development Guide
 
-Production MCP server for theological research. 7 tools, 4/4 MCP capabilities (Tools, Resources, Prompts, Logging), 8 Bible translations, 6 commentaries, 18 historical documents, Greek/Hebrew language tools.
+Production MCP server for theological research. 9 tools, 4/4 MCP capabilities (Tools, Resources, Prompts, Logging), 8 Bible translations, 6 commentaries, 18 historical documents, Greek/Hebrew language tools, x402 donation support.
 
 ## Quick Start
 
@@ -32,10 +32,12 @@ src/
 │   ├── bible/            # BibleService, CrossReferenceService, ParallelPassageService
 │   ├── commentary/       # CommentaryService, CcelService
 │   ├── historical/       # HistoricalDocumentService
-│   └── languages/        # StrongsService, MorphologyService
+│   ├── languages/        # StrongsService, MorphologyService
+│   └── donation/         # DonationService
 ├── adapters/             # External API clients + data repositories
 │   ├── bible/            # EsvAdapter, NetBibleAdapter, HelloAoAdapter
 │   ├── commentary/       # HelloAoCommentaryAdapter, CcelAdapter
+│   ├── donation/         # OnChainVerifier, FacilitatorClient
 │   ├── data/             # SQLite repositories (Node.js — better-sqlite3)
 │   ├── d1/               # D1 repositories (Workers — Cloudflare D1)
 │   └── shared/           # Database.ts, HttpClient.ts, HtmlParser.ts
@@ -76,7 +78,7 @@ test/
 
 ## MCP Capabilities
 
-### Tools (7)
+### Tools (9)
 
 | Tool | Description |
 |------|-------------|
@@ -87,6 +89,8 @@ test/
 | `classic_text_lookup` | 18 local docs + 1000+ CCEL works, unified search |
 | `original_language_lookup` | Strong's concordance (14,298 entries), Greek/Hebrew word studies |
 | `bible_verse_morphology` | Word-by-word grammatical analysis for all 66 books |
+| `donation_config` | Donation configuration: supported tokens, recipient, x402 endpoint |
+| `verify_donation` | On-chain donation verification across Ethereum, Base, and Radius |
 
 All tools have annotations: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ These prompts provide structured research methodologies. **Auto-trigger**: when 
 | `passage-exegesis` | `/mcp__theologai__passage-exegesis` | Exegete a passage, do deep analysis of verses, or study a text systematically |
 | `compare-translations` | `/mcp__theologai__compare-translations` | Compare how different translations render a passage, or explore translation differences |
 | `confession-study` | `/mcp__theologai__confession-study` | Compare doctrines across creeds, confessions, and catechisms from different traditions |
+| `donate` | `/mcp__theologai__donate` | Donate, support the project, contribute financially, or ask about donations |
 
 When a user asks "what can you do?" or seems unsure how to proceed, mention these workflows as available research modes.
 

--- a/src/adapters/donation/FacilitatorClient.ts
+++ b/src/adapters/donation/FacilitatorClient.ts
@@ -1,0 +1,50 @@
+/**
+ * x402 facilitator client for settling payments.
+ *
+ * Mirrors the settle API from coinbase/x402 HTTPFacilitatorClient
+ * without importing the x402 package.
+ */
+
+import { PaymentError } from '../../kernel/errors.js';
+import type {
+  PaymentPayload,
+  PaymentRequirements,
+  SettleResponse,
+} from '../../kernel/donation-types.js';
+
+export class FacilitatorClient {
+  constructor(
+    private url: string,
+    private apiKey?: string,
+  ) {}
+
+  async settle(
+    paymentPayload: PaymentPayload,
+    paymentRequirements: PaymentRequirements,
+  ): Promise<SettleResponse> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.apiKey) {
+      headers['X-API-Key'] = this.apiKey;
+    }
+
+    const response = await fetch(`${this.url}/settle`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        x402Version: 2,
+        paymentPayload,
+        paymentRequirements,
+      }),
+    });
+
+    const data = await response.json() as SettleResponse;
+
+    if (!response.ok || !data.success) {
+      throw new PaymentError(
+        data.errorReason ?? data.errorMessage ?? `Settlement failed (${response.status})`,
+      );
+    }
+
+    return data;
+  }
+}

--- a/src/adapters/donation/OnChainVerifier.ts
+++ b/src/adapters/donation/OnChainVerifier.ts
@@ -1,0 +1,178 @@
+/**
+ * On-chain transaction verifier using JSON-RPC.
+ *
+ * Verifies donation transactions across Ethereum, Base, and Radius
+ * by calling eth_getTransactionReceipt and eth_getTransactionByHash.
+ * Uses raw fetch (not HttpClient) because JSON-RPC requires POST.
+ */
+
+import { Cache } from '../../kernel/cache.js';
+import { PaymentError } from '../../kernel/errors.js';
+import {
+  DEFAULT_RPC_URLS,
+  SUPPORTED_TOKENS,
+  type VerifiedTransfer,
+} from '../../kernel/donation-types.js';
+
+/** ERC-20 Transfer(address,address,uint256) event topic */
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+interface RpcConfig {
+  chainId: number;
+  url: string;
+  name: string;
+}
+
+interface RpcReceiptLog {
+  address: string;
+  topics: string[];
+  data: string;
+}
+
+interface RpcReceipt {
+  status: string;
+  blockNumber: string;
+  from: string;
+  to: string;
+  logs: RpcReceiptLog[];
+}
+
+interface RpcTransaction {
+  from: string;
+  to: string;
+  value: string;
+  blockNumber: string;
+}
+
+export class OnChainVerifier {
+  private cache: Cache<VerifiedTransfer>;
+  private rpcs: RpcConfig[];
+
+  constructor(rpcUrls: {
+    ethereum?: string;
+    base?: string;
+    radius?: string;
+  } = {}) {
+    this.cache = new Cache<VerifiedTransfer>(50, 5 * 60 * 1000);
+    this.rpcs = [
+      { chainId: 1, url: rpcUrls.ethereum ?? DEFAULT_RPC_URLS.ethereum, name: 'Ethereum' },
+      { chainId: 8453, url: rpcUrls.base ?? DEFAULT_RPC_URLS.base, name: 'Base' },
+      { chainId: 723, url: rpcUrls.radius ?? DEFAULT_RPC_URLS.radius, name: 'Radius' },
+    ];
+  }
+
+  async verify(txHash: string): Promise<VerifiedTransfer> {
+    // Check cache across all chains
+    for (const rpc of this.rpcs) {
+      const cached = this.cache.get(`${txHash}:${rpc.chainId}`);
+      if (cached) return cached;
+    }
+
+    // Parallel chain detection via Promise.allSettled
+    const results = await Promise.allSettled(
+      this.rpcs.map(rpc => this.verifyOnChain(rpc, txHash)),
+    );
+
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value !== null) {
+        const transfer = result.value;
+        this.cache.set(`${txHash}:${transfer.chainId}`, transfer);
+        return transfer;
+      }
+    }
+
+    throw new PaymentError(
+      `Transaction not found on any supported chain (Ethereum, Base, Radius)`,
+      txHash,
+    );
+  }
+
+  private async verifyOnChain(
+    rpc: RpcConfig,
+    txHash: string,
+  ): Promise<VerifiedTransfer | null> {
+    // Fetch receipt and transaction data in parallel
+    const [receipt, tx] = await Promise.all([
+      this.rpcCall<RpcReceipt>(rpc.url, 'eth_getTransactionReceipt', [txHash]),
+      this.rpcCall<RpcTransaction>(rpc.url, 'eth_getTransactionByHash', [txHash]),
+    ]);
+
+    if (!receipt || !tx) return null;
+
+    const confirmed = receipt.status === '0x1';
+    const blockNumber = parseInt(receipt.blockNumber, 16);
+
+    // Check for ERC-20 Transfer events
+    const transferLog = receipt.logs.find(
+      log => log.topics.length >= 3 && log.topics[0] === TRANSFER_TOPIC,
+    );
+
+    if (transferLog) {
+      const from = '0x' + transferLog.topics[1].slice(26);
+      const to = '0x' + transferLog.topics[2].slice(26);
+      const amount = BigInt(transferLog.data).toString();
+      const tokenAddress = transferLog.address.toLowerCase();
+
+      const token = SUPPORTED_TOKENS.find(
+        t => t.chainId === rpc.chainId && !t.isNative && t.asset.toLowerCase() === tokenAddress,
+      );
+
+      return {
+        txHash,
+        chainId: rpc.chainId,
+        from,
+        to,
+        amount,
+        symbol: token?.symbol ?? 'UNKNOWN',
+        tokenAddress,
+        blockNumber,
+        confirmed,
+      };
+    }
+
+    // Fall back to native ETH/value transfer
+    const value = BigInt(tx.value);
+    if (value > 0n) {
+      const token = SUPPORTED_TOKENS.find(
+        t => t.chainId === rpc.chainId && t.isNative,
+      );
+
+      return {
+        txHash,
+        chainId: rpc.chainId,
+        from: tx.from,
+        to: tx.to,
+        amount: value.toString(),
+        symbol: token?.symbol ?? 'ETH',
+        tokenAddress: null,
+        blockNumber,
+        confirmed,
+      };
+    }
+
+    return null;
+  }
+
+  private async rpcCall<T>(url: string, method: string, params: unknown[]): Promise<T | null> {
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+      });
+
+      if (!response.ok) return null;
+
+      const json = await response.json() as { result?: T; error?: { message: string } };
+      if (json.error || !json.result) return null;
+
+      return json.result;
+    } catch {
+      return null;
+    }
+  }
+
+  dispose(): void {
+    this.cache.dispose();
+  }
+}

--- a/src/formatters/donationFormatter.ts
+++ b/src/formatters/donationFormatter.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure Markdown formatting for donation tool responses.
+ */
+
+import type {
+  DonationConfig,
+  DonationVerifyResult,
+} from '../kernel/donation-types.js';
+
+export function formatDonationConfig(config: DonationConfig): string {
+  let s = '**TheologAI Donation Options**\n\n';
+
+  s += `**Recipient:** \`${config.recipientAddress}\`\n\n`;
+
+  s += '| Token | Chain | Contract | Decimals | x402 |\n';
+  s += '|-------|-------|----------|----------|------|\n';
+  for (const t of config.tokens) {
+    const contract = t.isNative ? 'native' : `\`${t.asset}\``;
+    const x402 = t.x402Supported ? 'Yes' : 'No';
+    s += `| ${t.symbol} | ${t.chainName} | ${contract} | ${t.decimals} | ${x402} |\n`;
+  }
+
+  if (config.facilitators.length > 0) {
+    s += '\n**x402 Facilitators:**\n';
+    for (const f of config.facilitators) {
+      s += `- **${f.name}** — ${f.networks.join(', ')}`;
+      if (f.requiresApiKey) s += ' (API key required)';
+      s += '\n';
+    }
+  }
+
+  if (config.x402PayEndpoint) {
+    s += `\n**x402 Endpoint:** \`${config.x402PayEndpoint}\`\n`;
+  }
+
+  s += '\n*Donations are entirely voluntary and do not gate any features.*';
+
+  return s.trim();
+}
+
+export function formatDonationVerifyResult(result: DonationVerifyResult): string {
+  const status = result.confirmed ? 'Confirmed' : 'Pending';
+  let s = `**Donation ${status}**\n\n`;
+
+  s += `| Field | Value |\n`;
+  s += `|-------|-------|\n`;
+  s += `| Amount | ${result.amount} ${result.symbol} |\n`;
+  s += `| Chain | ${result.chainName} |\n`;
+  s += `| From | \`${result.from}\` |\n`;
+  s += `| Transaction | \`${result.txHash}\` |\n`;
+
+  if (result.explorerUrl) {
+    s += `\n[View on Explorer](${result.explorerUrl})\n`;
+  }
+
+  if (!result.isToRecipient) {
+    s += '\n**Warning:** This transaction was not sent to the TheologAI donation address.\n';
+  } else {
+    s += `\nThank you for your donation of ${result.amount} ${result.symbol} on ${result.chainName}!\n`;
+  }
+
+  return s.trim();
+}

--- a/src/formatters/donationFormatter.ts
+++ b/src/formatters/donationFormatter.ts
@@ -7,6 +7,26 @@ import type {
   DonationVerifyResult,
 } from '../kernel/donation-types.js';
 
+export function formatDonationConfigHuman(config: DonationConfig): string {
+  let s = '**TheologAI Donations**\n\n';
+
+  s += 'Donations help support TheologAI\'s development and are entirely voluntary — all features are free regardless.\n\n';
+
+  s += '**Easiest option:** Donate via the web at [theologai.pages.dev](https://theologai.pages.dev/), which has a donation section with wallet connection support.\n\n';
+
+  s += '**Manual transfer options:**\n';
+  s += '- USDC on Base (lowest fees, recommended)\n';
+  s += '- USDC or ETH on Ethereum\n';
+  s += '- SBC on Radius\n\n';
+
+  s += `Recipient address: \`${config.recipientAddress}\`\n\n`;
+
+  s += '---\n\n';
+  s += '*If the user has a wallet MCP tool available, you can help them send a transaction directly — call `donation_config` with format="technical" to get the contract addresses and chain details needed.*';
+
+  return s.trim();
+}
+
 export function formatDonationConfig(config: DonationConfig): string {
   let s = '**TheologAI Donation Options**\n\n';
 

--- a/src/kernel/donation-types.ts
+++ b/src/kernel/donation-types.ts
@@ -1,0 +1,223 @@
+/**
+ * Donation and x402 payment types for TheologAI.
+ *
+ * Kept separate from types.ts to isolate financial domain types
+ * from the theological research domain.
+ */
+
+// ── Constants ──
+
+/** TheologAI donation recipient address */
+export const RECIPIENT_ADDRESS = '0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04';
+
+/** Default RPC endpoints (public, free) */
+export const DEFAULT_RPC_URLS: Record<string, string> = {
+  ethereum: 'https://eth.llamarpc.com',
+  base: 'https://mainnet.base.org',
+  radius: 'https://rpc.radiustech.xyz',
+};
+
+/** Block explorer base URLs by chain ID */
+export const EXPLORER_URLS: Record<number, string> = {
+  1: 'https://etherscan.io/tx/',
+  8453: 'https://basescan.org/tx/',
+  723: 'https://network.radiustech.xyz/tx/',
+};
+
+// ── Token configuration ──
+
+export interface TokenConfig {
+  symbol: string;
+  name: string;
+  chainId: number;
+  chainName: string;
+  network: string;
+  asset: string;
+  decimals: number;
+  isNative: boolean;
+  x402Supported: boolean;
+}
+
+export const SUPPORTED_TOKENS: TokenConfig[] = [
+  {
+    symbol: 'USDC',
+    name: 'USD Coin',
+    chainId: 8453,
+    chainName: 'Base',
+    network: 'eip155:8453',
+    asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    decimals: 6,
+    isNative: false,
+    x402Supported: true,
+  },
+  {
+    symbol: 'USDC',
+    name: 'USD Coin',
+    chainId: 1,
+    chainName: 'Ethereum',
+    network: 'eip155:1',
+    asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    decimals: 6,
+    isNative: false,
+    x402Supported: false,
+  },
+  {
+    symbol: 'ETH',
+    name: 'Ether',
+    chainId: 1,
+    chainName: 'Ethereum',
+    network: 'eip155:1',
+    asset: 'native',
+    decimals: 18,
+    isNative: true,
+    x402Supported: false,
+  },
+  {
+    symbol: 'ETH',
+    name: 'Ether',
+    chainId: 8453,
+    chainName: 'Base',
+    network: 'eip155:8453',
+    asset: 'native',
+    decimals: 18,
+    isNative: true,
+    x402Supported: false,
+  },
+  {
+    symbol: 'SBC',
+    name: 'Stablecoin',
+    chainId: 723,
+    chainName: 'Radius',
+    network: 'eip155:723',
+    asset: '0x33ad9e4bd16b69b5bfded37d8b5d9ff9aba014fb',
+    decimals: 6,
+    isNative: false,
+    x402Supported: true,
+  },
+];
+
+// ── Facilitator configuration ──
+
+export interface FacilitatorConfig {
+  name: string;
+  url: string;
+  networks: string[];
+  requiresApiKey: boolean;
+}
+
+export const FACILITATORS: FacilitatorConfig[] = [
+  {
+    name: 'Coinbase',
+    url: 'https://x402.org/facilitator',
+    networks: ['eip155:8453'],
+    requiresApiKey: false,
+  },
+  {
+    name: 'SBC',
+    url: 'https://x402.stablecoin.xyz',
+    networks: ['eip155:723'],
+    requiresApiKey: true,
+  },
+];
+
+// ── Tool output types ──
+
+export interface DonationConfig {
+  recipientAddress: string;
+  tokens: TokenConfig[];
+  facilitators: FacilitatorConfig[];
+  x402PayEndpoint: string;
+}
+
+export interface DonationVerifyResult {
+  txHash: string;
+  chainId: number;
+  chainName: string;
+  from: string;
+  amount: string;
+  symbol: string;
+  confirmed: boolean;
+  isToRecipient: boolean;
+  explorerUrl: string;
+}
+
+// ── Adapter output (internal) ──
+
+export interface VerifiedTransfer {
+  txHash: string;
+  chainId: number;
+  from: string;
+  to: string;
+  amount: string;
+  symbol: string;
+  tokenAddress: string | null;
+  blockNumber: number;
+  confirmed: boolean;
+}
+
+// ── x402 V2 protocol types ──
+// Hand-rolled from coinbase/x402 source (no zod dependency)
+
+export interface PaymentRequirements {
+  scheme: string;
+  network: string;
+  amount: string;
+  asset: string;
+  payTo: string;
+  maxTimeoutSeconds: number;
+  extra: Record<string, unknown>;
+}
+
+export interface ResourceInfo {
+  url: string;
+  description?: string;
+  mimeType?: string;
+}
+
+export interface PaymentRequired {
+  x402Version: 2;
+  error?: string;
+  resource: ResourceInfo;
+  accepts: PaymentRequirements[];
+}
+
+export interface PaymentPayload {
+  x402Version: 2;
+  resource?: ResourceInfo;
+  accepted: PaymentRequirements;
+  payload: Record<string, unknown>;
+}
+
+export interface SettleResponse {
+  success: boolean;
+  errorReason?: string;
+  errorMessage?: string;
+  payer?: string;
+  transaction: string;
+  network: string;
+}
+
+// ── x402 accepts for the /x402/pay endpoint ──
+// Only tokens with x402Supported=true and EIP-3009 transferWithAuthorization
+// Native ETH cannot use x402 exact scheme
+
+export const X402_ACCEPTS: PaymentRequirements[] = [
+  {
+    scheme: 'exact',
+    network: 'eip155:8453',
+    amount: '1000000',
+    asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    payTo: RECIPIENT_ADDRESS,
+    maxTimeoutSeconds: 900,
+    extra: {},
+  },
+  {
+    scheme: 'exact',
+    network: 'eip155:723',
+    amount: '1000000',
+    asset: '0x33ad9e4bd16b69b5bfded37d8b5d9ff9aba014fb',
+    payTo: RECIPIENT_ADDRESS,
+    maxTimeoutSeconds: 900,
+    extra: {},
+  },
+];

--- a/src/kernel/errors.ts
+++ b/src/kernel/errors.ts
@@ -67,6 +67,17 @@ export class NotFoundError extends TheologAIError {
   }
 }
 
+/** Payment / donation verification failure */
+export class PaymentError extends TheologAIError {
+  constructor(
+    message: string,
+    public readonly txHash?: string,
+  ) {
+    super(message);
+    this.name = 'PaymentError';
+  }
+}
+
 /** User-friendly error message */
 export function getUserMessage(error: Error): string {
   if (error instanceof RateLimitError) {
@@ -77,6 +88,11 @@ export function getUserMessage(error: Error): string {
   }
   if (error instanceof NotFoundError) {
     return error.message;
+  }
+  if (error instanceof PaymentError) {
+    return error.txHash
+      ? `Payment verification failed for tx ${error.txHash}: ${error.message}`
+      : `Payment error: ${error.message}`;
   }
   if (error instanceof AdapterError) {
     return `Error from ${error.source}: ${error.message}`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -293,6 +293,11 @@ export class BibleMCPServer {
               { name: 'traditions', description: 'Comma-separated traditions to focus on', required: false },
             ],
           },
+          {
+            name: 'donate',
+            description: 'Guide for donating to support TheologAI development',
+            arguments: [],
+          },
         ],
       };
     });
@@ -313,6 +318,9 @@ export class BibleMCPServer {
 
         case 'confession-study':
           return this.getConfessionStudyPrompt(args?.topic ?? '', args?.traditions);
+
+        case 'donate':
+          return this.getDonatePrompt();
 
         default:
           throw new Error(`Unknown prompt: ${name}`);
@@ -462,6 +470,38 @@ Follow this methodology:
 3. **Read sections** — Browse specific documents
 4. **Biblical foundations** — \`bible_lookup\` + \`bible_cross_references\`
 5. **Comparison** — Agreement, divergence, Scripture, historical context`,
+          },
+        },
+      ],
+    };
+  }
+
+  private getDonatePrompt() {
+    return {
+      description: 'Guide for donating to support TheologAI',
+      messages: [
+        {
+          role: 'user' as const,
+          content: {
+            type: 'text' as const,
+            text: `The user wants to donate to TheologAI. Guide them through the options:
+
+**TheologAI Donations**
+
+Donations help support TheologAI's development and are entirely voluntary — all features are free regardless.
+
+**Easiest option:** Donate via the web at [theologai.pages.dev](https://theologai.pages.dev/), which has a donation section with wallet connection support.
+
+**Manual transfer options:**
+- USDC on Base (lowest fees, recommended)
+- USDC or ETH on Ethereum
+- SBC on Radius
+
+Recipient address: \`0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04\`
+
+---
+
+If the user has a wallet MCP tool available, you can help them send a transaction directly — call \`donation_config\` to get the contract addresses and chain details needed. For programmatic x402 payment flows, also use \`donation_config\` for the full technical config.`,
           },
         },
       ],

--- a/src/services/donation/DonationService.ts
+++ b/src/services/donation/DonationService.ts
@@ -1,0 +1,74 @@
+/**
+ * Donation service — business logic for donation config and verification.
+ */
+
+import type { OnChainVerifier } from '../../adapters/donation/OnChainVerifier.js';
+import { PaymentError } from '../../kernel/errors.js';
+import {
+  RECIPIENT_ADDRESS,
+  SUPPORTED_TOKENS,
+  FACILITATORS,
+  EXPLORER_URLS,
+  type DonationConfig,
+  type DonationVerifyResult,
+} from '../../kernel/donation-types.js';
+
+export class DonationService {
+  constructor(
+    private verifier: OnChainVerifier,
+    private x402BaseUrl: string,
+  ) {}
+
+  getConfig(): DonationConfig {
+    return {
+      recipientAddress: RECIPIENT_ADDRESS,
+      tokens: SUPPORTED_TOKENS,
+      facilitators: FACILITATORS,
+      x402PayEndpoint: this.x402BaseUrl ? `${this.x402BaseUrl}/x402/pay` : '',
+    };
+  }
+
+  async verifyDonation(txHash: string): Promise<DonationVerifyResult> {
+    if (!txHash || !/^0x[0-9a-fA-F]{64}$/.test(txHash)) {
+      throw new PaymentError('Invalid transaction hash format. Expected 0x-prefixed 64-char hex string.');
+    }
+
+    const transfer = await this.verifier.verify(txHash);
+
+    const isToRecipient = transfer.to.toLowerCase() === RECIPIENT_ADDRESS.toLowerCase();
+
+    // Match token for decimal formatting
+    const token = SUPPORTED_TOKENS.find(
+      t => t.chainId === transfer.chainId && t.symbol === transfer.symbol,
+    );
+    const decimals = token?.decimals ?? 18;
+    const chainName = token?.chainName ?? `Chain ${transfer.chainId}`;
+    const explorerBase = EXPLORER_URLS[transfer.chainId] ?? '';
+
+    return {
+      txHash: transfer.txHash,
+      chainId: transfer.chainId,
+      chainName,
+      from: transfer.from,
+      amount: formatDecimal(transfer.amount, decimals),
+      symbol: transfer.symbol,
+      confirmed: transfer.confirmed,
+      isToRecipient,
+      explorerUrl: explorerBase ? `${explorerBase}${transfer.txHash}` : '',
+    };
+  }
+}
+
+/**
+ * Convert raw integer amount string to human-readable decimal.
+ * e.g. "1500000" with 6 decimals → "1.5"
+ */
+function formatDecimal(rawAmount: string, decimals: number): string {
+  if (decimals === 0) return rawAmount;
+
+  const padded = rawAmount.padStart(decimals + 1, '0');
+  const intPart = padded.slice(0, -decimals) || '0';
+  const fracPart = padded.slice(-decimals).replace(/0+$/, '');
+
+  return fracPart ? `${intPart}.${fracPart}` : intPart;
+}

--- a/src/tools/v2/donationConfig.ts
+++ b/src/tools/v2/donationConfig.ts
@@ -7,17 +7,23 @@
 
 import type { ToolHandler } from '../../kernel/types.js';
 import type { DonationService } from '../../services/donation/DonationService.js';
-import { formatDonationConfig } from '../../formatters/donationFormatter.js';
+import { formatDonationConfig, formatDonationConfigHuman } from '../../formatters/donationFormatter.js';
 import { handleToolError } from '../../kernel/errors.js';
 
 export function createDonationConfigHandler(donationService: DonationService): ToolHandler {
   return {
     name: 'donation_config',
     description:
-      'Get technical donation configuration for programmatic payment flows: supported tokens, contract addresses, chain IDs, x402 endpoint, and facilitators. Donations are voluntary and do not gate features. For a human-friendly donation guide, use the "donate" prompt instead.',
+      'Get TheologAI donation configuration. Donations are voluntary and do not gate features. Use format="human" (default) for a user-friendly donation guide, or format="technical" for the full structured config needed for programmatic x402 payment flows.',
     inputSchema: {
       type: 'object' as const,
-      properties: {},
+      properties: {
+        format: {
+          type: 'string',
+          enum: ['human', 'technical'],
+          description: 'Response format: "human" for a friendly donation guide (default), "technical" for full contract addresses, chain IDs, and x402 config.',
+        },
+      },
       required: [],
     },
     annotations: {
@@ -26,11 +32,15 @@ export function createDonationConfigHandler(donationService: DonationService): T
       idempotentHint: true,
     },
 
-    handler: async () => {
+    handler: async (params) => {
       try {
+        const format = (params.format as string) ?? 'human';
         const config = donationService.getConfig();
+        const text = format === 'technical'
+          ? formatDonationConfig(config)
+          : formatDonationConfigHuman(config);
         return {
-          content: [{ type: 'text' as const, text: formatDonationConfig(config) }],
+          content: [{ type: 'text' as const, text }],
         };
       } catch (error) {
         return handleToolError(error as Error);

--- a/src/tools/v2/donationConfig.ts
+++ b/src/tools/v2/donationConfig.ts
@@ -14,7 +14,7 @@ export function createDonationConfigHandler(donationService: DonationService): T
   return {
     name: 'donation_config',
     description:
-      'Get TheologAI donation configuration: supported tokens, recipient address, x402 payment endpoint, and facilitator details. Donations are voluntary and do not gate features.',
+      'Get technical donation configuration for programmatic payment flows: supported tokens, contract addresses, chain IDs, x402 endpoint, and facilitators. Donations are voluntary and do not gate features. For a human-friendly donation guide, use the "donate" prompt instead.',
     inputSchema: {
       type: 'object' as const,
       properties: {},

--- a/src/tools/v2/donationConfig.ts
+++ b/src/tools/v2/donationConfig.ts
@@ -1,0 +1,40 @@
+/**
+ * donation_config tool handler.
+ *
+ * Returns TheologAI donation configuration: supported tokens,
+ * recipient address, x402 payment endpoint, and facilitator details.
+ */
+
+import type { ToolHandler } from '../../kernel/types.js';
+import type { DonationService } from '../../services/donation/DonationService.js';
+import { formatDonationConfig } from '../../formatters/donationFormatter.js';
+import { handleToolError } from '../../kernel/errors.js';
+
+export function createDonationConfigHandler(donationService: DonationService): ToolHandler {
+  return {
+    name: 'donation_config',
+    description:
+      'Get TheologAI donation configuration: supported tokens, recipient address, x402 payment endpoint, and facilitator details. Donations are voluntary and do not gate features.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+      required: [],
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+
+    handler: async () => {
+      try {
+        const config = donationService.getConfig();
+        return {
+          content: [{ type: 'text' as const, text: formatDonationConfig(config) }],
+        };
+      } catch (error) {
+        return handleToolError(error as Error);
+      }
+    },
+  };
+}

--- a/src/tools/v2/index.ts
+++ b/src/tools/v2/index.ts
@@ -40,6 +40,12 @@ import { createCommentaryHandler } from './commentary.js';
 import { createClassicTextsHandler } from './classicTexts.js';
 import { createStrongsLookupHandler } from './strongsLookup.js';
 import { createVerseMorphologyHandler } from './verseMorphology.js';
+import { createDonationConfigHandler } from './donationConfig.js';
+import { createVerifyDonationHandler } from './verifyDonation.js';
+
+// Donation
+import { OnChainVerifier } from '../../adapters/donation/OnChainVerifier.js';
+import { DonationService } from '../../services/donation/DonationService.js';
 
 import { getDatabase } from '../../adapters/shared/Database.js';
 
@@ -89,6 +95,10 @@ export function createCompositionRoot(): CompositionRoot {
   const strongsService = new StrongsService(strongsRepo);
   const morphService = new MorphologyService(morphRepo);
 
+  // Donation (no DB dependency)
+  const onChainVerifier = new OnChainVerifier({});
+  const donationService = new DonationService(onChainVerifier, process.env.X402_BASE_URL ?? '');
+
   // Tool handlers
   const tools = [
     createBibleLookupHandler(bibleService),
@@ -98,6 +108,8 @@ export function createCompositionRoot(): CompositionRoot {
     createClassicTextsHandler(historicalService, ccelService),
     createStrongsLookupHandler(strongsService),
     createVerseMorphologyHandler(morphService),
+    createDonationConfigHandler(donationService),
+    createVerifyDonationHandler(donationService),
   ];
 
   return {

--- a/src/tools/v2/verifyDonation.ts
+++ b/src/tools/v2/verifyDonation.ts
@@ -1,0 +1,46 @@
+/**
+ * verify_donation tool handler.
+ *
+ * Verifies a donation transaction on-chain across Ethereum, Base, and Radius.
+ */
+
+import type { ToolHandler } from '../../kernel/types.js';
+import type { DonationService } from '../../services/donation/DonationService.js';
+import { formatDonationVerifyResult } from '../../formatters/donationFormatter.js';
+import { handleToolError } from '../../kernel/errors.js';
+
+export function createVerifyDonationHandler(donationService: DonationService): ToolHandler {
+  return {
+    name: 'verify_donation',
+    description:
+      'Verify a donation transaction on-chain. Supports USDC on Ethereum/Base, ETH on Ethereum/Base, and SBC on Radius. Provide the transaction hash to check confirmation status and recipient.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        tx_hash: {
+          type: 'string',
+          description: 'Transaction hash (0x-prefixed, 64 hex characters)',
+          pattern: '^0x[0-9a-fA-F]{64}$',
+        },
+      },
+      required: ['tx_hash'],
+    },
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+
+    handler: async (params) => {
+      try {
+        const txHash = params.tx_hash as string;
+        const result = await donationService.verifyDonation(txHash);
+        return {
+          content: [{ type: 'text' as const, text: formatDonationVerifyResult(result) }],
+        };
+      } catch (error) {
+        return handleToolError(error as Error);
+      }
+    },
+  };
+}

--- a/src/tools/worker/index.ts
+++ b/src/tools/worker/index.ts
@@ -42,6 +42,12 @@ import { createCommentaryHandler } from '../v2/commentary.js';
 import { createClassicTextsHandler } from '../v2/classicTexts.js';
 import { createStrongsLookupHandler } from '../v2/strongsLookup.js';
 import { createVerseMorphologyHandler } from '../v2/verseMorphology.js';
+import { createDonationConfigHandler } from '../v2/donationConfig.js';
+import { createVerifyDonationHandler } from '../v2/verifyDonation.js';
+
+// Donation
+import { OnChainVerifier } from '../../adapters/donation/OnChainVerifier.js';
+import { DonationService } from '../../services/donation/DonationService.js';
 
 // Static data (imported as JSON module in Workers bundle)
 import parallelPassagesData from '../../data/parallel-passages.json';
@@ -75,12 +81,30 @@ const ccelService = new CcelService(ccelAdapter);
 // Once created, they persist for the isolate's lifetime (secret changes require redeployment).
 let _bibleService: BibleService | null = null;
 
+// Donation service is HTTP-only (no D1 dependency), safe to cache at module scope.
+let _donationService: DonationService | null = null;
+
 function getBibleService(env: Env): BibleService {
   if (!_bibleService) {
     const esvAdapter = new EsvAdapter(env.ESV_API_KEY);
     _bibleService = new BibleService([esvAdapter, netAdapter, helloaoAdapter]);
   }
   return _bibleService;
+}
+
+export function getDonationService(env: Env): DonationService {
+  if (!_donationService) {
+    const verifier = new OnChainVerifier({
+      ethereum: env.ETH_RPC_URL,
+      base: env.BASE_RPC_URL,
+      radius: env.RADIUS_RPC_URL,
+    });
+    _donationService = new DonationService(
+      verifier,
+      'https://theologai.tjfrederick.workers.dev',
+    );
+  }
+  return _donationService;
 }
 
 // ── Per-request creation (D1-dependent) ──
@@ -108,6 +132,7 @@ export function createWorkerCompositionRoot(env: Env): WorkerCompositionRoot {
 
   // Module-scope services (cached across requests)
   const bibleService = getBibleService(env);
+  const donationService = getDonationService(env);
 
   // Tool handlers (per-request — hold D1-dependent services)
   const tools = [
@@ -118,6 +143,8 @@ export function createWorkerCompositionRoot(env: Env): WorkerCompositionRoot {
     createClassicTextsHandler(historicalService, ccelService),
     createStrongsLookupHandler(strongsService),
     createVerseMorphologyHandler(morphService),
+    createDonationConfigHandler(donationService),
+    createVerifyDonationHandler(donationService),
   ];
 
   return {

--- a/src/worker-env.ts
+++ b/src/worker-env.ts
@@ -9,4 +9,10 @@ export interface Env {
   ESV_API_KEY?: string;
   /** Server version (set via wrangler.toml [vars]) */
   THEOLOGAI_VERSION: string;
+  /** SBC facilitator API key for Radius x402 settlements */
+  SBC_FACILITATOR_API_KEY?: string;
+  /** Custom RPC endpoints (optional — defaults to public endpoints) */
+  ETH_RPC_URL?: string;
+  BASE_RPC_URL?: string;
+  RADIUS_RPC_URL?: string;
 }

--- a/src/worker-server.ts
+++ b/src/worker-server.ts
@@ -240,6 +240,11 @@ export function createWorkerMcpServer(root: WorkerCompositionRoot, version: stri
           { name: 'traditions', description: 'Comma-separated traditions to focus on', required: false },
         ],
       },
+      {
+        name: 'donate',
+        description: 'Guide for donating to support TheologAI development',
+        arguments: [],
+      },
     ],
   }));
 
@@ -384,6 +389,34 @@ Follow this methodology:
           }],
         };
       }
+
+      case 'donate':
+        return {
+          messages: [{
+            role: 'user' as const,
+            content: {
+              type: 'text' as const,
+              text: `The user wants to donate to TheologAI. Guide them through the options:
+
+**TheologAI Donations**
+
+Donations help support TheologAI's development and are entirely voluntary — all features are free regardless.
+
+**Easiest option:** Donate via the web at [theologai.pages.dev](https://theologai.pages.dev/), which has a donation section with wallet connection support.
+
+**Manual transfer options:**
+- USDC on Base (lowest fees, recommended)
+- USDC or ETH on Ethereum
+- SBC on Radius
+
+Recipient address: \`0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04\`
+
+---
+
+If the user has a wallet MCP tool available, you can help them send a transaction directly — call \`donation_config\` to get the contract addresses and chain details needed. For programmatic x402 payment flows, also use \`donation_config\` for the full technical config.`,
+            },
+          }],
+        };
 
       default:
         throw new Error(`Unknown prompt: ${name}`);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3,16 +3,145 @@
  *
  * Serves the MCP protocol over Streamable HTTP via the Cloudflare
  * Agents SDK. Auth is handled at the Cloudflare edge (rate limiting).
+ *
+ * Also serves the /x402/pay endpoint for x402 V2 donation payments.
  */
 
 import { createMcpHandler } from 'agents/mcp';
 import type { Env } from './worker-env.js';
-import { createWorkerCompositionRoot } from './tools/worker/index.js';
+import { createWorkerCompositionRoot, getDonationService } from './tools/worker/index.js';
 import { createWorkerMcpServer } from './worker-server.js';
+import { FacilitatorClient } from './adapters/donation/FacilitatorClient.js';
+import {
+  RECIPIENT_ADDRESS,
+  FACILITATORS,
+  X402_ACCEPTS,
+  type PaymentRequired,
+  type PaymentPayload,
+} from './kernel/donation-types.js';
+
+// ── x402 CORS headers ──
+
+const X402_CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Payment-Signature',
+  'Access-Control-Expose-Headers': 'Payment-Required, Payment-Response',
+  'Access-Control-Max-Age': '86400',
+};
+
+// ── x402 handler ──
+
+function buildPaymentRequiredResponse(): Response {
+  const paymentRequired: PaymentRequired = {
+    x402Version: 2,
+    resource: {
+      url: 'https://theologai.tjfrederick.workers.dev/x402/pay',
+      description: 'TheologAI voluntary donation',
+      mimeType: 'application/json',
+    },
+    accepts: X402_ACCEPTS,
+  };
+
+  const encoded = btoa(JSON.stringify(paymentRequired));
+
+  return new Response(
+    JSON.stringify({
+      error: 'Payment Required',
+      message: 'Send a donation to TheologAI. Include a Payment-Signature header with your x402 payment payload.',
+      x402Version: 2,
+    }),
+    {
+      status: 402,
+      headers: {
+        'Content-Type': 'application/json',
+        'Payment-Required': encoded,
+        ...X402_CORS_HEADERS,
+      },
+    },
+  );
+}
+
+async function handleX402Settlement(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const signatureHeader = request.headers.get('Payment-Signature');
+  if (!signatureHeader) {
+    return buildPaymentRequiredResponse();
+  }
+
+  try {
+    // Decode the payment payload from the header
+    const paymentPayload = JSON.parse(atob(signatureHeader)) as PaymentPayload;
+    const network = paymentPayload.accepted?.network;
+
+    if (!network) {
+      return buildPaymentRequiredResponse();
+    }
+
+    // Find the matching facilitator for this network
+    const facilitatorConfig = FACILITATORS.find(f => f.networks.includes(network));
+    if (!facilitatorConfig) {
+      return new Response(
+        JSON.stringify({ error: `Unsupported network: ${network}` }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...X402_CORS_HEADERS } },
+      );
+    }
+
+    // Find matching payment requirements from our accepts
+    const paymentRequirements = X402_ACCEPTS.find(a => a.network === network);
+    if (!paymentRequirements) {
+      return buildPaymentRequiredResponse();
+    }
+
+    // Settle via facilitator
+    const apiKey = facilitatorConfig.requiresApiKey ? env.SBC_FACILITATOR_API_KEY : undefined;
+    const client = new FacilitatorClient(facilitatorConfig.url, apiKey);
+    const settleResult = await client.settle(paymentPayload, paymentRequirements);
+
+    const encodedResponse = btoa(JSON.stringify(settleResult));
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Thank you for your donation to TheologAI!',
+        transaction: settleResult.transaction,
+        network: settleResult.network,
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Payment-Response': encodedResponse,
+          ...X402_CORS_HEADERS,
+        },
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Settlement failed';
+    return new Response(
+      JSON.stringify({ error: message }),
+      { status: 402, headers: { 'Content-Type': 'application/json', ...X402_CORS_HEADERS } },
+    );
+  }
+}
+
+// ── Worker entry point ──
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    // Fresh composition root per request (D1 binding is per-request)
+    const url = new URL(request.url);
+
+    // x402 payment endpoint — routed before MCP handler
+    if (url.pathname === '/x402/pay') {
+      if (request.method === 'OPTIONS') {
+        return new Response(null, { status: 204, headers: X402_CORS_HEADERS });
+      }
+      return handleX402Settlement(request, env);
+    }
+
+    // MCP handler (existing)
     const root = createWorkerCompositionRoot(env);
     const mcpServer = createWorkerMcpServer(root, env.THEOLOGAI_VERSION || '0.0.0');
 

--- a/test/unit/adapters/donation/OnChainVerifier.test.ts
+++ b/test/unit/adapters/donation/OnChainVerifier.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OnChainVerifier } from '../../../../src/adapters/donation/OnChainVerifier.js';
+import { PaymentError } from '../../../../src/kernel/errors.js';
+
+// ── Helpers ──
+
+const TX_HASH = '0x' + 'ab'.repeat(32);
+const USDC_BASE_CONTRACT = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+function makeReceiptResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      status: '0x1',
+      blockNumber: '0x100',
+      from: '0x' + '11'.repeat(20),
+      to: USDC_BASE_CONTRACT,
+      logs: [],
+      ...overrides,
+    },
+  };
+}
+
+function makeTxResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: {
+      from: '0x' + '11'.repeat(20),
+      to: '0x' + '22'.repeat(20),
+      value: '0x0',
+      blockNumber: '0x100',
+      ...overrides,
+    },
+  };
+}
+
+function makeErc20Receipt(from: string, to: string, amount: string) {
+  const fromTopic = '0x' + '0'.repeat(24) + from.slice(2);
+  const toTopic = '0x' + '0'.repeat(24) + to.slice(2);
+  const data = '0x' + BigInt(amount).toString(16).padStart(64, '0');
+
+  return makeReceiptResponse({
+    logs: [{
+      address: USDC_BASE_CONTRACT,
+      topics: [TRANSFER_TOPIC, fromTopic, toTopic],
+      data,
+    }],
+  });
+}
+
+function mockFetch(responses: Record<string, unknown>[]) {
+  let callIndex = 0;
+  return vi.fn().mockImplementation(() => {
+    const resp = responses[callIndex] ?? { jsonrpc: '2.0', id: 1, result: null };
+    callIndex++;
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(resp),
+    });
+  });
+}
+
+describe('OnChainVerifier', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('verify', () => {
+    it('detects ERC-20 Transfer and returns amount as string', async () => {
+      const sender = '0x' + '11'.repeat(20);
+      const recipient = '0x' + '22'.repeat(20);
+
+      // 6 responses: receipt+tx for each of 3 chains (all called in parallel)
+      // Chain 1 (Ethereum) returns the match
+      globalThis.fetch = mockFetch([
+        makeErc20Receipt(sender, recipient, '1500000'),
+        makeTxResponse({ from: sender, to: USDC_BASE_CONTRACT, value: '0x0' }),
+        // Chain 2 & 3 return null
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+      ]);
+
+      const verifier = new OnChainVerifier({
+        ethereum: 'https://fake-eth.test',
+        base: 'https://fake-base.test',
+        radius: 'https://fake-radius.test',
+      });
+
+      const result = await verifier.verify(TX_HASH);
+
+      expect(result.amount).toBe('1500000');
+      expect(typeof result.amount).toBe('string');
+      expect(result.from).toContain('1111');
+      expect(result.to).toContain('2222');
+      expect(result.confirmed).toBe(true);
+
+      verifier.dispose();
+    });
+
+    it('detects native ETH transfer', async () => {
+      const sender = '0x' + '11'.repeat(20);
+      const recipient = '0x' + '22'.repeat(20);
+      const weiAmount = '0x' + BigInt('1000000000000000000').toString(16); // 1 ETH
+
+      // All chains return no ERC-20, but Ethereum has native value
+      globalThis.fetch = mockFetch([
+        makeReceiptResponse({ logs: [] }),
+        makeTxResponse({ from: sender, to: recipient, value: weiAmount }),
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+      ]);
+
+      const verifier = new OnChainVerifier({
+        ethereum: 'https://fake-eth.test',
+        base: 'https://fake-base.test',
+        radius: 'https://fake-radius.test',
+      });
+
+      const result = await verifier.verify(TX_HASH);
+
+      expect(result.amount).toBe('1000000000000000000');
+      expect(result.symbol).toBe('ETH');
+      expect(result.tokenAddress).toBeNull();
+
+      verifier.dispose();
+    });
+
+    it('calls all RPCs in parallel (not sequential)', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ jsonrpc: '2.0', id: 1, result: null }),
+      });
+      globalThis.fetch = fetchMock;
+
+      const verifier = new OnChainVerifier({
+        ethereum: 'https://fake-eth.test',
+        base: 'https://fake-base.test',
+        radius: 'https://fake-radius.test',
+      });
+
+      await expect(verifier.verify(TX_HASH)).rejects.toThrow(PaymentError);
+
+      // All 3 chains should have been tried (2 calls each = 6 total)
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+
+      verifier.dispose();
+    });
+
+    it('throws PaymentError when tx not found on any chain', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ jsonrpc: '2.0', id: 1, result: null }),
+      });
+
+      const verifier = new OnChainVerifier({
+        ethereum: 'https://fake-eth.test',
+        base: 'https://fake-base.test',
+        radius: 'https://fake-radius.test',
+      });
+
+      await expect(verifier.verify(TX_HASH)).rejects.toThrow(PaymentError);
+      await expect(verifier.verify(TX_HASH)).rejects.toThrow('not found');
+
+      verifier.dispose();
+    });
+
+    it('returns cached result on repeat calls', async () => {
+      const sender = '0x' + '11'.repeat(20);
+      const recipient = '0x' + '22'.repeat(20);
+
+      const fetchMock = mockFetch([
+        makeErc20Receipt(sender, recipient, '1000000'),
+        makeTxResponse({ from: sender, to: USDC_BASE_CONTRACT, value: '0x0' }),
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+        { jsonrpc: '2.0', id: 1, result: null },
+      ]);
+      globalThis.fetch = fetchMock;
+
+      const verifier = new OnChainVerifier({
+        ethereum: 'https://fake-eth.test',
+        base: 'https://fake-base.test',
+        radius: 'https://fake-radius.test',
+      });
+
+      const result1 = await verifier.verify(TX_HASH);
+      const callCount = fetchMock.mock.calls.length;
+
+      const result2 = await verifier.verify(TX_HASH);
+
+      expect(result2).toEqual(result1);
+      // No additional fetch calls on second verify
+      expect(fetchMock.mock.calls.length).toBe(callCount);
+
+      verifier.dispose();
+    });
+
+    it('handles RPC errors gracefully', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('network error'));
+
+      const verifier = new OnChainVerifier({
+        ethereum: 'https://fake-eth.test',
+        base: 'https://fake-base.test',
+        radius: 'https://fake-radius.test',
+      });
+
+      await expect(verifier.verify(TX_HASH)).rejects.toThrow(PaymentError);
+
+      verifier.dispose();
+    });
+  });
+});

--- a/test/unit/formatters/donationFormatter.test.ts
+++ b/test/unit/formatters/donationFormatter.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { formatDonationConfig, formatDonationVerifyResult } from '../../../src/formatters/donationFormatter.js';
+import type { DonationConfig, DonationVerifyResult } from '../../../src/kernel/donation-types.js';
+
+// ── Fixture factories ──
+
+function makeDonationConfig(overrides: Partial<DonationConfig> = {}): DonationConfig {
+  return {
+    recipientAddress: '0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04',
+    tokens: [
+      { symbol: 'USDC', name: 'USD Coin', chainId: 8453, chainName: 'Base', network: 'eip155:8453', asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', decimals: 6, isNative: false, x402Supported: true },
+      { symbol: 'ETH', name: 'Ether', chainId: 1, chainName: 'Ethereum', network: 'eip155:1', asset: 'native', decimals: 18, isNative: true, x402Supported: false },
+    ],
+    facilitators: [
+      { name: 'Coinbase', url: 'https://x402.org/facilitator', networks: ['eip155:8453'], requiresApiKey: false },
+    ],
+    x402PayEndpoint: 'https://test.example.com/x402/pay',
+    ...overrides,
+  };
+}
+
+function makeDonationVerifyResult(overrides: Partial<DonationVerifyResult> = {}): DonationVerifyResult {
+  return {
+    txHash: '0x' + 'ab'.repeat(32),
+    chainId: 8453,
+    chainName: 'Base',
+    from: '0x' + '11'.repeat(20),
+    amount: '1.5',
+    symbol: 'USDC',
+    confirmed: true,
+    isToRecipient: true,
+    explorerUrl: 'https://basescan.org/tx/0x' + 'ab'.repeat(32),
+    ...overrides,
+  };
+}
+
+describe('formatDonationConfig', () => {
+  it('includes recipient address', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toContain('0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04');
+  });
+
+  it('lists tokens in a table', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toContain('USDC');
+    expect(out).toContain('ETH');
+    expect(out).toContain('Base');
+    expect(out).toContain('Ethereum');
+  });
+
+  it('marks x402-supported tokens', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toContain('Yes');
+    expect(out).toContain('No');
+  });
+
+  it('includes facilitator info', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toContain('Coinbase');
+    expect(out).toContain('eip155:8453');
+  });
+
+  it('includes x402 endpoint', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toContain('https://test.example.com/x402/pay');
+  });
+
+  it('includes voluntary disclaimer', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toContain('voluntary');
+    expect(out).toContain('do not gate');
+  });
+
+  it('returns trimmed output', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toBe(out.trim());
+  });
+
+  it('shows native for native tokens', () => {
+    const out = formatDonationConfig(makeDonationConfig());
+    expect(out).toContain('native');
+  });
+});
+
+describe('formatDonationVerifyResult', () => {
+  it('includes amount and symbol', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult());
+    expect(out).toContain('1.5');
+    expect(out).toContain('USDC');
+  });
+
+  it('shows Confirmed status', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult({ confirmed: true }));
+    expect(out).toContain('Confirmed');
+  });
+
+  it('shows Pending status', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult({ confirmed: false }));
+    expect(out).toContain('Pending');
+  });
+
+  it('includes chain name', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult());
+    expect(out).toContain('Base');
+  });
+
+  it('includes explorer link', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult());
+    expect(out).toContain('basescan.org');
+    expect(out).toContain('View on Explorer');
+  });
+
+  it('shows thank-you when isToRecipient', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult({ isToRecipient: true }));
+    expect(out).toContain('Thank you');
+  });
+
+  it('shows warning when not sent to recipient', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult({ isToRecipient: false }));
+    expect(out).toContain('Warning');
+    expect(out).not.toContain('Thank you');
+  });
+
+  it('returns trimmed output', () => {
+    const out = formatDonationVerifyResult(makeDonationVerifyResult());
+    expect(out).toBe(out.trim());
+  });
+});

--- a/test/unit/formatters/donationFormatter.test.ts
+++ b/test/unit/formatters/donationFormatter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDonationConfig, formatDonationVerifyResult } from '../../../src/formatters/donationFormatter.js';
+import { formatDonationConfig, formatDonationConfigHuman, formatDonationVerifyResult } from '../../../src/formatters/donationFormatter.js';
 import type { DonationConfig, DonationVerifyResult } from '../../../src/kernel/donation-types.js';
 
 // ── Fixture factories ──
@@ -79,6 +79,48 @@ describe('formatDonationConfig', () => {
   it('shows native for native tokens', () => {
     const out = formatDonationConfig(makeDonationConfig());
     expect(out).toContain('native');
+  });
+});
+
+describe('formatDonationConfigHuman', () => {
+  it('includes recipient address', () => {
+    const out = formatDonationConfigHuman(makeDonationConfig());
+    expect(out).toContain('0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04');
+  });
+
+  it('includes web UI link', () => {
+    const out = formatDonationConfigHuman(makeDonationConfig());
+    expect(out).toContain('theologai.pages.dev');
+  });
+
+  it('lists transfer options in plain language', () => {
+    const out = formatDonationConfigHuman(makeDonationConfig());
+    expect(out).toContain('USDC on Base');
+    expect(out).toContain('Ethereum');
+    expect(out).toContain('Radius');
+  });
+
+  it('includes voluntary disclaimer', () => {
+    const out = formatDonationConfigHuman(makeDonationConfig());
+    expect(out).toContain('voluntary');
+  });
+
+  it('includes wallet tool hint', () => {
+    const out = formatDonationConfigHuman(makeDonationConfig());
+    expect(out).toContain('wallet MCP tool');
+    expect(out).toContain('donation_config');
+  });
+
+  it('does not include contract addresses or facilitator details', () => {
+    const out = formatDonationConfigHuman(makeDonationConfig());
+    expect(out).not.toContain('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+    expect(out).not.toContain('Coinbase');
+    expect(out).not.toContain('x402.org');
+  });
+
+  it('returns trimmed output', () => {
+    const out = formatDonationConfigHuman(makeDonationConfig());
+    expect(out).toBe(out.trim());
   });
 });
 

--- a/test/unit/kernel/errors.test.ts
+++ b/test/unit/kernel/errors.test.ts
@@ -5,6 +5,7 @@ import {
   RateLimitError,
   AdapterError,
   NotFoundError,
+  PaymentError,
   TheologAIError,
   getUserMessage,
   handleToolError,
@@ -17,6 +18,7 @@ describe('Error hierarchy', () => {
     expect(new RateLimitError(60)).toBeInstanceOf(TheologAIError);
     expect(new AdapterError('ESV', 'fail')).toBeInstanceOf(TheologAIError);
     expect(new NotFoundError('verse', 'not found')).toBeInstanceOf(TheologAIError);
+    expect(new PaymentError('fail')).toBeInstanceOf(TheologAIError);
   });
 
   it('all errors extend Error', () => {
@@ -55,6 +57,17 @@ describe('Error hierarchy', () => {
     const err = new NotFoundError('verse', 'Gen 999:999 not found');
     expect(err.resource).toBe('verse');
   });
+
+  it('PaymentError stores optional txHash', () => {
+    const err = new PaymentError('fail', '0xabc');
+    expect(err.txHash).toBe('0xabc');
+    expect(err.name).toBe('PaymentError');
+  });
+
+  it('PaymentError works without txHash', () => {
+    const err = new PaymentError('fail');
+    expect(err.txHash).toBeUndefined();
+  });
 });
 
 describe('getUserMessage', () => {
@@ -68,6 +81,14 @@ describe('getUserMessage', () => {
 
   it('NotFoundError → returns message', () => {
     expect(getUserMessage(new NotFoundError('verse', 'verse not found'))).toBe('verse not found');
+  });
+
+  it('PaymentError with txHash → includes hash', () => {
+    expect(getUserMessage(new PaymentError('bad sig', '0xabc'))).toContain('0xabc');
+  });
+
+  it('PaymentError without txHash → payment error message', () => {
+    expect(getUserMessage(new PaymentError('bad sig'))).toContain('Payment error');
   });
 
   it('generic Error → fallback', () => {

--- a/test/unit/services/donation/DonationService.test.ts
+++ b/test/unit/services/donation/DonationService.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DonationService } from '../../../../src/services/donation/DonationService.js';
+import { PaymentError } from '../../../../src/kernel/errors.js';
+import { RECIPIENT_ADDRESS, SUPPORTED_TOKENS, FACILITATORS } from '../../../../src/kernel/donation-types.js';
+
+// ── Mock factory ──
+
+function makeMockVerifier(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    verify: vi.fn().mockResolvedValue({
+      txHash: '0x' + 'ab'.repeat(32),
+      chainId: 8453,
+      from: '0x' + '11'.repeat(20),
+      to: RECIPIENT_ADDRESS,
+      amount: '1500000',
+      symbol: 'USDC',
+      tokenAddress: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      blockNumber: 12345,
+      confirmed: true,
+      ...overrides,
+    }),
+    dispose: vi.fn(),
+  };
+}
+
+describe('DonationService', () => {
+  let service: DonationService;
+  let mockVerifier: ReturnType<typeof makeMockVerifier>;
+
+  beforeEach(() => {
+    mockVerifier = makeMockVerifier();
+    service = new DonationService(mockVerifier as any, 'https://test.example.com');
+  });
+
+  describe('getConfig', () => {
+    it('returns correct recipient address', () => {
+      const config = service.getConfig();
+      expect(config.recipientAddress).toBe(RECIPIENT_ADDRESS);
+    });
+
+    it('returns all 5 supported tokens', () => {
+      const config = service.getConfig();
+      expect(config.tokens).toHaveLength(5);
+    });
+
+    it('returns facilitators', () => {
+      const config = service.getConfig();
+      expect(config.facilitators).toEqual(FACILITATORS);
+    });
+
+    it('returns x402 pay endpoint', () => {
+      const config = service.getConfig();
+      expect(config.x402PayEndpoint).toBe('https://test.example.com/x402/pay');
+    });
+  });
+
+  describe('verifyDonation', () => {
+    it('formats USDC amount correctly (6 decimals)', async () => {
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.amount).toBe('1.5');
+      expect(result.symbol).toBe('USDC');
+    });
+
+    it('formats ETH amount correctly (18 decimals)', async () => {
+      mockVerifier = makeMockVerifier({
+        chainId: 1,
+        amount: '1000000000000000000',
+        symbol: 'ETH',
+        tokenAddress: null,
+      });
+      service = new DonationService(mockVerifier as any, 'https://test.example.com');
+
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.amount).toBe('1');
+      expect(result.symbol).toBe('ETH');
+    });
+
+    it('formats small USDC amounts', async () => {
+      mockVerifier = makeMockVerifier({ amount: '100000' });
+      service = new DonationService(mockVerifier as any, 'https://test.example.com');
+
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.amount).toBe('0.1');
+    });
+
+    it('formats whole number amounts without trailing decimal', async () => {
+      mockVerifier = makeMockVerifier({ amount: '5000000' });
+      service = new DonationService(mockVerifier as any, 'https://test.example.com');
+
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.amount).toBe('5');
+    });
+
+    it('sets isToRecipient true when to matches', async () => {
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.isToRecipient).toBe(true);
+    });
+
+    it('sets isToRecipient false when to does not match', async () => {
+      mockVerifier = makeMockVerifier({ to: '0x' + '99'.repeat(20) });
+      service = new DonationService(mockVerifier as any, 'https://test.example.com');
+
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.isToRecipient).toBe(false);
+    });
+
+    it('is case-insensitive for recipient check', async () => {
+      mockVerifier = makeMockVerifier({ to: RECIPIENT_ADDRESS.toLowerCase() });
+      service = new DonationService(mockVerifier as any, 'https://test.example.com');
+
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.isToRecipient).toBe(true);
+    });
+
+    it('builds explorer URL for Base', async () => {
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.explorerUrl).toContain('basescan.org');
+    });
+
+    it('builds explorer URL for Ethereum', async () => {
+      mockVerifier = makeMockVerifier({ chainId: 1, symbol: 'ETH', amount: '1000000000000000000', tokenAddress: null });
+      service = new DonationService(mockVerifier as any, 'https://test.example.com');
+
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.explorerUrl).toContain('etherscan.io');
+    });
+
+    it('returns chainName from token config', async () => {
+      const result = await service.verifyDonation('0x' + 'ab'.repeat(32));
+      expect(result.chainName).toBe('Base');
+    });
+
+    it('throws PaymentError for invalid hash format', async () => {
+      await expect(service.verifyDonation('not-a-hash')).rejects.toThrow(PaymentError);
+      await expect(service.verifyDonation('')).rejects.toThrow(PaymentError);
+      await expect(service.verifyDonation('0xshort')).rejects.toThrow(PaymentError);
+    });
+
+    it('calls verifier.verify with the tx hash', async () => {
+      const hash = '0x' + 'ab'.repeat(32);
+      await service.verifyDonation(hash);
+      expect(mockVerifier.verify).toHaveBeenCalledWith(hash);
+    });
+  });
+});

--- a/test/unit/tools/worker/compositionRoot.test.ts
+++ b/test/unit/tools/worker/compositionRoot.test.ts
@@ -56,6 +56,8 @@ const EXPECTED_TOOL_NAMES = [
   'classic_text_lookup',
   'original_language_lookup',
   'bible_verse_morphology',
+  'donation_config',
+  'verify_donation',
 ];
 
 function makeEnv(overrides: Partial<Env> = {}): Env {
@@ -77,9 +79,9 @@ describe('createWorkerCompositionRoot', () => {
   });
 
   describe('tool creation', () => {
-    it('creates exactly 7 tools', () => {
+    it('creates exactly 9 tools', () => {
       const root = createWorkerCompositionRoot(makeEnv());
-      expect(root.tools).toHaveLength(7);
+      expect(root.tools).toHaveLength(9);
     });
 
     it('creates tools with correct names', () => {

--- a/test/unit/worker-server/workerMcpServer.test.ts
+++ b/test/unit/worker-server/workerMcpServer.test.ts
@@ -50,6 +50,8 @@ const TOOL_NAMES = [
   'classic_text_lookup',
   'original_language_lookup',
   'bible_verse_morphology',
+  'donation_config',
+  'verify_donation',
 ];
 
 function makeMockRoot(): WorkerCompositionRoot {
@@ -122,10 +124,10 @@ describe('createWorkerMcpServer', () => {
   });
 
   describe('ListTools handler', () => {
-    it('returns all 7 tools', async () => {
+    it('returns all 9 tools', async () => {
       const handler = capturedHandlers.get('tools/list')!;
       const result = await handler({});
-      expect(result.tools).toHaveLength(7);
+      expect(result.tools).toHaveLength(9);
     });
 
     it('each tool has name, description, inputSchema, annotations', async () => {

--- a/test/unit/worker-server/workerMcpServer.test.ts
+++ b/test/unit/worker-server/workerMcpServer.test.ts
@@ -225,15 +225,16 @@ describe('createWorkerMcpServer', () => {
   });
 
   describe('prompts', () => {
-    it('ListPrompts returns 4 prompts with correct names', async () => {
+    it('ListPrompts returns 5 prompts with correct names', async () => {
       const handler = capturedHandlers.get('prompts/list')!;
       const result = await handler({});
-      expect(result.prompts).toHaveLength(4);
+      expect(result.prompts).toHaveLength(5);
       const names = result.prompts.map((p: any) => p.name);
       expect(names).toContain('word-study');
       expect(names).toContain('passage-exegesis');
       expect(names).toContain('compare-translations');
       expect(names).toContain('confession-study');
+      expect(names).toContain('donate');
     });
 
     it('GetPrompt returns messages for word-study', async () => {
@@ -242,6 +243,17 @@ describe('createWorkerMcpServer', () => {
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0].role).toBe('user');
       expect(result.messages[0].content.text).toContain('agape');
+    });
+
+    it('GetPrompt returns donation guide for donate', async () => {
+      const handler = capturedHandlers.get('prompts/get')!;
+      const result = await handler({ params: { name: 'donate', arguments: {} } });
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].role).toBe('user');
+      expect(result.messages[0].content.text).toContain('theologai.pages.dev');
+      expect(result.messages[0].content.text).toContain('USDC on Base');
+      expect(result.messages[0].content.text).toContain('0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04');
+      expect(result.messages[0].content.text).toContain('donation_config');
     });
 
     it('GetPrompt throws for unknown prompt', async () => {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,11 @@ binding = "THEOLOGAI_DB"
 database_name = "theologai-db"
 database_id = "50de6fbe-852b-4a50-875f-729ef58d3fcb"
 
+# Optional: Custom RPC endpoints (defaults to public endpoints in code)
+# ETH_RPC_URL = "https://eth.llamarpc.com"
+# BASE_RPC_URL = "https://mainnet.base.org"
+# RADIUS_RPC_URL = "https://rpc.radiustech.xyz"
+
 # ── Preview environment (deployed by CI on PRs) ──
 # Uses a separate D1 database. One-time setup:
 #   wrangler d1 create theologai-db-preview
@@ -34,4 +39,5 @@ database_name = "theologai-db-preview"
 database_id = "f9f415e1-219b-4d17-bcf5-33a8abad02fa"
 
 # Secrets (set via `wrangler secret put`):
-#   ESV_API_KEY  — ESV API key (optional)
+#   ESV_API_KEY            — ESV API key (optional)
+#   SBC_FACILITATOR_API_KEY — SBC facilitator API key for Radius x402 settlements


### PR DESCRIPTION
## Summary
- **2 new MCP tools**: `donation_config` (returns supported tokens, recipient, facilitators) and `verify_donation` (on-chain tx verification across Ethereum, Base, and Radius)
- **x402 V2 payment endpoint**: `/x402/pay` route in the Cloudflare Worker with dual facilitator routing (Coinbase for Base USDC, SBC for Radius SBC)
- **Zero new npm dependencies** — hand-rolled x402 V2 types and JSON-RPC verification
- **38 new tests** (374 total): OnChainVerifier (6), DonationService (16), donationFormatter (16)

### New files
- `src/kernel/donation-types.ts` — token constants, x402 V2 types, facilitator config
- `src/adapters/donation/OnChainVerifier.ts` — parallel chain detection with 5-min LRU cache
- `src/adapters/donation/FacilitatorClient.ts` — x402 facilitator API client
- `src/services/donation/DonationService.ts` — business logic for config + verification
- `src/formatters/donationFormatter.ts` — Markdown formatters
- `src/tools/v2/donationConfig.ts` + `verifyDonation.ts` — tool handlers

### Modified files
- `src/worker.ts` — added `/x402/pay` endpoint with CORS and settlement logic
- `src/worker-env.ts` — RPC URL and facilitator API key env bindings
- `src/tools/worker/index.ts` — lazy singleton wiring for DonationService
- `src/kernel/errors.ts` — added `PaymentError` class
- `wrangler.toml` — documented RPC and secret env vars

## Test plan
- [x] `npm test` — 374/374 tests passing (38 new donation tests)
- [x] `npm run build` — TypeScript compiles without errors
- [ ] Deploy to preview environment and test `/x402/pay` endpoint
- [ ] Verify `donation_config` and `verify_donation` tools via MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)