### PR TITLE
Add MCP structured output and provenance foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added stable MCP 2025-11-25 structured output and server-side schema
+  validation for `bible_lookup` and `original_language_lookup`, while keeping
+  their existing Markdown content available for legacy clients.
+- Added bounded, result-local provenance records and structured-first guidance
+  to the word-study, passage-exegesis, and compare-translations prompts.
+
 ### Corrected
 
 - Reconciled the current public contract at version 3.6.0: nine tools, five

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Cross-boundary event members such as John or Paul remain available as thematic
 connections in `thematic` and `auto` modes.
 
 All tools are annotated as read-only, non-destructive, and idempotent. Tool
-inputs use closed, bounded JSON Schema 2020-12 contracts.
+inputs use closed, bounded JSON Schema 2020-12 contracts. `bible_lookup` and
+`original_language_lookup` also advertise versioned object-root `outputSchema`
+contracts and return matching `structuredContent` beside the existing Markdown
+content. Their structured results include bounded, result-local provenance
+records; all other tools retain their current Markdown-only result contract.
 
 ### Resources
 
@@ -246,8 +250,10 @@ per-request D1 repositories. Both targets share one MCP registry.
 - The local historical collection needs document-level edition, source, and
   license metadata before redistribution claims can be made.
 - Hosted MCP Logging would require a deliberate stateful-session design.
-- Authentication, saved workspaces, structured tool output, completions, and
-  MCP tasks should be added only when a concrete workflow requires them.
+- Authentication, saved workspaces, completions, and MCP tasks should be added
+  only when a concrete workflow requires them. Structured output is currently
+  limited to the two representative lookup tools above; further conversions
+  require separate compatibility review.
 - Remote D1 compatibility must be checked before any deployment; migration or
   corpus replacement requires separate review and approval.
 

--- a/src/formatters/languagesFormatter.ts
+++ b/src/formatters/languagesFormatter.ts
@@ -26,7 +26,7 @@ export function formatStrongsResult(result: EnhancedStrongsResult, detailLevel: 
     if (result.extended.morphologyCode) s += `Morphology: ${result.extended.morphologyCode}\n`;
     if (result.extended.source) s += `Lexicon: ${result.extended.source}\n`;
     if (result.extended.definition) {
-      s += `Definition: ${cleanLexiconText(result.extended.definition)}\n`;
+      s += `Definition: ${normalizeLexiconText(result.extended.definition)}\n`;
     }
     if (result.extended.occurrences) {
       s += `Occurrences: ${result.extended.occurrences}\n`;
@@ -48,17 +48,42 @@ export function formatStrongsResult(result: EnhancedStrongsResult, detailLevel: 
   return s.trim();
 }
 
-function cleanLexiconText(value: string): string {
-  return value
+/** Normalize STEPBible markup before exposing it in either result view. */
+export function normalizeLexiconText(value: string): string {
+  return decodeLexiconEntities(value)
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<ref=['"][^'"]*['"]>/gi, '')
     .replace(/<\/ref>/gi, '')
     .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
     .replace(/[ \t]+/g, ' ')
     .replace(/\n\s+/g, '\n')
     .trim();
+}
+
+function decodeLexiconEntities(value: string): string {
+  return value.replace(/&(#x[\da-f]+|#\d+|nbsp|amp|lt|gt|quot|apos);/gi, (_match, entity: string) => {
+    const normalized = entity.toLowerCase();
+    if (normalized === 'nbsp') return ' ';
+    if (normalized === 'amp') return '&';
+    if (normalized === 'lt') return '<';
+    if (normalized === 'gt') return '>';
+    if (normalized === 'quot') return '"';
+    if (normalized === 'apos') return "'";
+    const code = normalized.startsWith('#x')
+      ? Number.parseInt(normalized.slice(2), 16)
+      : Number.parseInt(normalized.slice(1), 10);
+    return !Number.isInteger(code) || code < 0 || code > 0x10FFFF
+      ? _match
+      : String.fromCodePoint(code);
+  });
+}
+
+/** Produce the bounded discovery summary used by Markdown and structured search. */
+export function summarizeDefinition(value: string, maxLength = 240): string {
+  const definition = normalizeLexiconText(value).replace(/\s+/g, ' ').trim();
+  return definition.length > maxLength
+    ? `${definition.slice(0, maxLength - 3)}…`
+    : definition;
 }
 
 /** Format lightweight search hits before the caller chooses an exact entry. */
@@ -73,8 +98,7 @@ export function formatStrongsSearchResults(query: string, results: StrongsEntry[
     ...results.map(entry => {
       const language = entry.testament === 'NT' ? 'Greek' : 'Hebrew';
       const transliteration = entry.transliteration ? ` — ${entry.transliteration}` : '';
-      const definition = entry.definition.replace(/\s+/g, ' ').trim();
-      const summary = definition.length > 240 ? `${definition.slice(0, 237)}…` : definition;
+      const summary = summarizeDefinition(entry.definition);
       return `- **${entry.strongs_number}** (${language}): ${entry.lemma}${transliteration} — ${summary}`;
     }),
     '',

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -51,6 +51,16 @@ export {
 // Cache
 export { Cache } from './cache.js';
 
+// Provenance
+export {
+  provenanceFromCitation,
+  type ProvenanceKind,
+  type ProvenanceStatus,
+  type ProvenanceRecord,
+  type ProvenanceLink,
+  type ProvenanceContext,
+} from './provenance.js';
+
 // Types
 export type {
   ToolHandler,

--- a/src/kernel/provenance.ts
+++ b/src/kernel/provenance.ts
@@ -1,0 +1,73 @@
+import type { Citation } from './types.js';
+
+export type ProvenanceKind =
+  | 'primary_text'
+  | 'translation'
+  | 'lexicon'
+  | 'morphology_dataset'
+  | 'cross_reference_dataset'
+  | 'curated_dataset'
+  | 'repository'
+  | 'delivery_provider';
+
+export type ProvenanceStatus =
+  | 'verified_source'
+  | 'provider_attributed'
+  | 'transcription_source_uncertain';
+
+export interface ProvenanceRecord {
+  id: string;
+  kind: ProvenanceKind;
+  label: string;
+  url?: string;
+  license?: {
+    label: string;
+    url?: string;
+  };
+  rightsNotice?: string;
+  attribution?: string;
+  version?: string;
+  locator?: string;
+  status: ProvenanceStatus;
+  note?: string;
+}
+
+export interface ProvenanceLink {
+  provenanceIds: string[];
+}
+
+export interface ProvenanceContext {
+  id: string;
+  kind: ProvenanceKind;
+  status?: ProvenanceStatus;
+  license?: {
+    label: string;
+    url?: string;
+  };
+  locator?: string;
+  attribution?: string;
+  version?: string;
+  note?: string;
+}
+
+/** Map the legacy citation shape without inferring rights or source-chain facts. */
+export function provenanceFromCitation(
+  citation: Citation,
+  context: ProvenanceContext,
+): ProvenanceRecord {
+  const record: ProvenanceRecord = {
+    id: context.id,
+    kind: context.kind,
+    label: citation.source,
+    status: context.status ?? 'provider_attributed',
+  };
+
+  if (citation.url) record.url = citation.url;
+  if (citation.copyright) record.rightsNotice = citation.copyright;
+  if (context.license) record.license = { ...context.license };
+  if (context.attribution) record.attribution = context.attribution;
+  if (context.version) record.version = context.version;
+  if (context.locator) record.locator = context.locator;
+  if (context.note) record.note = context.note;
+  return record;
+}

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -14,12 +14,14 @@ export interface ToolHandler {
   name: string;
   description: string;
   inputSchema: Tool['inputSchema'];
+  outputSchema?: Tool['outputSchema'];
   annotations?: Tool['annotations'];
   handler: (params: Record<string, unknown>) => Promise<ToolResult>;
 }
 
 export interface ToolResult {
   content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
   isError?: boolean;
 }
 

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -127,7 +127,7 @@ export function registerPromptHandlers(server: Server): void {
           : '';
         text = `Conduct a thorough word study on "${word}".${testamentHint}
 
-1. **Identify the original term** — ${callText(calls[0])}. If this is a search, choose the best matching Strong's number and make an exact detailed lookup.
+1. **Identify the original term** — ${callText(calls[0])}. Prefer structured \`mode\`, \`entries\`, \`detailLevel\`, and \`provenanceIds\` when present, with Markdown as fallback. For a search, first use its summary entries and only make a detailed extended lookup for a clearly selected Strong's entry. Do not treat one English gloss as exhausting the term's semantic range.
 2. **Examine morphological usage** — Find a key verse and use \`bible_verse_morphology\` to study its grammatical form.
 3. **Study contextual meaning** — Read 2–3 significant passages with \`bible_lookup\` and compare translations.
 4. **Explore cross-references** — Use \`bible_cross_references\` on a key verse.
@@ -138,7 +138,7 @@ export function registerPromptHandlers(server: Server): void {
         const reference = args?.reference ?? '';
         text = `Perform a systematic exegesis of ${reference}.
 
-1. **Read the text** — ${callText(calls[0])}; compare with ${callText(calls[1])}.
+1. **Read the text** — ${callText(calls[0])}; compare with ${callText(calls[1])}. Prefer structured \`passages[]\` and retain each translation's \`provenanceIds\`; distinguish an unavailable translation in \`failures[]\` from a translation whose text is absent.
 2. **Examine the original language** — ${callText(calls[2])}, then make exact \`original_language_lookup\` calls for significant Strong's numbers.
 3. **Explore connections** — ${callText(calls[3])} and ${callText(calls[4])}.
 4. **Consult commentaries** — ${callText(calls[5])} and ${callText(calls[6])}; note agreement and divergence.
@@ -153,6 +153,7 @@ export function registerPromptHandlers(server: Server): void {
 
 1. **Retrieve each translation**
 ${lookupCalls}
+Use structured \`passages[]\` when available, compare by its \`translation\`, report every \`failures[]\` item, and keep each citation/provenance link attached to the relevant translation. Fall back to the Markdown text when structured fields are unavailable.
 2. **Examine the original language** — ${callText(calls.at(-1)!)}.
 3. **Investigate divergences** — Make exact \`original_language_lookup\` calls for the relevant Strong's numbers.
 4. **Summarize** — Compare literal/dynamic choices and any theologically significant differences.`;

--- a/src/mcp/schemas/bibleLookup.ts
+++ b/src/mcp/schemas/bibleLookup.ts
@@ -1,0 +1,92 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { ProvenanceRecord } from '../../kernel/provenance.js';
+import { createProvenanceRecordSchema } from './provenance.js';
+
+export interface BibleLookupOutputV1 {
+  [key: string]: unknown;
+  schemaVersion: '1';
+  kind: 'bible_lookup';
+  requestedReference: string;
+  requestedTranslations: string[];
+  passages: Array<{
+    reference: string;
+    translation: string;
+    text: string;
+    footnotes?: Array<{
+      caller: string;
+      text: string;
+      chapter: number;
+      verse: number;
+    }>;
+    provenanceIds: string[];
+  }>;
+  failures: Array<{ translation: string; reason: string }>;
+  provenance: ProvenanceRecord[];
+}
+
+const translationEnum = ['ESV', 'NET', 'KJV', 'WEB', 'BSB', 'ASV', 'YLT', 'DBY'];
+
+export const bibleLookupOutputSchema = {
+  type: 'object',
+  properties: {
+    schemaVersion: { const: '1' },
+    kind: { const: 'bible_lookup' },
+    requestedReference: { type: 'string', minLength: 1, maxLength: 100 },
+    requestedTranslations: {
+      type: 'array', minItems: 1, maxItems: 8, uniqueItems: true,
+      items: { type: 'string', enum: translationEnum },
+    },
+    passages: {
+      type: 'array', maxItems: 8,
+      items: {
+        type: 'object',
+        properties: {
+          reference: { type: 'string', minLength: 1, maxLength: 100 },
+          translation: { type: 'string', enum: translationEnum },
+          text: { type: 'string', minLength: 1, maxLength: 500_000 },
+          footnotes: {
+            type: 'array', maxItems: 1000,
+            items: {
+              type: 'object',
+              properties: {
+                caller: { type: 'string', minLength: 1, maxLength: 20 },
+                text: { type: 'string', minLength: 1, maxLength: 10_000 },
+                chapter: { type: 'integer', minimum: 1, maximum: 200 },
+                verse: { type: 'integer', minimum: 1, maximum: 200 },
+              },
+              required: ['caller', 'text', 'chapter', 'verse'],
+              additionalProperties: false,
+            },
+          },
+          provenanceIds: {
+            type: 'array', minItems: 1, maxItems: 16, uniqueItems: true,
+            items: { type: 'string', minLength: 1, maxLength: 64 },
+          },
+        },
+        required: ['reference', 'translation', 'text', 'provenanceIds'],
+        additionalProperties: false,
+      },
+    },
+    failures: {
+      type: 'array', maxItems: 8,
+      items: {
+        type: 'object',
+        properties: {
+          translation: { type: 'string', enum: translationEnum },
+          reason: { type: 'string', minLength: 1, maxLength: 500 },
+        },
+        required: ['translation', 'reason'],
+        additionalProperties: false,
+      },
+    },
+    provenance: {
+      type: 'array', maxItems: 16,
+      items: createProvenanceRecordSchema(),
+    },
+  },
+  required: [
+    'schemaVersion', 'kind', 'requestedReference', 'requestedTranslations',
+    'passages', 'failures', 'provenance',
+  ],
+  additionalProperties: false,
+} as NonNullable<Tool['outputSchema']>;

--- a/src/mcp/schemas/originalLanguage.ts
+++ b/src/mcp/schemas/originalLanguage.ts
@@ -1,0 +1,131 @@
+import type { Schema } from '@cfworker/json-schema';
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { ProvenanceRecord } from '../../kernel/provenance.js';
+import { createProvenanceRecordSchema } from './provenance.js';
+
+export interface OriginalLanguageSenseV1 {
+  gloss: string;
+  usage: string;
+  count: number;
+}
+
+export interface OriginalLanguageExtendedV1 {
+  strongsExtended?: string;
+  morphologyCode?: string;
+  lexicon?: string;
+  definition?: string;
+  occurrences?: number;
+  senses?: OriginalLanguageSenseV1[];
+}
+
+export interface OriginalLanguageEntryV1 {
+  strongsNumber: string;
+  language: 'Greek' | 'Hebrew';
+  testament: 'NT' | 'OT';
+  lemma: string | null;
+  transliteration?: string;
+  pronunciation?: string;
+  gloss?: string;
+  definition: string | null;
+  derivation?: string;
+  extended?: OriginalLanguageExtendedV1;
+  provenanceIds: string[];
+}
+
+export interface OriginalLanguageNextStepV1 {
+  tool: 'original_language_lookup';
+  arguments: { strongs_number: string; detail_level: 'detailed'; include_extended: true };
+}
+
+export interface OriginalLanguageOutputV1 {
+  [key: string]: unknown;
+  schemaVersion: '1';
+  kind: 'original_language_lookup';
+  mode: 'search' | 'entry';
+  query?: string;
+  detailLevel: 'summary' | 'detailed';
+  entries: OriginalLanguageEntryV1[];
+  nextStep?: OriginalLanguageNextStepV1;
+  provenance: ProvenanceRecord[];
+}
+
+const entrySchema: Schema = {
+  type: 'object',
+  properties: {
+    strongsNumber: { type: 'string', minLength: 2, maxLength: 16, pattern: '^[GHgh]\\d+[a-z]?$' },
+    language: { type: 'string', enum: ['Greek', 'Hebrew'] },
+    testament: { type: 'string', enum: ['NT', 'OT'] },
+    lemma: { type: ['string', 'null'], minLength: 1, maxLength: 500 },
+    transliteration: { type: 'string', minLength: 1, maxLength: 500 },
+    pronunciation: { type: 'string', minLength: 1, maxLength: 500 },
+    gloss: { type: 'string', minLength: 1, maxLength: 1000 },
+    definition: { type: ['string', 'null'], minLength: 1, maxLength: 20_000 },
+    derivation: { type: 'string', minLength: 1, maxLength: 5000 },
+    extended: {
+      type: 'object',
+      properties: {
+        strongsExtended: { type: 'string', minLength: 1, maxLength: 100 },
+        morphologyCode: { type: 'string', minLength: 1, maxLength: 200 },
+        lexicon: { type: 'string', minLength: 1, maxLength: 500 },
+        definition: { type: 'string', minLength: 1, maxLength: 50_000 },
+        occurrences: { type: 'integer', minimum: 0, maximum: 1_000_000 },
+        senses: {
+          type: 'array', maxItems: 100,
+          items: {
+            type: 'object',
+            properties: {
+              gloss: { type: 'string', minLength: 1, maxLength: 1000 },
+              usage: { type: 'string', minLength: 1, maxLength: 5000 },
+              count: { type: 'integer', minimum: 0, maximum: 1_000_000 },
+            },
+            required: ['gloss', 'usage', 'count'],
+            additionalProperties: false,
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+    provenanceIds: {
+      type: 'array', minItems: 1, maxItems: 8, uniqueItems: true,
+      items: { type: 'string', minLength: 1, maxLength: 64 },
+    },
+  },
+  required: ['strongsNumber', 'language', 'testament', 'lemma', 'definition', 'provenanceIds'],
+  additionalProperties: false,
+};
+
+export const originalLanguageOutputSchema = {
+  type: 'object',
+  properties: {
+    schemaVersion: { const: '1' },
+    kind: { const: 'original_language_lookup' },
+    mode: { type: 'string', enum: ['search', 'entry'] },
+    query: { type: 'string', minLength: 2, maxLength: 100 },
+    detailLevel: { type: 'string', enum: ['summary', 'detailed'] },
+    entries: { type: 'array', maxItems: 20, items: entrySchema },
+    nextStep: {
+      type: 'object',
+      properties: {
+        tool: { const: 'original_language_lookup' },
+        arguments: {
+          type: 'object',
+          properties: {
+            strongs_number: { type: 'string', minLength: 2, maxLength: 16, pattern: '^[GHgh]\\d+[a-z]?$' },
+            detail_level: { const: 'detailed' },
+            include_extended: { const: true },
+          },
+          required: ['strongs_number', 'detail_level', 'include_extended'],
+          additionalProperties: false,
+        },
+      },
+      required: ['tool', 'arguments'],
+      additionalProperties: false,
+    },
+    provenance: {
+      type: 'array', minItems: 1, maxItems: 8,
+      items: createProvenanceRecordSchema(),
+    },
+  },
+  required: ['schemaVersion', 'kind', 'mode', 'detailLevel', 'entries', 'provenance'],
+  additionalProperties: false,
+} as NonNullable<Tool['outputSchema']>;

--- a/src/mcp/schemas/provenance.ts
+++ b/src/mcp/schemas/provenance.ts
@@ -1,0 +1,48 @@
+import type { Schema } from '@cfworker/json-schema';
+
+export const PROVENANCE_KINDS = [
+  'primary_text',
+  'translation',
+  'lexicon',
+  'morphology_dataset',
+  'cross_reference_dataset',
+  'curated_dataset',
+  'repository',
+  'delivery_provider',
+] as const;
+
+export const PROVENANCE_STATUSES = [
+  'verified_source',
+  'provider_attributed',
+  'transcription_source_uncertain',
+] as const;
+
+/** Inline this fragment in each output schema; stable clients need no ref resolver. */
+export function createProvenanceRecordSchema(): Schema {
+  return {
+    type: 'object',
+    properties: {
+      id: { type: 'string', minLength: 1, maxLength: 64 },
+      kind: { type: 'string', enum: [...PROVENANCE_KINDS] },
+      label: { type: 'string', minLength: 1, maxLength: 240 },
+      url: { type: 'string', minLength: 1, maxLength: 1000 },
+      license: {
+        type: 'object',
+        properties: {
+          label: { type: 'string', minLength: 1, maxLength: 500 },
+          url: { type: 'string', minLength: 1, maxLength: 1000 },
+        },
+        required: ['label'],
+        additionalProperties: false,
+      },
+      rightsNotice: { type: 'string', minLength: 1, maxLength: 1000 },
+      attribution: { type: 'string', minLength: 1, maxLength: 500 },
+      version: { type: 'string', minLength: 1, maxLength: 200 },
+      locator: { type: 'string', minLength: 1, maxLength: 500 },
+      status: { type: 'string', enum: [...PROVENANCE_STATUSES] },
+      note: { type: 'string', minLength: 1, maxLength: 500 },
+    },
+    required: ['id', 'kind', 'label', 'status'],
+    additionalProperties: false,
+  };
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -18,12 +18,18 @@ export function registerToolHandlers(
   const validators = new Map<string, SchemaValidator<Record<string, unknown>>>(
     tools.map(tool => [tool.name, validatorFor(tool.inputSchema)]),
   );
+  const outputValidators = new Map<string, SchemaValidator<Record<string, unknown>>>(
+    tools
+      .filter(tool => tool.outputSchema)
+      .map(tool => [tool.name, validatorFor(tool.outputSchema!)]),
+  );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: tools.map(tool => ({
       name: tool.name,
       description: tool.description,
       inputSchema: tool.inputSchema,
+      ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
       annotations: tool.annotations,
     })),
   }));
@@ -58,10 +64,42 @@ export function registerToolHandlers(
       });
     }
 
+    let result;
     try {
-      return await tool.handler(toolArguments) as CallToolResult;
+      result = await tool.handler(toolArguments);
     } catch {
       throw internalError();
     }
+
+    if (result.isError) return result as CallToolResult;
+
+    if (tool.outputSchema) {
+      if (result.structuredContent === undefined) {
+        await reportOutputValidationFailure(server, logging, name);
+        throw internalError();
+      }
+      const validation = outputValidators.get(name)?.(result.structuredContent);
+      if (!validation?.valid) {
+        await reportOutputValidationFailure(server, logging, name);
+        throw internalError();
+      }
+    }
+
+    return result as CallToolResult;
+  });
+}
+
+async function reportOutputValidationFailure(
+  server: Server,
+  logging: boolean,
+  tool: string,
+): Promise<void> {
+  if (!logging) return;
+  await server.sendLoggingMessage({
+    level: 'error',
+    logger: 'theologai.tools',
+    data: { event: 'tool_output_validation_failed', tool },
+  }).catch(() => {
+    // Logging is observational and must not alter the sanitized protocol error.
   });
 }

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -1,6 +1,6 @@
 import { Validator, type Schema } from '@cfworker/json-schema';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import type { ToolHandler } from '../kernel/types.js';
+import type { JsonSchemaType } from '@modelcontextprotocol/sdk/validation/types.js';
 
 export type SchemaValidationResult<T> = {
   valid: true;
@@ -15,7 +15,7 @@ export type SchemaValidationResult<T> = {
 export type SchemaValidator<T> = (input: unknown) => SchemaValidationResult<T>;
 
 export const jsonSchemaValidator = {
-  getValidator<T>(schema: ToolHandler['inputSchema']): SchemaValidator<T> {
+  getValidator<T>(schema: JsonSchemaType): SchemaValidator<T> {
     const validator = new Validator(schema as Schema, '2020-12', true);
     return (input: unknown): SchemaValidationResult<T> => {
       const result = validator.validate(input);
@@ -35,14 +35,14 @@ export const jsonSchemaValidator = {
 const validatorCache = new Map<string, SchemaValidator<Record<string, unknown>>>();
 
 export function validatorFor(
-  schema: ToolHandler['inputSchema'],
+  schema: JsonSchemaType,
 ): SchemaValidator<Record<string, unknown>> {
   const serializedSchema = JSON.stringify(schema);
   const cached = validatorCache.get(serializedSchema);
   if (cached) return cached;
 
   const validator = jsonSchemaValidator.getValidator<Record<string, unknown>>(
-    JSON.parse(serializedSchema),
+    JSON.parse(serializedSchema) as JsonSchemaType,
   );
   validatorCache.set(serializedSchema, validator);
   return validator;

--- a/src/presenters/bibleStructured.ts
+++ b/src/presenters/bibleStructured.ts
@@ -1,0 +1,77 @@
+import type {
+  BibleLookupMultipleResult,
+  BibleResult,
+  Citation,
+} from '../kernel/types.js';
+import {
+  provenanceFromCitation,
+  type ProvenanceRecord,
+} from '../kernel/provenance.js';
+import type { BibleLookupOutputV1 } from '../mcp/schemas/bibleLookup.js';
+
+type BibleLookupData = BibleLookupMultipleResult | BibleResult;
+
+/** Present the Bible service result as the versioned machine-readable view. */
+export function presentBibleLookupStructured(
+  data: BibleLookupData,
+  requestedReference: string,
+  requestedTranslations: string[],
+): BibleLookupOutputV1 {
+  const multiple: BibleLookupMultipleResult = 'results' in data
+    ? data
+    : { reference: data.reference, results: [data], failures: [] };
+  const provenance: ProvenanceRecord[] = [];
+  const provenanceByKey = new Map<string, string>();
+
+  const passages = multiple.results.map(result => ({
+    reference: result.reference,
+    translation: result.translation,
+    text: result.text,
+    ...(result.footnotes?.length ? {
+      footnotes: result.footnotes.map(footnote => ({
+        caller: footnote.caller,
+        text: footnote.text,
+        chapter: footnote.reference.chapter,
+        verse: footnote.reference.verse,
+      })),
+    } : {}),
+    provenanceIds: [getProvenanceId(result, provenance, provenanceByKey)],
+  }));
+
+  return {
+    schemaVersion: '1',
+    kind: 'bible_lookup',
+    requestedReference,
+    requestedTranslations: [...requestedTranslations],
+    passages,
+    failures: multiple.failures.map(failure => ({ ...failure })),
+    provenance,
+  };
+}
+
+function getProvenanceId(
+  result: BibleResult,
+  provenance: ProvenanceRecord[],
+  provenanceByKey: Map<string, string>,
+): string {
+  const candidate = provenanceFromCitation(result.citation, {
+    id: `src-${provenance.length + 1}`,
+    kind: 'translation',
+    status: 'provider_attributed',
+    license: recognizedLicense(result.citation),
+    locator: result.reference,
+  });
+  const key = JSON.stringify({ ...candidate, id: undefined });
+  const existing = provenanceByKey.get(key);
+  if (existing) return existing;
+
+  provenance.push(candidate);
+  provenanceByKey.set(key, candidate.id);
+  return candidate.id;
+}
+
+function recognizedLicense(citation: Citation): { label: string } | undefined {
+  return /^public domain(?:\s+\([^)]*\))?$/i.test(citation.copyright?.trim() ?? '')
+    ? { label: 'Public Domain' }
+    : undefined;
+}

--- a/src/presenters/originalLanguageStructured.ts
+++ b/src/presenters/originalLanguageStructured.ts
@@ -1,0 +1,150 @@
+import {
+  provenanceFromCitation,
+  type ProvenanceRecord,
+} from '../kernel/provenance.js';
+import type { StrongsEntry } from '../kernel/repositories.js';
+import type { EnhancedStrongsResult } from '../kernel/types.js';
+import type {
+  OriginalLanguageEntryV1,
+  OriginalLanguageExtendedV1,
+  OriginalLanguageOutputV1,
+} from '../mcp/schemas/originalLanguage.js';
+import { normalizeLexiconText, summarizeDefinition } from '../formatters/languagesFormatter.js';
+
+const STRONGS_CITATION = {
+  source: "Strong's Concordance",
+  copyright: 'Public Domain (OpenScriptures)',
+  url: 'https://github.com/openscriptures/strongs',
+};
+
+/** Present search hits without coupling the repository entry to MCP output. */
+export function presentOriginalLanguageSearch(
+  query: string,
+  results: StrongsEntry[],
+): OriginalLanguageOutputV1 {
+  const provenance: ProvenanceRecord[] = [strongsProvenance()];
+  const entries = results.map(entry => ({
+    strongsNumber: entry.strongs_number,
+    language: languageFor(entry.testament),
+    testament: entry.testament,
+    lemma: nullableText(entry.lemma),
+    ...(entry.transliteration ? { transliteration: entry.transliteration } : {}),
+    ...(entry.pronunciation ? { pronunciation: entry.pronunciation } : {}),
+    definition: nullableText(summarizeDefinition(entry.definition)),
+    provenanceIds: ['src-1'],
+  }));
+
+  return {
+    schemaVersion: '1',
+    kind: 'original_language_lookup',
+    mode: 'search',
+    query,
+    detailLevel: 'summary',
+    entries,
+    ...(results.length === 1 ? {
+      nextStep: {
+        tool: 'original_language_lookup' as const,
+        arguments: {
+          strongs_number: results[0].strongs_number,
+          detail_level: 'detailed' as const,
+          include_extended: true as const,
+        },
+      },
+    } : {}),
+    provenance,
+  };
+}
+
+/** Present an exact lookup with progressive summary/detail disclosure. */
+export function presentOriginalLanguageEntry(
+  result: EnhancedStrongsResult,
+  detailLevel: 'simple' | 'detailed',
+): OriginalLanguageOutputV1 {
+  const base = provenanceFromCitation(result.citation, {
+    id: 'src-1',
+    kind: 'lexicon',
+    status: 'verified_source',
+    license: { label: 'Public Domain' },
+    attribution: 'OpenScriptures',
+  });
+  const provenance: ProvenanceRecord[] = [base];
+  const provenanceIds = [base.id];
+
+  if (result.extended && result.extendedCitation) {
+    const extended = provenanceFromCitation(result.extendedCitation, {
+      id: 'src-2',
+      kind: 'lexicon',
+      status: 'verified_source',
+      license: {
+        label: 'CC BY 4.0',
+        url: 'https://creativecommons.org/licenses/by/4.0/',
+      },
+      attribution: 'Tyndale House, Cambridge',
+    });
+    provenance.push(extended);
+    provenanceIds.push(extended.id);
+  }
+
+  const extended = result.extended;
+  const entry: OriginalLanguageEntryV1 = {
+    strongsNumber: result.strongs_number,
+    language: languageFor(result.testament),
+    testament: result.testament,
+    lemma: nullableText(result.lemma),
+    ...(result.transliteration ? { transliteration: result.transliteration } : {}),
+    ...(result.pronunciation ? { pronunciation: result.pronunciation } : {}),
+    ...(extended?.gloss ? { gloss: extended.gloss } : {}),
+    definition: nullableText(result.definition),
+    ...(detailLevel === 'detailed' && result.derivation ? { derivation: result.derivation } : {}),
+    ...(extended ? { extended: presentExtended(extended) } : {}),
+    provenanceIds,
+  };
+
+  return {
+    schemaVersion: '1',
+    kind: 'original_language_lookup',
+    mode: 'entry',
+    detailLevel: detailLevel === 'detailed' ? 'detailed' : 'summary',
+    entries: [entry],
+    provenance,
+  };
+}
+
+function presentExtended(extended: NonNullable<EnhancedStrongsResult['extended']>): OriginalLanguageExtendedV1 {
+  const definition = extended.definition
+    ? normalizeLexiconText(extended.definition)
+    : '';
+
+  return {
+    ...(extended.strongsExtended ? { strongsExtended: extended.strongsExtended } : {}),
+    ...(extended.morphologyCode ? { morphologyCode: extended.morphologyCode } : {}),
+    ...(extended.source ? { lexicon: extended.source } : {}),
+    ...(definition ? { definition } : {}),
+    ...(extended.occurrences !== undefined ? { occurrences: extended.occurrences } : {}),
+    ...(extended.senses ? {
+      senses: Object.values(extended.senses).map(sense => ({
+        gloss: sense.gloss,
+        usage: sense.usage,
+        count: sense.count,
+      })),
+    } : {}),
+  };
+}
+
+function strongsProvenance(): ProvenanceRecord {
+  return provenanceFromCitation(STRONGS_CITATION, {
+    id: 'src-1',
+    kind: 'lexicon',
+    status: 'verified_source',
+    license: { label: 'Public Domain' },
+    attribution: 'OpenScriptures',
+  });
+}
+
+function languageFor(testament: 'OT' | 'NT'): 'Greek' | 'Hebrew' {
+  return testament === 'NT' ? 'Greek' : 'Hebrew';
+}
+
+function nullableText(value: string | null | undefined): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}

--- a/src/tools/v2/bibleLookup.ts
+++ b/src/tools/v2/bibleLookup.ts
@@ -7,6 +7,8 @@ import type { ToolHandler } from '../../kernel/types.js';
 import type { BibleService } from '../../services/bible/BibleService.js';
 import { formatBibleResponse, formatMultiBibleResponse } from '../../formatters/bibleFormatter.js';
 import { handleToolError } from '../../kernel/errors.js';
+import { bibleLookupOutputSchema } from '../../mcp/schemas/bibleLookup.js';
+import { presentBibleLookupStructured } from '../../presenters/bibleStructured.js';
 
 export function createBibleLookupHandler(bibleService: BibleService): ToolHandler {
   return {
@@ -29,6 +31,7 @@ export function createBibleLookupHandler(bibleService: BibleService): ToolHandle
       required: ['reference'],
       additionalProperties: false,
     },
+    outputSchema: bibleLookupOutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
 
     handler: async (params) => {
@@ -41,11 +44,25 @@ export function createBibleLookupHandler(bibleService: BibleService): ToolHandle
             translation: translations[0],
             includeFootnotes: params.includeFootnotes as boolean,
           });
-          return { content: [{ type: 'text', text: formatBibleResponse(result) }] };
+          return {
+            content: [{ type: 'text', text: formatBibleResponse(result) }],
+            structuredContent: presentBibleLookupStructured(
+              result,
+              params.reference as string,
+              translations,
+            ),
+          };
         }
 
         const results = await bibleService.lookupMultiple(params.reference as string, translations);
-        return { content: [{ type: 'text', text: formatMultiBibleResponse(results) }] };
+        return {
+          content: [{ type: 'text', text: formatMultiBibleResponse(results) }],
+          structuredContent: presentBibleLookupStructured(
+            results,
+            params.reference as string,
+            translations,
+          ),
+        };
       } catch (error) {
         return handleToolError(error as Error);
       }

--- a/src/tools/v2/strongsLookup.ts
+++ b/src/tools/v2/strongsLookup.ts
@@ -6,6 +6,11 @@ import type { ToolHandler } from '../../kernel/types.js';
 import type { StrongsService } from '../../services/languages/StrongsService.js';
 import { formatStrongsResult, formatStrongsSearchResults } from '../../formatters/languagesFormatter.js';
 import { handleToolError, ValidationError } from '../../kernel/errors.js';
+import { originalLanguageOutputSchema } from '../../mcp/schemas/originalLanguage.js';
+import {
+  presentOriginalLanguageEntry,
+  presentOriginalLanguageSearch,
+} from '../../presenters/originalLanguageStructured.js';
 
 export function createStrongsLookupHandler(service: StrongsService): ToolHandler {
   return {
@@ -40,6 +45,7 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
       },
       additionalProperties: false,
     },
+    outputSchema: originalLanguageOutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
 
     handler: async (params) => {
@@ -50,7 +56,10 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
           const limit = typeof params.limit === 'number' ? params.limit : 10;
           const query = params.query as string;
           const results = await service.search(query, limit);
-          return { content: [{ type: 'text', text: formatStrongsSearchResults(query, results) }] };
+          return {
+            content: [{ type: 'text', text: formatStrongsSearchResults(query, results) }],
+            structuredContent: presentOriginalLanguageSearch(query, results),
+          };
         }
 
         const result = await service.lookup(
@@ -58,7 +67,13 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
           params.include_extended === true,
         );
         const text = formatStrongsResult(result, params.detail_level as string);
-        return { content: [{ type: 'text', text }] };
+        return {
+          content: [{ type: 'text', text }],
+          structuredContent: presentOriginalLanguageEntry(
+            result,
+            params.detail_level === 'detailed' ? 'detailed' : 'simple',
+          ),
+        };
       } catch (error) {
         return handleToolError(error as Error);
       }

--- a/test/integration/current/mcp-protocol.test.ts
+++ b/test/integration/current/mcp-protocol.test.ts
@@ -93,6 +93,20 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
         'donation_config',
         'verify_donation',
       ]);
+      expect(listed.tools.filter(tool => tool.outputSchema).map(tool => tool.name)).toEqual([
+        'bible_lookup',
+        'original_language_lookup',
+      ]);
+      expect(listed.tools.find(tool => tool.name === 'bible_lookup')?.outputSchema).toMatchObject({
+        type: 'object',
+        additionalProperties: false,
+        properties: { schemaVersion: { const: '1' }, kind: { const: 'bible_lookup' } },
+      });
+      expect(listed.tools.find(tool => tool.name === 'original_language_lookup')?.outputSchema).toMatchObject({
+        type: 'object',
+        additionalProperties: false,
+        properties: { schemaVersion: { const: '1' }, kind: { const: 'original_language_lookup' } },
+      });
       expect(listed.tools).toEqual(expect.arrayContaining([
         expect.objectContaining({
           name: 'bible_lookup',
@@ -170,6 +184,12 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
           text: '**John 3:16 (ESV)**\n\nFor God so loved the world.\n\n*Source: Deterministic test fixture*',
         },
       ]);
+      expect(result.structuredContent).toMatchObject({
+        schemaVersion: '1',
+        kind: 'bible_lookup',
+        passages: [{ translation: 'ESV', text: 'For God so loved the world.', provenanceIds: ['src-1'] }],
+        failures: [],
+      });
     } finally {
       await Promise.allSettled([client.close(), harness.server.close()]);
     }

--- a/test/unit/formatters/languagesFormatter.test.ts
+++ b/test/unit/formatters/languagesFormatter.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   formatStrongsResult,
   formatMorphologyResult,
+  normalizeLexiconText,
+  summarizeDefinition,
 } from '../../../src/formatters/languagesFormatter.js';
 import type { EnhancedStrongsResult, VerseMorphologyResult, VerseWord } from '../../../src/kernel/types.js';
 
@@ -49,6 +51,28 @@ function makeMorphResult(overrides: Partial<VerseMorphologyResult> = {}): VerseM
 // ── formatStrongsResult ──
 
 describe('formatStrongsResult', () => {
+  it('normalizes markup and common entities through the shared pure helper', () => {
+    expect(normalizeLexiconText('<b>love</b><BR/>A &amp; B &lt; 3 &#39;D&#39;')).toBe(
+      "love\nA & B < 3 'D'",
+    );
+  });
+
+  it('strips encoded markup tags from Markdown extended definitions', () => {
+    const out = formatStrongsResult(makeStrongsResult({
+      extended: { definition: '&lt;b&gt;love&lt;/b&gt;&lt;br/&gt;divine love &amp; charity' },
+    }));
+
+    expect(out).toContain('Definition: love\ndivine love & charity');
+    expect(out).not.toContain('&lt;b&gt;');
+    expect(out).not.toContain('<b>');
+  });
+
+  it('bounds search definitions with the shared summary helper', () => {
+    const value = 'a'.repeat(240) + ' trailing detail';
+    expect(summarizeDefinition(value).length).toBeLessThanOrEqual(240);
+    expect(summarizeDefinition(value)).toMatch(/…$/);
+  });
+
   it('shows Strong\'s number and testament language', () => {
     const out = formatStrongsResult(makeStrongsResult());
     expect(out).toContain('**G26** (Greek)');

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { ToolHandler } from '../../../src/kernel/types.js';
+import { createTheologAiMcpServer } from '../../../src/mcp/server.js';
+import { createBibleLookupHandler } from '../../../src/tools/v2/bibleLookup.js';
+import { createStrongsLookupHandler } from '../../../src/tools/v2/strongsLookup.js';
+import type { BibleService } from '../../../src/services/bible/BibleService.js';
+import type { StrongsService } from '../../../src/services/languages/StrongsService.js';
+import { createDeterministicMcpFixture } from '../../fixtures/mcpCompositionRoot.js';
+
+const connected: Array<{ client: Client; server: Server }> = [];
+type LogMessage = { level: string; logger?: string; data: unknown };
+
+async function connect(tools: ToolHandler[], logs?: LogMessage[]): Promise<Client> {
+  const root = {
+    tools,
+    services: {
+      bibleService: { getSupportedTranslations: () => ['ESV'] },
+      commentaryService: { getAvailableCommentators: () => ['Test'] },
+      historicalService: {
+        listDocuments: async () => [],
+        getDocument: async () => undefined,
+        getSections: async () => [],
+      },
+      strongsService: { lookup: async () => undefined },
+    },
+  };
+  const server = createTheologAiMcpServer(root, 'output-validation-test').server;
+  const client = new Client({ name: 'output-validation-client', version: '1.0.0' }, { capabilities: {} });
+  if (logs) {
+    client.setNotificationHandler(LoggingMessageNotificationSchema, notification => {
+      logs.push(notification.params);
+    });
+  }
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  connected.push({ client, server });
+  return client;
+}
+
+afterEach(async () => {
+  await Promise.allSettled(connected.splice(0).flatMap(({ client, server }) => [client.close(), server.close()]));
+});
+
+describe('MCP structured output validation', () => {
+  it('advertises output schemas for exactly the two converted tools', async () => {
+    const { root } = createDeterministicMcpFixture();
+    const client = await connect(root.tools);
+    const listed = await client.listTools();
+
+    const withOutput = listed.tools.filter(tool => tool.outputSchema).map(tool => tool.name);
+    expect(withOutput).toEqual(['bible_lookup', 'original_language_lookup']);
+    for (const toolName of withOutput) {
+      const schema = listed.tools.find(tool => tool.name === toolName)?.outputSchema;
+      expect(schema).toMatchObject({ type: 'object', additionalProperties: false });
+      expect(schema).not.toHaveProperty('$ref');
+      expect(schema?.properties?.schemaVersion).toMatchObject({ const: '1' });
+    }
+  });
+
+  it('rejects missing successful structured results with a sanitized error', async () => {
+    const schema = {
+      type: 'object' as const,
+      properties: { value: { type: 'string' } },
+      required: ['value'],
+      additionalProperties: false,
+    };
+    const handler = vi.fn().mockResolvedValue({ content: [{ type: 'text' as const, text: 'private passage' }] });
+    const client = await connect([{
+      name: 'structured_test',
+      description: 'Test structured output',
+      inputSchema: { type: 'object', additionalProperties: false },
+      outputSchema: schema,
+      handler,
+    }]);
+
+    await expect(client.callTool({ name: 'structured_test', arguments: {} }))
+      .rejects.toMatchObject({ code: -32603, message: expect.stringContaining('Internal server error') });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('rejects malformed successful structured results without disclosing payloads', async () => {
+    const handler = vi.fn().mockResolvedValue({
+      content: [{ type: 'text' as const, text: 'private passage' }],
+      structuredContent: { value: 42, secret: 'private payload' },
+    });
+    const logs: LogMessage[] = [];
+    const client = await connect([{
+      name: 'malformed_structured_test',
+      description: 'Test malformed structured output',
+      inputSchema: { type: 'object', additionalProperties: false },
+      outputSchema: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+      handler,
+    }], logs);
+
+    await client.setLoggingLevel('error');
+    const failure = await client.callTool({ name: 'malformed_structured_test', arguments: {} }).catch(error => error as Error);
+    expect(failure).toMatchObject({ code: -32603, message: expect.stringContaining('Internal server error') });
+    expect(JSON.stringify(failure)).not.toContain('private passage');
+    expect(JSON.stringify(failure)).not.toContain('private payload');
+    expect(logs).toEqual([{
+      level: 'error',
+      logger: 'theologai.tools',
+      data: { event: 'tool_output_validation_failed', tool: 'malformed_structured_test' },
+    }]);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('rejects additional fields even when required structured fields are valid', async () => {
+    const client = await connect([{
+      name: 'additional_field_structured_test',
+      description: 'Test additional structured output field',
+      inputSchema: { type: 'object', additionalProperties: false },
+      outputSchema: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+      handler: async () => ({
+        content: [{ type: 'text' as const, text: 'safe text' }],
+        structuredContent: { value: 'valid', unexpected: 'private payload' },
+      }),
+    }]);
+
+    const failure = await client.callTool({ name: 'additional_field_structured_test', arguments: {} })
+      .catch(error => error as Error);
+    expect(failure).toMatchObject({ code: -32603, message: expect.stringContaining('Internal server error') });
+    expect(JSON.stringify(failure)).not.toContain('private payload');
+  });
+
+  it('accepts all converted success modes through the registry and SDK client', async () => {
+    const bibleService = {
+      lookup: async () => ({
+        reference: 'John 3:16',
+        translation: 'ESV',
+        text: 'For God so loved the world.',
+        citation: { source: 'English Standard Version', copyright: 'Copyright notice' },
+      }),
+      lookupMultiple: async () => ({
+        reference: 'John 3:16',
+        results: [{
+          reference: 'John 3:16',
+          translation: 'ESV',
+          text: 'For God so loved the world.',
+          citation: { source: 'English Standard Version', copyright: 'Copyright notice' },
+        }],
+        failures: [{ translation: 'KJV', reason: 'Unavailable' }],
+      }),
+    } as unknown as BibleService;
+    const strongsService = {
+      search: async () => [{
+        strongs_number: 'G26',
+        testament: 'NT' as const,
+        lemma: 'ἀγάπη',
+        transliteration: 'agapē',
+        pronunciation: 'ag-ah-pay',
+        definition: 'love '.repeat(100),
+        derivation: 'from G25',
+      }],
+      lookup: async (_number: string, includeExtended?: boolean) => ({
+        strongs_number: 'G26',
+        testament: 'NT' as const,
+        lemma: 'ἀγάπη',
+        transliteration: 'agapē',
+        pronunciation: 'ag-ah-pay',
+        definition: 'love',
+        derivation: 'from G25',
+        citation: { source: "Strong's Concordance", copyright: 'Public Domain (OpenScriptures)' },
+        ...(includeExtended ? {
+          extendedCitation: { source: 'STEPBible lexicon data', copyright: 'CC BY 4.0 (Tyndale House, Cambridge)' },
+          extended: {
+            strongsExtended: 'G0026',
+            gloss: 'love',
+            morphologyCode: 'G:N-F',
+            source: 'STEPBible',
+            definition: '&lt;b&gt;love&lt;/b&gt;&lt;br/&gt;divine love &amp; charity',
+            senses: { first: { gloss: 'love', usage: 'divine love', count: 1 } },
+          },
+        } : {}),
+      }),
+    } as unknown as StrongsService;
+    const client = await connect([
+      createBibleLookupHandler(bibleService),
+      createStrongsLookupHandler(strongsService),
+    ]);
+
+    await client.listTools();
+    const bibleSingle = await client.callTool({ name: 'bible_lookup', arguments: { reference: 'John 3:16' } });
+    const biblePartial = await client.callTool({ name: 'bible_lookup', arguments: { reference: 'John 3:16', translation: ['ESV', 'KJV'] } });
+    const search = await client.callTool({ name: 'original_language_lookup', arguments: { query: 'love' } });
+    const simple = await client.callTool({ name: 'original_language_lookup', arguments: { strongs_number: 'G26' } });
+    const detailed = await client.callTool({ name: 'original_language_lookup', arguments: { strongs_number: 'G26', detail_level: 'detailed' } });
+    const extended = await client.callTool({ name: 'original_language_lookup', arguments: { strongs_number: 'G26', include_extended: true, detail_level: 'detailed' } });
+
+    for (const result of [bibleSingle, biblePartial, search, simple, detailed, extended]) {
+      expect(result.isError).not.toBe(true);
+      expect(result.content[0]).toMatchObject({ type: 'text', text: expect.any(String) });
+      expect(result.structuredContent).toMatchObject({ schemaVersion: '1' });
+    }
+    expect(biblePartial.structuredContent).toMatchObject({
+      passages: [expect.anything()],
+      failures: [{ translation: 'KJV', reason: 'Unavailable' }],
+    });
+    expect(search.structuredContent).toMatchObject({ mode: 'search', detailLevel: 'summary', nextStep: expect.any(Object) });
+    expect(simple.structuredContent).toMatchObject({ mode: 'entry', detailLevel: 'summary' });
+    expect(detailed.structuredContent).toMatchObject({ mode: 'entry', detailLevel: 'detailed' });
+    expect(extended.structuredContent).toMatchObject({
+      mode: 'entry',
+      entries: [{ extended: { definition: 'love\ndivine love & charity' } }],
+    });
+  });
+
+  it('accepts corpus-empty Strong\'s text through the registry and SDK client', async () => {
+    const client = await connect([createStrongsLookupHandler({
+      lookup: async () => ({
+        strongs_number: 'G302',
+        testament: 'NT' as const,
+        lemma: 'ἄν',
+        transliteration: null,
+        pronunciation: null,
+        definition: '',
+        derivation: null,
+        citation: { source: "Strong's Concordance", copyright: 'Public Domain (OpenScriptures)' },
+      }),
+      search: async () => [{
+        strongs_number: 'G2717',
+        testament: 'NT' as const,
+        lemma: '',
+        transliteration: null,
+        pronunciation: null,
+        definition: '',
+        derivation: null,
+      }],
+    } as unknown as StrongsService)]);
+
+    await client.listTools();
+    const exact = await client.callTool({
+      name: 'original_language_lookup',
+      arguments: { strongs_number: 'G302' },
+    });
+    const search = await client.callTool({
+      name: 'original_language_lookup',
+      arguments: { query: 'empty' },
+    });
+
+    expect(exact.isError).not.toBe(true);
+    expect(exact.structuredContent).toMatchObject({
+      mode: 'entry',
+      entries: [{ strongsNumber: 'G302', lemma: 'ἄν', definition: null }],
+    });
+    expect(search.isError).not.toBe(true);
+    expect(search.structuredContent).toMatchObject({
+      mode: 'search',
+      entries: [{ strongsNumber: 'G2717', lemma: null, definition: null }],
+    });
+  });
+
+  it('skips success-schema validation for existing isError results', async () => {
+    const client = await connect([{
+      name: 'structured_error',
+      description: 'Test structured error',
+      inputSchema: { type: 'object', additionalProperties: false },
+      outputSchema: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+      handler: async () => ({
+        content: [{ type: 'text' as const, text: 'Actionable error' }],
+        isError: true,
+      }),
+    }]);
+
+    await expect(client.callTool({ name: 'structured_error', arguments: {} }))
+      .resolves.toMatchObject({ isError: true, content: [{ text: 'Actionable error' }] });
+  });
+});

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -409,6 +409,31 @@ describe('shared MCP registration', () => {
       type: 'text',
       text: expect.stringContaining('G26'),
     }));
+    expect(wordStudy.messages[0].content).toEqual(expect.objectContaining({
+      text: expect.stringContaining('mode`, `entries`, `detailLevel`, and `provenanceIds`'),
+    }));
+    expect(wordStudy.messages[0].content).toEqual(expect.objectContaining({
+      text: expect.stringContaining('Do not treat one English gloss as exhausting'),
+    }));
+
+    const passageExegesis = await client.getPrompt({
+      name: 'passage-exegesis',
+      arguments: { reference: 'John 3:16' },
+    });
+    expect(passageExegesis.messages[0].content).toEqual(expect.objectContaining({
+      text: expect.stringContaining('`passages[]` and retain each translation'),
+    }));
+    expect(passageExegesis.messages[0].content).toEqual(expect.objectContaining({
+      text: expect.stringContaining('distinguish an unavailable translation'),
+    }));
+
+    const compareTranslations = await client.getPrompt({
+      name: 'compare-translations',
+      arguments: { reference: 'John 3:16' },
+    });
+    expect(compareTranslations.messages[0].content).toEqual(expect.objectContaining({
+      text: expect.stringContaining('compare by its `translation`, report every `failures[]` item'),
+    }));
 
     const searchedWord = await client.getPrompt({ name: 'word-study', arguments: { word: 'love' } });
     expect(searchedWord.messages[0].content).toEqual(expect.objectContaining({

--- a/test/unit/mcp/validation.test.ts
+++ b/test/unit/mcp/validation.test.ts
@@ -9,10 +9,44 @@ import { createParallelPassagesHandler } from '../../../src/tools/v2/parallelPas
 import { createStrongsLookupHandler } from '../../../src/tools/v2/strongsLookup.js';
 import { createVerifyDonationHandler } from '../../../src/tools/v2/verifyDonation.js';
 import { createVerseMorphologyHandler } from '../../../src/tools/v2/verseMorphology.js';
+import { bibleLookupOutputSchema } from '../../../src/mcp/schemas/bibleLookup.js';
+import { originalLanguageOutputSchema } from '../../../src/mcp/schemas/originalLanguage.js';
 
 const unused = {} as never;
 
 describe('Worker-safe JSON Schema validation', () => {
+  it('validates the two advertised output schemas with the same Worker-safe validator', () => {
+    const bible = validatorFor(bibleLookupOutputSchema);
+    const language = validatorFor(originalLanguageOutputSchema);
+
+    expect(bible({
+      schemaVersion: '1',
+      kind: 'bible_lookup',
+      requestedReference: 'John 3:16',
+      requestedTranslations: ['ESV'],
+      passages: [],
+      failures: [{ translation: 'ESV', reason: 'Unavailable' }],
+      provenance: [],
+    }).valid).toBe(true);
+    expect(language({
+      schemaVersion: '1',
+      kind: 'original_language_lookup',
+      mode: 'search',
+      query: 'love',
+      detailLevel: 'summary',
+      entries: [],
+      provenance: [{ id: 'src-1', kind: 'lexicon', label: "Strong's Concordance", status: 'verified_source' }],
+    }).valid).toBe(true);
+    expect(language({
+      schemaVersion: '1',
+      kind: 'original_language_lookup',
+      mode: 'entry',
+      detailLevel: 'summary',
+      entries: [{ strongsNumber: 'G26', language: 'Greek', testament: 'NT', lemma: 'ἀγάπη', definition: 'love', provenanceIds: ['src-1'], extra: true }],
+      provenance: [{ id: 'src-1', kind: 'lexicon', label: "Strong's Concordance", status: 'verified_source' }],
+    }).valid).toBe(false);
+  });
+
   it('validates draft 2020-12 dependencies without dynamic code evaluation', () => {
     const originalFunction = globalThis.Function;
     Object.defineProperty(globalThis, 'Function', {

--- a/test/unit/presenters/bibleStructured.test.ts
+++ b/test/unit/presenters/bibleStructured.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { presentBibleLookupStructured } from '../../../src/presenters/bibleStructured.js';
+
+const citation = {
+  source: 'English Standard Version',
+  copyright: 'ESV license',
+  url: 'https://example.test/esv',
+};
+
+describe('Bible structured presenter', () => {
+  it('presents a single passage with footnote fields and provenance', () => {
+    const result = presentBibleLookupStructured({
+      reference: 'John 3:16',
+      translation: 'ESV',
+      text: 'For God so loved the world.',
+      footnotes: [{
+        id: 1,
+        caller: 'a',
+        text: 'A translation note.',
+        reference: { chapter: 3, verse: 16 },
+      }],
+      citation,
+    }, 'John 3:16', ['ESV']);
+
+    expect(result).toMatchObject({
+      schemaVersion: '1',
+      kind: 'bible_lookup',
+      requestedReference: 'John 3:16',
+      requestedTranslations: ['ESV'],
+      passages: [{
+        reference: 'John 3:16',
+        translation: 'ESV',
+        text: 'For God so loved the world.',
+        footnotes: [{ caller: 'a', text: 'A translation note.', chapter: 3, verse: 16 }],
+        provenanceIds: ['src-1'],
+      }],
+    });
+    expect(result.provenance).toEqual([expect.objectContaining({
+      id: 'src-1',
+      kind: 'translation',
+      label: 'English Standard Version',
+      rightsNotice: 'ESV license',
+      status: 'provider_attributed',
+    })]);
+    expect(result.provenance[0]).not.toHaveProperty('license');
+  });
+
+  it('recognizes explicit public-domain notices without treating other notices as licenses', () => {
+    const result = presentBibleLookupStructured({
+      reference: 'John 3:16',
+      translation: 'KJV',
+      text: 'For God so loved the world.',
+      citation: { source: 'King James Version', copyright: 'Public Domain' },
+    }, 'John 3:16', ['KJV']);
+
+    expect(result.provenance[0]).toMatchObject({
+      rightsNotice: 'Public Domain',
+      license: { label: 'Public Domain' },
+    });
+  });
+
+  it('keeps partial translation failures and deduplicates equal citations', () => {
+    const result = presentBibleLookupStructured({
+      reference: 'John 3:16',
+      results: [
+        { reference: 'John 3:16', translation: 'ESV', text: 'ESV text', citation: { source: 'Same source' } },
+        { reference: 'John 3:16', translation: 'KJV', text: 'KJV text', citation: { source: 'Same source' } },
+      ],
+      failures: [{ translation: 'NET', reason: 'Translation could not be retrieved.' }],
+    }, 'John 3:16', ['ESV', 'KJV', 'NET']);
+
+    expect(result.failures).toEqual([{ translation: 'NET', reason: 'Translation could not be retrieved.' }]);
+    expect(result.passages.map(passage => passage.provenanceIds)).toEqual([['src-1'], ['src-1']]);
+    expect(result.provenance).toHaveLength(1);
+  });
+});

--- a/test/unit/presenters/originalLanguageStructured.test.ts
+++ b/test/unit/presenters/originalLanguageStructured.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { presentOriginalLanguageEntry, presentOriginalLanguageSearch } from '../../../src/presenters/originalLanguageStructured.js';
+
+describe('original-language structured presenter', () => {
+  it('keeps ambiguous search results at summary level without guessing nextStep', () => {
+    const result = presentOriginalLanguageSearch('love', [
+      { strongs_number: 'G25', testament: 'NT', lemma: 'ἀγαπάω', transliteration: 'agapaō', pronunciation: null, definition: 'to love', derivation: null },
+      { strongs_number: 'G26', testament: 'NT', lemma: 'ἀγάπη', transliteration: 'agapē', pronunciation: null, definition: 'love', derivation: null },
+    ]);
+
+    expect(result).toMatchObject({
+      mode: 'search',
+      query: 'love',
+      detailLevel: 'summary',
+      entries: [
+        { strongsNumber: 'G25', language: 'Greek', testament: 'NT', provenanceIds: ['src-1'] },
+        { strongsNumber: 'G26', language: 'Greek', testament: 'NT', provenanceIds: ['src-1'] },
+      ],
+    });
+    expect(result).not.toHaveProperty('nextStep');
+    expect(result.provenance).toEqual([expect.objectContaining({
+      rightsNotice: 'Public Domain (OpenScriptures)',
+      license: { label: 'Public Domain' },
+    })]);
+  });
+
+  it('offers a detailed exact lookup for one unambiguous search hit', () => {
+    const result = presentOriginalLanguageSearch('agape', [
+      { strongs_number: 'G26', testament: 'NT', lemma: 'ἀγάπη', transliteration: 'agapē', pronunciation: null, definition: 'love', derivation: null },
+    ]);
+
+    expect(result.nextStep).toEqual({
+      tool: 'original_language_lookup',
+      arguments: { strongs_number: 'G26', detail_level: 'detailed', include_extended: true },
+    });
+  });
+
+  it('maps detailed and extended exact fields to linked provenance', () => {
+    const result = presentOriginalLanguageEntry({
+      strongs_number: 'G25',
+      testament: 'NT',
+      lemma: 'ἀγαπάω',
+      transliteration: 'agapaō',
+      pronunciation: 'ag-ap-ah-o',
+      definition: 'to love',
+      derivation: 'perhaps from agan',
+      citation: { source: "Strong's Concordance", copyright: 'Public Domain' },
+      extendedCitation: { source: 'STEPBible lexicon data', copyright: 'CC BY 4.0' },
+      extended: {
+        strongsExtended: 'H1',
+        gloss: 'love',
+        morphologyCode: 'V-AAI-1S',
+        source: 'STEPBible',
+        definition: 'Extended definition',
+        occurrences: 143,
+        senses: { first: { gloss: 'love', usage: 'in context', count: 12 } },
+      },
+    }, 'detailed');
+
+    expect(result.entries[0]).toMatchObject({
+      strongsNumber: 'G25',
+      language: 'Greek',
+      derivation: 'perhaps from agan',
+      extended: {
+        strongsExtended: 'H1',
+        lexicon: 'STEPBible',
+        occurrences: 143,
+        senses: [{ gloss: 'love', usage: 'in context', count: 12 }],
+      },
+      provenanceIds: ['src-1', 'src-2'],
+    });
+    expect(result.provenance).toMatchObject([
+      {
+        id: 'src-1',
+        rightsNotice: 'Public Domain',
+        license: { label: 'Public Domain' },
+        attribution: 'OpenScriptures',
+      },
+      {
+        id: 'src-2',
+        rightsNotice: 'CC BY 4.0',
+        license: { label: 'CC BY 4.0' },
+        attribution: 'Tyndale House, Cambridge',
+      },
+    ]);
+  });
+});

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -126,6 +126,12 @@ describe('bible_lookup handler', () => {
     expect(lookupMultiple).not.toHaveBeenCalled();
     expect(textOf(result)).toContain('John 3:16 (ESV)');
     expect(textOf(result)).toContain('For God so loved the world.');
+    expect(result.structuredContent).toMatchObject({
+      kind: 'bible_lookup',
+      requestedTranslations: ['ESV'],
+      passages: [{ translation: 'ESV', text: 'For God so loved the world.' }],
+      failures: [],
+    });
   });
 
   it('dispatches an array to multi-translation lookup', async () => {
@@ -171,6 +177,33 @@ describe('bible_lookup handler', () => {
     expect(textOf(result)).toContain('(2 translations requested; 1 available)');
     expect(textOf(result)).toContain('**WEB:**');
     expect(textOf(result)).toContain('**DBY:** unavailable');
+    expect(result.structuredContent).toMatchObject({
+      passages: [{ translation: 'WEB', text: 'Yahweh is my shepherd.' }],
+      failures: [{ translation: 'DBY', reason: 'Translation could not be retrieved.' }],
+    });
+  });
+
+  it('returns a valid empty-provenance structure when every requested translation fails', async () => {
+    const lookupMultiple = vi.fn<BibleService['lookupMultiple']>().mockResolvedValue({
+      reference: 'John 3:16',
+      results: [],
+      failures: [
+        { translation: 'ESV', reason: 'Translation could not be retrieved.' },
+        { translation: 'KJV', reason: 'Translation could not be retrieved.' },
+      ],
+    });
+    const handler = createBibleLookupHandler(serviceDouble<BibleService>({
+      lookup: vi.fn<BibleService['lookup']>(),
+      lookupMultiple,
+    }));
+
+    const result = await handler.handler({
+      reference: 'John 3:16',
+      translation: ['ESV', 'KJV'],
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(result.structuredContent).toMatchObject({ passages: [], failures: expect.any(Array), provenance: [] });
   });
 
   it('treats a malformed legacy array string as a single translation value', async () => {
@@ -203,6 +236,7 @@ describe('bible_lookup handler', () => {
 
     expect(result.isError).toBe(true);
     expect(textOf(result)).toContain('Invalid input: A verse reference is required');
+    expect(result.structuredContent).toBeUndefined();
   });
 });
 
@@ -517,6 +551,12 @@ describe('original_language_lookup handler', () => {
     expect(lookup).toHaveBeenCalledWith('G25', true);
     expect(textOf(result)).toContain('**Derivation:** perhaps from agan');
     expect(textOf(result)).toContain('Occurrences: 143');
+    expect(result.structuredContent).toMatchObject({
+      kind: 'original_language_lookup',
+      mode: 'entry',
+      detailLevel: 'detailed',
+      entries: [{ strongsNumber: 'G25', derivation: 'perhaps from agan', extended: { occurrences: 143 } }],
+    });
   });
 
   it('performs a bounded search without requesting an exact lookup', async () => {
@@ -538,6 +578,12 @@ describe('original_language_lookup handler', () => {
     expect(lookup).not.toHaveBeenCalled();
     expect(textOf(result)).toContain("Strong's search results");
     expect(textOf(result)).toContain('**G26**');
+    expect(result.structuredContent).toMatchObject({
+      mode: 'search',
+      query: 'love',
+      detailLevel: 'summary',
+      entries: [{ strongsNumber: 'G26', language: 'Greek' }],
+    });
   });
 
   it('advertises both exact and search fields without a client-hostile branch schema', () => {

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -120,8 +120,34 @@ describe('Worker MCP endpoint in workerd', () => {
     expect(listed.message.error).toBeUndefined();
     expect(listed.message.result).toMatchObject({
       tools: expect.arrayContaining([
-        expect.objectContaining({ name: 'original_language_lookup' }),
+        expect.objectContaining({
+          name: 'bible_lookup',
+          outputSchema: expect.objectContaining({ type: 'object', additionalProperties: false }),
+        }),
+        expect.objectContaining({
+          name: 'original_language_lookup',
+          outputSchema: expect.objectContaining({ type: 'object', additionalProperties: false }),
+        }),
       ]),
+    });
+  });
+
+  it('returns structured Bible content alongside the legacy Markdown result', async () => {
+    const toolResult = await rpc('tools/call', {
+      name: 'bible_lookup',
+      arguments: { reference: 'John 3:16', translation: 'KJV' },
+    }, 21);
+
+    expect(toolResult.response.status).toBe(200);
+    expect(toolResult.message.error).toBeUndefined();
+    expect(toolResult.message.result).toMatchObject({
+      content: [expect.objectContaining({ type: 'text', text: expect.stringContaining('John 3:16 (KJV)') })],
+      structuredContent: {
+        schemaVersion: '1',
+        kind: 'bible_lookup',
+        passages: [expect.objectContaining({ translation: 'KJV', provenanceIds: expect.any(Array) })],
+        failures: [],
+      },
     });
   });
 
@@ -156,6 +182,12 @@ describe('Worker MCP endpoint in workerd', () => {
           text: expect.stringContaining('love, goodwill, benevolence'),
         }),
       ],
+      structuredContent: {
+        schemaVersion: '1',
+        kind: 'original_language_lookup',
+        mode: 'entry',
+        entries: [expect.objectContaining({ strongsNumber: 'G0026', language: 'Greek' })],
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds the MCP 2025-11-25 structured-output/provenance foundation for exactly `bible_lookup` and `original_language_lookup`.
- Preserves the existing human-readable Markdown response while adding object-root `outputSchema` and matching `structuredContent`.
- Adds shared bounded provenance records/presenters/schemas, server-side successful-result validation, and sanitized diagnostics.
- Normalizes STEPBible markup/entities consistently and represents real empty Strong's corpus fields as `null` without inventing source content.

## Compatibility and rights semantics

- Uses the existing MCP SDK/protocol surface and shared Node/Worker registrar; both runtimes advertise and validate the same structured contracts.
- Legacy clients continue to receive the Markdown content; structured-capable clients can consume `structuredContent`.
- `rightsNotice` is kept separate from recognized `license` or public-domain status. ESV/NET notices do not become licenses; unknown licenses are omitted. Explicit Public Domain and CC BY 4.0 claims are emitted only where the source metadata supports them.
- Structured payloads remain bounded, with concise search summaries and bounded detailed/extended fields.

## Scope

- Only `bible_lookup` and `original_language_lookup` are migrated.
- No storage, source data, D1, transport, protocol-draft upgrade, additional tool, or deployment changes.
- No deploy preview has been added; this PR is not deployed.

## Verification

- Node 22 typechecks: Node, Worker, and Worker-runtime.
- Full unit suite: 55 files, 728 tests passed.
- Integration: 3 passed; Worker runtime: 17 passed; docs: 4 passed.
- Production build, MCP conformance scenarios, Worker configuration type check, and `git diff --check` passed.
- Corpus replay validated all 14,298 exact and search original-language outputs plus 12,199 reachable extended outputs against the advertised schemas; normalization and null-field checks passed.

## Review notes

- Existing dependency sourcemap warnings remain non-fatal in Worker-runtime output; no application test failures were observed.
