### PR TITLE
Add pinned UBS/Paratext parallel-passage compiler

### DIFF
--- a/data/data-manifest.json
+++ b/data/data-manifest.json
@@ -2,6 +2,24 @@
   "manifestVersion": 1,
   "schemaVersion": "0001_initial_schema",
   "algorithm": "sha256",
+  "sources": {
+    "ubs_paratext_parallel_passages": {
+      "sourceId": "ubs_paratext_parallel_passages",
+      "title": "UBS Parallel Passage Database",
+      "publisher": "United Bible Societies",
+      "copyright": "© 2023 United Bible Societies",
+      "license": "CC BY-SA 4.0",
+      "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0/",
+      "sourceUrl": "https://github.com/ubsicap/ubs-open-license/tree/fd7bcf88b20a1522d3916f437f012c561466fe7b/parallel%20passages",
+      "sourcePath": "parallel passages/ParallelPassages.xml",
+      "sourceCommit": "fd7bcf88b20a1522d3916f437f012c561466fe7b",
+      "sourceCommitDate": "2023-07-10",
+      "sourceBlob": "b30af22e9ee4740f6c339eb267a59b8fdb9f83f7",
+      "sourceBytes": 336250,
+      "sourceSha256": "d43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394",
+      "transformVersion": 1
+    }
+  },
   "files": [
     {
       "path": "data/biblical-languages/stepbible-lexicons/tbesg-greek.json",
@@ -360,8 +378,28 @@
       "sha256": "581bdbd02fe99b97a6e236b893bce459d8b8b477789df9e16c5ef8dbcf612b85"
     },
     {
+      "path": "data/parallel-passages/ubs-paratext/LICENSE.md",
+      "sha256": "c6ededb4b82093ea27e8fc2f5b12c156b1d85fdad9e6579e96c7beffd53689a1"
+    },
+    {
+      "path": "data/parallel-passages/ubs-paratext/ParallelPassages.xml",
+      "sha256": "d43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394"
+    },
+    {
+      "path": "data/parallel-passages/ubs-paratext/README.md",
+      "sha256": "26ce6d4df0d2661357a903a390b3b9ca731d4c078ee5802c34fdaaa6bcbfa46b"
+    },
+    {
+      "path": "data/parallel-passages/ubs-paratext/SOURCE.json",
+      "sha256": "ba0bbf93da809494a9e033e7047fd47bf04d905499a8b695f41e263b1c4239d9"
+    },
+    {
       "path": "src/data/parallel-passages.json",
       "sha256": "17b8310977868b9638f9fadb8bb7912488777a4f9b5fc1669112e021c4ddc66b"
+    },
+    {
+      "path": "src/data/ubs-parallel-passages.generated.json",
+      "sha256": "164c1ab52366e1421b550ede91b3ac3d79f05eaf7bef054d065fb37d27006b4d"
     }
   ],
   "expectedCounts": {

--- a/data/data-manifest.json
+++ b/data/data-manifest.json
@@ -379,7 +379,7 @@
     },
     {
       "path": "data/parallel-passages/ubs-paratext/LICENSE.md",
-      "sha256": "c6ededb4b82093ea27e8fc2f5b12c156b1d85fdad9e6579e96c7beffd53689a1"
+      "sha256": "924513d06ecd19f5abb3d5a41973452983bf2b471347253d07d7cc529a466c8c"
     },
     {
       "path": "data/parallel-passages/ubs-paratext/ParallelPassages.xml",
@@ -387,7 +387,7 @@
     },
     {
       "path": "data/parallel-passages/ubs-paratext/README.md",
-      "sha256": "26ce6d4df0d2661357a903a390b3b9ca731d4c078ee5802c34fdaaa6bcbfa46b"
+      "sha256": "252675adaa4296c1eb2b9b0cfab75cdc1d765cc2ef2425685c0e26f5525731f9"
     },
     {
       "path": "data/parallel-passages/ubs-paratext/SOURCE.json",

--- a/data/parallel-passages/ubs-paratext/LICENSE.md
+++ b/data/parallel-passages/ubs-paratext/LICENSE.md
@@ -1,0 +1,13 @@
+# UBS Parallel Passage Database
+
+Copyright © 2023 United Bible Societies.
+
+The UBS Parallel Passage Database is released under the Creative Commons
+Attribution-ShareAlike 4.0 International license (CC BY-SA 4.0):
+
+https://creativecommons.org/licenses/by-sa/4.0/
+
+The upstream UBS resource description states that the collection is released
+under CC BY-SA 4.0 and asks that UBS be credited. This file is the local
+license and attribution notice for the vendored snapshot. It does not add
+terms to, or replace, the Creative Commons license.

--- a/data/parallel-passages/ubs-paratext/ParallelPassages.xml
+++ b/data/parallel-passages/ubs-paratext/ParallelPassages.xml
@@ -1,0 +1,9655 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Passages>
+  <Passage>
+    <Verse HEB="000000002222">GEN 1:27</Verse>
+    <Verse HEB="22200000000">GEN 5:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000003000052222">GEN 1:27</Verse>
+    <Verse HEB="222223003000003000">GEN 5:2</Verse>
+    <Verse GRK="0000300012252222">MAT 19:4</Verse>
+    <Verse GRK="202152222">MRK 10:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000300005222225222200">GEN 2:2</Verse>
+    <Verse GRK="000000052222222252222">HEB 4:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000300000003222222">GEN 2:7</Verse>
+    <Verse GRK="00052020222300000">1CO 15:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222222222222">GEN 2:24</Verse>
+    <Verse GRK="00222222222211122222222">MAT 19:5</Verse>
+    <Verse GRK="222222222222222222222220000000">MRK 10:7-8</Verse>
+    <Verse GRK="0000010000020022222">1CO 6:16</Verse>
+    <Verse GRK="1222222222222222222222">EPH 5:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0020052212222">GEN 5:24</Verse>
+    <Verse GRK="02000005221222230000000">HEB 11:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252252">GEN 10:2</Verse>
+    <Verse HEB="2222522520">1CH 1:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22242">GEN 10:3</Verse>
+    <Verse HEB="22242">1CH 1:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222151">GEN 10:4</Verse>
+    <Verse HEB="2221510">1CH 1:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122242">GEN 10:6</Verse>
+    <Verse HEB="122242">1CH 1:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225225222">GEN 10:7</Verse>
+    <Verse HEB="222252252220">1CH 1:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252222">GEN 10:8</Verse>
+    <Verse HEB="222522220">1CH 1:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">GEN 10:13</Verse>
+    <Verse HEB="2222522">1CH 1:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22522252">GEN 10:14</Verse>
+    <Verse HEB="22522252">1CH 1:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">GEN 10:15</Verse>
+    <Verse HEB="22222">1CH 1:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222">GEN 10:16</Verse>
+    <Verse HEB="2222">1CH 1:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222">GEN 10:17</Verse>
+    <Verse HEB="222">1CH 1:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2223000">GEN 10:18</Verse>
+    <Verse HEB="2220">1CH 1:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222411221">GEN 10:22-23</Verse>
+    <Verse HEB="222222242210">1CH 1:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">GEN 10:24</Verse>
+    <Verse HEB="222522">1CH 1:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225225222522">GEN 10:25</Verse>
+    <Verse HEB="22225225222522">1CH 1:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252">GEN 10:26</Verse>
+    <Verse HEB="222252">1CH 1:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222">GEN 10:27</Verse>
+    <Verse HEB="222">1CH 1:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122">GEN 10:28</Verse>
+    <Verse HEB="122">1CH 1:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">GEN 10:29</Verse>
+    <Verse HEB="2225220">1CH 1:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="200004230000300003000500042">GEN 11:12-14</Verse>
+    <Verse HEB="212512">1CH 1:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22000522225222250000005222222">GEN 12:1</Verse>
+    <Verse GRK="22005222252222505222222">ACT 7:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000021211">GEN 12:3</Verse>
+    <Verse HEB="00000021222">GEN 18:18</Verse>
+    <Verse HEB="112220000">GEN 22:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000222221122">GEN 12:3</Verse>
+    <Verse HEB="000000000222121122">GEN 18:18</Verse>
+    <Verse HEB="12211121122000000">GEN 22:18</Verse>
+    <Verse GRK="0000000000000000222211">GAL 3:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000003002220000300003000">GEN 12:7</Verse>
+    <Verse GRK="00000030003000030000003222000">GAL 3:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000030105220032200000000000003222300030222225111003000003000000">GEN 14:17-19</Verse>
+    <Verse GRK="00022252222300152222511">HEB 7:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000000511222">GEN 14:20</Verse>
+    <Verse GRK="022221130000300003000">HEB 7:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000000000000122222">GEN 15:5</Verse>
+    <Verse GRK="000000000000000122222">ROM 4:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222222">GEN 15:6</Verse>
+    <Verse GRK="000002122222222">ROM 4:3</Verse>
+    <Verse GRK="000000000000002121122">ROM 4:9</Verse>
+    <Verse GRK="022222">ROM 4:22</Verse>
+    <Verse GRK="0222222222">GAL 3:6</Verse>
+    <Verse GRK="00000021222222220000">JAS 2:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000030522221221152152030022">GEN 15:13</Verse>
+    <Verse GRK="000005222122215215252">ACT 7:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122222251223000">GEN 15:14</Verse>
+    <Verse GRK="1222222230042223000000">ACT 7:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000000000222222">GEN 17:5</Verse>
+    <Verse GRK="00222222000000000000000">ROM 4:17</Verse>
+    <Verse GRK="000000000022200000000">ROM 4:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202222000022000">GEN 17:8</Verse>
+    <Verse HEB="000000002202222">GEN 48:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="002222220000000">GEN 18:10</Verse>
+    <Verse HEB="0000222222">GEN 18:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000222222212200000000000000">GEN 18:10</Verse>
+    <Verse HEB="00000012220002222022">GEN 18:14</Verse>
+    <Verse GRK="000002222022222">ROM 9:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000522022225222222322210">GEN 21:10</Verse>
+    <Verse GRK="0000052222225202222252211">GAL 4:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000000000000000000000222222">GEN 21:12</Verse>
+    <Verse GRK="0000000022222">ROM 9:7</Verse>
+    <Verse GRK="000222222">HEB 11:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0211003000003000000000">GEN 22:16</Verse>
+    <Verse GRK="000000300000421">HEB 6:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02222522111300000300000000300003000">GEN 22:17</Verse>
+    <Verse GRK="0022222221">HEB 6:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000031402252525122300000">GEN 25:1-3</Verse>
+    <Verse HEB="0100422525242220">1CH 1:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252522">GEN 25:4</Verse>
+    <Verse HEB="22222525220">1CH 1:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="100031522522">GEN 25:13</Verse>
+    <Verse HEB="11522522">1CH 1:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121">GEN 25:14</Verse>
+    <Verse HEB="12100">1CH 1:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00522">GEN 25:15</Verse>
+    <Verse HEB="22230000">1CH 1:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00003000000300000003000322222">GEN 25:23</Verse>
+    <Verse GRK="000000000322222">ROM 9:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000524242">GEN 35:23</Verse>
+    <Verse HEB="000524242">1CH 2:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00223000203000003003000">GEN 35:24-26</Verse>
+    <Verse HEB="2220000">1CH 2:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00250005000322200005000030130000">GEN 36:10-12</Verse>
+    <Verse HEB="225500005220000510">1CH 1:35-36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0222122300000">GEN 36:13</Verse>
+    <Verse HEB="2221220">1CH 1:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000301122">GEN 36:14</Verse>
+    <Verse HEB="00001220">1CH 1:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0100052225223000000">GEN 36:20-21</Verse>
+    <Verse HEB="112222522">1CH 1:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1121522">GEN 36:22</Verse>
+    <Verse HEB="11215220">1CH 1:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0221221231123000003000">GEN 36:23-24</Verse>
+    <Verse HEB="221221204112">1CH 1:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022304114222">GEN 36:25-26</Verse>
+    <Verse HEB="22204142220">1CH 1:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022213122">GEN 36:27-28</Verse>
+    <Verse HEB="222141220">1CH 1:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252223022522">GEN 36:31-32</Verse>
+    <Verse HEB="222222522252522">1CH 1:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2252222">GEN 36:33</Verse>
+    <Verse HEB="2252222">1CH 1:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2252222">GEN 36:34</Verse>
+    <Verse HEB="2252222">1CH 1:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2252225222522">GEN 36:35</Verse>
+    <Verse HEB="22522252225202">1CH 1:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="225222">GEN 36:36</Verse>
+    <Verse HEB="225222">1CH 1:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2252222">GEN 36:37</Verse>
+    <Verse HEB="2252222">1CH 1:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2252222">GEN 36:38</Verse>
+    <Verse HEB="2252222">1CH 1:49</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22205215215222222">GEN 36:39</Verse>
+    <Verse HEB="2225215215222222">1CH 1:50</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000030522222">GEN 36:40</Verse>
+    <Verse HEB="0003005220222">1CH 1:51</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">GEN 36:41</Verse>
+    <Verse HEB="222222">1CH 1:52</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">GEN 36:42</Verse>
+    <Verse HEB="222222">1CH 1:53</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252200030000">GEN 36:43</Verse>
+    <Verse HEB="22225220">1CH 1:54</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000121">GEN 41:1</Verse>
+    <Verse HEB="00001211">GEN 41:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222111222">GEN 41:2</Verse>
+    <Verse HEB="22222121122">GEN 41:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222220111200000">GEN 41:3</Verse>
+    <Verse HEB="2222201101200000">GEN 41:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22111022200100">GEN 41:4</Verse>
+    <Verse HEB="221122201">GEN 41:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11122222212">GEN 41:5</Verse>
+    <Verse HEB="1122222212">GEN 41:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211222">GEN 41:6</Verse>
+    <Verse HEB="222011222">GEN 41:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222110000">GEN 41:7</Verse>
+    <Verse HEB="222222100000">GEN 41:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122">GEN 46:11</Verse>
+    <Verse HEB="22122">1CH 6:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000521222222">GEN 47:31</Verse>
+    <Verse GRK="0100000052222222">HEB 11:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21222252222">EXO 1:8</Verse>
+    <Verse GRK="112222252222">ACT 7:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212222222222222222222000000000000">EXO 2:14</Verse>
+    <Verse GRK="220000012222222222222222222">ACT 7:27-28</Verse>
+    <Verse GRK="00000122222200000000000000000">ACT 7:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20220522002300000000000">EXO 3:2</Verse>
+    <Verse GRK="00005200000025222">ACT 7:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0200042202225221212222">EXO 3:5</Verse>
+    <Verse GRK="20000422222522122222">ACT 7:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022522211252222222302000401000">EXO 3:6</Verse>
+    <Verse HEB="022201130000522221522222223000300000000">EXO 3:15</Verse>
+    <Verse GRK="22222222222223000000">MAT 22:32</Verse>
+    <Verse GRK="000000000000000322220522222222222">MRK 12:26</Verse>
+    <Verse GRK="00000000000300222222222">LUK 20:37</Verse>
+    <Verse GRK="222222222222211130000000000000300">ACT 3:13</Verse>
+    <Verse GRK="22211222222223002111">ACT 7:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000030030000000030000000051112212">EXO 3:12</Verse>
+    <Verse GRK="0000000030030005112212">ACT 7:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000042222125222222222">EXO 9:16</Verse>
+    <Verse GRK="00000003000042222125222222222">ROM 9:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000041002520">EXO 12:14</Verse>
+    <Verse HEB="0030003000411222">EXO 12:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222230000030000003000">EXO 12:15</Verse>
+    <Verse HEB="22222122300000">EXO 12:18</Verse>
+    <Verse HEB="222221122522222005222">LEV 23:5-6</Verse>
+    <Verse HEB="222222225222225222">NUM 28:16-17</Verse>
+    <Verse HEB="2222200151222">EZK 45:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222130000031211113002">EXO 12:15</Verse>
+    <Verse HEB="11252120030000300000300">DEU 16:3</Verse>
+    <Verse HEB="1212320003000">DEU 16:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2223002241130000000">EXO 12:16</Verse>
+    <Verse HEB="222225222">LEV 23:7</Verse>
+    <Verse HEB="2225222">NUM 28:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000000222222">EXO 12:46</Verse>
+    <Verse HEB="00000002222220000000">NUM 9:12</Verse>
+    <Verse GRK="00000002222">JHN 19:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000222225221223000000">EXO 16:18</Verse>
+    <Verse GRK="0022222522122">2CO 8:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000001211">EXO 17:1</Verse>
+    <Verse HEB="121000">NUM 20:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22220003000000">EXO 17:2</Verse>
+    <Verse HEB="22220000000">NUM 20:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000502241111">EXO 17:3</Verse>
+    <Verse HEB="000000401152200000300000000">NUM 20:4-5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1220005000400003003000004141141412000">EXO 17:5-6</Verse>
+    <Verse HEB="122051300004103040114104211141">NUM 20:7-9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11013000004111114111">EXO 18:21</Verse>
+    <Verse HEB="111103041003000">DEU 1:13-14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1110422152121222">EXO 18:25</Verse>
+    <Verse HEB="10011042215212122230">DEU 1:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2200520223000000">EXO 19:6</Verse>
+    <Verse GRK="2200522230030003000030000">1PE 2:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000003000300010030022003000300230030000000300000300000030000">EXO 19:12-13</Verse>
+    <Verse GRK="00000301222">HEB 12:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222">EXO 20:2</Verse>
+    <Verse HEB="222222222">DEU 5:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">EXO 20:3</Verse>
+    <Verse HEB="22222">DEU 5:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222">EXO 20:4</Verse>
+    <Verse HEB="2222222222222">DEU 5:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222222">EXO 20:5</Verse>
+    <Verse HEB="22222222222222222">DEU 5:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222220">EXO 20:6</Verse>
+    <Verse HEB="22222020">DEU 5:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222220">EXO 20:7</Verse>
+    <Verse HEB="22222222222220">DEU 5:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222">EXO 20:8</Verse>
+    <Verse HEB="12220000">DEU 5:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">EXO 20:9</Verse>
+    <Verse HEB="22222">DEU 5:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222221222">EXO 20:10</Verse>
+    <Verse HEB="2222222222200122200000">DEU 5:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="002022220000002200">EXO 20:11</Verse>
+    <Verse HEB="00000220002002220000000">NEH 9:6</Verse>
+    <Verse HEB="22222000">PSA 146:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000022222222222222200000000000000000">EXO 20:11</Verse>
+    <Verse HEB="0000002001222000000000222000002222222000000000000">NEH 9:6</Verse>
+    <Verse HEB="01222222222222000000">PSA 146:6</Verse>
+    <Verse GRK="0000000000010112222222222222">ACT 4:24</Verse>
+    <Verse GRK="0000000000000000000010122222222222222">ACT 14:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222">EXO 20:12</Verse>
+    <Verse HEB="22200002220002222222">DEU 5:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222200000000000000000000">EXO 20:12</Verse>
+    <Verse HEB="2222222100000000000000000000000000">DEU 5:16</Verse>
+    <Verse GRK="000022222200000000">MAT 15:4</Verse>
+    <Verse GRK="2222220000000">MAT 19:19</Verse>
+    <Verse GRK="0002222222200000000">MRK 7:10</Verse>
+    <Verse GRK="00000000000002222222">MRK 10:19</Verse>
+    <Verse GRK="000000000002222222">LUK 18:20</Verse>
+    <Verse GRK="2222222000000">EPH 6:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222">EXO 20:13</Verse>
+    <Verse HEB="222">DEU 5:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220">EXO 20:13</Verse>
+    <Verse HEB="220">DEU 5:17</Verse>
+    <Verse GRK="000002200000000">MAT 5:21</Verse>
+    <Verse GRK="0000000022000000">MAT 19:18</Verse>
+    <Verse GRK="00012000000000000000">MRK 10:19</Verse>
+    <Verse GRK="000001200000000000">LUK 18:20</Verse>
+    <Verse GRK="0000220000000000000000000000">ROM 13:9</Verse>
+    <Verse GRK="000000012000000000">JAS 2:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="120">EXO 20:14</Verse>
+    <Verse HEB="120">DEU 5:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220">EXO 20:14</Verse>
+    <Verse HEB="220">DEU 5:18</Verse>
+    <Verse GRK="00022">MAT 5:27</Verse>
+    <Verse GRK="0000000000220000">MAT 19:18</Verse>
+    <Verse GRK="00000120000000000000">MRK 10:19</Verse>
+    <Verse GRK="000120000000000000">LUK 18:20</Verse>
+    <Verse GRK="0022000000000000000000000000">ROM 13:9</Verse>
+    <Verse GRK="000120000000000000">JAS 2:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="120">EXO 20:15</Verse>
+    <Verse HEB="120">DEU 5:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220">EXO 20:15</Verse>
+    <Verse HEB="220">DEU 5:19</Verse>
+    <Verse GRK="0000000000002200">MAT 19:18</Verse>
+    <Verse GRK="00000001200000000000">MRK 10:19</Verse>
+    <Verse GRK="000000012000000000">LUK 18:20</Verse>
+    <Verse GRK="0000002200000000000000000000">ROM 13:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12210">EXO 20:16</Verse>
+    <Verse HEB="12210">DEU 5:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">EXO 20:16</Verse>
+    <Verse HEB="22222222">DEU 5:20</Verse>
+    <Verse GRK="0000000000000022">MAT 19:18</Verse>
+    <Verse GRK="00000000012000000000">MRK 10:19</Verse>
+    <Verse GRK="000000000120000000">LUK 18:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122212222122220">EXO 20:17</Verse>
+    <Verse HEB="122201122022122220">DEU 5:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22000000000000000000000000000000000000000000">EXO 20:17</Verse>
+    <Verse HEB="22000000000000000000000000000000000000000000">DEU 5:21</Verse>
+    <Verse GRK="000000000000000000000000000022">ROM 7:7</Verse>
+    <Verse GRK="0000000022000000000000000000">ROM 13:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="004143003">EXO 20:19</Verse>
+    <Verse HEB="0003000041130000040">DEU 5:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00012214111">EXO 21:2</Verse>
+    <Verse HEB="0201300030003000">LEV 25:39-40</Verse>
+    <Verse HEB="11211142241111">DEU 15:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0001300000">EXO 21:3</Verse>
+    <Verse HEB="1000030000">LEV 25:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111410052130041004111410">EXO 21:5-6</Verse>
+    <Verse HEB="111521310300414114111300">DEU 15:16-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">EXO 21:24</Verse>
+    <Verse HEB="000222222000000000">LEV 24:20</Verse>
+    <Verse HEB="0000000000222222222222">DEU 19:21</Verse>
+    <Verse GRK="0002220222">MAT 5:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00031222222">EXO 22:27</Verse>
+    <Verse GRK="00003000003004222222">ACT 23:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1115221522">EXO 23:8</Verse>
+    <Verse HEB="003004152211522">DEU 16:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000004103000300003000004111000411100052222122">EXO 23:14-17</Verse>
+    <Verse HEB="22222122003000030030000300">EXO 34:23-24</Verse>
+    <Verse HEB="2222212000041111130000300300000">DEU 16:16-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122501">EXO 23:18</Verse>
+    <Verse HEB="12251000">EXO 34:25</Verse>
+    <Verse HEB="00000050000001">DEU 16:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222220">EXO 23:19</Verse>
+    <Verse HEB="222222222220">EXO 34:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000041122225112230000">EXO 24:8</Verse>
+    <Verse GRK="112222512211">HEB 9:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000300114111111300005225222225222222424222242222">EXO 25:1-7</Verse>
+    <Verse HEB="0000030000411141111115225222225222222424222242222">EXO 35:4-9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122222222222">EXO 25:10</Verse>
+    <Verse HEB="10122222222222">EXO 37:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112222011222">EXO 25:11</Verse>
+    <Verse HEB="1222211222">EXO 37:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222022222222222">EXO 25:12</Verse>
+    <Verse HEB="1122222222222222">EXO 37:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222122">EXO 25:13</Verse>
+    <Verse HEB="1222122">EXO 37:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222220">EXO 25:14</Verse>
+    <Verse HEB="12222222">EXO 37:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222222">EXO 25:17</Verse>
+    <Verse HEB="1222222222">EXO 37:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122212222">EXO 25:18</Verse>
+    <Verse HEB="1122212222">EXO 37:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222221212">EXO 25:19</Verse>
+    <Verse HEB="222222212102">EXO 37:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222222222122">EXO 25:20</Verse>
+    <Verse HEB="1222222222221220">EXO 37:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222222222">EXO 25:23</Verse>
+    <Verse HEB="11222222222">EXO 37:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122211222">EXO 25:24</Verse>
+    <Verse HEB="122211222">EXO 37:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112221222">EXO 25:25</Verse>
+    <Verse HEB="112221222">EXO 37:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122212222222">EXO 25:26</Verse>
+    <Verse HEB="1122212222222">EXO 37:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22121222">EXO 25:27</Verse>
+    <Verse HEB="22121222">EXO 37:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122212212">EXO 25:28</Verse>
+    <Verse HEB="122212212">EXO 37:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122112222200">EXO 25:29</Verse>
+    <Verse HEB="100022111222220">EXO 37:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222122222221">EXO 25:31</Verse>
+    <Verse HEB="11222122222221">EXO 37:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222">EXO 25:32</Verse>
+    <Verse HEB="22222222222222">EXO 37:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222112222222">EXO 25:33</Verse>
+    <Verse HEB="2222222222112222222">EXO 37:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">EXO 25:34</Verse>
+    <Verse HEB="222222">EXO 37:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222221">EXO 25:35</Verse>
+    <Verse HEB="222222222222222221">EXO 37:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122222">EXO 25:36</Verse>
+    <Verse HEB="222122222">EXO 37:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122000002222">EXO 25:37-38</Verse>
+    <Verse HEB="1222222">EXO 37:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212111">EXO 25:39</Verse>
+    <Verse HEB="22212110">EXO 37:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22522212222">EXO 25:40</Verse>
+    <Verse GRK="0000000300000050020522212222">HEB 8:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212252222252212">EXO 26:1</Verse>
+    <Verse HEB="100022252222252212">EXO 36:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252222522">EXO 26:2</Verse>
+    <Verse HEB="22222252222522">EXO 36:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22111152111">EXO 26:3</Verse>
+    <Verse HEB="1221152111">EXO 36:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222214122222">EXO 26:4</Verse>
+    <Verse HEB="1222222214122222">EXO 36:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122521222225211">EXO 26:5</Verse>
+    <Verse HEB="22122521222225211">EXO 36:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222421124220">EXO 26:6</Verse>
+    <Verse HEB="1222421124220">EXO 36:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122225212">EXO 26:7</Verse>
+    <Verse HEB="122225212">EXO 36:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222224112252222">EXO 26:8</Verse>
+    <Verse HEB="222224112252222">EXO 36:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222300000">EXO 26:9</Verse>
+    <Verse HEB="1222222">EXO 36:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222220215222222">EXO 26:10</Verse>
+    <Verse HEB="122222215202222">EXO 36:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12223004212">EXO 26:11</Verse>
+    <Verse HEB="12224212">EXO 36:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222252220">EXO 26:14</Verse>
+    <Verse HEB="12222252220">EXO 36:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222">EXO 26:15</Verse>
+    <Verse HEB="122222">EXO 36:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222522">EXO 26:16</Verse>
+    <Verse HEB="2222222522">EXO 36:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221151222">EXO 26:17</Verse>
+    <Verse HEB="222221151222">EXO 36:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12221212">EXO 26:18</Verse>
+    <Verse HEB="12221212">EXO 36:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221221522222522222">EXO 26:19</Verse>
+    <Verse HEB="221221522222522222">EXO 36:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221">EXO 26:20</Verse>
+    <Verse HEB="22222021">EXO 36:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225222252222">EXO 26:21</Verse>
+    <Verse HEB="2225222252222">EXO 36:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222422">EXO 26:22</Verse>
+    <Verse HEB="222422">EXO 36:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222">EXO 26:23</Verse>
+    <Verse HEB="221222">EXO 36:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222252212220">EXO 26:24</Verse>
+    <Verse HEB="12222225221222">EXO 36:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222225222200000">EXO 26:25</Verse>
+    <Verse HEB="222222225200222">EXO 36:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222221">EXO 26:26</Verse>
+    <Verse HEB="11222221">EXO 36:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225220222">EXO 26:27</Verse>
+    <Verse HEB="22222522222">EXO 36:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222122">EXO 26:28</Verse>
+    <Verse HEB="02212222">EXO 36:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21251252422">EXO 26:29</Verse>
+    <Verse HEB="21251252422">EXO 36:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222">EXO 26:31</Verse>
+    <Verse HEB="2222222222222">EXO 36:35</Verse>
+    <Verse HEB="2222110020">2CH 3:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222122222">EXO 26:32</Verse>
+    <Verse HEB="1122212220022">EXO 36:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122252222252">EXO 26:36</Verse>
+    <Verse HEB="122252222252">EXO 36:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0021040210302020">EXO 26:37</Verse>
+    <Verse HEB="12410023220">EXO 36:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122521521500522">EXO 27:1</Verse>
+    <Verse HEB="11122521515522">EXO 38:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222512422">EXO 27:2</Verse>
+    <Verse HEB="12222512422">EXO 38:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1104111412">EXO 27:3</Verse>
+    <Verse HEB="10014111412">EXO 38:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122224022011130211230000">EXO 27:4-5</Verse>
+    <Verse HEB="1122225120422113000">EXO 38:4-5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="110022422">EXO 27:6</Verse>
+    <Verse HEB="1122422">EXO 38:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112301121252123000000">EXO 27:7-8</Verse>
+    <Verse HEB="11241212052120">EXO 38:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111052412222300">EXO 27:9</Verse>
+    <Verse HEB="11522412222">EXO 38:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122225222">EXO 27:10</Verse>
+    <Verse HEB="122225222">EXO 38:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11200203122225000">EXO 27:11</Verse>
+    <Verse HEB="1220422225000">EXO 38:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1112215222">EXO 27:12</Verse>
+    <Verse HEB="122152223000">EXO 38:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1112222">EXO 27:13</Verse>
+    <Verse HEB="12222">EXO 38:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112015222">EXO 27:14</Verse>
+    <Verse HEB="11215222">EXO 38:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222">EXO 27:15</Verse>
+    <Verse HEB="22000022205222">EXO 38:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11142522222523000">EXO 27:16</Verse>
+    <Verse HEB="111525222224200000300">EXO 38:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220224212">EXO 27:17</Verse>
+    <Verse HEB="1124102300322222">EXO 38:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000041120">EXO 27:19</Verse>
+    <Verse HEB="111020">EXO 38:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11225222222522">EXO 27:20</Verse>
+    <Verse HEB="1225222222522">LEV 24:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222211522022225210000">EXO 27:21</Verse>
+    <Verse HEB="2212252222220521">LEV 24:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112030">EXO 28:2</Verse>
+    <Verse HEB="000030004110230000">EXO 39:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00222522042225222252">EXO 28:5-6</Verse>
+    <Verse HEB="12225222230200302023220252">EXO 39:2-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0221121">EXO 28:7</Verse>
+    <Verse HEB="2121021">EXO 39:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222215222222">EXO 28:8</Verse>
+    <Verse HEB="222221252222223000">EXO 39:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00130000300003003003005210052252200">EXO 28:9-11</Verse>
+    <Verse HEB="011522422522">EXO 39:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1112225222300003000">EXO 28:12</Verse>
+    <Verse HEB="11222522230000">EXO 39:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11122520522225200">EXO 28:15</Verse>
+    <Verse HEB="1122525222252">EXO 39:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2125222">EXO 28:16</Verse>
+    <Verse HEB="2120052220">EXO 39:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1100212522222">EXO 28:17</Verse>
+    <Verse HEB="1212522222">EXO 39:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">EXO 28:18</Verse>
+    <Verse HEB="22222">EXO 39:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">EXO 28:19</Verse>
+    <Verse HEB="22222">EXO 39:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222124202">EXO 28:20</Verse>
+    <Verse HEB="222123122">EXO 39:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202252252223122">EXO 28:21</Verse>
+    <Verse HEB="22232225222422">EXO 39:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12125222">EXO 28:22</Verse>
+    <Verse HEB="12125222">EXO 39:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="10122422222">EXO 28:23</Verse>
+    <Verse HEB="1000122422222">EXO 39:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12125212">EXO 28:24</Verse>
+    <Verse HEB="12125212">EXO 39:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222241242222">EXO 28:25</Verse>
+    <Verse HEB="2222241242222">EXO 39:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12224122252222">EXO 28:26</Verse>
+    <Verse HEB="1222422252222">EXO 39:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12224122252252222">EXO 28:27</Verse>
+    <Verse HEB="1222422252252222">EXO 39:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="120252225225222">EXO 28:28</Verse>
+    <Verse HEB="122522252252223000">EXO 39:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222">EXO 28:31</Verse>
+    <Verse HEB="1220022">EXO 39:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="01250223022052">EXO 28:32</Verse>
+    <Verse HEB="122252252">EXO 39:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1152222301242">EXO 28:33</Verse>
+    <Verse HEB="1115222203120301130200">EXO 39:24-25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2022025223013000300000">EXO 28:34-35</Verse>
+    <Verse HEB="2222522400000">EXO 39:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222425222">EXO 28:36</Verse>
+    <Verse HEB="120224215222">EXO 39:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111242300">EXO 28:37</Verse>
+    <Verse HEB="111242030000">EXO 39:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1223224052">EXO 28:39</Verse>
+    <Verse HEB="1223000312300300040003005200000">EXO 39:27-29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000300030003003000003100300030103004222">EXO 29:1-3</Verse>
+    <Verse HEB="000030000411222311">LEV 8:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111300422">EXO 29:4</Verse>
+    <Verse HEB="1111422">LEV 8:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00412411514222">EXO 29:5</Verse>
+    <Verse HEB="11230030130230221203013000">LEV 8:7-8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1224222">EXO 29:6</Verse>
+    <Verse HEB="1224200300223000">LEV 8:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1224142">EXO 29:7</Verse>
+    <Verse HEB="11223003030000300300400111420">LEV 8:10-12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11424220042230000300">EXO 29:8-9</Verse>
+    <Verse HEB="1111424224223000">LEV 8:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11000422221">EXO 29:10</Verse>
+    <Verse HEB="11114222211">LEV 8:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="100000041142214122">EXO 29:11-12</Verse>
+    <Verse HEB="141142201304122300">LEV 8:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121151122240042">EXO 29:13</Verse>
+    <Verse HEB="1211511224412">LEV 8:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122422230">EXO 29:14</Verse>
+    <Verse HEB="121242223000">LEV 8:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111422222">EXO 29:15</Verse>
+    <Verse HEB="1111422222">LEV 8:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1000422">EXO 29:16</Verse>
+    <Verse HEB="140022">LEV 8:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211300311">EXO 29:17</Verse>
+    <Verse HEB="21230140">LEV 8:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12252011522">EXO 29:18</Verse>
+    <Verse HEB="000041225215225222">LEV 8:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222422252">EXO 29:19</Verse>
+    <Verse HEB="12200422252">LEV 8:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1012422230005225224222">EXO 29:20</Verse>
+    <Verse HEB="1112422030030030030000052252241222">LEV 8:23-24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="10224112225221115223000">EXO 29:22</Verse>
+    <Verse HEB="122411222521522">LEV 8:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222225242222">EXO 29:23</Verse>
+    <Verse HEB="42222311222225230000">LEV 8:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222242222">EXO 29:24</Verse>
+    <Verse HEB="1222222242222">LEV 8:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1204225200222">EXO 29:25</Verse>
+    <Verse HEB="112004223022222">LEV 8:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12000041222412">EXO 29:26</Verse>
+    <Verse HEB="1124222301123000">LEV 8:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00204111422002222224100000000000">EXO 29:31-33</Verse>
+    <Verse HEB="0000112223112222300221">LEV 8:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="010101220000">EXO 29:34</Verse>
+    <Verse HEB="21121">LEV 8:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00003105211300003011300">EXO 29:35-36</Verse>
+    <Verse HEB="00000003000032211300040011">LEV 8:33-34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000022220">EXO 29:38</Verse>
+    <Verse HEB="00000002202202">NUM 28:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122222222">EXO 29:39</Verse>
+    <Verse HEB="2122222222">NUM 28:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1242212422022">EXO 29:40</Verse>
+    <Verse HEB="1020422123000030004222230000">NUM 28:5-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252114212">EXO 29:41</Verse>
+    <Verse HEB="222222521141220">NUM 28:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121152005222205222">EXO 30:1-2</Verse>
+    <Verse HEB="121525222252202">EXO 37:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222252241222">EXO 30:3</Verse>
+    <Verse HEB="1222252241222">EXO 37:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222152222322322221">EXO 30:4</Verse>
+    <Verse HEB="22215222252252221">EXO 37:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222422">EXO 30:5</Verse>
+    <Verse HEB="1222422">EXO 37:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122220300030000">EXO 30:18</Verse>
+    <Verse HEB="122222230003000">EXO 38:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="10213022300">EXO 30:25</Verse>
+    <Verse HEB="1211300520">EXO 37:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000041252222">EXO 31:1-2</Verse>
+    <Verse HEB="0000410252222">EXO 35:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222422">EXO 31:3</Verse>
+    <Verse HEB="12222422">EXO 35:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222">EXO 31:4</Verse>
+    <Verse HEB="122222">EXO 35:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222251">EXO 31:5</Verse>
+    <Verse HEB="22222510">EXO 35:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000012230000000">EXO 31:6</Verse>
+    <Verse HEB="0000122300000003000003000">EXO 35:34-35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000000000000002222222222222222222000">EXO 32:1</Verse>
+    <Verse HEB="0000000000022222222222222">EXO 32:23</Verse>
+    <Verse GRK="000222222222222220222222">ACT 7:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000030003222222522">EXO 32:6</Verse>
+    <Verse GRK="00030000522222522">1CO 10:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1102521130003000">EXO 32:15</Verse>
+    <Verse HEB="112000521111">DEU 9:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00001100010101100">EXO 32:19</Verse>
+    <Verse HEB="100000010000000000111110">DEU 9:16-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121142422000300">EXO 32:20</Verse>
+    <Verse HEB="0121402301022030000">DEU 9:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000003000000003222222222">EXO 33:19</Verse>
+    <Verse GRK="0000522222222">ROM 9:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1215222422522252">EXO 34:1</Verse>
+    <Verse HEB="001215222300000042252225200">DEU 10:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222300110300032110">EXO 34:4</Verse>
+    <Verse HEB="0000422241112">DEU 10:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000020002220000222022222220022">EXO 34:6-7</Verse>
+    <Verse HEB="2222222222222222">NUM 14:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000312151222">EXO 34:11</Verse>
+    <Verse HEB="00000300402104222230000">DEU 7:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0022220000000">EXO 34:12</Verse>
+    <Verse HEB="2222000000000">EXO 34:15</Verse>
+    <Verse HEB="0000000011100">DEU 7:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0222221">EXO 34:13</Verse>
+    <Verse HEB="000222221000">DEU 7:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11141114111">EXO 34:16</Verse>
+    <Verse HEB="00000411141141130030">DEU 7:3-4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12100000000">EXO 34:22</Verse>
+    <Verse HEB="11200000000000">DEU 16:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000050051212">EXO 35:10-11</Verse>
+    <Verse HEB="02000510212">EXO 39:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121522">EXO 35:12</Verse>
+    <Verse HEB="000000052240211">EXO 39:34-35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202222">EXO 35:13</Verse>
+    <Verse HEB="22222">EXO 39:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1041522">EXO 35:14</Verse>
+    <Verse HEB="104001522">EXO 39:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2002225222011">EXO 35:15</Verse>
+    <Verse HEB="2202225222211">EXO 39:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2202222222">EXO 35:16</Verse>
+    <Verse HEB="2202222222">EXO 39:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222411242301">EXO 35:17-18</Verse>
+    <Verse HEB="2222241241300200">EXO 39:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">EXO 35:19</Verse>
+    <Verse HEB="22222222222">EXO 39:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12003002300003003000">EXO 40:34-35</Verse>
+    <Verse HEB="0004220030030">NUM 9:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122152200">EXO 40:36</Verse>
+    <Verse HEB="01221322230003000">NUM 9:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0001101">EXO 40:37</Verse>
+    <Verse HEB="00000000000000000000000110000000000000000001000000000000000000000000000000000000">NUM 9:18-23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="010101020300">EXO 40:38</Verse>
+    <Verse HEB="0001112">NUM 9:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222220">LEV 2:3</Verse>
+    <Verse HEB="22222222">LEV 2:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">LEV 3:4</Verse>
+    <Verse HEB="222222222222">LEV 7:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">LEV 3:10</Verse>
+    <Verse HEB="222222222222">LEV 3:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000512200042222252252">LEV 11:2-3</Verse>
+    <Verse HEB="2122300003000000422221252252">DEU 14:4-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252530000000055215214123000300000">LEV 11:4-6</Verse>
+    <Verse HEB="222222520502521221412">DEU 14:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222000411222522222300">LEV 11:7-8</Verse>
+    <Verse HEB="2222412225222220">DEU 14:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522230002">LEV 11:9</Verse>
+    <Verse HEB="2222252222">DEU 14:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222000003000041200032200422220412">LEV 11:10-12</Verse>
+    <Verse HEB="22222224120">DEU 14:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00011015222">LEV 11:13</Verse>
+    <Verse HEB="0003011522">DEU 14:11-12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1224222225222">LEV 11:14-16</Verse>
+    <Verse HEB="12024222225222">DEU 14:13-15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222521">LEV 11:17-18</Verse>
+    <Verse HEB="222512">DEU 14:16-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022252">LEV 11:19</Verse>
+    <Verse HEB="22252">DEU 14:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222001220">LEV 11:20</Verse>
+    <Verse HEB="22212200">DEU 14:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000030122222300000030000000">LEV 12:8</Verse>
+    <Verse GRK="00000000000422222">LUK 2:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0001100011000012222200000">LEV 18:5</Verse>
+    <Verse GRK="00000001101212222">ROM 10:5</Verse>
+    <Verse GRK="10100000121222">GAL 3:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000003000522223000">LEV 19:2</Verse>
+    <Verse GRK="000522220">1PE 1:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000000222222000">LEV 19:18</Verse>
+    <Verse GRK="000222200000">MAT 5:43</Verse>
+    <Verse GRK="0000000222222">MAT 19:19</Verse>
+    <Verse GRK="0000222222">MAT 22:39</Verse>
+    <Verse GRK="00222222000000">MRK 12:31</Verse>
+    <Verse GRK="00000000000000000001111210000000">MRK 12:33</Verse>
+    <Verse GRK="00002000000000000000000000000000022222">LUK 10:27</Verse>
+    <Verse GRK="0000000000000000000000222222">ROM 13:9</Verse>
+    <Verse GRK="0000000000222222">GAL 5:14</Verse>
+    <Verse GRK="0000000022222200">JAS 2:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">LEV 19:30</Verse>
+    <Verse HEB="2222220">LEV 26:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000052252220">LEV 23:8</Verse>
+    <Verse HEB="2220052220">NUM 28:25</Verse>
+    <Verse HEB="0000521114110">DEU 16:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="100000001100">LEV 23:15</Verse>
+    <Verse HEB="1110000111">DEU 16:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20220221111100000000">LEV 23:18</Verse>
+    <Verse HEB="20000111112222">NUM 28:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000022252223000">LEV 23:21</Verse>
+    <Verse HEB="0000003222522230000300000000">NUM 28:26-27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="225000000052220">LEV 23:29</Verse>
+    <Verse GRK="002250000005222">ACT 3:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">NUM 7:14</Verse>
+    <Verse HEB="222222">NUM 7:20</Verse>
+    <Verse HEB="222222">NUM 7:26</Verse>
+    <Verse HEB="222222">NUM 7:32</Verse>
+    <Verse HEB="222222">NUM 7:38</Verse>
+    <Verse HEB="222222">NUM 7:44</Verse>
+    <Verse HEB="222222">NUM 7:50</Verse>
+    <Verse HEB="222222">NUM 7:56</Verse>
+    <Verse HEB="222222">NUM 7:62</Verse>
+    <Verse HEB="222222">NUM 7:68</Verse>
+    <Verse HEB="222222">NUM 7:74</Verse>
+    <Verse HEB="222222">NUM 7:80</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">NUM 7:15</Verse>
+    <Verse HEB="22222222">NUM 7:21</Verse>
+    <Verse HEB="22222222">NUM 7:27</Verse>
+    <Verse HEB="22222222">NUM 7:33</Verse>
+    <Verse HEB="22222222">NUM 7:39</Verse>
+    <Verse HEB="22222222">NUM 7:45</Verse>
+    <Verse HEB="22222222">NUM 7:51</Verse>
+    <Verse HEB="22222222">NUM 7:57</Verse>
+    <Verse HEB="22222222">NUM 7:63</Verse>
+    <Verse HEB="22222222">NUM 7:69</Verse>
+    <Verse HEB="22222222">NUM 7:75</Verse>
+    <Verse HEB="22222222">NUM 7:81</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222">NUM 7:16</Verse>
+    <Verse HEB="222">NUM 7:22</Verse>
+    <Verse HEB="222">NUM 7:28</Verse>
+    <Verse HEB="222">NUM 7:34</Verse>
+    <Verse HEB="222">NUM 7:40</Verse>
+    <Verse HEB="222">NUM 7:46</Verse>
+    <Verse HEB="222">NUM 7:52</Verse>
+    <Verse HEB="222">NUM 7:58</Verse>
+    <Verse HEB="222">NUM 7:64</Verse>
+    <Verse HEB="222">NUM 7:70</Verse>
+    <Verse HEB="222">NUM 7:76</Verse>
+    <Verse HEB="222">NUM 7:82</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222222222">NUM 7:25</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:31</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:37</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:43</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:49</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:55</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:61</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:67</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:73</Verse>
+    <Verse HEB="2222222222222222222">NUM 7:79</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000001122211">NUM 10:35</Verse>
+    <Verse HEB="1121211">PSA 68:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">NUM 14:26</Verse>
+    <Verse HEB="22222">NUM 16:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000030000301104100032">NUM 14:39-40</Verse>
+    <Verse HEB="0002041000003000011">DEU 1:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000000421125222">NUM 14:41-42</Verse>
+    <Verse HEB="000004102125222">DEU 1:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1111000000">NUM 14:44</Verse>
+    <Verse HEB="0000000111">DEU 1:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0002223110">NUM 14:45</Verse>
+    <Verse HEB="002220300004101">DEU 1:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000030000003021122230000003000000">NUM 16:5</Verse>
+    <Verse GRK="00000003000512223000300000">2TI 2:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1111">NUM 17:9</Verse>
+    <Verse HEB="1111">NUM 20:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="102212">NUM 21:21</Verse>
+    <Verse HEB="1200211002">DEU 2:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2200000000000000">NUM 21:22</Verse>
+    <Verse HEB="22000000000000000000">DEU 2:27-28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1101130051103200">NUM 21:23</Verse>
+    <Verse HEB="111001130000030000030000003000005010002">DEU 2:30-32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="10110000000">NUM 21:25</Verse>
+    <Verse HEB="110000000000">DEU 2:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112222212222">NUM 21:33</Verse>
+    <Verse HEB="112222212222">DEU 3:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221225222225222222222">NUM 21:34</Verse>
+    <Verse HEB="221225222225222222222">DEU 3:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="010252200">NUM 21:35</Verse>
+    <Verse HEB="000001023222">DEU 3:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="100041211213000000">NUM 28:20-21</Verse>
+    <Verse HEB="112121300">EZK 45:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222220">NUM 29:16</Verse>
+    <Verse HEB="222222220">NUM 29:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">NUM 29:18</Verse>
+    <Verse HEB="2222222">NUM 29:21</Verse>
+    <Verse HEB="2222222">NUM 29:24</Verse>
+    <Verse HEB="2222222">NUM 29:27</Verse>
+    <Verse HEB="2222222">NUM 29:30</Verse>
+    <Verse HEB="2222222">NUM 29:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222220">NUM 29:28</Verse>
+    <Verse HEB="22222222">NUM 29:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0022122000">DEU 4:24</Verse>
+    <Verse GRK="0022122">HEB 12:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000003000000003000052522222252222252222522222522212">DEU 6:4-5</Verse>
+    <Verse GRK="00000052522222252222252222522222300000522212">MRK 12:29-30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000030000000030000300000022">DEU 6:4</Verse>
+    <Verse GRK="0000030000322000000">MRK 12:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222522222522212">DEU 6:5</Verse>
+    <Verse GRK="00005222212222512222512202">MAT 22:37</Verse>
+    <Verse GRK="22222222222522222522202522212">MRK 12:30</Verse>
+    <Verse GRK="20112222522215222130000000000000">MRK 12:33</Verse>
+    <Verse GRK="00005222222222512222512212512202300000">LUK 10:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1112222222">DEU 6:7</Verse>
+    <Verse HEB="11112222222">DEU 11:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1212221">DEU 6:8</Verse>
+    <Verse HEB="0000011212221">DEU 11:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22220">DEU 6:9</Verse>
+    <Verse HEB="2222">DEU 11:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221222000000000">DEU 6:13</Verse>
+    <Verse GRK="000000000222212202">MAT 4:10</Verse>
+    <Verse GRK="0000000222212202">LUK 4:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222000000">DEU 6:16</Verse>
+    <Verse GRK="000000222222">MAT 4:7</Verse>
+    <Verse GRK="00000000222222">LUK 4:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000000000000022222222222202222000">DEU 8:3</Verse>
+    <Verse GRK="00000222222222222222">MAT 4:4</Verse>
+    <Verse GRK="000000022222222">LUK 4:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222223000000300000030000003000003000000300000">DEU 9:4</Verse>
+    <Verse GRK="0000000522222300003000">ROM 10:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0220000003000000300000000">DEU 9:19</Verse>
+    <Verse GRK="000000302200">HEB 12:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000003000300000003122222">DEU 17:7</Verse>
+    <Verse GRK="000000422222">1CO 5:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222000202220222221000000000000000000000000000000000">DEU 18:15-16</Verse>
+    <Verse GRK="00002022220222000222221100">ACT 3:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222212221122030">DEU 18:15</Verse>
+    <Verse GRK="00000000051222222122">ACT 7:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11112221111100000000">DEU 18:19</Verse>
+    <Verse GRK="111112221110000">ACT 3:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000000000000222221121222">DEU 19:15</Verse>
+    <Verse GRK="000000000000222212222">MAT 18:16</Verse>
+    <Verse GRK="00000222222222">2CO 13:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000300000003100222230000300000000">DEU 21:23</Verse>
+    <Verse GRK="00000000300000420222">GAL 3:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000000000000000000220100002121111">DEU 24:1</Verse>
+    <Verse GRK="00000000121">MAT 5:31</Verse>
+    <Verse GRK="000000122212">MAT 19:7</Verse>
+    <Verse GRK="0000022121">MRK 10:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225224210">DEU 24:16</Verse>
+    <Verse HEB="000030000052252231201">2KI 14:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222">DEU 25:4</Verse>
+    <Verse GRK="0000002122000000">1CO 9:9</Verse>
+    <Verse GRK="000022220000000">1TI 5:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2001000021114111130000000005211111111112000">DEU 25:5</Verse>
+    <Verse GRK="0000112122232222215122114222220212222">MAT 22:23-24</Verse>
+    <Verse GRK="0121111222312222220522211222115222222222222">MRK 12:18-19</Verse>
+    <Verse GRK="1011111222522222252221221115222222222222">LUK 20:27-28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2205220221520222300000">DEU 27:26</Verse>
+    <Verse GRK="0000003003002252222130022222">GAL 3:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000052022230003000">DEU 30:12</Verse>
+    <Verse GRK="0000000300000522223000">ROM 10:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222205222222223000000">DEU 30:14</Verse>
+    <Verse GRK="0002222252222222230000000">ROM 10:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000030000042122252221">DEU 32:21</Verse>
+    <Verse GRK="00000030042122252221">ROM 10:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00123000000300003000">DEU 32:35</Verse>
+    <Verse GRK="00003000000311230">ROM 12:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000200300003000300003222223000003000300000">DEU 32:35-36</Verse>
+    <Verse GRK="000030123022222">HEB 10:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000052200">JOS 15:14</Verse>
+    <Verse HEB="0000030003222">JDG 1:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222">JOS 15:15</Verse>
+    <Verse HEB="1222222">JDG 1:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222">JOS 15:16</Verse>
+    <Verse HEB="2222252222">JDG 1:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222">JOS 15:17</Verse>
+    <Verse HEB="22222005222">JDG 1:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222220522222">JOS 15:18</Verse>
+    <Verse HEB="222220522222">JDG 1:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2125225222252215210">JOS 15:19</Verse>
+    <Verse HEB="201252225222502215210">JDG 1:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122222222222221222222">JOS 24:31</Verse>
+    <Verse HEB="11222222222222212220222">JDG 2:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222220">JDG 17:6</Verse>
+    <Verse HEB="222222222">JDG 21:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222220000000000">1SA 2:8</Verse>
+    <Verse HEB="12222222000">PSA 113:7-8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000030001222130000000003000000">1SA 13:14</Verse>
+    <Verse GRK="00000030000003000042221300000">ACT 13:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212411225221">1SA 31:1</Verse>
+    <Verse HEB="21241225221">1CH 10:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22115222222">1SA 31:2</Verse>
+    <Verse HEB="2211115222222">1CH 10:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2215202501">1SA 31:3</Verse>
+    <Verse HEB="22152251">1CH 10:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212522252202522222252222">1SA 31:4</Verse>
+    <Verse HEB="2212522252225222222052222">1CH 10:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252120">1SA 31:5</Verse>
+    <Verse HEB="2222252120">1CH 10:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221111002">1SA 31:6</Verse>
+    <Verse HEB="2222120">1CH 10:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211100050022251222210">1SA 31:7</Verse>
+    <Verse HEB="21115222251222210">1CH 10:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222225211221">1SA 31:8</Verse>
+    <Verse HEB="222222521221">1CH 10:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12115225112">1SA 31:9</Verse>
+    <Verse HEB="1121522512">1CH 10:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222142021">1SA 31:10</Verse>
+    <Verse HEB="222142210">1CH 10:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="201222122">1SA 31:11</Verse>
+    <Verse HEB="21222122">1CH 10:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220041221200041000322115220">1SA 31:12-13</Verse>
+    <Verse HEB="2224122124112111522">1CH 10:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0111231222">2SA 3:2</Verse>
+    <Verse HEB="001101242223000">1CH 3:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1102001412222">2SA 3:3</Verse>
+    <Verse HEB="000000030004121412222300">1CH 3:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122421">2SA 3:4</Verse>
+    <Verse HEB="0000004224213000">1CH 3:2-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1221141120">2SA 3:5</Verse>
+    <Verse HEB="000422141230000300000">1CH 3:3-4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11122321222">2SA 5:1</Verse>
+    <Verse HEB="112251222">1CH 11:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222205000102252222225211">2SA 5:2</Verse>
+    <Verse HEB="120222512252022222521112">1CH 11:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225202222252220">2SA 5:3</Verse>
+    <Verse HEB="22222522222252223000">1CH 11:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2112412420223000030052222222">2SA 5:6-7</Verse>
+    <Verse HEB="211211311240021225212222">1CH 11:4-5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22112250120">2SA 5:9</Verse>
+    <Verse HEB="2211122501203000">1CH 11:7-8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222220222">2SA 5:10</Verse>
+    <Verse HEB="22222222">1CH 11:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522120211">2SA 5:11</Verse>
+    <Verse HEB="220222522221111">1CH 14:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222224112220">2SA 5:12</Verse>
+    <Verse HEB="2222224012220">1CH 14:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22201130042122">2SA 5:13</Verse>
+    <Verse HEB="2221141222">1CH 14:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221125222">2SA 5:14</Verse>
+    <Verse HEB="2124222300">1CH 3:5</Verse>
+    <Verse HEB="2211125212">1CH 14:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222">2SA 5:15</Verse>
+    <Verse HEB="212222">1CH 3:6-7</Verse>
+    <Verse HEB="222222">1CH 14:5-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220">2SA 5:16</Verse>
+    <Verse HEB="2220">1CH 3:8</Verse>
+    <Verse HEB="222">1CH 14:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22422152225200">2SA 5:17</Verse>
+    <Verse HEB="22422152225200">1CH 14:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122">2SA 5:18</Verse>
+    <Verse HEB="22122">1CH 14:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212511252151112">2SA 5:19</Verse>
+    <Verse HEB="221251012512512">1CH 14:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122225212122512222">2SA 5:20</Verse>
+    <Verse HEB="1222250212122512222">1CH 14:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="210000">2SA 5:21</Verse>
+    <Verse HEB="2100000">1CH 14:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220110">2SA 5:22</Verse>
+    <Verse HEB="22211">1CH 14:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221522515221">2SA 5:23</Verse>
+    <Verse HEB="2021500220515221">1CH 14:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20221222041112212">2SA 5:24</Verse>
+    <Verse HEB="222122200412212">1CH 14:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220221411110">2SA 5:25</Verse>
+    <Verse HEB="2222141111">1CH 14:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="012100115222252020220">2SA 6:2</Verse>
+    <Verse HEB="121100015222252222">1CH 13:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212322002200210300000000000">2SA 6:3-4</Verse>
+    <Verse HEB="22212522221">1CH 13:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21122141122211">2SA 6:5</Verse>
+    <Verse HEB="212214122211">1CH 13:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221220011222">2SA 6:6</Verse>
+    <Verse HEB="22122011222">1CH 13:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221200022111">2SA 6:7</Verse>
+    <Verse HEB="221200002211">1CH 13:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2211122152221222">2SA 6:8</Verse>
+    <Verse HEB="22122152221222">1CH 13:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122411221">2SA 6:9</Verse>
+    <Verse HEB="221224112221">1CH 13:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1212101250122">2SA 6:10</Verse>
+    <Verse HEB="1212125122">1CH 13:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22112202252111">2SA 6:11</Verse>
+    <Verse HEB="221122022521110">1CH 13:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000300042421222002">2SA 6:12</Verse>
+    <Verse HEB="12000014212220">1CH 15:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2002100111">2SA 6:13</Verse>
+    <Verse HEB="20002111111">1CH 15:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211004122">2SA 6:14</Verse>
+    <Verse HEB="211130003000422">1CH 15:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111221222">2SA 6:15</Verse>
+    <Verse HEB="122122230000">1CH 15:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122212522225221100522">2SA 6:16</Verse>
+    <Verse HEB="120221252222522115220">1CH 15:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122052222402212">2SA 6:17</Verse>
+    <Verse HEB="221225222242221">1CH 16:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252220">2SA 6:18</Verse>
+    <Verse HEB="222225222">1CH 16:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211212511020203000">2SA 6:19</Verse>
+    <Verse HEB="212125122">1CH 16:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21123000512241222151011">2SA 7:1-2</Verse>
+    <Verse HEB="211125122422215111">1CH 17:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222022120">2SA 7:3</Verse>
+    <Verse HEB="22122222120">1CH 17:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222122">2SA 7:4</Verse>
+    <Verse HEB="2222122">1CH 17:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122221211">2SA 7:5</Verse>
+    <Verse HEB="222122211211">1CH 17:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222111102222111">2SA 7:6</Verse>
+    <Verse HEB="222211111222111">1CH 17:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22115221252220252222">2SA 7:7</Verse>
+    <Verse HEB="221522125222252222">1CH 17:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222222422221">2SA 7:8</Verse>
+    <Verse HEB="2222052222224222221">1CH 17:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222242252202222">2SA 7:9</Verse>
+    <Verse HEB="222224225222222">1CH 17:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222152222252222">2SA 7:10</Verse>
+    <Verse HEB="222152222252222">1CH 17:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222411422110">2SA 7:11</Verse>
+    <Verse HEB="1222224142112">1CH 17:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1121152251121">2SA 7:12</Verse>
+    <Verse HEB="1121152251121">1CH 17:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2115112">2SA 7:13</Verse>
+    <Verse HEB="211512">1CH 17:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222300000005112240101">2SA 7:14-15</Verse>
+    <Verse HEB="22222251122411">1CH 17:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222200000000000000000">2SA 7:14</Verse>
+    <Verse GRK="0212221122100000">2CO 6:18</Verse>
+    <Verse GRK="000000000000000022222222222">HEB 1:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111201222">2SA 7:16</Verse>
+    <Verse HEB="11121222">1CH 17:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221222220">2SA 7:17</Verse>
+    <Verse HEB="22221222220">1CH 17:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222225111152222">2SA 7:18</Verse>
+    <Verse HEB="222222511152222">1CH 17:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202211501231211">2SA 7:19</Verse>
+    <Verse HEB="2221512312011">1CH 17:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1220252200">2SA 7:20</Verse>
+    <Verse HEB="122200522">1CH 17:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222251">2SA 7:21</Verse>
+    <Verse HEB="0212222251">1CH 17:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="001112522222">2SA 7:22</Verse>
+    <Verse HEB="112522222">1CH 17:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122251214120012422220220">2SA 7:23</Verse>
+    <Verse HEB="22122251122141212422222">1CH 17:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1022222522220">2SA 7:24</Verse>
+    <Verse HEB="12222252222">1CH 17:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2202222242222">2SA 7:25</Verse>
+    <Verse HEB="222222242222">1CH 17:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225211522022">2SA 7:26</Verse>
+    <Verse HEB="022225211005222">1CH 17:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2001122202152202100">2SA 7:27</Verse>
+    <Verse HEB="22122211252221">1CH 17:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211220005122">2SA 7:28</Verse>
+    <Verse HEB="21225122">1CH 17:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21122222511011000">2SA 7:29</Verse>
+    <Verse HEB="21122222511100">1CH 17:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222200022">2SA 8:1</Verse>
+    <Verse HEB="22222220022">1CH 18:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2230000300300422122">2SA 8:2</Verse>
+    <Verse HEB="22421222">1CH 18:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22202221222">2SA 8:3</Verse>
+    <Verse HEB="222202122">1CH 18:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221222225222222">2SA 8:4</Verse>
+    <Verse HEB="2222011222225222222">1CH 18:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1212222222222">2SA 8:5</Verse>
+    <Verse HEB="1212222222222">1CH 18:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22021122122221222">2SA 8:6</Verse>
+    <Verse HEB="2221122122221222">1CH 18:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222212222">2SA 8:7</Verse>
+    <Verse HEB="222222212222">1CH 18:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222022120">2SA 8:8</Verse>
+    <Verse HEB="1122222123000000000">1CH 18:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122222222">2SA 8:9</Verse>
+    <Verse HEB="2122222220">1CH 18:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20125222222522122301111">2SA 8:10</Verse>
+    <Verse HEB="2123222222252212231111">1CH 18:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522120042222230000">2SA 8:11-12</Verse>
+    <Verse HEB="2222252212422222">1CH 18:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000111222">2SA 8:13</Verse>
+    <Verse HEB="001111222">1CH 18:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220004222522222">2SA 8:14</Verse>
+    <Verse HEB="2224222522222">1CH 18:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222502222">2SA 8:15</Verse>
+    <Verse HEB="22252222">1CH 18:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2012225001202522100000">2SA 8:16-18</Verse>
+    <Verse HEB="20102202130222302212">2SA 20:23-25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">2SA 8:16</Verse>
+    <Verse HEB="222522">1CH 18:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212212">2SA 8:17</Verse>
+    <Verse HEB="2212212">1CH 18:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222000">2SA 8:18</Verse>
+    <Verse HEB="221220000">1CH 18:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2252225022">2SA 10:1</Verse>
+    <Verse HEB="225022522">1CH 19:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222224122252211522122">2SA 10:2</Verse>
+    <Verse HEB="222224222521215221200">1CH 19:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221052222225211114112">2SA 10:3</Verse>
+    <Verse HEB="222152222225211114120">1CH 19:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222111522112">2SA 10:4</Verse>
+    <Verse HEB="2222152212">1CH 19:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252225222422">2SA 10:5</Verse>
+    <Verse HEB="022022522252224122">1CH 19:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222115150000000300000000">2SA 10:6</Verse>
+    <Verse HEB="22221150110000000000050000000030000000000">1CH 19:6-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212">2SA 10:7</Verse>
+    <Verse HEB="2222212">1CH 19:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222211111122">2SA 10:8</Verse>
+    <Verse HEB="22222211122">1CH 19:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221151120222">2SA 10:9</Verse>
+    <Verse HEB="2222211512222">1CH 19:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222224222">2SA 10:10</Verse>
+    <Verse HEB="22222224222">1CH 19:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222215222111">2SA 10:11</Verse>
+    <Verse HEB="2222221052221">1CH 19:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122222222">2SA 10:12</Verse>
+    <Verse HEB="2122222222">1CH 19:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222122">2SA 10:13</Verse>
+    <Verse HEB="222211222">1CH 19:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222221510200022">2SA 10:14</Verse>
+    <Verse HEB="2222220210512220">1CH 19:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122004012222004222">2SA 10:15-16</Verse>
+    <Verse HEB="22212240122224222">1CH 19:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220225221412152">2SA 10:17</Verse>
+    <Verse HEB="22225221301121052">1CH 19:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212522112521511010">2SA 10:18</Verse>
+    <Verse HEB="221252211252115111">1CH 19:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202252225114222220">2SA 10:19</Verse>
+    <Verse HEB="2225222511422220">1CH 19:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212221300000411115220">2SA 11:1</Verse>
+    <Verse HEB="211222130004110115223000">1CH 20:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22224221252252222">2SA 12:30</Verse>
+    <Verse HEB="2022241201252252222">1CH 20:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22242221030005222252222">2SA 12:31</Verse>
+    <Verse HEB="2224222152022252222">1CH 20:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221112522211110">2SA 21:18</Verse>
+    <Verse HEB="22111252221110">1CH 20:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="210152111112252220">2SA 21:19</Verse>
+    <Verse HEB="211521111225222">1CH 20:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225211411122220511">2SA 21:20</Verse>
+    <Verse HEB="2225214222511">1CH 20:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221122">2SA 21:21</Verse>
+    <Verse HEB="2222122">1CH 20:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0111222220">2SA 21:22</Verse>
+    <Verse HEB="11122220">1CH 20:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222222222212">2SA 22:1</Verse>
+    <Verse HEB="00010122222222212">PSA 18:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222112222220000">2SA 22:2-3</Verse>
+    <Verse HEB="20002221122222">PSA 18:2-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">2SA 22:4</Verse>
+    <Verse HEB="22222">PSA 18:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="021422">2SA 22:5</Verse>
+    <Verse HEB="21422">PSA 18:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252">2SA 22:6</Verse>
+    <Verse HEB="222522">PSA 18:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222142222">2SA 22:7</Verse>
+    <Verse HEB="222214222002">PSA 18:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122412522">2SA 22:8</Verse>
+    <Verse HEB="122412522">PSA 18:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522522">2SA 22:9</Verse>
+    <Verse HEB="22252522">PSA 18:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">2SA 22:10</Verse>
+    <Verse HEB="222522">PSA 18:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22242">2SA 22:11</Verse>
+    <Verse HEB="22242">PSA 18:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1221422">2SA 22:12</Verse>
+    <Verse HEB="12021422">PSA 18:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2211">2SA 22:13</Verse>
+    <Verse HEB="220101">PSA 18:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112522">2SA 22:14</Verse>
+    <Verse HEB="11252230">PSA 18:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212410">2SA 22:15</Verse>
+    <Verse HEB="212401">PSA 18:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22142212521">2SA 22:16</Verse>
+    <Verse HEB="22142212521">PSA 18:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">2SA 22:17</Verse>
+    <Verse HEB="222522">PSA 18:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2224222">2SA 22:18</Verse>
+    <Verse HEB="222422">PSA 18:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225212">2SA 22:19</Verse>
+    <Verse HEB="22512">PSA 18:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121522">2SA 22:20</Verse>
+    <Verse HEB="125222">PSA 18:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212222">2SA 22:21</Verse>
+    <Verse HEB="2212222">PSA 18:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522">2SA 22:22</Verse>
+    <Verse HEB="22252">PSA 18:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2112511">2SA 22:23</Verse>
+    <Verse HEB="212511">PSA 18:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22142">2SA 22:24</Verse>
+    <Verse HEB="22142">PSA 18:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221422">2SA 22:25</Verse>
+    <Verse HEB="2214122">PSA 18:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22422">2SA 22:26</Verse>
+    <Verse HEB="22422">PSA 18:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2151">2SA 22:27</Verse>
+    <Verse HEB="2151">PSA 18:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112412">2SA 22:28</Verse>
+    <Verse HEB="112412">PSA 18:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222422">2SA 22:29</Verse>
+    <Verse HEB="2022422">PSA 18:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222242">2SA 22:30</Verse>
+    <Verse HEB="22242">PSA 18:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252252222">2SA 22:31</Verse>
+    <Verse HEB="2225252222">PSA 18:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21225212">2SA 22:32</Verse>
+    <Verse HEB="211225212">PSA 18:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2124202">2SA 22:33</Verse>
+    <Verse HEB="212422">PSA 18:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2022522">2SA 22:34</Verse>
+    <Verse HEB="222522">PSA 18:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222422">2SA 22:35</Verse>
+    <Verse HEB="222422">PSA 18:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212">2SA 22:36</Verse>
+    <Verse HEB="2220042">PSA 18:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">2SA 22:37</Verse>
+    <Verse HEB="222522">PSA 18:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121522">2SA 22:38</Verse>
+    <Verse HEB="12152">PSA 18:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0111422">2SA 22:39</Verse>
+    <Verse HEB="111422">PSA 18:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122522">2SA 22:40</Verse>
+    <Verse HEB="122522">PSA 18:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222241">2SA 22:41</Verse>
+    <Verse HEB="222241">PSA 18:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122422">2SA 22:42</Verse>
+    <Verse HEB="12422">PSA 18:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21511">2SA 22:43</Verse>
+    <Verse HEB="210521">PSA 18:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121422522">2SA 22:44</Verse>
+    <Verse HEB="121422522">PSA 18:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2214222">2SA 22:45</Verse>
+    <Verse HEB="122251">PSA 18:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22242">2SA 22:46</Verse>
+    <Verse HEB="2242">PSA 18:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225202">2SA 22:47</Verse>
+    <Verse HEB="222522">PSA 18:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222322">2SA 22:48</Verse>
+    <Verse HEB="2222322">PSA 18:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0242512">2SA 22:49</Verse>
+    <Verse HEB="02312512">PSA 18:49</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222251">2SA 22:50</Verse>
+    <Verse HEB="222251">PSA 18:50</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222525220">2SA 22:51</Verse>
+    <Verse HEB="2122522522">PSA 18:51</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112224112141111122020">2SA 23:8</Verse>
+    <Verse HEB="1122241211411222">1CH 11:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02211140220422000">2SA 23:9</Verse>
+    <Verse HEB="22110420200422300003000">1CH 11:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000300422215122">2SA 23:11</Verse>
+    <Verse HEB="0000300422215122">1CH 11:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1214212220">2SA 23:12</Verse>
+    <Verse HEB="121421222">1CH 11:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202223122242222">2SA 23:13</Verse>
+    <Verse HEB="2222422242222">1CH 11:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212212">2SA 23:14</Verse>
+    <Verse HEB="22212212">1CH 11:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222222">2SA 23:15</Verse>
+    <Verse HEB="11222222222">1CH 11:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2102252222522522122">2SA 23:16</Verse>
+    <Verse HEB="212252222522502122">1CH 11:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222112521252222220">2SA 23:17</Verse>
+    <Verse HEB="222112520000215222222">1CH 11:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1220220252222222">2SA 23:18</Verse>
+    <Verse HEB="122022522222022">1CH 11:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202222222">2SA 23:19</Verse>
+    <Verse HEB="202222222">1CH 11:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121122522222522112222">2SA 23:20</Verse>
+    <Verse HEB="1212252222252212222">1CH 11:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211020522222522222">2SA 23:21</Verse>
+    <Verse HEB="211200052200222522222">1CH 11:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">2SA 23:22</Verse>
+    <Verse HEB="2222222">1CH 11:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222210">2SA 23:23</Verse>
+    <Verse HEB="2020222210">1CH 11:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2202212">2SA 23:24</Verse>
+    <Verse HEB="0022222120">1CH 11:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12300515220">2SA 23:25-26</Verse>
+    <Verse HEB="12510522300">1CH 11:27-28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22420">2SA 23:27</Verse>
+    <Verse HEB="10052042400">1CH 11:28-29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12520">2SA 23:28</Verse>
+    <Verse HEB="00420523000">1CH 11:29-30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1220522222">2SA 23:29</Verse>
+    <Verse HEB="00422052222230">1CH 11:30-31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211222">2SA 23:30</Verse>
+    <Verse HEB="000000511222300">1CH 11:31-32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12210">2SA 23:31</Verse>
+    <Verse HEB="000042021300">1CH 11:32-33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="225120">2SA 23:32</Verse>
+    <Verse HEB="005205102300">1CH 11:33-34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022120">2SA 23:33</Verse>
+    <Verse HEB="0000020512300">1CH 11:34-35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11101110">2SA 23:34</Verse>
+    <Verse HEB="00041011110">1CH 11:35-36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202110">2SA 23:35</Verse>
+    <Verse HEB="22110">1CH 11:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1110110">2SA 23:36</Verse>
+    <Verse HEB="111110">1CH 11:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22022022220">2SA 23:37</Verse>
+    <Verse HEB="222222220">1CH 11:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">2SA 23:38</Verse>
+    <Verse HEB="22222">1CH 11:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220000">2SA 23:39</Verse>
+    <Verse HEB="22000">1CH 11:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111152000120">2SA 24:1</Verse>
+    <Verse HEB="1115212">1CH 21:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212003001114111110">2SA 24:2</Verse>
+    <Verse HEB="212003111113011">1CH 21:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22012012022300412111">2SA 24:3</Verse>
+    <Verse HEB="2212122230000051113000">1CH 21:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111000520000000">2SA 24:4</Verse>
+    <Verse HEB="111520000">1CH 21:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222214101212241122">2SA 24:9</Verse>
+    <Verse HEB="2222141001212241102200">1CH 21:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000521222250222222">2SA 24:10</Verse>
+    <Verse HEB="22122220052222220">1CH 21:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00004020222">2SA 24:11</Verse>
+    <Verse HEB="112222">1CH 21:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222512212">2SA 24:12</Verse>
+    <Verse HEB="122022225122112">1CH 21:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22022411220421100412114012220">2SA 24:13</Verse>
+    <Verse HEB="22222300422421100042001100000412220">1CH 21:11-12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221250221">2SA 24:14</Verse>
+    <Verse HEB="222221252021">1CH 21:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222200041000222">2SA 24:15</Verse>
+    <Verse HEB="222241222">1CH 21:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="201115015220222252120120">2SA 24:16</Verse>
+    <Verse HEB="201110005152222225212120">1CH 21:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221000030000052225222220">2SA 24:17</Verse>
+    <Verse HEB="2213000030005222005222220000">1CH 21:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00001141222012">2SA 24:18</Verse>
+    <Verse HEB="000011040122212">1CH 21:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221112">2SA 24:19</Verse>
+    <Verse HEB="2211112">1CH 21:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1121000205122">2SA 24:20</Verse>
+    <Verse HEB="0001121205122">1CH 21:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000521111225222">2SA 24:21</Verse>
+    <Verse HEB="22010212200005222">1CH 21:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21241222025212002300000300000">2SA 24:22-23</Verse>
+    <Verse HEB="2124122225021223000">1CH 21:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222014120123000000">2SA 24:24</Verse>
+    <Verse HEB="2201222114102112300000000">1CH 21:24-25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222223000000">2SA 24:25</Verse>
+    <Verse HEB="22222222300000000">1CH 21:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220222222222200">1KI 2:11</Verse>
+    <Verse HEB="22222222222220">1CH 29:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1110000000000000">1KI 3:4</Verse>
+    <Verse HEB="11000010000000000">2CH 1:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02111150222">1KI 3:5</Verse>
+    <Verse HEB="1121150222">2CH 1:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222211222300000003000300000">1KI 3:6</Verse>
+    <Verse HEB="22022122230">2CH 1:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221000000300000000000400000">1KI 3:7-8</Verse>
+    <Verse HEB="221000003001100">2CH 1:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000005211212">1KI 3:9</Verse>
+    <Verse HEB="00000000512210">2CH 1:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000">1KI 3:10</Verse>
+    <Verse HEB="000000000000000000000000000">2CH 1:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000000000000001211220000">1KI 3:12-13</Verse>
+    <Verse HEB="00121010220000000">2CH 1:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000052000030000000">1KI 3:15</Verse>
+    <Verse HEB="20002300000">2CH 1:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0102222012020000000">1KI 5:25</Verse>
+    <Verse HEB="000012012220000000020200">2CH 2:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000002200022100111">1KI 6:1</Verse>
+    <Verse HEB="00110000000000000000220221">2CH 3:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2020212222000">1KI 6:2</Verse>
+    <Verse HEB="002221200022202">2CH 3:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220022222200000">1KI 6:3</Verse>
+    <Verse HEB="202222220000000">2CH 3:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212311512311512">1KI 7:21</Verse>
+    <Verse HEB="2212411151024120">2CH 3:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225221225223222222">1KI 7:23</Verse>
+    <Verse HEB="222522122522522222">2CH 4:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1112225222242121">1KI 7:24</Verse>
+    <Verse HEB="111102225222242121">2CH 4:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222252222252222252">1KI 7:25</Verse>
+    <Verse HEB="212222252222252222252">2CH 4:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222214120">1KI 7:26</Verse>
+    <Verse HEB="2222221311120">2CH 4:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211225221522211">1KI 7:40</Verse>
+    <Verse HEB="21122052021522211">2CH 4:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2211122522222222">1KI 7:41</Verse>
+    <Verse HEB="2211122522222222">2CH 4:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212222222222">1KI 7:42</Verse>
+    <Verse HEB="22222112222222222">2CH 4:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21212">1KI 7:43</Verse>
+    <Verse HEB="21212">2CH 4:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212211">1KI 7:44</Verse>
+    <Verse HEB="21221">2CH 4:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2214100321221251">1KI 7:45</Verse>
+    <Verse HEB="2214511221251">2CH 4:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222122221">1KI 7:46</Verse>
+    <Verse HEB="2222122221">2CH 4:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1211022222">1KI 7:47</Verse>
+    <Verse HEB="121112022220">2CH 4:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221422111220">1KI 7:48</Verse>
+    <Verse HEB="22222214221122">2CH 4:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2000052225222">1KI 7:49</Verse>
+    <Verse HEB="200052225222300">2CH 4:20-21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022222241212212220">1KI 7:50</Verse>
+    <Verse HEB="2222224211221222">2CH 4:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222202125222242122210">1KI 7:51</Verse>
+    <Verse HEB="22221205222242122210">2CH 5:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222224222521115222222">1KI 8:1</Verse>
+    <Verse HEB="2222242225215222222">2CH 5:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22052002522">1KI 8:2</Verse>
+    <Verse HEB="22522522">2CH 5:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212">1KI 8:3</Verse>
+    <Verse HEB="2222212">2CH 5:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2112252224221">1KI 8:4</Verse>
+    <Verse HEB="212252224221">2CH 5:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222202252222222">1KI 8:5</Verse>
+    <Verse HEB="2222222252222222">2CH 5:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225221222">1KI 8:6</Verse>
+    <Verse HEB="222225221222">2CH 5:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02221242222">1KI 8:7</Verse>
+    <Verse HEB="02221242222">2CH 5:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212252211222">1KI 8:8</Verse>
+    <Verse HEB="222221225221222">2CH 5:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222101112252222211">1KI 8:9</Verse>
+    <Verse HEB="2222112252222210">2CH 5:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222210">1KI 8:11</Verse>
+    <Verse HEB="22222222210">2CH 5:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">1KI 8:12</Verse>
+    <Verse HEB="2222222">2CH 6:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02222122">1KI 8:13</Verse>
+    <Verse HEB="0222122">2CH 6:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222">1KI 8:14</Verse>
+    <Verse HEB="2222222222">2CH 6:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522222422">1KI 8:15</Verse>
+    <Verse HEB="22222522222422">2CH 6:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222201522222252222222">1KI 8:16</Verse>
+    <Verse HEB="22221152222222223000000052222222">2CH 6:5-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222">1KI 8:17</Verse>
+    <Verse HEB="2222222222">2CH 6:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222225222222">1KI 8:18</Verse>
+    <Verse HEB="222222225222222">2CH 6:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225122522">1KI 8:19</Verse>
+    <Verse HEB="222225122522">2CH 6:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222522222522222">1KI 8:20</Verse>
+    <Verse HEB="222222222522222522222">2CH 6:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220122252100000">1KI 8:21</Verse>
+    <Verse HEB="2212225211">2CH 6:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20222222220">1KI 8:22</Verse>
+    <Verse HEB="222222222">2CH 6:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20000222221">1KI 8:22</Verse>
+    <Verse HEB="00000000003000005000222221">2CH 6:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222220005222222">1KI 8:23</Verse>
+    <Verse HEB="222222205222222">2CH 6:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222522222">1KI 8:24</Verse>
+    <Verse HEB="22222222522222">2CH 6:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222222225222222252250222">1KI 8:25</Verse>
+    <Verse HEB="22225222222225222222252250222">2CH 6:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222200222210">1KI 8:26</Verse>
+    <Verse HEB="2022222221">2CH 6:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222252222">1KI 8:27</Verse>
+    <Verse HEB="000032222130011000">2CH 2:5</Verse>
+    <Verse HEB="22220251222252222">2CH 6:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252222220">1KI 8:28</Verse>
+    <Verse HEB="2222225222222">2CH 6:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222115221125222222">1KI 8:29</Verse>
+    <Verse HEB="22222115221125222222">2CH 6:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122222225212122">1KI 8:30</Verse>
+    <Verse HEB="2122222225212122">2CH 6:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11122222222222">1KI 8:31</Verse>
+    <Verse HEB="122222222222">2CH 6:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122241222522222">1KI 8:32</Verse>
+    <Verse HEB="22122241222522222">2CH 6:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222212502222122">1KI 8:33</Verse>
+    <Verse HEB="122221252222122">2CH 6:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212222522210">1KI 8:34</Verse>
+    <Verse HEB="2212222522110">2CH 6:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212252222521222">1KI 8:35</Verse>
+    <Verse HEB="212252222521222">2CH 6:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222225212225222222">1KI 8:36</Verse>
+    <Verse HEB="222222225212225222222">2CH 6:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222221522212221">1KI 8:37</Verse>
+    <Verse HEB="222222221522212221">2CH 6:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212422222115222">1KI 8:38</Verse>
+    <Verse HEB="22212422222115222">2CH 6:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212223222222522212">1KI 8:39</Verse>
+    <Verse HEB="2212225222225222212">2CH 6:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225222522">1KI 8:40</Verse>
+    <Verse HEB="2200252225220">2CH 6:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252222300222224122">1KI 8:41-42</Verse>
+    <Verse HEB="222222252222252224122">2CH 6:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12112522225222212225222222">1KI 8:43</Verse>
+    <Verse HEB="12112522225222212225222222">2CH 6:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212225122222522">1KI 8:44</Verse>
+    <Verse HEB="222122251220222522">2CH 6:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222">1KI 8:45</Verse>
+    <Verse HEB="212222">2CH 6:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222225220222">1KI 8:46</Verse>
+    <Verse HEB="222222222222522222">2CH 6:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522212511">1KI 8:47</Verse>
+    <Verse HEB="22222522212511">2CH 6:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212220222224221111">1KI 8:48</Verse>
+    <Verse HEB="22222122222222422111">2CH 6:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21122152222230000000">1KI 8:49-50</Verse>
+    <Verse HEB="211221522222">2CH 6:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2112222">1KI 8:62</Verse>
+    <Verse HEB="2122220">2CH 7:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222000042222222521201">1KI 8:63</Verse>
+    <Verse HEB="20224222222252121">2CH 7:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0011222225210222522000422111">1KI 8:64</Verse>
+    <Verse HEB="112222252122252200004221">2CH 7:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522222223000000000">1KI 8:65</Verse>
+    <Verse HEB="2222200522202222">2CH 7:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22220032222115222022">1KI 8:66</Verse>
+    <Verse HEB="02203000000003000022522215222022">2CH 7:9-10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="01202225121120">1KI 9:1</Verse>
+    <Verse HEB="122222511220000">2CH 7:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222000005012203000000030000000">1KI 9:2-3</Verse>
+    <Verse HEB="22205122300000">2CH 7:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000002220012222222">1KI 9:3</Verse>
+    <Verse HEB="0022212222222">2CH 7:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222004222122">1KI 9:4</Verse>
+    <Verse HEB="22222224222122">2CH 7:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2210051122522111">1KI 9:5</Verse>
+    <Verse HEB="22215112252211">2CH 7:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112004112222522222">1KI 9:6</Verse>
+    <Verse HEB="12421222522222">2CH 7:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11211222522212241222">1KI 9:7</Verse>
+    <Verse HEB="111222502221224222">2CH 7:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22121220412222222">1KI 9:8</Verse>
+    <Verse HEB="22012122412222222">2CH 7:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222151122222322252022222">1KI 9:9</Verse>
+    <Verse HEB="222221151222225225222222">2CH 7:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222002211">1KI 9:10</Verse>
+    <Verse HEB="2222222221">2CH 8:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="200221">1KI 9:17</Verse>
+    <Verse HEB="200022130000">2CH 8:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2000052222251222251222252222">1KI 9:18-19</Verse>
+    <Verse HEB="252222251222251222252222">2CH 8:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22111122112">1KI 9:20</Verse>
+    <Verse HEB="22111122112">2CH 8:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222221221521222">1KI 9:21</Verse>
+    <Verse HEB="122222122521222">2CH 8:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222215210412220">1KI 9:22</Verse>
+    <Verse HEB="2202210521142220">2CH 8:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1221012112200">1KI 9:23</Verse>
+    <Verse HEB="1202112122">2CH 8:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11122122300">1KI 9:24</Verse>
+    <Verse HEB="11022122300000003000000">2CH 8:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="002220000003000011">1KI 9:25</Verse>
+    <Verse HEB="0000000022200000000000001110">2CH 8:13,16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11121112122">1KI 9:26</Verse>
+    <Verse HEB="112112122">2CH 8:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11110221522222222125222">1KI 9:27-28</Verse>
+    <Verse HEB="1110202152222221225222">2CH 8:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21220051230222422215222512222">1KI 10:1-2</Verse>
+    <Verse HEB="212251123222422215222512222">2CH 9:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212112222">1KI 10:3</Verse>
+    <Verse HEB="2221212222">2CH 9:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212222">1KI 10:4</Verse>
+    <Verse HEB="22212222">2CH 9:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222220222122222222">1KI 10:5</Verse>
+    <Verse HEB="222222220122222222">2CH 9:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220222222">1KI 10:6</Verse>
+    <Verse HEB="222222222">2CH 9:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222521110122">1KI 10:7</Verse>
+    <Verse HEB="2122225221011122">2CH 9:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212222212">1KI 10:8</Verse>
+    <Verse HEB="2212222212">2CH 9:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222211512212222">1KI 10:9</Verse>
+    <Verse HEB="22222222100051202112222">2CH 9:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222221222122002222">1KI 10:10</Verse>
+    <Verse HEB="2222222122211222222">2CH 9:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11212210210022">1KI 10:11</Verse>
+    <Verse HEB="1200012212122">2CH 9:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211222222000011000">1KI 10:12</Verse>
+    <Verse HEB="2221122222210000">2CH 9:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222500000052220">1KI 10:13</Verse>
+    <Verse HEB="2222222500052220">2CH 9:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222221211">1KI 10:14</Verse>
+    <Verse HEB="2222222221211">2CH 9:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222112122">1KI 10:15</Verse>
+    <Verse HEB="2221121220000">2CH 9:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">1KI 10:16</Verse>
+    <Verse HEB="22222222220222">2CH 9:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222112222221222">1KI 10:17</Verse>
+    <Verse HEB="2222112222221222">2CH 9:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221">1KI 10:18</Verse>
+    <Verse HEB="2222221">2CH 9:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1220212221222222">1KI 10:19</Verse>
+    <Verse HEB="12200212221222222">2CH 9:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222222221">1KI 10:20</Verse>
+    <Verse HEB="221222222221">2CH 9:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222202222">1KI 10:21</Verse>
+    <Verse HEB="222222222222222222">2CH 9:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11220211222112122222">1KI 10:22</Verse>
+    <Verse HEB="12022112221121222220">2CH 9:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222221">1KI 10:23</Verse>
+    <Verse HEB="22222221">2CH 9:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222212">1KI 10:24</Verse>
+    <Verse HEB="10122222212">2CH 9:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222221222220">1KI 10:25</Verse>
+    <Verse HEB="2222222221222220">2CH 9:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222212222">1KI 10:26</Verse>
+    <Verse HEB="2222222222212222">2CH 1:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">1KI 10:27</Verse>
+    <Verse HEB="222022222222">2CH 1:15</Verse>
+    <Verse HEB="22222222222">2CH 9:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">1KI 10:28</Verse>
+    <Verse HEB="22222222222">2CH 1:16</Verse>
+    <Verse HEB="11221">2CH 9:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112222222252212220">1KI 10:29</Verse>
+    <Verse HEB="11222222225221222">2CH 1:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12200022110">1KI 11:41</Verse>
+    <Verse HEB="1220022100000000000">2CH 9:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00122222">1KI 11:42</Verse>
+    <Verse HEB="122222">2CH 9:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122222220">1KI 11:43</Verse>
+    <Verse HEB="222122222220">2CH 9:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221221222">1KI 12:1</Verse>
+    <Verse HEB="221221222">2CH 10:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222220222222121">1KI 12:2</Verse>
+    <Verse HEB="22222222222121">2CH 10:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2202211222">1KI 12:3</Verse>
+    <Verse HEB="22221222">2CH 10:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211222222222">1KI 12:4</Verse>
+    <Verse HEB="2221222222222">2CH 10:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2202122212">1KI 12:5</Verse>
+    <Verse HEB="2221222120">2CH 10:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222122222222212">1KI 12:6</Verse>
+    <Verse HEB="222222122222222212">2CH 10:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022211121122222222">1KI 12:7</Verse>
+    <Verse HEB="2221112122222222">2CH 10:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222022">1KI 12:8</Verse>
+    <Verse HEB="222222222222">2CH 10:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222222">1KI 12:9</Verse>
+    <Verse HEB="222222222222222222">2CH 10:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222222022222222222122222">1KI 12:10</Verse>
+    <Verse HEB="2122222222222222222122222">2CH 10:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222002">1KI 12:11</Verse>
+    <Verse HEB="2222222222222220">2CH 10:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022222222222222">1KI 12:12</Verse>
+    <Verse HEB="22222222222222">2CH 10:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121222200">1KI 12:13</Verse>
+    <Verse HEB="122200222">2CH 10:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222201222122222002">1KI 12:14</Verse>
+    <Verse HEB="2222212221222222">2CH 10:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222212122222221222">1KI 12:15</Verse>
+    <Verse HEB="222212122222221222">2CH 10:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0122212220222222222222212">1KI 12:16</Verse>
+    <Verse HEB="1222122222222202222222120">2CH 10:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222220">1KI 12:17</Verse>
+    <Verse HEB="22222222">2CH 10:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122212222222222">1KI 12:18</Verse>
+    <Verse HEB="222122212222222220">2CH 10:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">1KI 12:19</Verse>
+    <Verse HEB="22222222">2CH 10:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02222121122222221121200211120">1KI 12:21-22</Verse>
+    <Verse HEB="222212122222221212021120">2CH 11:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222211200222222202222222220021000">1KI 12:23-24</Verse>
+    <Verse HEB="2222211122222222222222222002100">2CH 11:3-4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="201022222222222222222222222">1KI 14:21</Verse>
+    <Verse HEB="00201022222222222222222222222">2CH 12:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222220222">1KI 14:25</Verse>
+    <Verse HEB="222222222000">2CH 12:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252222512222">1KI 14:26</Verse>
+    <Verse HEB="000052252222512222">2CH 12:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222">1KI 14:27</Verse>
+    <Verse HEB="22222222222222">2CH 12:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212222">1KI 14:28</Verse>
+    <Verse HEB="22222021222">2CH 12:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112002200000000000">1KI 14:29-30</Verse>
+    <Verse HEB="1200220000000000">2CH 12:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222022000021220">1KI 14:31</Verse>
+    <Verse HEB="22222221220">2CH 12:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222220112">1KI 15:1</Verse>
+    <Verse HEB="22222112">2CH 13:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222200">1KI 15:2</Verse>
+    <Verse HEB="222222000000000">2CH 13:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222222220">1KI 15:8</Verse>
+    <Verse HEB="21222222222000000">2CH 13:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212200">1KI 15:11</Verse>
+    <Verse HEB="2211220">2CH 14:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22112522522522">1KI 15:13</Verse>
+    <Verse HEB="2110125225220522">2CH 15:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22522202">1KI 15:14</Verse>
+    <Verse HEB="22052222">2CH 15:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220121222">1KI 15:15</Verse>
+    <Verse HEB="222121222">2CH 15:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">1KI 15:16</Verse>
+    <Verse HEB="222222220">1KI 15:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222222222">1KI 15:17</Verse>
+    <Verse HEB="000001222222222222">2CH 16:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121101211020010020022222">1KI 15:18</Verse>
+    <Verse HEB="1211122121222222">2CH 16:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212222220222122222">1KI 15:19</Verse>
+    <Verse HEB="22212222222221222222">2CH 16:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222221212222121112">1KI 15:20</Verse>
+    <Verse HEB="222222222121222212112">2CH 16:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222210">1KI 15:21</Verse>
+    <Verse HEB="222222100">2CH 16:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11121122222222200202">1KI 15:22</Verse>
+    <Verse HEB="1112222222222220">2CH 16:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="01000000022001101111">1KI 15:23</Verse>
+    <Verse HEB="0110002211010111110000000">2CH 16:11-12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221022000000">1KI 15:24</Verse>
+    <Verse HEB="2220000010002200000000000000">2CH 16:13-14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222222222">1KI 19:10</Verse>
+    <Verse HEB="2222222222222222222220">1KI 19:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000002222022220011112222200">1KI 19:10</Verse>
+    <Verse GRK="02222222211122222">ROM 11:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0100111411111113000000">1KI 19:18</Verse>
+    <Verse GRK="0000004011411111">ROM 11:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0002001100000000000000">1KI 22:2-3</Verse>
+    <Verse HEB="20010000000000000">2CH 18:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22210225011221100">1KI 22:4</Verse>
+    <Verse HEB="200200212251221100">2CH 18:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">1KI 22:5</Verse>
+    <Verse HEB="22222222">2CH 18:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221222211222222122">1KI 22:6</Verse>
+    <Verse HEB="2221222211222222122">2CH 18:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222">1KI 22:7</Verse>
+    <Verse HEB="222222222">2CH 18:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222221121212222222">1KI 22:8</Verse>
+    <Verse HEB="2222222222112121102222222">2CH 18:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222122">1KI 22:9</Verse>
+    <Verse HEB="2222221022">2CH 18:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222222">1KI 22:10</Verse>
+    <Verse HEB="22222222202222222">2CH 18:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212222222222">1KI 22:11</Verse>
+    <Verse HEB="2212222222222">2CH 18:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">1KI 22:12</Verse>
+    <Verse HEB="222222222222">2CH 18:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122212222210211222">1KI 22:13</Verse>
+    <Verse HEB="2221222122222121222">2CH 18:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221022">1KI 22:14</Verse>
+    <Verse HEB="22222122">2CH 18:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222215222150111011">1KI 22:15</Verse>
+    <Verse HEB="2222215222151111">2CH 18:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222">1KI 22:16</Verse>
+    <Verse HEB="2222222222222">2CH 18:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222122122222222">1KI 22:17</Verse>
+    <Verse HEB="2222122122222222">2CH 18:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222221">1KI 22:18</Verse>
+    <Verse HEB="222222222210">2CH 18:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122222221111">1KI 22:19</Verse>
+    <Verse HEB="2212222222111">2CH 18:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222521221">1KI 22:20</Verse>
+    <Verse HEB="22222022225201221">2CH 18:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">1KI 22:21</Verse>
+    <Verse HEB="222222222222">2CH 18:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122222222">1KI 22:22</Verse>
+    <Verse HEB="222122222222">2CH 18:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222122222">1KI 22:23</Verse>
+    <Verse HEB="22222221222220">2CH 18:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221222222222">1KI 22:24</Verse>
+    <Verse HEB="222122222022222">2CH 18:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">1KI 22:25</Verse>
+    <Verse HEB="22222222222">2CH 18:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221212222">1KI 22:26</Verse>
+    <Verse HEB="2221212222">2CH 18:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222212222222212">1KI 22:27</Verse>
+    <Verse HEB="1222212222222212">2CH 18:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">1KI 22:28</Verse>
+    <Verse HEB="2222222222220">2CH 18:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222212">1KI 22:29</Verse>
+    <Verse HEB="222212">2CH 18:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222212">1KI 22:30</Verse>
+    <Verse HEB="222222222222212">2CH 18:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222200222112222">1KI 22:31</Verse>
+    <Verse HEB="222222222112222">2CH 18:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222202212222">1KI 22:32</Verse>
+    <Verse HEB="22222222221222200000">2CH 18:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222212022">1KI 22:33</Verse>
+    <Verse HEB="2222111222">2CH 18:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222122222221221222">1KI 22:34</Verse>
+    <Verse HEB="22221222222212021222">2CH 18:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222121222210000">1KI 22:35</Verse>
+    <Verse HEB="1222102122212000">2CH 18:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="10120000032222222225222">1KI 22:41-42</Verse>
+    <Verse HEB="1125222222225222">2CH 20:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122212222">1KI 22:43</Verse>
+    <Verse HEB="2122212222">2CH 20:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222222">1KI 22:44</Verse>
+    <Verse HEB="22222222">2KI 12:4</Verse>
+    <Verse HEB="22222222">2KI 14:4</Verse>
+    <Verse HEB="22222222">2KI 15:4</Verse>
+    <Verse HEB="22222222200000">2KI 15:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222000">1KI 22:44</Verse>
+    <Verse HEB="222220000">2CH 20:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22200001221011">1KI 22:46</Verse>
+    <Verse HEB="222001210000211">2CH 20:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00122200211122">1KI 22:49</Verse>
+    <Verse HEB="00122200200000000000122110">2CH 20:36-37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222022220">1KI 22:51</Verse>
+    <Verse HEB="22222222222">2CH 21:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220220222">2KI 8:17</Verse>
+    <Verse HEB="222022222">2CH 21:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222212222">2KI 8:18</Verse>
+    <Verse HEB="22222222222212222">2CH 21:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212101122212">2KI 8:19</Verse>
+    <Verse HEB="22211200011122212">2CH 21:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">2KI 8:20</Verse>
+    <Verse HEB="22222222">2CH 21:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="210221221222222000">2KI 8:21</Verse>
+    <Verse HEB="210221221222222">2CH 21:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">2KI 8:22</Verse>
+    <Verse HEB="2222222222220000000">2CH 21:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000102200000">2KI 8:24</Verse>
+    <Verse HEB="00000000000122000">2CH 21:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222222222200">2KI 8:26</Verse>
+    <Verse HEB="1222222222222">2CH 22:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21222222220000">2KI 8:27</Verse>
+    <Verse HEB="011220000022222200000000">2CH 22:3-4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21221222212">2KI 8:28</Verse>
+    <Verse HEB="0002120021222212">2CH 22:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20022421025222422222422220">2KI 8:29</Verse>
+    <Verse HEB="22241212522242222242222">2CH 22:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11230000300000522222">2KI 10:30</Verse>
+    <Verse HEB="01012052222200">2KI 15:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1220222252222">2KI 11:1</Verse>
+    <Verse HEB="1222222522200">2CH 22:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21100215222025222412221">2KI 11:2</Verse>
+    <Verse HEB="2112152222322224000000300002221">2CH 22:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21112222222">2KI 11:3</Verse>
+    <Verse HEB="21112222222">2CH 22:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2202220230300003000000300">2KI 11:4</Verse>
+    <Verse HEB="2202222000000000000">2CH 23:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000000002120011112">2KI 11:4</Verse>
+    <Verse HEB="2121100112000000">2CH 23:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00222222220000">2KI 11:5</Verse>
+    <Verse HEB="222222220000">2CH 23:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20021000000">2KI 11:6</Verse>
+    <Verse HEB="2002100000">2CH 23:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0001111210">2KI 11:7</Verse>
+    <Verse HEB="00000000004121">2CH 23:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122222122211">2KI 11:8</Verse>
+    <Verse HEB="10122222122211">2CH 23:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2000222222222222012">2KI 11:9</Verse>
+    <Verse HEB="200222222222222000120">2CH 23:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220212222211">2KI 11:10</Verse>
+    <Verse HEB="20222102222211">2CH 23:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="100122222222222">2KI 11:11</Verse>
+    <Verse HEB="101122222222222">2CH 23:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12122222202222">2KI 11:12</Verse>
+    <Verse HEB="121222222002222">2CH 23:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212112222">2KI 11:13</Verse>
+    <Verse HEB="21211002222">2CH 23:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222210521522225121222">2KI 11:14</Verse>
+    <Verse HEB="22221052152222300005121222">2CH 23:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122202225222215212222122">2KI 11:15</Verse>
+    <Verse HEB="12222225222152122221122">2CH 23:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221122120">2KI 11:16</Verse>
+    <Verse HEB="22221122120">2CH 23:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221122222220000">2KI 11:17</Verse>
+    <Verse HEB="22212222222">2CH 23:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2112501220522222251212">2KI 11:18</Verse>
+    <Verse HEB="21252225222222512120003000000030000000">2CH 23:17-18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22214222422251022421">2KI 11:19</Verse>
+    <Verse HEB="22214122242225102240221">2CH 23:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222220000">2KI 11:20</Verse>
+    <Verse HEB="12222220">2CH 23:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221203000522252222">2KI 12:1-2</Verse>
+    <Verse HEB="221252225222">2CH 24:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222112222222022">2KI 14:2</Verse>
+    <Verse HEB="22211222222222">2CH 25:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222220000000">2KI 14:3</Verse>
+    <Verse HEB="22222200">2CH 25:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222112222">2KI 14:5</Verse>
+    <Verse HEB="2222112222">2CH 25:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112222152212224221210">2KI 14:6</Verse>
+    <Verse HEB="1220212152212224221210">2CH 25:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0110122222222">2KI 14:8</Verse>
+    <Verse HEB="010011222220222">2CH 25:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212225222222252225222222">2KI 14:9</Verse>
+    <Verse HEB="212225222222252225222222">2CH 25:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122221421225222">2KI 14:10</Verse>
+    <Verse HEB="01222213121225222">2CH 25:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22512225222222">2KI 14:11</Verse>
+    <Verse HEB="2200000030000512225222222">2CH 25:20-21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222202">2KI 14:12</Verse>
+    <Verse HEB="2222222">2CH 25:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211212223122221221222">2KI 14:13</Verse>
+    <Verse HEB="2221121222422221221222">2CH 25:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="01222142222221">2KI 14:14</Verse>
+    <Verse HEB="11222130122222210">2CH 25:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222221222222">2KI 14:17</Verse>
+    <Verse HEB="22222221222222">2CH 25:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221220011">2KI 14:18</Verse>
+    <Verse HEB="22200112210">2CH 25:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">2KI 14:19</Verse>
+    <Verse HEB="0000022222222222">2CH 25:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11210221">2KI 14:20</Verse>
+    <Verse HEB="1211221">2CH 25:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22202522225212">2KI 15:2</Verse>
+    <Verse HEB="222025222252012">2CH 26:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">2KI 15:3</Verse>
+    <Verse HEB="22222222">2CH 26:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1215222512511222">2KI 15:5</Verse>
+    <Verse HEB="000000300300003125002225102000005111222">2CH 26:20-21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221003000000">2KI 15:6</Verse>
+    <Verse HEB="221003000">2CH 26:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122220052222">2KI 15:7</Verse>
+    <Verse HEB="2122220030000052222">2CH 26:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252225212">2KI 15:33</Verse>
+    <Verse HEB="2220052225212">2CH 27:1</Verse>
+    <Verse HEB="222225222">2CH 27:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222050002211152222">2KI 15:34-35</Verse>
+    <Verse HEB="222222225000221522223000">2CH 27:2-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222001220011">2KI 15:36</Verse>
+    <Verse HEB="2220012211">2CH 27:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221022022222">2KI 15:38</Verse>
+    <Verse HEB="222112222222">2CH 27:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222225222022">2KI 16:2</Verse>
+    <Verse HEB="22222222522222">2CH 28:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21225112522220522">2KI 16:3</Verse>
+    <Verse HEB="21225000300041252222522">2CH 28:2-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">2KI 16:4</Verse>
+    <Verse HEB="2222222">2CH 28:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1201113000003000000">2KI 16:7</Verse>
+    <Verse HEB="001021100">2CH 28:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0200012112020">2KI 16:8</Verse>
+    <Verse HEB="0212120022000">2CH 28:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211004220011">2KI 16:19</Verse>
+    <Verse HEB="2100042211">2CH 28:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222102051222">2KI 16:20</Verse>
+    <Verse HEB="22212030000051222">2CH 28:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="120115200">2KI 17:5</Verse>
+    <Verse HEB="000003003000402152">2KI 18:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0101230003000300">2KI 17:7</Verse>
+    <Verse HEB="1111123030000030000">2KI 18:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211522225211">2KI 18:2</Verse>
+    <Verse HEB="11222522225211">2CH 29:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">2KI 18:3</Verse>
+    <Verse HEB="22222222">2CH 29:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="011421130000300000030">2KI 18:4</Verse>
+    <Verse HEB="00000004211410300003000000">2CH 31:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222152252222">2KI 18:13</Verse>
+    <Verse HEB="000042231000300">2CH 32:1</Verse>
+    <Verse HEB="11222152252222">ISA 36:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220042522213000042223222">2KI 18:17</Verse>
+    <Verse HEB="001024101411103000">2CH 32:9</Verse>
+    <Verse HEB="2242152224222522">ISA 36:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0051222242222">2KI 18:18</Verse>
+    <Verse HEB="21222242222">ISA 36:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222525222252222">2KI 18:19</Verse>
+    <Verse HEB="22022411300">2CH 32:10</Verse>
+    <Verse HEB="222525222252222">ISA 36:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222522222">2KI 18:20</Verse>
+    <Verse HEB="12222522222">ISA 36:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022022225222222252222">2KI 18:21</Verse>
+    <Verse HEB="2222225222222252222">ISA 36:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222252222252222220">2KI 18:22</Verse>
+    <Verse HEB="0000300000300000502225220521200">2CH 32:11-12</Verse>
+    <Verse HEB="122225222225222222">ISA 36:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222212522222222">2KI 18:23</Verse>
+    <Verse HEB="222212522222222">ISA 36:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222252222">2KI 18:24</Verse>
+    <Verse HEB="22222222252222">ISA 36:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12221115222122">2KI 18:25</Verse>
+    <Verse HEB="12221115222122">ISA 36:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2201225222225122222">2KI 18:26</Verse>
+    <Verse HEB="221225222225122222">ISA 36:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202422225225222522252222">2KI 18:27</Verse>
+    <Verse HEB="2242222522522252252222">ISA 36:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222223222222">2KI 18:28</Verse>
+    <Verse HEB="222225222222">ISA 36:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252221">2KI 18:29</Verse>
+    <Verse HEB="0212300005200020000320121">2CH 32:15</Verse>
+    <Verse HEB="2222225222">ISA 36:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222224222222">2KI 18:30</Verse>
+    <Verse HEB="222222224222222">ISA 36:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="225221222225222222">2KI 18:31</Verse>
+    <Verse HEB="2205221222225222222">ISA 36:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222230000003112522412222222">2KI 18:32-33</Verse>
+    <Verse HEB="00000000030000111">2CH 32:13</Verse>
+    <Verse HEB="2222252222242152242222222">ISA 36:17-18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222200422">2KI 18:34</Verse>
+    <Verse HEB="2222222422">ISA 36:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222225222">2KI 18:35</Verse>
+    <Verse HEB="221100051112300000">2CH 32:14</Verse>
+    <Verse HEB="22202225222">ISA 36:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20222222222">2KI 18:36</Verse>
+    <Verse HEB="2222222222">ISA 36:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212222222222222">2KI 18:37</Verse>
+    <Verse HEB="221222222222222220">ISA 36:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222222">2KI 19:1</Verse>
+    <Verse HEB="22225222222">ISA 37:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225222222522">2KI 19:2</Verse>
+    <Verse HEB="22252222222522">ISA 37:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522225222222">2KI 19:3</Verse>
+    <Verse HEB="22222522225222222">ISA 37:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212522222222522222222">2KI 19:4</Verse>
+    <Verse HEB="2222212522222222522222222">ISA 37:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">2KI 19:5</Verse>
+    <Verse HEB="22222">ISA 37:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122225222225222222">2KI 19:6</Verse>
+    <Verse HEB="2122225222225222222">ISA 37:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222251222">2KI 19:7</Verse>
+    <Verse HEB="22222251222">ISA 37:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222222">2KI 19:8</Verse>
+    <Verse HEB="222225222222">ISA 37:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122322205222">2KI 19:9</Verse>
+    <Verse HEB="212252205222">ISA 37:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222222522222">2KI 19:10</Verse>
+    <Verse HEB="222225222222522222">ISA 37:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222225222">2KI 19:11</Verse>
+    <Verse HEB="22222225222">ISA 37:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212522222">2KI 19:12</Verse>
+    <Verse HEB="2222212522222">ISA 37:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122252222">2KI 19:13</Verse>
+    <Verse HEB="122252222">ISA 37:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222422222220">2KI 19:14</Verse>
+    <Verse HEB="2222242222222">ISA 37:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22111522225222225222">2KI 19:15</Verse>
+    <Verse HEB="22115022225222225222">ISA 37:15-16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252222521251222">2KI 19:16</Verse>
+    <Verse HEB="22252222521251222">ISA 37:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222242">2KI 19:17</Verse>
+    <Verse HEB="2222242">ISA 37:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222522222">2KI 19:18</Verse>
+    <Verse HEB="1222222522222">ISA 37:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222202522222020">2KI 19:19</Verse>
+    <Verse HEB="22222522222">ISA 37:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222522220">2KI 19:20</Verse>
+    <Verse HEB="222225222522222">ISA 37:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222252222">2KI 19:21</Verse>
+    <Verse HEB="2222252222252222">ISA 37:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252212">2KI 19:22</Verse>
+    <Verse HEB="22222252212">ISA 37:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212250225222225221241222">2KI 19:23</Verse>
+    <Verse HEB="21225225222225221241222">ISA 37:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222052222">2KI 19:24</Verse>
+    <Verse HEB="222252222">ISA 37:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222212252212222">2KI 19:25</Verse>
+    <Verse HEB="222212252212222">ISA 37:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22215222222422">2KI 19:26</Verse>
+    <Verse HEB="22215222222422">ISA 37:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522">2KI 19:27</Verse>
+    <Verse HEB="2222522">ISA 37:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222522225222">2KI 19:28</Verse>
+    <Verse HEB="222222522225222">ISA 37:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252152225222">2KI 19:29</Verse>
+    <Verse HEB="22222521522252022">ISA 37:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222522">2KI 19:30</Verse>
+    <Verse HEB="222222522">ISA 37:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222520222">2KI 19:31</Verse>
+    <Verse HEB="222222252222">ISA 37:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222252222222">2KI 19:32</Verse>
+    <Verse HEB="22222222252222222">ISA 37:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212252222">2KI 19:33</Verse>
+    <Verse HEB="212252222">ISA 37:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21225222">2KI 19:34</Verse>
+    <Verse HEB="212252220">ISA 37:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00022242222225222225222222522222520222522252220">2KI 19:35-37</Verse>
+    <Verse HEB="002400002025000322300312">2CH 32:21</Verse>
+    <Verse HEB="2224222222522222522222252222252222522252220">ISA 37:36-38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222252222252222522520">2KI 20:1-2</Verse>
+    <Verse HEB="222115200000">2CH 32:24</Verse>
+    <Verse HEB="222225222252222252222502252">ISA 38:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522221252222222">2KI 20:3</Verse>
+    <Verse HEB="0222522221252222222">ISA 38:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000004112">2KI 20:4</Verse>
+    <Verse HEB="1112">ISA 38:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122052222522250000000422225222225220000">2KI 20:5-6</Verse>
+    <Verse HEB="122522225222412222522222522">ISA 38:5-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221223122">2KI 20:7</Verse>
+    <Verse HEB="22122422">ISA 38:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2205210010022">2KI 20:8</Verse>
+    <Verse HEB="225211220">ISA 38:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122222211220">2KI 20:12</Verse>
+    <Verse HEB="22212222221220">ISA 39:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12221222221221222222222222">2KI 20:13</Verse>
+    <Verse HEB="122210222221221222222222222">ISA 39:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222222222">2KI 20:14</Verse>
+    <Verse HEB="222222222222222222202">ISA 39:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222">2KI 20:15</Verse>
+    <Verse HEB="222222222222222">ISA 39:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">2KI 20:16</Verse>
+    <Verse HEB="222220">ISA 39:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222212222">2KI 20:17</Verse>
+    <Verse HEB="2222222222212222">ISA 39:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222220222222">2KI 20:18</Verse>
+    <Verse HEB="222222222222">ISA 39:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222511222">2KI 20:19</Verse>
+    <Verse HEB="22222225121220">ISA 39:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221300030004221111">2KI 20:20</Verse>
+    <Verse HEB="2210420000510">2CH 32:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21252222">2KI 20:21</Verse>
+    <Verse HEB="212300030030052222">2CH 32:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222300">2KI 21:1</Verse>
+    <Verse HEB="2222252222">2CH 33:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222522222">2KI 21:2</Verse>
+    <Verse HEB="222222522222">2CH 33:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222112521213000052222">2KI 21:3</Verse>
+    <Verse HEB="22221125212152222">2CH 33:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222511">2KI 21:4</Verse>
+    <Verse HEB="2222222510">2CH 33:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522">2KI 21:5</Verse>
+    <Verse HEB="2222522">2CH 33:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12252221522221">2KI 21:6</Verse>
+    <Verse HEB="112200520221522221">2CH 33:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122152122222252222221">2KI 21:7</Verse>
+    <Verse HEB="221221052122222252222221">2CH 33:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122421152211241111">2KI 21:8</Verse>
+    <Verse HEB="22122412115221124111">2CH 33:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0012215222222">2KI 21:9</Verse>
+    <Verse HEB="120002152222220">2CH 33:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222003004111111">2KI 21:17</Verse>
+    <Verse HEB="22230003000004111">2CH 33:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222230000">2KI 21:19</Verse>
+    <Verse HEB="222222222">2CH 33:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">2KI 21:20</Verse>
+    <Verse HEB="2222222230000000">2CH 33:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212412">2KI 21:23</Verse>
+    <Verse HEB="22142">2CH 33:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222252222">2KI 21:24</Verse>
+    <Verse HEB="122222522220">2CH 33:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21225222230000">2KI 22:1</Verse>
+    <Verse HEB="212252222">2CH 34:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222251225220">2KI 22:2</Verse>
+    <Verse HEB="22225122522">2CH 34:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112111502200520">2KI 22:3</Verse>
+    <Verse HEB="11213005223000003220">2CH 34:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122242211511230">2KI 22:4</Verse>
+    <Verse HEB="12224221512230030030300">2CH 34:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1021252025212522112">2KI 22:5</Verse>
+    <Verse HEB="121252252125022112">2CH 34:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220101200">2KI 22:6</Verse>
+    <Verse HEB="02211200000000">2CH 34:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220125222251220">2KI 22:8</Verse>
+    <Verse HEB="0000032200030212522225122">2CH 34:14-15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12225224000005222200">2KI 22:9</Verse>
+    <Verse HEB="122250224000003000522022">2CH 34:16-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221022422225222">2KI 22:12</Verse>
+    <Verse HEB="22122422225222">2CH 34:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222232152105221125212300520">2KI 22:13</Verse>
+    <Verse HEB="2222500152115211252123052000">2CH 34:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220000052224152222252">2KI 22:14</Verse>
+    <Verse HEB="220052224115222225200">2CH 34:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21222222222">2KI 22:15</Verse>
+    <Verse HEB="212222222220">2CH 34:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221252115122">2KI 22:16</Verse>
+    <Verse HEB="222222125211151022">2CH 34:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252212422222">2KI 22:17</Verse>
+    <Verse HEB="222022252212422222">2CH 34:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222215222222522">2KI 22:18</Verse>
+    <Verse HEB="22222152202222522">2CH 34:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221151122500052125222">2KI 22:19</Verse>
+    <Verse HEB="2221151225005212522">2CH 34:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022152252225222522">2KI 22:20</Verse>
+    <Verse HEB="22152252225222205220">2CH 34:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2210222">2KI 23:1</Verse>
+    <Verse HEB="221222">2CH 34:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222521205021152222512">2KI 23:2</Verse>
+    <Verse HEB="22252125021152222512">2CH 34:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22152225125221414220522300">2KI 23:3</Verse>
+    <Verse HEB="2215222512522141422522">2CH 34:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1111150000411200">2KI 23:22</Verse>
+    <Verse HEB="111050042003000300300">2CH 35:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="01221222200">2KI 23:23</Verse>
+    <Verse HEB="12212222">2CH 35:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0502230140223000">2KI 23:29</Verse>
+    <Verse HEB="000000522301422">2CH 35:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2200424130003000000">2KI 23:30</Verse>
+    <Verse HEB="0205000042041130000">2CH 35:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000300042223022220">2KI 23:30</Verse>
+    <Verse HEB="1222520">2CH 36:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212222200000">2KI 23:31</Verse>
+    <Verse HEB="222122222">2CH 36:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">2KI 23:32</Verse>
+    <Verse HEB="22222222220000002222222">2KI 23:36-37</Verse>
+    <Verse HEB="222222222222220">2CH 36:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="111000002112222">2KI 23:33</Verse>
+    <Verse HEB="112112222">2CH 36:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21021300522424100">2KI 23:34</Verse>
+    <Verse HEB="2121305224020410">2CH 36:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222220000002222000">2KI 23:36-37</Verse>
+    <Verse HEB="222222222222220">2CH 36:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122220000000">2KI 24:1</Verse>
+    <Verse HEB="122220000">2CH 36:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221112200110002222">2KI 24:5-6</Verse>
+    <Verse HEB="222110012210122220">2CH 36:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="211222222000002222000">2KI 24:8-9</Verse>
+    <Verse HEB="21222200222222">2CH 36:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="201100000">2KI 24:17</Verse>
+    <Verse HEB="0000000000211000">2CH 36:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222222">2KI 24:18</Verse>
+    <Verse HEB="2222222222">2CH 36:11</Verse>
+    <Verse HEB="2222222222222222">JER 52:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">2KI 24:19</Verse>
+    <Verse HEB="222200000000">2CH 36:12</Verse>
+    <Verse HEB="2222222">JER 52:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221222222220">2KI 24:20</Verse>
+    <Verse HEB="22222122222222">JER 52:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21222222212222122222">2KI 25:1</Verse>
+    <Verse HEB="12102221221120">JER 39:1</Verse>
+    <Verse HEB="21222222212222122222">JER 52:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222222222212222222222122">2KI 25:2-4</Verse>
+    <Verse HEB="1110022120000000000000000000000002220010200122122">JER 39:2-4</Verse>
+    <Verse HEB="2222222220022222222222220001222222222122">JER 52:5-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221221222222222222121">2KI 25:5-6</Verse>
+    <Verse HEB="221212211212200121">JER 39:5</Verse>
+    <Verse HEB="22122122222222222200121">JER 52:8-9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121222222210">2KI 25:7</Verse>
+    <Verse HEB="100120200000022222111">JER 39:6-7</Verse>
+    <Verse HEB="10122000002222220100000">JER 52:10-11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122222212222122">2KI 25:8</Verse>
+    <Verse HEB="221222222122221022">JER 52:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222122">2KI 25:9</Verse>
+    <Verse HEB="22222222122">JER 52:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222221">2KI 25:10</Verse>
+    <Verse HEB="12222221">JER 52:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222212221222">2KI 25:11</Verse>
+    <Verse HEB="00222222212221222">JER 52:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222">2KI 25:12</Verse>
+    <Verse HEB="1220222">JER 52:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212222222212">2KI 25:13</Verse>
+    <Verse HEB="22212222222212">JER 52:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222112">2KI 25:14</Verse>
+    <Verse HEB="22202222112">JER 52:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222">2KI 25:15</Verse>
+    <Verse HEB="02200002222222">JER 52:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211222222022">2KI 25:16</Verse>
+    <Verse HEB="22210000122022222022">JER 52:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222221022222222220">2KI 25:17</Verse>
+    <Verse HEB="0222022200000000222220122222222220">JER 52:21-22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222121222">2KI 25:18</Verse>
+    <Verse HEB="22222121222">JER 52:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222122212222222122222222221">2KI 25:19</Verse>
+    <Verse HEB="22221222122222221222222222211">JER 52:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222122">2KI 25:20</Verse>
+    <Verse HEB="222222122">JER 52:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222222222">2KI 25:21</Verse>
+    <Verse HEB="122222222222">JER 52:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000022401220">2KI 25:22</Verse>
+    <Verse HEB="0001220420000003000030000">JER 40:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222152251151215224222">2KI 25:23</Verse>
+    <Verse HEB="22200215220030000030000511512015200024222">JER 40:7-8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221051252222220">2KI 25:24</Verse>
+    <Verse HEB="22200215125222222">JER 40:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222100000">2KI 25:25</Verse>
+    <Verse HEB="222222222002220000000000000002200010000">JER 41:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222212222222122221">2KI 25:27</Verse>
+    <Verse HEB="2222222222212222222122200201">JER 52:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222112222">2KI 25:28</Verse>
+    <Verse HEB="222221102222">JER 52:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222222">2KI 25:29</Verse>
+    <Verse HEB="1222222222">JER 52:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222122222">2KI 25:30</Verse>
+    <Verse HEB="2222212200222">JER 52:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222">1CH 3:7</Verse>
+    <Verse HEB="222">1CH 14:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">1CH 8:29</Verse>
+    <Verse HEB="22200222">1CH 9:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">1CH 8:30</Verse>
+    <Verse HEB="22222202">1CH 9:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221">1CH 8:31</Verse>
+    <Verse HEB="2210">1CH 9:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2211222222">1CH 8:32</Verse>
+    <Verse HEB="2211222222">1CH 9:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">1CH 8:33</Verse>
+    <Verse HEB="222222222222">1CH 9:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211220">1CH 8:34</Verse>
+    <Verse HEB="222122">1CH 9:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222210">1CH 8:35</Verse>
+    <Verse HEB="22221">1CH 9:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22112222222">1CH 8:36</Verse>
+    <Verse HEB="22112222222">1CH 9:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122222">1CH 8:37</Verse>
+    <Verse HEB="222122222">1CH 9:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222122">1CH 8:38</Verse>
+    <Verse HEB="222222222221220">1CH 9:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522">1CH 16:8</Verse>
+    <Verse HEB="2222522">PSA 105:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252">1CH 16:9</Verse>
+    <Verse HEB="2252">PSA 105:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225222">1CH 16:10</Verse>
+    <Verse HEB="2225222">PSA 105:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">1CH 16:11</Verse>
+    <Verse HEB="222522">PSA 105:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252">1CH 16:12</Verse>
+    <Verse HEB="22252">PSA 105:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212522">1CH 16:13</Verse>
+    <Verse HEB="212522">PSA 105:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252">1CH 16:14</Verse>
+    <Verse HEB="22252">PSA 105:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1225222">1CH 16:15</Verse>
+    <Verse HEB="1225222">PSA 105:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22251">1CH 16:16</Verse>
+    <Verse HEB="22251">PSA 105:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">1CH 16:17</Verse>
+    <Verse HEB="222522">PSA 105:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252">1CH 16:18</Verse>
+    <Verse HEB="222252">PSA 105:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122522">1CH 16:19</Verse>
+    <Verse HEB="122522">PSA 105:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222422">1CH 16:20</Verse>
+    <Verse HEB="222422">PSA 105:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212522">1CH 16:21</Verse>
+    <Verse HEB="212522">PSA 105:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22420">1CH 16:22</Verse>
+    <Verse HEB="2242">PSA 105:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22251252252">1CH 16:23-24</Verse>
+    <Verse HEB="0000522300051252252">PSA 96:1-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">1CH 16:24</Verse>
+    <Verse HEB="22222">PSA 96:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222422">1CH 16:25</Verse>
+    <Verse HEB="22222422">PSA 96:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522">1CH 16:26</Verse>
+    <Verse HEB="2222522">PSA 96:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222511">1CH 16:27</Verse>
+    <Verse HEB="22511">PSA 96:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222">1CH 16:28</Verse>
+    <Verse HEB="22225222">PSA 96:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225221522512522">1CH 16:29-30</Verse>
+    <Verse HEB="22225215225123000522300">PSA 96:8-10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22223000522312521112522">1CH 16:31-33</Verse>
+    <Verse HEB="2222522512521120052223000">PSA 96:11-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522">1CH 16:34</Verse>
+    <Verse HEB="0222522">PSA 106:1</Verse>
+    <Verse HEB="222222">PSA 118:1</Verse>
+    <Verse HEB="222222">PSA 118:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="021150252252">1CH 16:35</Verse>
+    <Verse HEB="2015252252">PSA 106:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522422110">1CH 16:36</Verse>
+    <Verse HEB="2225224221">PSA 106:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0220122250021211">2CH 6:41</Verse>
+    <Verse HEB="2212225121">PSA 132:8-9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0022230000">2CH 6:42</Verse>
+    <Verse HEB="000222">PSA 132:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11012220000000">2CH 36:19</Verse>
+    <Verse HEB="0010100221">JER 39:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1101000000">2CH 36:20</Verse>
+    <Verse HEB="00000000000011001">JER 39:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252115222252520">2CH 36:22</Verse>
+    <Verse HEB="222225211522225252">EZR 1:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252522225222522520225">2CH 36:23</Verse>
+    <Verse HEB="22222522522225222522520225000300003000">EZR 1:2-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222252022052122">EZR 2:1</Verse>
+    <Verse HEB="1222225222252122">NEH 7:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12223022421252222">EZR 2:2</Verse>
+    <Verse HEB="122230022421252222">NEH 7:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">EZR 2:3</Verse>
+    <Verse HEB="2222222">NEH 7:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">EZR 2:4</Verse>
+    <Verse HEB="2222222">NEH 7:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212112">EZR 2:5</Verse>
+    <Verse HEB="2212112">NEH 7:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221512120">EZR 2:6</Verse>
+    <Verse HEB="22221512120">NEH 7:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">EZR 2:7</Verse>
+    <Verse HEB="2222222">NEH 7:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212122">EZR 2:8</Verse>
+    <Verse HEB="2212122">NEH 7:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">EZR 2:9</Verse>
+    <Verse HEB="222222">NEH 7:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122212">EZR 2:10</Verse>
+    <Verse HEB="2122212">NEH 7:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212">EZR 2:11</Verse>
+    <Verse HEB="2222212">NEH 7:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2211222">EZR 2:12</Verse>
+    <Verse HEB="22111222">NEH 7:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212">EZR 2:13</Verse>
+    <Verse HEB="2222212">NEH 7:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222112">EZR 2:14</Verse>
+    <Verse HEB="222112">NEH 7:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212212">EZR 2:15</Verse>
+    <Verse HEB="2212212">NEH 7:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21222">EZR 2:16</Verse>
+    <Verse HEB="21222">NEH 7:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222200">EZR 2:17</Verse>
+    <Verse HEB="2222200">NEH 7:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="202220">EZR 2:18</Verse>
+    <Verse HEB="202220">NEH 7:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="220200">EZR 2:19</Verse>
+    <Verse HEB="2200200">NEH 7:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21222">EZR 2:20</Verse>
+    <Verse HEB="21222">NEH 7:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1200000100">EZR 2:21-22</Verse>
+    <Verse HEB="1210000">NEH 7:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">EZR 2:23</Verse>
+    <Verse HEB="222222">NEH 7:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11222">EZR 2:24</Verse>
+    <Verse HEB="11222">NEH 7:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1212252122">EZR 2:25</Verse>
+    <Verse HEB="1212252122">NEH 7:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12252222">EZR 2:26</Verse>
+    <Verse HEB="12252222">NEH 7:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="225122">EZR 2:27</Verse>
+    <Verse HEB="225122">NEH 7:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2224222">EZR 2:28</Verse>
+    <Verse HEB="2224222">NEH 7:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12222">EZR 2:29</Verse>
+    <Verse HEB="120222">NEH 7:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222220">EZR 2:31</Verse>
+    <Verse HEB="22252222">NEH 7:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">EZR 2:32</Verse>
+    <Verse HEB="222222">NEH 7:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222200">EZR 2:33</Verse>
+    <Verse HEB="22222200">NEH 7:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222220">EZR 2:34</Verse>
+    <Verse HEB="2222220">NEH 7:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22224221">EZR 2:35</Verse>
+    <Verse HEB="22224221">NEH 7:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222">EZR 2:36</Verse>
+    <Verse HEB="2222252222">NEH 7:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">EZR 2:37</Verse>
+    <Verse HEB="222222">NEH 7:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">EZR 2:38</Verse>
+    <Verse HEB="2222222">NEH 7:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222121">EZR 2:39</Verse>
+    <Verse HEB="222121">NEH 7:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22121222">EZR 2:40</Verse>
+    <Verse HEB="22121222">NEH 7:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222121">EZR 2:41</Verse>
+    <Verse HEB="2222121">NEH 7:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022252522232211">EZR 2:42</Verse>
+    <Verse HEB="2225252225211">NEH 7:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">EZR 2:43</Verse>
+    <Verse HEB="22222">NEH 7:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122">EZR 2:44</Verse>
+    <Verse HEB="2122">NEH 7:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222030222522252225222311022">EZR 2:45-50</Verse>
+    <Verse HEB="22205225222522251222">NEH 7:48-52</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222">EZR 2:51</Verse>
+    <Verse HEB="2222">NEH 7:53</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222">EZR 2:52</Verse>
+    <Verse HEB="1222">NEH 7:54</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222">EZR 2:53</Verse>
+    <Verse HEB="222">NEH 7:55</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222">EZR 2:54</Verse>
+    <Verse HEB="2222">NEH 7:56</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222121">EZR 2:55</Verse>
+    <Verse HEB="2222121">NEH 7:57</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222">EZR 2:56</Verse>
+    <Verse HEB="1222">NEH 7:58</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222221">EZR 2:57</Verse>
+    <Verse HEB="22222221">NEH 7:59</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222221">EZR 2:58</Verse>
+    <Verse HEB="222222221">NEH 7:60</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222221152222222">EZR 2:59</Verse>
+    <Verse HEB="22222221152222222">NEH 7:61</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252122">EZR 2:60</Verse>
+    <Verse HEB="222252122">NEH 7:62</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122222252222252">EZR 2:61</Verse>
+    <Verse HEB="122222252222252">NEH 7:63</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222122">EZR 2:62</Verse>
+    <Verse HEB="22222122">NEH 7:64</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222121">EZR 2:63</Verse>
+    <Verse HEB="222222222121">NEH 7:65</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221">EZR 2:64</Verse>
+    <Verse HEB="2222221">NEH 7:66</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222222">EZR 2:65</Verse>
+    <Verse HEB="22222222222222000">NEH 7:67</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000003000422225222220">EZR 2:66-67</Verse>
+    <Verse HEB="122220522222">NEH 7:68</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22000003000032225210052015201">EZR 2:68-69</Verse>
+    <Verse HEB="22222521152103000221152152000">NEH 7:70-71</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222250220">EZR 2:70</Verse>
+    <Verse HEB="222222522300000">NEH 7:72</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2125213000">JOB 5:13</Verse>
+    <Verse GRK="000000300003051025210">1CO 3:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000222">JOB 14:18</Verse>
+    <Verse HEB="00000022">JOB 18:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222">JOB 27:1</Verse>
+    <Verse HEB="22222">JOB 29:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">JOB 40:6</Verse>
+    <Verse HEB="2222222">JOB 38:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2210210000000">JOB 41:3</Verse>
+    <Verse GRK="2210210">ROM 11:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222522225222222522222223">PSA 2:1-2</Verse>
+    <Verse GRK="000000030000522522252222522222252222222">ACT 4:25-26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000022222222">PSA 2:7</Verse>
+    <Verse GRK="000000000000000000022222222">ACT 13:33</Verse>
+    <Verse GRK="000000222222220000000000000">HEB 1:5</Verse>
+    <Verse GRK="0000000000000022222222">HEB 5:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222300003000003">PSA 4:5</Verse>
+    <Verse GRK="222230003000">EPH 4:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000003000522225222">PSA 5:10</Verse>
+    <Verse GRK="222225222300000">ROM 3:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222300000000">PSA 8:3</Verse>
+    <Verse GRK="00000003000030005222222">MAT 21:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222522222">PSA 8:5</Verse>
+    <Verse GRK="00000522222522222">HEB 2:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252222">PSA 8:6</Verse>
+    <Verse GRK="22222252222">HEB 2:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000222222">PSA 8:7</Verse>
+    <Verse GRK="2222220000000000000000000">HEB 2:8</Verse>
+    <Verse GRK="201111200000000000000">1CO 15:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00221052003000000">PSA 10:7</Verse>
+    <Verse GRK="1220520">ROM 3:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="223000003000">PSA 14:1</Verse>
+    <Verse HEB="2002">PSA 53:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="002222222122">PSA 14:1</Verse>
+    <Verse HEB="2222222122">PSA 53:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122252222">PSA 14:2</Verse>
+    <Verse HEB="1222252222">PSA 53:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11225222">PSA 14:3</Verse>
+    <Verse HEB="11225222">PSA 53:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222000000000000000000000000000000000000000000000000">PSA 14:3</Verse>
+    <Verse GRK="00022111">ROM 3:10</Verse>
+    <Verse GRK="2222220222222">ROM 3:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22125222422">PSA 14:4</Verse>
+    <Verse HEB="22125222422">PSA 53:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22251111411">PSA 14:5-6</Verse>
+    <Verse HEB="22005111141">PSA 53:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222251225222">PSA 14:7</Verse>
+    <Verse HEB="2222251225222">PSA 53:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222252222222">PSA 16:8</Verse>
+    <Verse GRK="00000522222252222222">ACT 2:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252222522222222">PSA 16:9</Verse>
+    <Verse GRK="22222252222522222222">ACT 2:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222">PSA 16:10</Verse>
+    <Verse GRK="222222222222222">ACT 2:27</Verse>
+    <Verse GRK="000000021122111112">ACT 2:31</Verse>
+    <Verse GRK="000001222222">ACT 13:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222252222223000000">PSA 16:11</Verse>
+    <Verse GRK="22225222222">ACT 2:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222225222222223000000">PSA 19:5</Verse>
+    <Verse GRK="00000052222222522222222">ROM 10:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222220052223000000000">PSA 22:2</Verse>
+    <Verse GRK="112221222204122125122522">MAT 27:46</Verse>
+    <Verse GRK="12221222241221215212224222">MRK 15:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222222">PSA 22:19</Verse>
+    <Verse GRK="0000300300000300000522225222222300000">JHN 19:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222252222">PSA 22:23</Verse>
+    <Verse GRK="0122222252222">HEB 2:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000005222222230000000">PSA 24:1</Verse>
+    <Verse GRK="220222222">1CO 10:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00220022222222000">PSA 29:1-2</Verse>
+    <Verse HEB="220022222222000">PSA 96:7-8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222251522015220052223000">PSA 31:2-4</Verse>
+    <Verse HEB="222250152152220005222">PSA 71:1-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212223000000">PSA 31:6</Verse>
+    <Verse GRK="0000000322212223000">LUK 23:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0005222252222">PSA 32:1</Verse>
+    <Verse GRK="2222252222">ROM 4:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222223000000">PSA 32:2</Verse>
+    <Verse GRK="22222222">ROM 4:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0002221522422122521222252202222">PSA 34:13-14</Verse>
+    <Verse GRK="20221322242222522222">1PE 3:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12221242212">PSA 34:15</Verse>
+    <Verse GRK="102221242212">1PE 3:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222225222223000000000000">PSA 34:16-17</Verse>
+    <Verse GRK="02222522222522222">1PE 3:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000052222221">PSA 36:2</Verse>
+    <Verse GRK="22222221">ROM 3:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222242224222215222522222522222203000030000">PSA 40:7-9</Verse>
+    <Verse GRK="00000052222422242222152225222225222222">HEB 10:5-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="002522">PSA 40:14</Verse>
+    <Verse HEB="02522">PSA 70:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22022052222">PSA 40:15</Verse>
+    <Verse HEB="222252222">PSA 70:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1225022">PSA 40:16</Verse>
+    <Verse HEB="122522">PSA 70:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222422121">PSA 40:17</Verse>
+    <Verse HEB="2222422121">PSA 70:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22230042242">PSA 40:18</Verse>
+    <Verse HEB="2223042242">PSA 70:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000030051114221">PSA 41:10</Verse>
+    <Verse GRK="0000030003000051111422111">JHN 13:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">PSA 42:12</Verse>
+    <Verse HEB="22222222222">PSA 43:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222225222">PSA 44:23</Verse>
+    <Verse GRK="0025222225222">ROM 8:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222225222222">PSA 45:7</Verse>
+    <Verse GRK="00005222222222322222222">HEB 1:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522222222522222">PSA 45:8</Verse>
+    <Verse GRK="22222522222222522222">HEB 1:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">PSA 46:8</Verse>
+    <Verse HEB="2222222">PSA 46:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0003000005222222512222">PSA 51:6</Verse>
+    <Verse GRK="00000003000005222222512222">ROM 3:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222212222">PSA 53:4</Verse>
+    <Verse GRK="00022111">ROM 3:10</Verse>
+    <Verse GRK="2222220212222">ROM 3:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">PSA 57:6</Verse>
+    <Verse HEB="222522">PSA 57:12</Verse>
+    <Verse HEB="222522">PSA 108:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2220052">PSA 57:8</Verse>
+    <Verse HEB="222520">PSA 108:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0052252">PSA 57:9</Verse>
+    <Verse HEB="22252">PSA 108:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22152">PSA 57:10</Verse>
+    <Verse HEB="22152">PSA 108:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21252">PSA 57:11</Verse>
+    <Verse HEB="21252">PSA 108:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">PSA 59:7</Verse>
+    <Verse HEB="222222">PSA 59:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2225202">PSA 60:7</Verse>
+    <Verse HEB="222522">PSA 108:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522522">PSA 60:8</Verse>
+    <Verse HEB="222522522">PSA 108:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221252252">PSA 60:9</Verse>
+    <Verse HEB="221252252">PSA 108:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522411">PSA 60:10</Verse>
+    <Verse HEB="22252241">PSA 108:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221522">PSA 60:11</Verse>
+    <Verse HEB="2221522">PSA 108:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="112522">PSA 60:12</Verse>
+    <Verse HEB="12522">PSA 108:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522">PSA 60:13</Verse>
+    <Verse HEB="222522">PSA 108:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22522">PSA 60:14</Verse>
+    <Verse HEB="22522">PSA 108:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">PSA 67:4</Verse>
+    <Verse HEB="222222">PSA 67:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122124211300003000">PSA 68:19</Verse>
+    <Verse GRK="00422124211">EPH 4:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02222222000000000">PSA 69:10</Verse>
+    <Verse GRK="00000002222222">JHN 2:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000022222222">PSA 69:10</Verse>
+    <Verse GRK="000000000022222222">ROM 15:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22220022521222">PSA 69:23</Verse>
+    <Verse GRK="0005222225212223000">ROM 11:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222225222222">PSA 69:24</Verse>
+    <Verse GRK="22222225222222">ROM 11:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22211521112222">PSA 69:26</Verse>
+    <Verse GRK="00000522115222221300000">ACT 1:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222224121">PSA 78:2</Verse>
+    <Verse GRK="0000000052222241211">MAT 13:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000032222">PSA 78:24</Verse>
+    <Verse GRK="0000000003005002220">JHN 6:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22223000">PSA 82:6</Verse>
+    <Verse GRK="0000300000032222">JHN 10:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22200300000">PSA 89:21</Verse>
+    <Verse GRK="00000030000005220030000300000">ACT 13:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222220000022222222222">PSA 91:11-12</Verse>
+    <Verse GRK="00000000000002222222022222222222">MAT 4:6</Verse>
+    <Verse GRK="0022222220000022222222222">LUK 4:10-11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221522">PSA 94:11</Verse>
+    <Verse GRK="00522221522">1CO 3:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000000000022222222222222222222222">PSA 95:7-8</Verse>
+    <Verse GRK="000000022222222222222222222222">HEB 3:7-8</Verse>
+    <Verse GRK="000222222222222222">HEB 3:15</Verse>
+    <Verse GRK="000000000000022222222222">HEB 4:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222151222">PSA 95:9</Verse>
+    <Verse GRK="222221151222">HEB 3:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222215122224222222">PSA 95:10</Verse>
+    <Verse GRK="22022215122225122222">HEB 3:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">PSA 95:11</Verse>
+    <Verse GRK="222222222222">HEB 3:11</Verse>
+    <Verse GRK="0000000002222222222220000000">HEB 4:3</Verse>
+    <Verse GRK="0000222222">HEB 4:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222252222222">PSA 102:26</Verse>
+    <Verse GRK="0222222252222222">HEB 1:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222522125222222522222">PSA 102:27-28</Verse>
+    <Verse GRK="222225222252212302252222522222">HEB 1:11-12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221">PSA 103:8</Verse>
+    <Verse HEB="222221">PSA 145:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222522211">PSA 104:4</Verse>
+    <Verse GRK="000000522222522211">HEB 1:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221">PSA 107:6</Verse>
+    <Verse HEB="222222">PSA 107:13</Verse>
+    <Verse HEB="222222">PSA 107:19</Verse>
+    <Verse HEB="222221">PSA 107:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">PSA 107:8</Verse>
+    <Verse HEB="222222">PSA 107:15</Verse>
+    <Verse HEB="2222220">PSA 107:21</Verse>
+    <Verse HEB="222222">PSA 107:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000522212">PSA 109:8</Verse>
+    <Verse GRK="00000300003000000522212">ACT 1:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02252222252225222222222">PSA 110:1</Verse>
+    <Verse GRK="000021100015222252225222221222">MAT 22:43-44</Verse>
+    <Verse GRK="121111005222252225222221222">MRK 12:36</Verse>
+    <Verse GRK="10210025222252225222222222">LUK 20:42-43</Verse>
+    <Verse GRK="002000010152222252225222222222">ACT 2:34-35</Verse>
+    <Verse GRK="000001052225222222222">HEB 1:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000012210000000000">PSA 110:1</Verse>
+    <Verse GRK="0000000000000000122110000000">MAT 26:64</Verse>
+    <Verse GRK="000000000000221110000000">MRK 14:62</Verse>
+    <Verse GRK="0000000001221111">LUK 22:69</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222022222222">PSA 110:4</Verse>
+    <Verse GRK="00000222222222">HEB 5:6</Verse>
+    <Verse GRK="000012222">HEB 5:10</Verse>
+    <Verse GRK="000000222211222">HEB 6:20</Verse>
+    <Verse GRK="00000000000000000022220120000000">HEB 7:11</Verse>
+    <Verse GRK="000222222222">HEB 7:17</Verse>
+    <Verse GRK="0000000002222222222">HEB 7:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222000000">PSA 111:10</Verse>
+    <Verse HEB="222100000">PRO 1:7</Verse>
+    <Verse HEB="1222000">PRO 9:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222522222200300000">PSA 112:9</Verse>
+    <Verse GRK="0052225222222">2CO 9:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222">PSA 115:4</Verse>
+    <Verse HEB="1122222">PSA 135:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">PSA 115:5</Verse>
+    <Verse HEB="2222222">PSA 135:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22210000">PSA 115:6</Verse>
+    <Verse HEB="2221000">PSA 135:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">PSA 115:8</Verse>
+    <Verse HEB="222222">PSA 135:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02223000">PSA 116:10</Verse>
+    <Verse GRK="0000000300522300300">2CO 4:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="022222242222">PSA 117:1</Verse>
+    <Verse GRK="00222222312222">ROM 15:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222525222">PSA 118:6</Verse>
+    <Verse GRK="00005223225222">HEB 13:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522225222222222">PSA 118:22-23</Verse>
+    <Verse GRK="00000000052222522225222222222">MAT 21:42</Verse>
+    <Verse GRK="0000052222522225222222222">MRK 12:10-11</Verse>
+    <Verse GRK="000000000005222252222">LUK 20:17</Verse>
+    <Verse GRK="001111111141222">ACT 4:11</Verse>
+    <Verse GRK="00020000100000">1PE 2:4</Verse>
+    <Verse GRK="000000301222252222">1PE 2:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222200000">PSA 118:26</Verse>
+    <Verse GRK="0000000000000002222220000">MAT 21:9</Verse>
+    <Verse GRK="000000000000222222">MAT 23:39</Verse>
+    <Verse GRK="00000000222222">MRK 11:9</Verse>
+    <Verse GRK="00000000000000000222222">LUK 13:35</Verse>
+    <Verse GRK="0222002220000000">LUK 19:38</Verse>
+    <Verse GRK="000000000000022222200000">JHN 12:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000300005221112221">PSA 132:11</Verse>
+    <Verse GRK="000000000005221112221">ACT 2:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000005222223">PSA 140:4</Verse>
+    <Verse GRK="000003000522222">ROM 3:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222252222">PRO 3:11</Verse>
+    <Verse GRK="00003000050222252222">HEB 12:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522222">PRO 3:12</Verse>
+    <Verse GRK="22222522222">HEB 12:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1222222">PRO 3:34</Verse>
+    <Verse GRK="00000022222222">JAS 4:6</Verse>
+    <Verse GRK="0000000000022222222">1PE 5:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222">PRO 6:10</Verse>
+    <Verse HEB="22222222">PRO 24:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122222">PRO 6:11</Verse>
+    <Verse HEB="122222">PRO 24:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">PRO 9:4</Verse>
+    <Verse HEB="222222">PRO 9:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222000">PRO 10:15</Verse>
+    <Verse HEB="2222000">PRO 18:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222522222">PRO 11:31</Verse>
+    <Verse GRK="122222522222">1PE 4:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221">PRO 12:11</Verse>
+    <Verse HEB="222221">PRO 28:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122222">PRO 13:14</Verse>
+    <Verse HEB="1122222">PRO 14:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">PRO 14:12</Verse>
+    <Verse HEB="222222">PRO 16:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222000">PRO 17:3</Verse>
+    <Verse HEB="2222000">PRO 27:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222">PRO 18:8</Verse>
+    <Verse HEB="222222">PRO 26:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222111">PRO 19:24</Verse>
+    <Verse HEB="2222111">PRO 26:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222022">PRO 20:16</Verse>
+    <Verse HEB="222222">PRO 27:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2122222">PRO 21:9</Verse>
+    <Verse HEB="21220222">PRO 25:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22202222">PRO 22:3</Verse>
+    <Verse HEB="2222222">PRO 27:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2211111">PRO 22:13</Verse>
+    <Verse HEB="2211111">PRO 26:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222221252225222225222300000">PRO 25:21-22</Verse>
+    <Verse GRK="0222221252225222225222">ROM 12:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0111211130030000030000000000000">PRO 26:11</Verse>
+    <Verse GRK="000000412111030000">2PE 2:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22122">SNG 2:6</Verse>
+    <Verse HEB="22122">SNG 8:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222522222">SNG 2:7</Verse>
+    <Verse HEB="22225222522222">SNG 3:5</Verse>
+    <Verse HEB="2222412222">SNG 8:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222122">SNG 2:16</Verse>
+    <Verse HEB="2122220">SNG 6:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2212222222">SNG 4:2</Verse>
+    <Verse HEB="2212222222">SNG 6:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222200">SNG 4:5</Verse>
+    <Verse HEB="222222">SNG 7:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02222222522252222">ISA 1:9</Verse>
+    <Verse GRK="00005222222522252222">ROM 9:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22252222252211">ISA 2:2</Verse>
+    <Verse HEB="222522222502211">MIC 4:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21252224225222522252">ISA 2:3</Verse>
+    <Verse HEB="21252224225222522252">MIC 4:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2215115225242225220">ISA 2:4</Verse>
+    <Verse HEB="22115110522524222522">MIC 4:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000000222222">ISA 5:25</Verse>
+    <Verse HEB="0000000222222">ISA 9:11</Verse>
+    <Verse HEB="000000000000000222222">ISA 9:16</Verse>
+    <Verse HEB="00000002222220">ISA 9:20</Verse>
+    <Verse HEB="00000002222220">ISA 10:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000222222222222222222222220222222222222222222222222">ISA 6:9-10</Verse>
+    <Verse GRK="0000000022222222222222222222222222222222222222222222222">MAT 13:14-15</Verse>
+    <Verse GRK="12122121222212211">MRK 4:12</Verse>
+    <Verse GRK="0000000000000000002212121">LUK 8:10</Verse>
+    <Verse GRK="12220111101222212221222">JHN 12:40</Verse>
+    <Verse GRK="0000000022222222222222222222222222222222222222222222222">ACT 28:26-27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000522222522512222">ISA 7:14</Verse>
+    <Verse GRK="2222225225122223000000">MAT 1:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000022000021000000000000">ISA 8:14</Verse>
+    <Verse GRK="000000220210000000">ROM 9:33</Verse>
+    <Verse GRK="022021000000000">1PE 2:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000300000032222">ISA 8:17</Verse>
+    <Verse GRK="0012222300000030000">HEB 2:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222223000000000300000000">ISA 8:18</Verse>
+    <Verse GRK="0000000302222222222">HEB 2:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000300004202252300000032225223000">ISA 8:23</Verse>
+    <Verse GRK="1202252522522">MAT 4:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22212242241222225111">ISA 9:1</Verse>
+    <Verse GRK="22212251231122222511">MAT 4:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0211122222251123000000">ISA 10:22</Verse>
+    <Verse GRK="000000511111222222512">ROM 9:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0212111111">ISA 10:23</Verse>
+    <Verse GRK="2000121111">ROM 9:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000022122110">ISA 11:9</Verse>
+    <Verse HEB="2221122110">HAB 2:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0200005222522225222300000">ISA 11:10</Verse>
+    <Verse GRK="000052222522225222">ROM 15:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000030003003000000522522">ISA 22:13</Verse>
+    <Verse GRK="00000030000000522522">1CO 15:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1221300000000030000000030000">ISA 25:8</Verse>
+    <Verse GRK="000000030000030000042211">1CO 15:54</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000003000005211130000003000300000030000300">ISA 27:9</Verse>
+    <Verse GRK="000000052111">ROM 11:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11111141222003000030005111">ISA 28:11-12</Verse>
+    <Verse GRK="0000041111142225111130">1CO 14:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000211000220222000022222222">ISA 28:16</Verse>
+    <Verse GRK="112112200002222221">ROM 9:33</Verse>
+    <Verse GRK="11110222221">ROM 10:11</Verse>
+    <Verse GRK="11112112222222222222">1PE 2:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="01111201020000000000000">ISA 29:10</Verse>
+    <Verse GRK="001111122111000000000">ROM 11:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000002222201222222222222222202">ISA 29:13</Verse>
+    <Verse GRK="22222212222222222222222">MAT 15:8-9</Verse>
+    <Verse GRK="0000000000000022222212222222222222222">MRK 7:6-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000030000300322222522221">ISA 29:14</Verse>
+    <Verse GRK="0052222522221">1CO 1:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222220">ISA 35:10</Verse>
+    <Verse HEB="2222222222222220">ISA 51:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222111">ISA 40:3</Verse>
+    <Verse GRK="000000000022222222222221">MAT 3:3</Verse>
+    <Verse GRK="22222222222221">MRK 1:3</Verse>
+    <Verse GRK="0000000022222222222221">LUK 3:4</Verse>
+    <Verse GRK="0022222122200000">JHN 1:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222522222520222251121">ISA 40:4</Verse>
+    <Verse GRK="222522222522222511211">LUK 3:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000052222222300">ISA 40:5</Verse>
+    <Verse GRK="22222222">LUK 3:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000300052252215225225222">ISA 40:6-7</Verse>
+    <Verse GRK="00000003222522023111111300000000">JAS 1:11</Verse>
+    <Verse GRK="0220252215225225222">1PE 1:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221115222">ISA 40:8</Verse>
+    <Verse GRK="22215222300000000">1PE 1:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222212222000">ISA 40:13</Verse>
+    <Verse GRK="2022212222">ROM 11:34</Verse>
+    <Verse GRK="1022211100000">1CO 2:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0222113212412224222225221">ISA 42:1</Verse>
+    <Verse GRK="02221151241122242222232221">MAT 12:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1111511112">ISA 42:2</Verse>
+    <Verse GRK="1121511111112">MAT 12:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21215212241112">ISA 42:3</Verse>
+    <Verse GRK="2121521224111112">MAT 12:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000030000005022222">ISA 42:4</Verse>
+    <Verse GRK="222222">MAT 12:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000030003000003000030200240015211">ISA 43:20-21</Verse>
+    <Verse GRK="0022003000030003000030000">1PE 2:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000300000003000052222522222">ISA 45:23</Verse>
+    <Verse GRK="00300052222522222">ROM 14:11</Verse>
+    <Verse GRK="0000022100000222200000000">PHP 2:10-11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0003000000030000300000322200222522222222">ISA 49:6</Verse>
+    <Verse GRK="00000052222522222222">ACT 13:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000522252222230000000003000">ISA 49:8</Verse>
+    <Verse GRK="00522252222230003000">2CO 6:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000030000052220000300000">ISA 49:18</Verse>
+    <Verse GRK="00222230000300000">ROM 14:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000030000030000052002215222">ISA 52:5</Verse>
+    <Verse GRK="2021122522230">ROM 2:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2100032100302300000030000">ISA 52:7</Verse>
+    <Verse GRK="0000003051320132">ROM 10:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000052225221230000">ISA 52:11</Verse>
+    <Verse GRK="0222132005222300">2CO 6:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000300000322222252222">ISA 52:15</Verse>
+    <Verse GRK="00052222252222">ROM 15:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222">ISA 53:1</Verse>
+    <Verse GRK="000000000222222222222">JHN 12:38</Verse>
+    <Verse GRK="000000000222222">ROM 10:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1111111113000000300000">ISA 53:4</Verse>
+    <Verse GRK="000000000411111111">MAT 8:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000005222252222122522222">ISA 53:7</Verse>
+    <Verse GRK="0000000005222252222122522222">ACT 8:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222225222252222222300000000">ISA 53:8</Verse>
+    <Verse GRK="222022225222252222222">ACT 8:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000300000031225222222">ISA 53:9</Verse>
+    <Verse GRK="01225222222">1PE 2:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000030000300000005111230000300000">ISA 53:12</Verse>
+    <Verse GRK="0101002222">MRK 15:28</Verse>
+    <Verse GRK="00000010100022220000000">LUK 22:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222522222522222522222300">ISA 54:1</Verse>
+    <Verse GRK="0052222522222522222522222">GAL 4:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21000123000000">ISA 54:13</Verse>
+    <Verse GRK="000005011230000030000">JHN 6:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000300003030000003000052222">ISA 55:3</Verse>
+    <Verse GRK="000000300003000052222">ACT 13:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000000000000000000000002022222222">ISA 56:7</Verse>
+    <Verse GRK="0000222222000000">MAT 21:13</Verse>
+    <Verse GRK="00000000222222222000000">MRK 11:17</Verse>
+    <Verse GRK="0000122222000000">LUK 19:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="20220003223000005222222522213000000030000300000">ISA 59:7-8</Verse>
+    <Verse GRK="022222522222252221">ROM 3:15-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02122232222">ISA 59:20</Verse>
+    <Verse GRK="0000030512225222">ROM 11:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222223030000000300000000300000030000003003000000">ISA 59:21</Verse>
+    <Verse GRK="222222230000">ROM 11:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222225200000522222">ISA 61:1</Verse>
+    <Verse GRK="2222522222525222223000">LUK 4:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12223003000">ISA 61:2</Verse>
+    <Verse GRK="1222">LUK 4:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0002140101030000051111">ISA 64:3</Verse>
+    <Verse GRK="000311130213000005111111">1CO 2:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222225222230030000000">ISA 65:1</Verse>
+    <Verse GRK="00000502222522222">ROM 10:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222522223000030000">ISA 65:2</Verse>
+    <Verse GRK="00000522222252222">ROM 10:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000222252222225222512222">ISA 66:1</Verse>
+    <Verse GRK="22225222222522230512222">ACT 7:49</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222230000003000000003000000">ISA 66:2</Verse>
+    <Verse GRK="1222222">ACT 7:50</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000202222222022000000">ISA 66:24</Verse>
+    <Verse GRK="02222222222">MRK 9:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000101010">JER 1:10</Verse>
+    <Verse HEB="0000112222122">JER 24:6</Verse>
+    <Verse HEB="011222221022000000">JER 42:10</Verse>
+    <Verse HEB="0000000111011100">JER 45:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21122222222">JER 6:13</Verse>
+    <Verse HEB="00000021122222222">JER 8:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222222">JER 6:14</Verse>
+    <Verse HEB="221222222">JER 8:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222212212212220">JER 6:15</Verse>
+    <Verse HEB="222222122222212220">JER 8:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000222115212">JER 6:22</Verse>
+    <Verse HEB="2221520012">JER 50:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221222222222220">JER 6:23</Verse>
+    <Verse HEB="22221222222222220">JER 50:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="11212122">JER 6:24</Verse>
+    <Verse HEB="101212122">JER 50:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">JER 7:1</Verse>
+    <Verse HEB="2222222">JER 11:1</Verse>
+    <Verse HEB="2222222">JER 18:1</Verse>
+    <Verse HEB="2222222">JER 30:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000222000111100000000000000000">JER 9:23</Verse>
+    <Verse GRK="00022112">1CO 1:31</Verse>
+    <Verse GRK="202112">2CO 10:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222">JER 10:12</Verse>
+    <Verse HEB="222222222">JER 51:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222200000222222">JER 10:13</Verse>
+    <Verse HEB="22222000222222">JER 51:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">JER 10:14</Verse>
+    <Verse HEB="22222222222">JER 51:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222">JER 10:15</Verse>
+    <Verse HEB="2222222">JER 51:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222221122222">JER 10:16</Verse>
+    <Verse HEB="222222122222">JER 51:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222">JER 13:8</Verse>
+    <Verse HEB="2222">JER 16:1</Verse>
+    <Verse HEB="2222">JER 18:5</Verse>
+    <Verse HEB="2222">JER 24:4</Verse>
+    <Verse HEB="2222">EZK 6:1</Verse>
+    <Verse HEB="2222">EZK 7:1</Verse>
+    <Verse HEB="2222">EZK 11:14</Verse>
+    <Verse HEB="2222">EZK 12:1</Verse>
+    <Verse HEB="2222">EZK 12:17</Verse>
+    <Verse HEB="2222">EZK 12:21</Verse>
+    <Verse HEB="2222">EZK 12:26</Verse>
+    <Verse HEB="2222">EZK 13:1</Verse>
+    <Verse HEB="2222">EZK 14:2</Verse>
+    <Verse HEB="2222">EZK 14:12</Verse>
+    <Verse HEB="2222">EZK 15:1</Verse>
+    <Verse HEB="2222">EZK 17:1</Verse>
+    <Verse HEB="2222">EZK 17:11</Verse>
+    <Verse HEB="2222">EZK 18:1</Verse>
+    <Verse HEB="2222">EZK 20:2</Verse>
+    <Verse HEB="2222">EZK 21:1</Verse>
+    <Verse HEB="2222">EZK 21:1</Verse>
+    <Verse HEB="2222">EZK 21:13</Verse>
+    <Verse HEB="2222">EZK 22:17</Verse>
+    <Verse HEB="2222">EZK 22:23</Verse>
+    <Verse HEB="2222">EZK 23:1</Verse>
+    <Verse HEB="2222">EZK 24:15</Verse>
+    <Verse HEB="2222">EZK 25:1</Verse>
+    <Verse HEB="2222">EZK 27:1</Verse>
+    <Verse HEB="2222">EZK 28:1</Verse>
+    <Verse HEB="2222">EZK 28:20</Verse>
+    <Verse HEB="2222">EZK 30:1</Verse>
+    <Verse HEB="2222">EZK 33:1</Verse>
+    <Verse HEB="2222">EZK 33:23</Verse>
+    <Verse HEB="2222">EZK 34:1</Verse>
+    <Verse HEB="2222">EZK 35:1</Verse>
+    <Verse HEB="2222">EZK 36:16</Verse>
+    <Verse HEB="2222">EZK 37:15</Verse>
+    <Verse HEB="2222">EZK 38:1</Verse>
+    <Verse HEB="2222">ZEC 6:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="10020522222">JER 19:8</Verse>
+    <Verse HEB="102522222">JER 49:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="12211211220">JER 23:6</Verse>
+    <Verse HEB="112211211220">JER 33:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000030030003005225222222">JER 26:18</Verse>
+    <Verse HEB="0022252222220">MIC 3:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000522203121515214112522">JER 31:15</Verse>
+    <Verse GRK="22224210511123221522">MAT 2:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221251110511222">JER 31:31</Verse>
+    <Verse GRK="0000522125111124111222">HEB 8:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225122252222225222252222222522212">JER 31:32</Verse>
+    <Verse GRK="2222512225222222522225222222252212">HEB 8:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222225222125022222252221252222522222">JER 31:33</Verse>
+    <Verse GRK="222222222522212522222252221252222522222">HEB 8:10</Verse>
+    <Verse GRK="22222115222125002225122212">HEB 10:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222225222225222222520022252222252222222">JER 31:34</Verse>
+    <Verse GRK="2222222252222252222225222252222252222222">HEB 8:11-12</Verse>
+    <Verse GRK="022251125212">HEB 10:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000003000003000000300000030011252225212">JER 31:34</Verse>
+    <Verse GRK="022251125212">HEB 10:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2221225102">JER 49:9</Verse>
+    <Verse HEB="200100002522122">OBA 1:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0120100000000">JER 49:10</Verse>
+    <Verse HEB="01201">OBA 1:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="212222131212">JER 49:14</Verse>
+    <Verse HEB="00000051222214122">OBA 1:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122220">JER 49:15</Verse>
+    <Verse HEB="1222200">OBA 1:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02222511010422522">JER 49:16</Verse>
+    <Verse HEB="222511030000420002522">OBA 1:3-4</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222211522222">JER 49:18</Verse>
+    <Verse HEB="202221522222">JER 50:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222512222252222222220">JER 49:19</Verse>
+    <Verse HEB="2222222501222225222222222">JER 50:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222212521122225221">JER 49:20</Verse>
+    <Verse HEB="2222212521122225221">JER 50:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="21121120">JER 49:21</Verse>
+    <Verse HEB="211121120">JER 50:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222222222">EZK 3:17</Verse>
+    <Verse HEB="022222222222">EZK 33:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22220022222002222222">EZK 3:18</Verse>
+    <Verse HEB="22022222222222222">EZK 33:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22221202222220">EZK 3:19</Verse>
+    <Verse HEB="222100222222220">EZK 33:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0022200012222222">EZK 18:21</Verse>
+    <Verse HEB="000022222000001100002222">EZK 33:14-15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="121222112">EZK 18:22</Verse>
+    <Verse HEB="112122211112">EZK 33:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1012200000022022111122">EZK 18:24</Verse>
+    <Verse HEB="0000012222221122">EZK 33:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="122220000000122">EZK 18:25</Verse>
+    <Verse HEB="1002222012">EZK 33:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222210000">EZK 18:26</Verse>
+    <Verse HEB="222221">EZK 33:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22200222202">EZK 18:27</Verse>
+    <Verse HEB="222222022">EZK 33:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1002222000220000">EZK 18:29</Verse>
+    <Verse HEB="122220000220">EZK 33:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22220002">EZK 32:20</Verse>
+    <Verse HEB="0020212222">EZK 32:21</Verse>
+    <Verse HEB="002222222">EZK 32:22</Verse>
+    <Verse HEB="0021022222222222">EZK 32:23</Verse>
+    <Verse HEB="0022222222211222222222">EZK 32:24</Verse>
+    <Verse HEB="2211022222222222222221">EZK 32:25</Verse>
+    <Verse HEB="00022222122222">EZK 32:26</Verse>
+    <Verse HEB="0221202000000002222">EZK 32:27</Verse>
+    <Verse HEB="002022">EZK 32:28</Verse>
+    <Verse HEB="000002202222">EZK 32:29</Verse>
+    <Verse HEB="00000222212222222">EZK 32:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222222222222222222221">EZK 40:29</Verse>
+    <Verse HEB="222222222222222222221">EZK 40:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="1122222222222">EZK 40:34</Verse>
+    <Verse HEB="1122222222222">EZK 40:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000021122221222100000000000">DAN 7:13</Verse>
+    <Verse GRK="000000000003000000051121251222200000">MAT 24:30</Verse>
+    <Verse GRK="0000003003011212000003212222">MAT 26:64</Verse>
+    <Verse GRK="111121251200000">MRK 13:26</Verse>
+    <Verse GRK="000030511212000003222222">MRK 14:62</Verse>
+    <Verse GRK="111121251200000">LUK 21:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000000003000052222222522252222">HOS 2:1</Verse>
+    <Verse GRK="22222222522252222">ROM 9:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000000311131111111300000000">HOS 2:25</Verse>
+    <Verse GRK="000000411111131111">ROM 9:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="02222200000">HOS 6:6</Verse>
+    <Verse GRK="00000222220000000">MAT 9:13</Verse>
+    <Verse GRK="000002222200000">MAT 12:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000030000000312252522522">HOS 10:8</Verse>
+    <Verse GRK="0012252252252">LUK 23:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000003221111">HOS 11:1</Verse>
+    <Verse GRK="00000003000000003221111">MAT 2:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000030000511225222130000">HOS 13:14</Verse>
+    <Verse GRK="2221152122">1CO 15:55</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2211322222222522222222522212522222">JOL 3:1</Verse>
+    <Verse GRK="22111100052222222522222222522222522212">ACT 2:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22225222222252222">JOL 3:2</Verse>
+    <Verse GRK="2122205222022225222230">ACT 2:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222225222522222">JOL 3:3</Verse>
+    <Verse GRK="2222220502220522222">ACT 2:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222225222252225222">JOL 3:4</Verse>
+    <Verse GRK="222225222252225222">ACT 2:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222300000000030000000">JOL 3:5</Verse>
+    <Verse GRK="2222222222">ACT 2:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0022222222300000000030000000">JOL 3:5</Verse>
+    <Verse GRK="202222222">ROM 10:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222202220000">AMO 1:3</Verse>
+    <Verse HEB="22222022200000">AMO 1:6</Verse>
+    <Verse HEB="2222022200000000">AMO 1:9</Verse>
+    <Verse HEB="22222022200000000000">AMO 1:11</Verse>
+    <Verse HEB="222220222000000">AMO 1:13</Verse>
+    <Verse HEB="2222202220000">AMO 2:1</Verse>
+    <Verse HEB="22222022200000000000">AMO 2:4</Verse>
+    <Verse HEB="222220222000000">AMO 2:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2200220">AMO 1:4</Verse>
+    <Verse HEB="222022">AMO 1:7</Verse>
+    <Verse HEB="2220220">AMO 1:10</Verse>
+    <Verse HEB="2202200">AMO 1:12</Verse>
+    <Verse HEB="120022000000">AMO 1:14</Verse>
+    <Verse HEB="20220000000">AMO 2:2</Verse>
+    <Verse HEB="2202200">AMO 2:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222225222222">AMO 5:25</Verse>
+    <Verse GRK="0000300000003000005222225222222">ACT 7:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="22222252222225202205222030000000">AMO 5:26-27</Verse>
+    <Verse GRK="222222522222252220052220">ACT 7:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000422222300005222151230000">AMO 9:11</Verse>
+    <Verse GRK="000312222252221512">ACT 15:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222225222222222225200022">AMO 9:12</Verse>
+    <Verse GRK="2022222005222222222225222">ACT 15:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000003222222222222">JON 2:1</Verse>
+    <Verse GRK="002222222222223000000000000000">MAT 12:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="222000420021252020001012300000000">MIC 5:1</Verse>
+    <Verse GRK="222003122112520213000012">MAT 2:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0212511222522225101121112">MIC 7:6</Verse>
+    <Verse GRK="000111214212224212223211212">MAT 10:35-36</Verse>
+    <Verse GRK="111112114111122224111112222">LUK 12:53</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2223022022422222225222222">HAB 1:5</Verse>
+    <Verse GRK="222522242222222322222220">ACT 13:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="2222222222222222">HAB 2:4</Verse>
+    <Verse GRK="000000000000222222">ROM 1:17</Verse>
+    <Verse GRK="0000000000022222">GAL 3:11</Verse>
+    <Verse GRK="22222220222222222">HEB 10:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000522252122300000">HAG 2:6</Verse>
+    <Verse GRK="00000003000522241223022">HEB 12:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000525112230003000">ZEC 8:16</Verse>
+    <Verse GRK="000052511223000">EPH 4:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0022021222222000022221221">ZEC 9:9</Verse>
+    <Verse GRK="02222222222222121211">MAT 21:5</Verse>
+    <Verse GRK="0022222221221">JHN 12:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000300003000000300002230000300003000030000522225112211300">ZEC 11:12-13</Verse>
+    <Verse GRK="00000000052222300030000511221113000">MAT 27:9-10</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="000000000000000011111100000000000000">ZEC 12:10</Verse>
+    <Verse GRK="000001111">JHN 19:37</Verse>
+    <Verse GRK="0000001100011100000000000">REV 1:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="00000000000000122212200000000">ZEC 13:7</Verse>
+    <Verse GRK="0000000000000000122212200">MAT 26:31</Verse>
+    <Verse GRK="00000000001222221">MRK 14:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="0000300000300000003222522230000003000000">MAL 1:2-3</Verse>
+    <Verse GRK="002225222">ROM 9:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse HEB="221222412111300000003000000030030000">MAL 3:1</Verse>
+    <Verse GRK="222225222222225222222">MAT 11:10</Verse>
+    <Verse GRK="12000005222222252222">MRK 1:2</Verse>
+    <Verse GRK="22222522222225222222">LUK 7:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000001221222200001000000">MAT 3:1-2</Verse>
+    <Verse GRK="12212220222222">MRK 1:4</Verse>
+    <Verse GRK="00111111222222">LUK 3:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212222222">MAT 3:2</Verse>
+    <Verse GRK="000000212222222">MAT 4:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000010222022222222222222">MAT 3:3</Verse>
+    <Verse GRK="2200222000000000000022222222222222">MRK 1:2-3</Verse>
+    <Verse GRK="1200022222222222222222">LUK 3:4</Verse>
+    <Verse GRK="0022222122221222">JHN 1:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000211111122222222111112222">MAT 3:4</Verse>
+    <Verse GRK="01021122222222112222">MRK 1:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="122212222000000222222222222">MAT 3:5-6</Verse>
+    <Verse GRK="122222202110222222222222">MRK 1:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000000002222222222">MAT 3:7</Verse>
+    <Verse GRK="000000002222222222">LUK 3:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2211222212222222222222222222222">MAT 3:8-9</Verse>
+    <Verse GRK="2211222212222222222222222222222">LUK 3:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222222222222222">MAT 3:10</Verse>
+    <Verse GRK="22022222222222222222222">LUK 3:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222220020222220222211122222222">MAT 3:11</Verse>
+    <Verse GRK="0111222222222111111121222022222">MRK 1:7-8</Verse>
+    <Verse GRK="120222222211222222211111122222222">LUK 3:16</Verse>
+    <Verse GRK="10222222200000002222222111111111">JHN 1:26-27</Verse>
+    <Verse GRK="0201211221200000">ACT 1:5</Verse>
+    <Verse GRK="000000002012111222">ACT 11:16</Verse>
+    <Verse GRK="0002000000000000111222111111">ACT 13:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222223122251221222522222">MAT 3:12</Verse>
+    <Verse GRK="2222222422251222221522222">LUK 3:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11122221220001111">MAT 3:13</Verse>
+    <Verse GRK="1111111220221122211">MRK 1:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000021122311011411100222212251222204122222212">MAT 3:16-17</Verse>
+    <Verse GRK="0211224111411222125212224122222212">MRK 1:10-11</Verse>
+    <Verse GRK="0000000000030111212200012222521114122222212">LUK 3:21-22</Verse>
+    <Verse GRK="00000322222112122">JHN 1:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11212221111222512200012">MAT 4:1-2</Verse>
+    <Verse GRK="111111222300002212210000000000">MRK 1:12-13</Verse>
+    <Verse GRK="20000000001111222521222211100001112">LUK 4:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="102122222222211111">MAT 4:3</Verse>
+    <Verse GRK="21221222222111211">LUK 4:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00202222222200000000">MAT 4:4</Verse>
+    <Verse GRK="020000202222222">LUK 4:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1120021112202222251222222222222222222222222222222">MAT 4:5-6</Verse>
+    <Verse GRK="1122122222222122222222025222222220005022222222222">LUK 4:9-11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222201222222">MAT 4:7</Verse>
+    <Verse GRK="00222201222222">LUK 4:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112000000012222110000">MAT 4:8</Verse>
+    <Verse GRK="1121222211000">LUK 4:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22212022021">MAT 4:9</Verse>
+    <Verse GRK="222002211111111000000000112211000">LUK 4:6-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="022220020222222222">MAT 4:10</Verse>
+    <Verse GRK="0022222222222222">LUK 4:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111222020222">MAT 4:11</Verse>
+    <Verse GRK="000000000000000020222">MRK 1:13</Verse>
+    <Verse GRK="11112211100">LUK 4:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="001111222">MAT 4:12</Verse>
+    <Verse GRK="00111110022200000">MRK 1:14</Verse>
+    <Verse GRK="111100000222000000000">LUK 4:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="200001220000000">MAT 4:13</Verse>
+    <Verse GRK="2122202200001">MRK 1:21</Verse>
+    <Verse GRK="21220002010022">LUK 4:31</Verse>
+    <Verse GRK="111220000000000000000000">JHN 2:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000002202211">MAT 4:17</Verse>
+    <Verse GRK="000000022211200000">MRK 1:15</Verse>
+    <Verse GRK="0000000002002211">LUK 10:9</Verse>
+    <Verse GRK="000000000000000000022211">LUK 10:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112222220020002222110111222">MAT 4:18</Verse>
+    <Verse GRK="112222222222211111222">MRK 1:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222222222">MAT 4:19</Verse>
+    <Verse GRK="21211222222022">MRK 1:17</Verse>
+    <Verse GRK="0000000000000211111100000111">LUK 5:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01122222">MAT 4:20</Verse>
+    <Verse GRK="1122222">MRK 1:18</Verse>
+    <Verse GRK="10000002122">LUK 5:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2212000222222222222000002220000">MAT 4:21</Verse>
+    <Verse GRK="221222222222200222222">MRK 1:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="011211022211">MAT 4:22</Verse>
+    <Verse GRK="1100022220111000111">MRK 1:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="221222522225222225222222000">MAT 4:23</Verse>
+    <Verse GRK="2211111111522225222225222222">MAT 9:35</Verse>
+    <Verse GRK="212122212223000">MRK 1:39</Verse>
+    <Verse GRK="2112222300">LUK 4:15</Verse>
+    <Verse GRK="21212211">LUK 4:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="220112223022220000">MAT 4:25</Verse>
+    <Verse GRK="0000000000051122225111">MRK 3:7</Verse>
+    <Verse GRK="000000003000051111201222000000">LUK 6:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000001222002122211">MAT 5:2-3</Verse>
+    <Verse GRK="000000000012222122211">LUK 6:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2220000201">MAT 5:6</Verse>
+    <Verse GRK="222021000000">LUK 6:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222200211212021">MAT 5:11</Verse>
+    <Verse GRK="2220200000002211121221111">LUK 6:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1211222221112111000">MAT 5:12</Verse>
+    <Verse GRK="10000211122222111112111000">LUK 6:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00220052222521300000003000">MAT 5:13</Verse>
+    <Verse GRK="0000322522211521130003000">MRK 9:49-50</Verse>
+    <Verse GRK="00225202225213000000030030000">LUK 14:34-35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11231022252224111111">MAT 5:15</Verse>
+    <Verse GRK="0003001022215111302221">MRK 4:21</Verse>
+    <Verse GRK="202200051125211522222">LUK 8:16</Verse>
+    <Verse GRK="22200202225222522222">LUK 11:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000030111111411111111113000">MAT 5:18</Verse>
+    <Verse GRK="000111111411111">LUK 16:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222000000000000">MAT 5:21</Verse>
+    <Verse GRK="22200">MAT 5:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="001120300002225210011522115221">MAT 5:25</Verse>
+    <Verse GRK="0001112005220000051211152200115001122">LUK 12:58</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0222222502121">MAT 5:26</Verse>
+    <Verse GRK="222222501212">LUK 12:59</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="202220022120200111111111111111222">MAT 5:29</Verse>
+    <Verse GRK="022222222111100000011112202">MRK 9:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22202222120000101111111111111222">MAT 5:30</Verse>
+    <Verse GRK="2222222121111000011111220200000">MRK 9:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00002000202">MAT 5:31</Verse>
+    <Verse GRK="100021202220">MAT 19:7</Verse>
+    <Verse GRK="0011202122">MRK 10:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02222222222111001522212">MAT 5:32</Verse>
+    <Verse GRK="22222222221112222">MAT 19:9</Verse>
+    <Verse GRK="0002222222222005201110102">MRK 10:11-12</Verse>
+    <Verse GRK="22222220005221111">LUK 16:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0200220212200000212200000000000000000000000000000012112222200000000">MAT 5:34-37</Verse>
+    <Verse GRK="00200222222220000122022002200000">JAS 5:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000030000000040222300005220030022">MAT 5:39-40</Verse>
+    <Verse GRK="0000004222500002252200">LUK 6:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="122151111121">MAT 5:42</Verse>
+    <Verse GRK="122151111121">LUK 6:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000222200000">MAT 5:43</Verse>
+    <Verse GRK="0000000222222">MAT 19:19</Verse>
+    <Verse GRK="2210222222222222222222222200010022002222222">MAT 22:37-39</Verse>
+    <Verse GRK="0222222222222222222222222222222222222100211">MRK 12:30-31</Verse>
+    <Verse GRK="00202222222112222220222220000000">MRK 12:33</Verse>
+    <Verse GRK="22115222222222222222222222222222522222">LUK 10:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11225222521112302111111511112200300000">MAT 5:44-45</Verse>
+    <Verse GRK="12200522230000300051112300003000003000003021511120002">LUK 6:27-28,35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1112224114111111">MAT 5:46</Verse>
+    <Verse GRK="111222411141111111">LUK 6:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22111114114221222">MAT 5:47</Verse>
+    <Verse GRK="20211114111521222">LUK 6:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111142220012">MAT 5:48</Verse>
+    <Verse GRK="111322212">LUK 6:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111500000522252223000300000">MAT 6:9-10</Verse>
+    <Verse GRK="000111552225222">LUK 11:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222421">MAT 6:11</Verse>
+    <Verse GRK="2222242111">LUK 11:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2221123211111522222300000">MAT 6:12-13</Verse>
+    <Verse GRK="2221125011111522222">LUK 11:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="101112214222222130000030000000">MAT 6:14-15</Verse>
+    <Verse GRK="000041111132222211142221">MRK 11:25</Verse>
+    <Verse GRK="22111222200002222">MRK 11:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000003120003211111">MAT 6:20</Verse>
+    <Verse GRK="000000030000300005111421">LUK 12:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222221522221">MAT 6:21</Verse>
+    <Verse GRK="222221522212">LUK 12:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222224112222522221">MAT 6:22</Verse>
+    <Verse GRK="222222224222213222221300030000">LUK 11:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222225222222225222222522222">MAT 6:24</Verse>
+    <Verse GRK="2022225222222225222222522222">LUK 16:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22225222052000522022422222252222">MAT 6:25</Verse>
+    <Verse GRK="000000522252225252222512222252222">LUK 12:22-23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111115222241115211112142221">MAT 6:26</Verse>
+    <Verse GRK="1115222230001152121422211">LUK 12:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222220">MAT 6:27</Verse>
+    <Verse GRK="222222222222">LUK 12:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000042200215121522022222222222">MAT 6:28-29</Verse>
+    <Verse GRK="12221412152222222222222">LUK 12:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222112252222522141222">MAT 6:30</Verse>
+    <Verse GRK="221122225222252214222">LUK 12:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111151421300">MAT 6:31</Verse>
+    <Verse GRK="111151421300">LUK 12:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222251222002220">MAT 6:32</Verse>
+    <Verse GRK="2222200251222222">LUK 12:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2112211300052022">MAT 6:33</Verse>
+    <Verse GRK="122215222">LUK 12:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22422">MAT 7:1</Verse>
+    <Verse GRK="02241223003000330">LUK 6:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000003222222">MAT 7:2</Verse>
+    <Verse GRK="000000522222300">MRK 4:24</Verse>
+    <Verse GRK="00003000030000502212">LUK 6:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222521212222">MAT 7:3</Verse>
+    <Verse GRK="2222222222225221221222">LUK 6:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0212225222222251112222522222222522222522222">MAT 7:4-5</Verse>
+    <Verse GRK="21122232222122223022221115222222225222242222222">LUK 6:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22225225222">MAT 7:7</Verse>
+    <Verse GRK="00052225225222">LUK 11:9</Verse>
+    <Verse GRK="000000000521300000">JHN 16:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222252225222">MAT 7:8</Verse>
+    <Verse GRK="222225222252222">LUK 11:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="010221422201300032111222">MAT 7:9-10</Verse>
+    <Verse GRK="1022115221511222">LUK 11:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22220252222252220211151222">MAT 7:11</Verse>
+    <Verse GRK="2222025222225222211511222">LUK 11:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11111222224012230000000">MAT 7:12</Verse>
+    <Verse GRK="11122222521">LUK 6:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1222130000000300003211111">MAT 7:13</Verse>
+    <Verse GRK="112221320011300">LUK 13:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222421210002302111130221113021111422111">MAT 7:16-18</Verse>
+    <Verse GRK="00222222">MAT 7:20</Verse>
+    <Verse GRK="010220020241022002025022022">MAT 12:33</Verse>
+    <Verse GRK="0002212240221223022202241122230010">LUK 6:43-44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0011122300000301111111111300000030000003000003000000">MAT 7:21-22</Verse>
+    <Verse GRK="00112230111">LUK 6:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000004124224111">MAT 7:23</Verse>
+    <Verse GRK="0000000050223120312222">MAT 25:11-12</Verse>
+    <Verse GRK="000000300030003000052242125220030030000300000300052200422411">LUK 13:25-27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10112110512410310115223000000030003022252130000">MAT 7:24-25</Verse>
+    <Verse GRK="1100001211512300004114130003002223003002225211130000">LUK 6:47-48</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="102100005210410310022213000011130000000051511111">MAT 7:26-27</Verse>
+    <Verse GRK="2115214114222111311150151111111">LUK 6:49</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000050022225222222522220">MAT 7:28-29</Verse>
+    <Verse GRK="222222522222252222">MRK 1:22</Verse>
+    <Verse GRK="2222224111111">LUK 4:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000005021412522222">MAT 8:1-2</Verse>
+    <Verse GRK="211120031020052222">MRK 1:40</Verse>
+    <Verse GRK="0000000000521113000111002522222">LUK 5:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222522521222">MAT 8:3</Verse>
+    <Verse GRK="202222211022212122201">MRK 1:41-42</Verse>
+    <Verse GRK="2222222525222222">LUK 5:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222115225222225111422522">MAT 8:4</Verse>
+    <Verse GRK="0000005225202522222511111422522">MRK 1:43-44</Verse>
+    <Verse GRK="211251512222511111422522">LUK 5:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10022301300031111000130">MAT 8:5-6</Verse>
+    <Verse GRK="00000030000422401111300000">LUK 7:1-2</Verse>
+    <Verse GRK="00000000300003011111142">JHN 4:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="002212222222222202221222">MAT 8:8</Verse>
+    <Verse GRK="0000000000000000022102002022222222000000022221222">LUK 7:6-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222222222222222222222">MAT 8:9</Verse>
+    <Verse GRK="2222222022222222222222222222222">LUK 7:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222021102211222222">MAT 8:10</Verse>
+    <Verse GRK="22022200011112221222222">LUK 7:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000222225200000052211">MAT 8:11</Verse>
+    <Verse GRK="022222000005222211">LUK 13:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000000522222222">MAT 8:12</Verse>
+    <Verse GRK="22222222230000003000000003000">LUK 13:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="010022210111111">MAT 8:14</Verse>
+    <Verse GRK="00000012221000000101111000000">MRK 1:29-30</Verse>
+    <Verse GRK="00000122211111111100000">LUK 4:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212202222220221">MAT 8:15</Verse>
+    <Verse GRK="200012222222221">MRK 1:31</Verse>
+    <Verse GRK="200000022200021">LUK 4:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222112152110522222">MAT 8:16</Verse>
+    <Verse GRK="2221111411222250252022225212521211522">MRK 1:32,34</Verse>
+    <Verse GRK="1111111122112230000000213022010000300000501112520020">LUK 4:40-41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000011222">MAT 8:18</Verse>
+    <Verse GRK="0110000001222">MRK 4:35</Verse>
+    <Verse GRK="000000000000000011112220000">LUK 8:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="001121022222">MAT 8:19</Verse>
+    <Verse GRK="000000211122222">LUK 9:57</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222222222222222222222222">MAT 8:20</Verse>
+    <Verse GRK="21222222222222222222222222">LUK 9:58</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12000202222112222">MAT 8:21</Verse>
+    <Verse GRK="000100022222122222">LUK 9:59</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="020120002222222">MAT 8:22</Verse>
+    <Verse GRK="122222222200000000">LUK 9:60</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00021200222">MAT 8:23</Verse>
+    <Verse GRK="00000000111000000">MRK 4:36</Verse>
+    <Verse GRK="000000000220222000000000000">LUK 8:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21111000122111121120122102">MAT 8:24-25</Verse>
+    <Verse GRK="211111111122000001200000001212110100002">MRK 4:37-38</Verse>
+    <Verse GRK="000021110001100001221120000000000000000">LUK 8:23-24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2122221312112222222">MAT 8:26</Verse>
+    <Verse GRK="2222120220030002222222222111">MRK 4:39-40</Verse>
+    <Verse GRK="0000000030221111111002225121111000000300000000000000">LUK 8:24-25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000122221122222">MAT 8:27</Verse>
+    <Verse GRK="000000001122221122212">MRK 4:41</Verse>
+    <Verse GRK="0000000000000112222110211022">LUK 8:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="210222222211201222000000000000">MAT 8:28</Verse>
+    <Verse GRK="2122200222210000000122221111000022200000000">MRK 5:1-3</Verse>
+    <Verse GRK="21222210000000000011100011000000000000222">LUK 8:26-27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20115122222300011">MAT 8:29</Verse>
+    <Verse GRK="0000000312212215222222222410022242111111122">MRK 5:6-8</Verse>
+    <Verse GRK="0000042222152222222224122242111111223000000000030000000000">LUK 8:28-29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000221230012230012211115121421022250202222222251211">MAT 8:30-32</Verse>
+    <Verse GRK="22212222125222422110001522422111222252222222220051211">MRK 5:11-13</Verse>
+    <Verse GRK="222221212252201121152252210002222522222222151">LUK 8:32-33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222250222200000">MAT 8:33</Verse>
+    <Verse GRK="122025222222223010022">MRK 5:14</Verse>
+    <Verse GRK="1222222522222222">LUK 8:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20000111113000000000">MAT 8:34</Verse>
+    <Verse GRK="2122251212222000052">MRK 5:15</Verse>
+    <Verse GRK="000000122251221111112220000052">LUK 8:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000000021012222">MAT 8:34</Verse>
+    <Verse GRK="001222222">MRK 5:17</Verse>
+    <Verse GRK="01200000002220000300000">LUK 8:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="221122200000000000000000">MAT 9:2</Verse>
+    <Verse GRK="201112000">MRK 2:3</Verse>
+    <Verse GRK="2201221111000000000">LUK 5:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000002222222222022222">MAT 9:2</Verse>
+    <Verse GRK="222222202222222">MRK 2:5</Verse>
+    <Verse GRK="222222111222">LUK 5:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2022212122">MAT 9:3</Verse>
+    <Verse GRK="012220001211102002000000000">MRK 2:6-7</Verse>
+    <Verse GRK="200110001002001000000000">LUK 5:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212211224102222">MAT 9:4</Verse>
+    <Verse GRK="2102200000111104012222">MRK 2:8</Verse>
+    <Verse GRK="11221120200412222">LUK 5:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20222222222222">MAT 9:5</Verse>
+    <Verse GRK="22220022222220000022">MRK 2:9</Verse>
+    <Verse GRK="22221122022222">LUK 5:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222222022212211222222">MAT 9:6</Verse>
+    <Verse GRK="2222222222222222220012112222222">MRK 2:10-11</Verse>
+    <Verse GRK="2222222222222221220010111212222">LUK 5:24</Verse>
+    <Verse GRK="21001211200">JHN 5:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2122222000002222000000">MAT 9:7-8</Verse>
+    <Verse GRK="2100000000000000000000">MRK 2:12</Verse>
+    <Verse GRK="201000000222220000000222200000000">LUK 5:25-26</Verse>
+    <Verse GRK="20110000000000000000">JHN 5:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2200020222200522222222">MAT 9:9</Verse>
+    <Verse GRK="22200002222522222222">MRK 2:14</Verse>
+    <Verse GRK="000000000222251222200212">LUK 5:27-28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="211122250222202222222">MAT 9:10</Verse>
+    <Verse GRK="21112220522222222222300000">MRK 2:15</Verse>
+    <Verse GRK="2000002222501112100111">LUK 5:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222522252222222000">MAT 9:11</Verse>
+    <Verse GRK="200112300000052224222222">MRK 2:16</Verse>
+    <Verse GRK="00220000111115222222100">LUK 5:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122522222222230000000005022222">MAT 9:12-13</Verse>
+    <Verse GRK="12111005222222222522222">MRK 2:17</Verse>
+    <Verse GRK="1011200522212222251222200">LUK 5:31-32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00122222220000000">MAT 9:13</Verse>
+    <Verse GRK="001222222200000">MAT 12:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000222000022210222122">MAT 9:14</Verse>
+    <Verse GRK="0022222210000000222000000221222">MRK 2:18</Verse>
+    <Verse GRK="000002221000002211221111">LUK 5:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222252222214122222522222222522">MAT 9:15</Verse>
+    <Verse GRK="222225222224122222130000000005222222225222000">MRK 2:19-20</Verse>
+    <Verse GRK="2122115111224122222115220222222520000">LUK 5:34-35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="200222211502202112222">MAT 9:16</Verse>
+    <Verse GRK="222202113002222100002222">MRK 2:21</Verse>
+    <Verse GRK="000000052000002113000000000000000000">LUK 5:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11222225222111522122225122222300">MAT 9:17</Verse>
+    <Verse GRK="01122222522100115221222522222">MRK 2:22</Verse>
+    <Verse GRK="011222225222100001151122225222221300000003000">LUK 5:37-39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000022011122122110222200021">MAT 9:18</Verse>
+    <Verse GRK="010012200011111022022112110222200021">MRK 5:22-23</Verse>
+    <Verse GRK="02100220021100111111220000022001000001000000000">LUK 8:41-42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2000120000">MAT 9:19</Verse>
+    <Verse GRK="000021200000">MRK 5:24</Verse>
+    <Verse GRK="00000000000000000000">LUK 8:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20212200000000">MAT 9:20</Verse>
+    <Verse GRK="22111122000000000000000000000">MRK 5:25-26</Verse>
+    <Verse GRK="22111101100000000000">LUK 8:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000022222222">MAT 9:20</Verse>
+    <Verse GRK="0000100022222">MRK 5:27</Verse>
+    <Verse GRK="2222222200000000">LUK 8:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22002022222">MAT 9:21</Verse>
+    <Verse GRK="220220111200000000000000000">MRK 5:28-29</Verse>
+    <Verse GRK="0010022200000000">LUK 8:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22000002022222200000000">MAT 9:22</Verse>
+    <Verse GRK="22222222220000000000">MRK 5:34</Verse>
+    <Verse GRK="2222222222000">LUK 8:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1200222112100000140222002222230000012222122">MAT 9:23-25</Verse>
+    <Verse GRK="00000000000000000031211212110000030100000002222522000000000000000000000031221100000000000050122000000000003000000000000">MRK 5:37-43</Verse>
+    <Verse GRK="2122200000000000000000000030000000000222225220003012220000030000210000003000000000000">LUK 8:51-56</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2110130221125222">MAT 9:27</Verse>
+    <Verse GRK="2111230113022122242211252022">MAT 20:29-30</Verse>
+    <Verse GRK="212251122000001130005122223122220011152222">MRK 10:46-47</Verse>
+    <Verse GRK="111111225022221401000004112222141152222">LUK 18:35-38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02212111111121111000000000">MAT 9:29-30</Verse>
+    <Verse GRK="00002212201000">MAT 20:34</Verse>
+    <Verse GRK="00011011111201000000">MRK 10:52</Verse>
+    <Verse GRK="00011011111201000000000000000">LUK 18:42-43</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000012111512222252220300000">MAT 9:32-33</Verse>
+    <Verse GRK="01211115110111003000000300000">MAT 12:22-23</Verse>
+    <Verse GRK="00011111412212225222">LUK 11:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222522222220000">MAT 9:34</Verse>
+    <Verse GRK="222023022200202222">MAT 12:24</Verse>
+    <Verse GRK="111000023203022222222">MRK 3:22</Verse>
+    <Verse GRK="12112522222222">LUK 11:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2211220222500003201223000000">MAT 9:35</Verse>
+    <Verse GRK="000000522212">MRK 6:6</Verse>
+    <Verse GRK="000004111222501220030000">LUK 8:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10112115200012222">MAT 9:36</Verse>
+    <Verse GRK="001110211521222230000">MRK 6:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11111222222222222222222222">MAT 9:37-38</Verse>
+    <Verse GRK="1111222222222222222222222">LUK 10:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212200522223005201000">MAT 10:1</Verse>
+    <Verse GRK="212230000031220202">MRK 6:7</Verse>
+    <Verse GRK="0022520021011512">LUK 9:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10200000320025212252122521215225220051222252252111212">MAT 10:2-4</Verse>
+    <Verse GRK="0012300022521225212113000000005232225202321222232225222212">MRK 3:16-19</Verse>
+    <Verse GRK="200025222252523222522232232212322522211">LUK 6:14-16</Verse>
+    <Verse GRK="0000000000402020202502202520202022">ACT 1:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="022200000300000000003000000000">MAT 10:5-6</Verse>
+    <Verse GRK="002200010030000000">MRK 6:7</Verse>
+    <Verse GRK="021000000000">LUK 9:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00011122110522212212123000000">MAT 10:9-10</Verse>
+    <Verse GRK="21102122012042221211230001022">MRK 6:8-9</Verse>
+    <Verse GRK="2111512121212121140220">LUK 9:3</Verse>
+    <Verse GRK="1112212301110">LUK 10:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000005222112">MAT 10:10</Verse>
+    <Verse GRK="0000000000005222222300000">LUK 10:7</Verse>
+    <Verse GRK="000000000222222">1TI 5:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222000200000011222">MAT 10:11</Verse>
+    <Verse GRK="00011202222222">MRK 6:10</Verse>
+    <Verse GRK="02222222021">LUK 9:4</Verse>
+    <Verse GRK="2222220000004111120000003000000000000">LUK 10:5,7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1020211220200012222112200111121">MAT 10:12-13</Verse>
+    <Verse GRK="2000121111112202001212221220121">LUK 10:5-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222221111221111222222222">MAT 10:14</Verse>
+    <Verse GRK="22212222121122100222221">MRK 6:11</Verse>
+    <Verse GRK="2122122122222022212211">LUK 9:5</Verse>
+    <Verse GRK="1102100212000000022000022001110000000000">LUK 10:10-11</Verse>
+    <Verse GRK="001222200000">ACT 13:51</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0222222002222222">MAT 10:15</Verse>
+    <Verse GRK="2221112222222">MAT 11:22</Verse>
+    <Verse GRK="2221222222221">MAT 11:24</Verse>
+    <Verse GRK="22122220222222">LUK 10:12</Verse>
+    <Verse GRK="21112221122">LUK 10:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20222122230000000000">MAT 10:16</Verse>
+    <Verse GRK="022221222">LUK 10:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12000502225111010522022152222011">MAT 10:17-18</Verse>
+    <Verse GRK="12005222521152121152222">MRK 13:9</Verse>
+    <Verse GRK="0000000000004202004222241123021">LUK 21:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22125222224022222115222222220000000">MAT 10:19-20</Verse>
+    <Verse GRK="1202151223001222221152222222222">MRK 13:11</Verse>
+    <Verse GRK="22121221111115222211115022112122111">LUK 12:11-12</Verse>
+    <Verse GRK="020000100000412200311110000300030000021141111113000000000">LUK 21:12-15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222522222225222222225222222">MAT 10:21-22</Verse>
+    <Verse GRK="1111111152222002222">MAT 24:9</Verse>
+    <Verse GRK="2222222">MAT 24:13</Verse>
+    <Verse GRK="2222222225222222252222222252222220000000">MRK 13:12-13</Verse>
+    <Verse GRK="122111111115211522222222">LUK 21:16-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222223000004111122223000000300003000000000">MAT 10:24-25</Verse>
+    <Verse GRK="22222241112222">LUK 6:40</Verse>
+    <Verse GRK="00125222222300000">JHN 13:16</Verse>
+    <Verse GRK="00001125222222300000300003000">JHN 15:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000522122252222">MAT 10:26</Verse>
+    <Verse GRK="2222111151211222">MRK 4:22</Verse>
+    <Verse GRK="222211115222111222">LUK 8:17</Verse>
+    <Verse GRK="211222252222">LUK 12:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00022222225212211222">MAT 10:27</Verse>
+    <Verse GRK="00022222221521220000122200000">LUK 12:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02122222300000400110000111">MAT 10:28</Verse>
+    <Verse GRK="000000512222230000000300004100011111130000">LUK 12:4-5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212115222200000000">MAT 10:29</Verse>
+    <Verse GRK="2121115222200000">LUK 12:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="012222221050222202222222">MAT 10:30-31</Verse>
+    <Verse GRK="122222021522222222222">LUK 12:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="211122222412221111111">MAT 10:32</Verse>
+    <Verse GRK="0002111222224111112221111">LUK 12:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111121224001111111100000000">MAT 10:33</Verse>
+    <Verse GRK="1112122411111">LUK 12:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="012112111400021">MAT 10:34</Verse>
+    <Verse GRK="12211111400211">LUK 12:51</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00111020221220021220">MAT 10:35</Verse>
+    <Verse GRK="100001120000221220000002122">LUK 12:53</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11202011121000000001121">MAT 10:37</Verse>
+    <Verse GRK="1100001102000200000000000000000011121">LUK 14:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="012122151222121">MAT 10:38</Verse>
+    <Verse GRK="121221512221121">LUK 14:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222225212222222">MAT 10:39</Verse>
+    <Verse GRK="222222222252222222222">MAT 16:25</Verse>
+    <Verse GRK="222222222252212222200022">MRK 8:35</Verse>
+    <Verse GRK="2212222222522222222022">LUK 9:24</Verse>
+    <Verse GRK="221222122522212">LUK 17:33</Verse>
+    <Verse GRK="2122212521222000000012">JHN 12:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2122232212222">MAT 10:40</Verse>
+    <Verse GRK="0112211222222">MAT 18:5</Verse>
+    <Verse GRK="1121112222222522210020222">MRK 9:37</Verse>
+    <Verse GRK="0004121112222225222122223000000000">LUK 9:48</Verse>
+    <Verse GRK="0000032122152211222">LUK 10:16</Verse>
+    <Verse GRK="0000511112152211212">JHN 13:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12221111210111522222222">MAT 10:42</Verse>
+    <Verse GRK="21221211111152202222220000000">MRK 9:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2020000000040222005222212">MAT 11:2-3</Verse>
+    <Verse GRK="0000000003000222521000052222123000000300000005222212">LUK 7:18-20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22002252221215202252222322022">MAT 11:4-5</Verse>
+    <Verse GRK="222252221215222522225222">LUK 7:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222">MAT 11:6</Verse>
+    <Verse GRK="222222222">LUK 7:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="121200211225222222222">MAT 11:7</Verse>
+    <Verse GRK="1211122111225222222222">LUK 7:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222252111221112">MAT 11:8</Verse>
+    <Verse GRK="222222202521111112212">LUK 7:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222522222">MAT 11:9</Verse>
+    <Verse GRK="22222522222">LUK 7:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222022222222222222">MAT 11:10</Verse>
+    <Verse GRK="12000002222222222222">MRK 1:2</Verse>
+    <Verse GRK="22222222222222222222">LUK 7:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02211222220052222211222">MAT 11:11</Verse>
+    <Verse GRK="22222221152222211222">LUK 7:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111111100521112112">MAT 11:12</Verse>
+    <Verse GRK="0000000412211121121">LUK 16:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222">MAT 11:15</Verse>
+    <Verse GRK="202122222224111111115222">MAT 13:8-9</Verse>
+    <Verse GRK="00000000000005222">MAT 13:43</Verse>
+    <Verse GRK="2222222222230111121121123052222">MRK 4:8-9</Verse>
+    <Verse GRK="222222">MRK 4:23</Verse>
+    <Verse GRK="222202">MRK 7:16</Verse>
+    <Verse GRK="212222212012130052222">LUK 8:8</Verse>
+    <Verse GRK="0000000030052222">LUK 14:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212111412211141111522225221">MAT 11:16-17</Verse>
+    <Verse GRK="212111113000412211241111522225221">LUK 7:31-32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12212225222">MAT 11:18</Verse>
+    <Verse GRK="122001202205122">LUK 7:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="122222225122222522252222112222222">MAT 11:19</Verse>
+    <Verse GRK="122222225122222522252222011222222">LUK 7:34-35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222252222212222225222222">MAT 11:21</Verse>
+    <Verse GRK="222222522222122222252222202">LUK 10:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222225223000000000030000">MAT 11:23</Verse>
+    <Verse GRK="22222225022">LUK 10:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2111100252222222250222222222522222222">MAT 11:25-26</Verse>
+    <Verse GRK="21111000000252222222250222222222522222222">LUK 10:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222211122224112122222222222">MAT 11:27</Verse>
+    <Verse GRK="2222222221111122224211122222222222">LUK 10:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11111000022251220021221">MAT 12:1</Verse>
+    <Verse GRK="00011112225222200122">MRK 2:23</Verse>
+    <Verse GRK="00111022512222122000">LUK 6:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22202240002222011">MAT 12:2</Verse>
+    <Verse GRK="1221242222222">MRK 2:24</Verse>
+    <Verse GRK="121225122222">LUK 6:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111112222522222">MAT 12:3</Verse>
+    <Verse GRK="211122225000222222">MRK 2:25</Verse>
+    <Verse GRK="201111110042222222220">LUK 6:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222522221411102022222111">MAT 12:4</Verse>
+    <Verse GRK="2222222000522222522222225202110">MRK 2:26</Verse>
+    <Verse GRK="0222222522220252222522222122">LUK 6:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20222222222222222222">MAT 12:8</Verse>
+    <Verse GRK="0222222022">MRK 2:28</Verse>
+    <Verse GRK="0002222222222222222222">LUK 6:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20012220512222512050221522">MAT 12:9-10</Verse>
+    <Verse GRK="2102205222120251252210522">MRK 3:1-2</Verse>
+    <Verse GRK="01000402222052220011000241200000501115112">LUK 6:6-7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01211002000030010002141100">MAT 12:11</Verse>
+    <Verse GRK="111212000211310110000">LUK 14:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000322211">MAT 12:12</Verse>
+    <Verse GRK="00052211225221000">MRK 3:4</Verse>
+    <Verse GRK="0000000032111225221">LUK 6:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0222222252220000">MAT 12:13</Verse>
+    <Verse GRK="2220030000005222225222222">MRK 3:5</Verse>
+    <Verse GRK="220230222241122222">LUK 6:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212221522222222">MAT 12:14</Verse>
+    <Verse GRK="122200002152222222222">MRK 3:6</Verse>
+    <Verse GRK="0000300030000222222222">LUK 6:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212020510115111">MAT 12:15</Verse>
+    <Verse GRK="12200002000511000132222010000300000000300000003000030000003000411300011000">MRK 3:7-10</Verse>
+    <Verse GRK="0000000051100222005022210000003000000000300000030000113000051200000">LUK 6:17-19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222222">MAT 12:16</Verse>
+    <Verse GRK="201222222000000000">MRK 3:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22112225211125100211141">MAT 12:25</Verse>
+    <Verse GRK="002221300000512111410001">MRK 3:24-25</Verse>
+    <Verse GRK="0222112252221251114">LUK 11:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222000222502222">MAT 12:26</Verse>
+    <Verse GRK="222202202411000">MRK 3:26</Verse>
+    <Verse GRK="212222215222230000000">LUK 11:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12222222522222522222">MAT 12:27</Verse>
+    <Verse GRK="21222222522222522222">LUK 11:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22212222222222222">MAT 12:28</Verse>
+    <Verse GRK="22212222222222222">LUK 11:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112112222232221222222522222">MAT 12:29</Verse>
+    <Verse GRK="11212222215221222222522222">MRK 3:27</Verse>
+    <Verse GRK="000000003000003000000300000041111">LUK 11:21-22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222222">MAT 12:30</Verse>
+    <Verse GRK="22222222222222200000000">LUK 11:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="002241212113222152">MAT 12:31</Verse>
+    <Verse GRK="2211211122225221122115200000000000000000">MAT 12:32</Verse>
+    <Verse GRK="02231211111150100052212221251100000000">MRK 3:28-29</Verse>
+    <Verse GRK="212121112222422222152">LUK 12:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000005202022225222222115222222011">MAT 12:34-35</Verse>
+    <Verse GRK="22222220011152222211152222220">LUK 6:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="100000010300020">MAT 12:38</Verse>
+    <Verse GRK="202200211212200">MAT 16:1</Verse>
+    <Verse GRK="20220000122212220">MRK 8:11</Verse>
+    <Verse GRK="012212122">LUK 11:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000522222522225222200">MAT 12:39</Verse>
+    <Verse GRK="222222522225222251222222222222">MAT 16:4</Verse>
+    <Verse GRK="0000003222223001211125120020002222222222">MRK 8:12-13</Verse>
+    <Verse GRK="000000522000525222252222">LUK 11:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="120200000000005222220000000000">MAT 12:40</Verse>
+    <Verse GRK="12020005202222000">LUK 11:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222225222222252222">MAT 12:41</Verse>
+    <Verse GRK="222222222252222222252222">LUK 11:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222225212222222222252222">MAT 12:42</Verse>
+    <Verse GRK="2222222002225212222222222252222">LUK 11:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2022222225222222114222221225220222">MAT 12:43-44</Verse>
+    <Verse GRK="22222222522222211421222222522222">LUK 11:24-25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222200222225222522222222230000000">MAT 12:45</Verse>
+    <Verse GRK="22222222252225222222222">LUK 11:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000022222242000">MAT 12:46</Verse>
+    <Verse GRK="11220222232100000">MRK 3:31</Verse>
+    <Verse GRK="110022222223000000">LUK 8:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11025222222222111">MAT 12:47</Verse>
+    <Verse GRK="00000112522222220000212">MRK 3:32</Verse>
+    <Verse GRK="112522222222112">LUK 8:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22220005222220022230000000004222222242222221111142222222">MAT 12:48-50</Verse>
+    <Verse GRK="121152222222230000000422222224222222242222222">MRK 3:33-35</Verse>
+    <Verse GRK="222211522223001122001">LUK 8:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000003222512211522222522211115112220300000">MAT 13:1-3</Verse>
+    <Verse GRK="0000222512211522222000522200011115112223000000">MRK 4:1-2</Verse>
+    <Verse GRK="11113000022300">LUK 8:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000052222152222122222512221">MAT 13:3-4</Verse>
+    <Verse GRK="022222302222222225122022">MRK 4:3-4</Verse>
+    <Verse GRK="2222200052222222222005220021">LUK 8:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122112222251222222241122222222">MAT 13:5-6</Verse>
+    <Verse GRK="212211222225122222224011122222222">MRK 4:5-6</Verse>
+    <Verse GRK="21121150222221">LUK 8:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1121225222211">MAT 13:7</Verse>
+    <Verse GRK="21212252222123000">MRK 4:7</Verse>
+    <Verse GRK="2121111512212">LUK 8:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212122222223020010012220">MAT 13:8-9</Verse>
+    <Verse GRK="1222222222230001010010023000222">MRK 4:8-9</Verse>
+    <Verse GRK="112222212141130022222">LUK 8:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="202211001100">MAT 13:10</Verse>
+    <Verse GRK="200001111111111">MRK 4:10</Verse>
+    <Verse GRK="11122000011">LUK 8:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000032222222115200">MAT 13:11</Verse>
+    <Verse GRK="00030002222520022000">MRK 4:11</Verse>
+    <Verse GRK="0005222222224212230000000">LUK 8:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12252224122522222">MAT 13:12</Verse>
+    <Verse GRK="20225225222522222">MAT 25:29</Verse>
+    <Verse GRK="222525222522222">MRK 4:25</Verse>
+    <Verse GRK="0000512152521215211222">LUK 8:18</Verse>
+    <Verse GRK="0005225522225222">LUK 19:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0022104211520111">MAT 13:13</Verse>
+    <Verse GRK="22200052112230000">MRK 4:12</Verse>
+    <Verse GRK="0000000000004012252125222">LUK 8:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000022212202221221022000000000222122220000022122222">MAT 13:14-15</Verse>
+    <Verse GRK="12222212222222212">MRK 4:12</Verse>
+    <Verse GRK="0000000000000000012212222">LUK 8:10</Verse>
+    <Verse GRK="12220102211222012222222">JHN 12:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0022211300000">MAT 13:16</Verse>
+    <Verse GRK="000000005221100">LUK 10:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02222222002222222222222">MAT 13:17</Verse>
+    <Verse GRK="22222220022022222222222">LUK 10:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0002200311100000511211211114112220">MAT 13:18-19</Verse>
+    <Verse GRK="000302200000004111142222223011001321122221211">MRK 4:13-15</Verse>
+    <Verse GRK="000114111100522222113211222211113000">LUK 8:11-12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1222214012213222125112112115122222221">MAT 13:20-21</Verse>
+    <Verse GRK="1100222152222522125222112114222222221">MRK 4:16-17</Verse>
+    <Verse GRK="122115225212250222011041111">LUK 8:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1222214112215112222222422222">MAT 13:22</Verse>
+    <Verse GRK="0001222152222251122222223000001422222">MRK 4:18-19</Verse>
+    <Verse GRK="122221522251121000014211">LUK 8:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12222114102212130100112112112">MAT 13:23</Verse>
+    <Verse GRK="10012002214122215222112112">MRK 4:20</Verse>
+    <Verse GRK="1211114110000012215220">LUK 8:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00001522211225221111132002225112220211502222022222">MAT 13:31-32</Verse>
+    <Verse GRK="123111221122004221011115022200003201302022000050000022222">MRK 4:30-32</Verse>
+    <Verse GRK="2132222221212522222211114121114222212222">LUK 13:18-19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00005200002522222225222">MAT 13:33</Verse>
+    <Verse GRK="000000000522522222225222">LUK 13:20-21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111000211422122">MAT 13:34</Verse>
+    <Verse GRK="0121110000051212230000000">MRK 4:33-34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222222222222">MAT 13:42</Verse>
+    <Verse GRK="22222222222222222">MAT 13:50</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000005122224022203101152220522">MAT 13:53-54</Verse>
+    <Verse GRK="00021222230000030101222300115200022000522000000">MRK 6:1-2</Verse>
+    <Verse GRK="211111130000000001111301">LUK 4:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222111300001501012121215222002203000052223000030000000000000">MAT 13:55-57</Verse>
+    <Verse GRK="2222132015112121215002220225222">MRK 6:3</Verse>
+    <Verse GRK="000000000003000003012212">LUK 4:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00005122252222222252222">MAT 13:57</Verse>
+    <Verse GRK="11222252222222223000022222">MRK 6:4</Verse>
+    <Verse GRK="20000242112222">LUK 4:24</Verse>
+    <Verse GRK="0001252212121">JHN 4:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2210112222">MAT 13:58</Verse>
+    <Verse GRK="220011130000000302222300000">MRK 6:5-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000522211131000302113210252222222">MAT 14:1-2</Verse>
+    <Verse GRK="1200230000031021112252222222">MRK 6:14</Verse>
+    <Verse GRK="21222111300000032222">LUK 9:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="022122522220522222225222152221">MAT 14:3-4</Verse>
+    <Verse GRK="0222012252222522222223002222113222211111">MRK 6:17-18</Verse>
+    <Verse GRK="2120030001112223000000030000212222">LUK 3:19-20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212210030000">MAT 14:5</Verse>
+    <Verse GRK="000005122000300100300000300300003000">MRK 6:19-20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11111411110003222311121221">MAT 14:6-7</Verse>
+    <Verse GRK="11111111130000300000003011113122200030000000000003110202011030000">MRK 6:21-23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000011242002222222">MAT 14:8</Verse>
+    <Verse GRK="00011200300222113000000000300122222222">MRK 6:24-25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212222222100">MAT 14:9</Verse>
+    <Verse GRK="211222222210000">MRK 6:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21211222">MAT 14:10</Verse>
+    <Verse GRK="201000000003021222">MRK 6:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2111222512251222">MAT 14:11</Verse>
+    <Verse GRK="21112225102250010222">MRK 6:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2022222251100000">MAT 14:12</Verse>
+    <Verse GRK="2022200222051112">MRK 6:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00011022222225122222222">MAT 14:13</Verse>
+    <Verse GRK="0120222222510000032202200011">MRK 6:32-33</Verse>
+    <Verse GRK="0000000030012211115121223000000000300000">LUK 9:10-11</Verse>
+    <Verse GRK="001221111111">JHN 6:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222130000">MAT 14:14</Verse>
+    <Verse GRK="222222221300000000000">MRK 6:34</Verse>
+    <Verse GRK="00000001311000000300000">JHN 6:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1221222152222022051122222221">MAT 14:15</Verse>
+    <Verse GRK="1111222220132222222051222012222211">MRK 6:35-36</Verse>
+    <Verse GRK="12111201110511212212220012300111">LUK 9:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2202230005222">MAT 14:16</Verse>
+    <Verse GRK="220225222410422213000">MRK 6:37</Verse>
+    <Verse GRK="22115222311000000000030102000000">LUK 9:13</Verse>
+    <Verse GRK="000052100000000">JHN 6:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00003000022222">MAT 14:17</Verse>
+    <Verse GRK="0211020003002222">MRK 6:38</Verse>
+    <Verse GRK="12110000300000001221230000000000">LUK 9:13</Verse>
+    <Verse GRK="00003000000000030000000000030000220021300000">JHN 6:7-9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="211112113000000000000000000000000">MAT 14:19</Verse>
+    <Verse GRK="21011002101300000000">MRK 6:39-40</Verse>
+    <Verse GRK="00122000000411000300000">LUK 9:14-15</Verse>
+    <Verse GRK="0001111001000030020012">JHN 6:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="200000005222222252222511110030011">MAT 14:19</Verse>
+    <Verse GRK="22222222252222520022220310511100">MRK 6:41</Verse>
+    <Verse GRK="212222222522220322222411">LUK 9:16</Verse>
+    <Verse GRK="101100014110511100">JHN 6:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222521102221">MAT 14:20</Verse>
+    <Verse GRK="222225212113000">MRK 6:42-43</Verse>
+    <Verse GRK="2222051210212">LUK 9:17</Verse>
+    <Verse GRK="00000003111000030002223000000000">JHN 6:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20122223000">MAT 14:21</Verse>
+    <Verse GRK="02110022">MRK 6:44</Verse>
+    <Verse GRK="20222300000300000">LUK 9:14</Verse>
+    <Verse GRK="0000000300000030220012">JHN 6:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222222252022221111">MAT 14:22</Verse>
+    <Verse GRK="2122202222522220021111">MRK 6:45</Verse>
+    <Verse GRK="00000110000312201000030000000000">JHN 6:16-17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="211112220022122012020111111000000000">MAT 14:23-24</Verse>
+    <Verse GRK="211122221221221111002111">MRK 6:46-47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000400022222401221222211">MAT 14:24-25</Verse>
+    <Verse GRK="00010002222204112212222113000">MRK 6:48</Verse>
+    <Verse GRK="1011000">JHN 6:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2202222223022221111522002152222">MAT 14:26-27</Verse>
+    <Verse GRK="2222222232222130002132220012252222">MRK 6:49-50</Verse>
+    <Verse GRK="000000004112222300002131222222">JHN 6:19-20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="210222222">MAT 14:32</Verse>
+    <Verse GRK="210022222223000000">MRK 6:51</Verse>
+    <Verse GRK="000022230000000000">JHN 6:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222">MAT 14:34</Verse>
+    <Verse GRK="2222222230">MRK 6:53</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000003022125100222">MAT 14:35</Verse>
+    <Verse GRK="000000000322125100022210000">MRK 6:54-55</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222212222225221">MAT 14:36</Verse>
+    <Verse GRK="00000000000030000052221222222520201">MRK 6:56</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11112222245222212222411111111">MAT 15:1-2</Verse>
+    <Verse GRK="111112200102241112002521122212222411111">MRK 7:1,5</Verse>
+    <Verse GRK="101000111111">LUK 11:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="010123000122224222">MAT 15:3</Verse>
+    <Verse GRK="11231222242221">MRK 7:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="020222222222222222222122222222222221112200122221222">MAT 15:4-6</Verse>
+    <Verse GRK="0222221222122222222222221222220002222221000122000122222221100000">MRK 7:10-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0222220522222252222222">MAT 15:7-8</Verse>
+    <Verse GRK="00002222200300222222252222222">MRK 7:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222">MAT 15:9</Verse>
+    <Verse GRK="22222222">MRK 7:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222212421">MAT 15:10</Verse>
+    <Verse GRK="220221240021">MRK 7:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111111115112111122">MAT 15:11</Verse>
+    <Verse GRK="11111111111151211111122">MRK 7:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000502015221">MAT 15:14</Verse>
+    <Verse GRK="000003022132221">LUK 6:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0110222252222221152200000">MAT 15:16-17</Verse>
+    <Verse GRK="110022225222202211300030000003222300003000">MRK 7:18-19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10121100001222">MAT 15:18</Verse>
+    <Verse GRK="000121111222">MRK 7:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222151222232">MAT 15:19</Verse>
+    <Verse GRK="1222200320102222300000500">MRK 7:21-22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="201122000000000">MAT 15:20</Verse>
+    <Verse GRK="0200000222">MRK 7:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112001211200">MAT 15:21</Verse>
+    <Verse GRK="2111211230000000000">MRK 7:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000004024120041111">MAT 15:22</Verse>
+    <Verse GRK="002112511">MAT 15:25</Verse>
+    <Verse GRK="0000004111111511111">MRK 7:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0101422222222222">MAT 15:26</Verse>
+    <Verse GRK="111000004022222222222">MRK 7:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="221022022122220122000">MAT 15:27</Verse>
+    <Verse GRK="2200102222122122220">MRK 7:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0002220152225222222222251220001222">MAT 15:32</Verse>
+    <Verse GRK="000000000000052210522252222222222511220001222300000">MRK 8:1-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212225011100211">MAT 15:33</Verse>
+    <Verse GRK="2122203210002111">MRK 8:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="211002225222000">MAT 15:34</Verse>
+    <Verse GRK="2112225222">MRK 8:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212222114222000322222231011">MAT 15:35-36</Verse>
+    <Verse GRK="21222211312225222220301011">MRK 8:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22022501022220">MAT 15:37</Verse>
+    <Verse GRK="2222521222">MRK 8:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0002200000">MAT 15:38</Verse>
+    <Verse GRK="2002000">MRK 8:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20001222022111">MAT 15:39</Verse>
+    <Verse GRK="201222000022111">MRK 8:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="020110000000000000000020222110001111">MAT 16:2-3</Verse>
+    <Verse GRK="120110000000000000000000000000022000221111000110000000">LUK 12:54-56</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2000000522">MAT 16:5</Verse>
+    <Verse GRK="2222300000000000">MRK 8:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000125022222200">MAT 16:6</Verse>
+    <Verse GRK="002151222220000">MRK 8:15</Verse>
+    <Verse GRK="000000000031111105022200022">LUK 12:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0121102221">MAT 16:7</Verse>
+    <Verse GRK="12112221">MRK 8:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="210015200022225212222113221">MAT 16:8-9</Verse>
+    <Verse GRK="12105222225221300003000000004120222011152001300">MRK 8:17-19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122222220221">MAT 16:9</Verse>
+    <Verse GRK="1111111110220222002222001000">MRK 8:18-19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0220110111">MAT 16:10</Verse>
+    <Verse GRK="022011110010000">MRK 8:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="011000000000000000">MAT 16:11</Verse>
+    <Verse GRK="0001100000000">MRK 8:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="110021122242222522220000">MAT 16:13</Verse>
+    <Verse GRK="112200002112223000122220522222">MRK 8:27</Verse>
+    <Verse GRK="00000000000003112522112">LUK 9:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222002225220000122">MAT 16:14</Verse>
+    <Verse GRK="222010222422222122">MRK 8:28</Verse>
+    <Verse GRK="221222222252211000">LUK 9:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12222222520215222002200">MAT 16:15-16</Verse>
+    <Verse GRK="0000222222502105222">MRK 8:29</Verse>
+    <Verse GRK="102222222522041220000000000">LUK 9:20</Verse>
+    <Verse GRK="000003222022">JHN 6:69</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000012122221202212122221202">MAT 16:19</Verse>
+    <Verse GRK="000121222212221212222122">MAT 18:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01115210000022222222222">MAT 16:20</Verse>
+    <Verse GRK="1125210022222222222">MRK 8:30</Verse>
+    <Verse GRK="01121510">LUK 9:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00200111152100032222252225222222">MAT 16:21</Verse>
+    <Verse GRK="021152222252221225022025221111">MRK 8:31</Verse>
+    <Verse GRK="0222222522222252225222222">LUK 9:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222300000000">MAT 16:22</Verse>
+    <Verse GRK="0000052222222">MRK 8:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22111252220005222222222">MAT 16:23</Verse>
+    <Verse GRK="22100000020152225222222222">MRK 8:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00002225222215222222522">MAT 16:24</Verse>
+    <Verse GRK="00000222005222215222222522">MRK 8:34</Verse>
+    <Verse GRK="0000522221422222200522">LUK 9:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2212022212222141122222">MAT 16:26</Verse>
+    <Verse GRK="221112221122241122222">MRK 8:36-37</Verse>
+    <Verse GRK="2212122202001">LUK 9:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222152222222000000110">MAT 16:28</Verse>
+    <Verse GRK="000522222202522222222222000222222222">MRK 9:1</Verse>
+    <Verse GRK="202122202422222222222222222222">LUK 9:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222522200052222222522220111000202222000">MAT 17:1-2</Verse>
+    <Verse GRK="222222222502202522222220522222222020000000000">MRK 9:2-3</Verse>
+    <Verse GRK="011000011312222232020300000001120101210">LUK 9:28-29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222211">MAT 17:3</Verse>
+    <Verse GRK="22221100211">MRK 9:4</Verse>
+    <Verse GRK="22001100222">LUK 9:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212222242222230112222222222">MAT 17:4</Verse>
+    <Verse GRK="122212242222252222222222240111000">MRK 9:5-6</Verse>
+    <Verse GRK="000000005221114222225222222222224111">LUK 9:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="021420115122222522222211122">MAT 17:5</Verse>
+    <Verse GRK="02211522222522222222">MRK 9:7</Verse>
+    <Verse GRK="0021520123000000005222222522222122">LUK 9:34-35</Verse>
+    <Verse GRK="0000000030000000522221221111">2PE 1:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111112211122">MAT 17:8</Verse>
+    <Verse GRK="111022112200">MRK 9:8</Verse>
+    <Verse GRK="00000011130000000000000000000000000">LUK 9:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222420001111412222221">MAT 17:9</Verse>
+    <Verse GRK="22222242011114112222221">MRK 9:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2120024122222222">MAT 17:10</Verse>
+    <Verse GRK="2122422222222">MRK 9:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2201221012">MAT 17:11</Verse>
+    <Verse GRK="22102210123000000000000">MRK 9:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212220150003202213000000000">MAT 17:12</Verse>
+    <Verse GRK="12220215222130000000000000000">MRK 9:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2121200000">MAT 17:14</Verse>
+    <Verse GRK="212000210030000300000003000">MRK 9:14-15</Verse>
+    <Verse GRK="00000000000011">LUK 9:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21402223000021121220211">MAT 17:15</Verse>
+    <Verse GRK="2101122502220032000011003100000030000000000">MRK 9:17-18</Verse>
+    <Verse GRK="2212211221000000000000">MRK 9:22</Verse>
+    <Verse GRK="2011221150000222000030211000300010000000">LUK 9:38-39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20022222211">MAT 17:16</Verse>
+    <Verse GRK="00000000000000051222222221">MRK 9:18</Verse>
+    <Verse GRK="21112222222">LUK 9:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222522222200252222122">MAT 17:17</Verse>
+    <Verse GRK="222115222222252222211">MRK 9:19</Verse>
+    <Verse GRK="22222522222222242212111">LUK 9:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1212252000051110000">MAT 17:18</Verse>
+    <Verse GRK="000000052222003000000030000000500002300000000031000001100">MRK 9:25-27</Verse>
+    <Verse GRK="0000000000522222225111000000">LUK 9:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122002214122222">MAT 17:19</Verse>
+    <Verse GRK="110002202210422222">MRK 9:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222211115022112222422211141300000000000000">MAT 17:20</Verse>
+    <Verse GRK="1021221115220021222111111300000000000041">MRK 11:22-23</Verse>
+    <Verse GRK="1221412222421111111114111">LUK 17:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000012005222222225225111130000000">MAT 17:22-23</Verse>
+    <Verse GRK="00000012052221222522501111">MRK 9:31</Verse>
+    <Verse GRK="0000000005022222222">LUK 9:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000202100000">MAT 18:1</Verse>
+    <Verse GRK="000000100022">MRK 9:34</Verse>
+    <Verse GRK="12122220122">LUK 9:46</Verse>
+    <Verse GRK="120122222012">LUK 22:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222222">MAT 18:2</Verse>
+    <Verse GRK="2122222230000">MRK 9:36</Verse>
+    <Verse GRK="000000000422200">LUK 9:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="225223000021152122211">MAT 18:3</Verse>
+    <Verse GRK="222522222222252222">MRK 10:15</Verse>
+    <Verse GRK="2225222222222522220000000">LUK 18:17</Verse>
+    <Verse GRK="222205222522205212222">JHN 3:3</Verse>
+    <Verse GRK="2252225222000052122222">JHN 3:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222222222242112222225111111">MAT 18:6</Verse>
+    <Verse GRK="12222222222241211122222251222">MRK 9:42</Verse>
+    <Verse GRK="0000002222512220022222">LUK 17:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000011122220022002">MAT 18:7</Verse>
+    <Verse GRK="000000111221122222">LUK 17:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122202221241000051222222025222222222221">MAT 18:8</Verse>
+    <Verse GRK="2222222525222222250222122222221">MRK 9:43</Verse>
+    <Verse GRK="22222225252222222502222222">MRK 9:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212221232010051222112522222220000000000">MAT 18:9</Verse>
+    <Verse GRK="212221242512222110052222222">MRK 9:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222">MAT 18:11</Verse>
+    <Verse GRK="22222200222">LUK 19:10</Verse>
+    <Verse GRK="021001122200223011100">JHN 3:17</Verse>
+    <Verse GRK="00000003112222123000">1TI 1:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000001122212224122211151011">MAT 18:12</Verse>
+    <Verse GRK="1100022212224122211151011000">LUK 15:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="211100003100030000000">MAT 18:13</Verse>
+    <Verse GRK="21000001">LUK 15:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000003222111052022111">MAT 18:13</Verse>
+    <Verse GRK="22201000011115222111111000000">LUK 15:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20000000041113122222222511103000">MAT 19:1-2</Verse>
+    <Verse GRK="2114222220222510111300000">MRK 10:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="210252015212020000">MAT 19:3</Verse>
+    <Verse GRK="212105212252">MRK 10:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000022222222">MAT 19:4</Verse>
+    <Verse GRK="202222222">MRK 10:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00222222222512225222222522222252222222">MAT 19:5-6</Verse>
+    <Verse GRK="22222202225222225222222522222252222222">MRK 10:7-9</Verse>
+    <Verse GRK="0000010000050022222">1CO 6:16</Verse>
+    <Verse GRK="0222222225222225222222">EPH 5:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222252222222">MAT 19:6</Verse>
+    <Verse GRK="0000000522222252222222">MRK 10:8-9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12302222421111300000">MAT 19:8</Verse>
+    <Verse GRK="00012522242111">MRK 10:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122211110052222">MAT 19:13</Verse>
+    <Verse GRK="122222152222">MRK 10:13</Verse>
+    <Verse GRK="212011221322212">LUK 18:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222522222200052222211">MAT 19:14</Verse>
+    <Verse GRK="0222002052222222252222222">MRK 10:14</Verse>
+    <Verse GRK="222001522222222252222222">LUK 18:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212210022222222">MAT 19:15</Verse>
+    <Verse GRK="20001221122222222">MRK 10:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22201152022122">MAT 19:16</Verse>
+    <Verse GRK="10000020001252222222">MRK 10:17</Verse>
+    <Verse GRK="22000021521222">LUK 10:25</Verse>
+    <Verse GRK="1102015221222">LUK 18:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222252111151123000000300">MAT 19:17</Verse>
+    <Verse GRK="2222252225222222">MRK 10:18</Verse>
+    <Verse GRK="2222252225222222">LUK 18:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000012121212">MAT 19:18</Verse>
+    <Verse GRK="22222222222002222222">MRK 10:19</Verse>
+    <Verse GRK="222222222222222222">LUK 18:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="102052230042223000521115222522225222">MAT 19:20-21</Verse>
+    <Verse GRK="22103221220502003001251152225222522215222">MRK 10:20-21</Verse>
+    <Verse GRK="22152222300000321132225125222025222">LUK 18:21-22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2220115252222">MAT 19:22</Verse>
+    <Verse GRK="2211115252222">MRK 10:22</Verse>
+    <Verse GRK="2221405211">LUK 18:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222300012122211">MAT 19:23</Verse>
+    <Verse GRK="00000222522222222221">MRK 10:23</Verse>
+    <Verse GRK="0000000052200113000222221">MRK 10:24</Verse>
+    <Verse GRK="02022002522222222221">LUK 18:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000222512252222222">MAT 19:24</Verse>
+    <Verse GRK="22250102252222222">MRK 10:25</Verse>
+    <Verse GRK="2022511152222222">LUK 18:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22205125122">MAT 19:25</Verse>
+    <Verse GRK="22122005222">MRK 10:26</Verse>
+    <Verse GRK="12225222">LUK 18:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222225202221222">MAT 19:26</Verse>
+    <Verse GRK="222215221022202222">MRK 10:27</Verse>
+    <Verse GRK="222312222222">LUK 18:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10222252222223000">MAT 19:27</Verse>
+    <Verse GRK="012225222212">MRK 10:28</Verse>
+    <Verse GRK="21225211122">LUK 18:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000051110003000000000500201222222">MAT 19:28</Verse>
+    <Verse GRK="20011110000">LUK 22:28</Verse>
+    <Verse GRK="0000000000003221222222000000000">LUK 22:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="011222222522222222001515220">MAT 19:29</Verse>
+    <Verse GRK="11152252222222252222222213000">MRK 10:29</Verse>
+    <Verse GRK="121202222512124112120052222222">MRK 10:30</Verse>
+    <Verse GRK="2010522322222002230222000041211222252222222">LUK 18:29-30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222">MAT 19:30</Verse>
+    <Verse GRK="021222222">MAT 20:16</Verse>
+    <Verse GRK="222222222">MRK 10:31</Verse>
+    <Verse GRK="0012122212112">LUK 13:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="110022422000322222">MAT 20:17</Verse>
+    <Verse GRK="01222122300000300000420221213000">MRK 10:32</Verse>
+    <Verse GRK="21225223122300003000000">LUK 18:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22225222222222522252222001212122221">MAT 20:18-19</Verse>
+    <Verse GRK="02222522222222025222522222102102122251112">MRK 10:33-34</Verse>
+    <Verse GRK="0000000522230000000111140222120112122522222">LUK 18:31-33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222301212152221">MAT 20:19</Verse>
+    <Verse GRK="00000300000000003000522225102102122221112">MRK 10:33-34</Verse>
+    <Verse GRK="10225120212122222222">LUK 18:32-33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112001120000001011">MAT 20:20</Verse>
+    <Verse GRK="11200011211300000000">MRK 10:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22212100321000005222222102112">MAT 20:21</Verse>
+    <Verse GRK="22212100030000025222222112112">MRK 10:36-37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="022222222522222114224220212522222122522025220000">MAT 20:22-23</Verse>
+    <Verse GRK="22220222252222210000000301223001222111230000005222221225222252">MRK 10:38-40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222212111">MAT 20:24</Verse>
+    <Verse GRK="2222012111">MRK 10:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222225221222252222">MAT 20:25</Verse>
+    <Verse GRK="1222212522112222522022">MRK 10:42</Verse>
+    <Verse GRK="2222412212521200">LUK 22:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2212252122222522">MAT 20:26</Verse>
+    <Verse GRK="0000000041111500002">MRK 9:35</Verse>
+    <Verse GRK="22212252122222522">MRK 10:43</Verse>
+    <Verse GRK="1222511221000300011">LUK 22:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222212">MAT 20:27</Verse>
+    <Verse GRK="22222222212">MRK 10:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1222222252222222222222222222">MAT 20:28</Verse>
+    <Verse GRK="11222222252222222222222222222">MRK 10:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11111211211021012">MAT 20:31</Verse>
+    <Verse GRK="111121121111221">MRK 10:48</Verse>
+    <Verse GRK="1111121120111221">LUK 18:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22221102511142221111">MAT 20:32-33</Verse>
+    <Verse GRK="2222200311100300030000000000300000511152012121">MRK 10:49-51</Verse>
+    <Verse GRK="112200000300115111521221">LUK 18:40-41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2212200221222230221">MAT 21:1</Verse>
+    <Verse GRK="2212222222222242220">MRK 11:1</Verse>
+    <Verse GRK="200122222220025222">LUK 19:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="221222222512010200300">MAT 21:2</Verse>
+    <Verse GRK="0122222222512112225221224221">MRK 11:2</Verse>
+    <Verse GRK="2222224122225221225121">LUK 19:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222125220225111">MAT 21:3</Verse>
+    <Verse GRK="22222110152222421100">MRK 11:3</Verse>
+    <Verse GRK="2221111102522222">LUK 19:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00222222200012202200">MAT 21:5</Verse>
+    <Verse GRK="0022222221222">JHN 12:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12112021222">MAT 21:6</Verse>
+    <Verse GRK="11220000000000030000004112252202122300">MRK 11:4-6</Verse>
+    <Verse GRK="12112212300000000004122522000000">LUK 19:32-34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2000225111225111">MAT 21:7</Verse>
+    <Verse GRK="21222225112225222">MRK 11:7</Verse>
+    <Verse GRK="22122251222111400">LUK 19:35</Verse>
+    <Verse GRK="00011222000">JHN 12:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11112122222521111111222">MAT 21:8</Verse>
+    <Verse GRK="1122221115211111">MRK 11:8</Verse>
+    <Verse GRK="0000222222">LUK 19:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0002202222220022222222222">MAT 21:9</Verse>
+    <Verse GRK="02222222222222000000022222">MRK 11:9-10</Verse>
+    <Verse GRK="2222112220000122">LUK 19:38</Verse>
+    <Verse GRK="000000000001222222201100">JHN 12:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2102200000000">MAT 21:10</Verse>
+    <Verse GRK="21220000000000000000000000000">MRK 11:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01022252022522225222225222222">MAT 21:12</Verse>
+    <Verse GRK="00005222252225022225222252222222">MRK 11:15</Verse>
+    <Verse GRK="222225222">LUK 19:45</Verse>
+    <Verse GRK="202225200000300030000050000000005220005221">JHN 2:14-15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122522222522122">MAT 21:13</Verse>
+    <Verse GRK="00112020522222000521222">MRK 11:17</Verse>
+    <Verse GRK="1224122222522122">LUK 19:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111112">MAT 21:18</Verse>
+    <Verse GRK="11111112">MRK 11:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22200005223222222205125221022230000">MAT 21:19</Verse>
+    <Verse GRK="2220000500002230225222230000050125222220103000000000000000">MRK 11:13-14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000141122">MAT 21:20</Verse>
+    <Verse GRK="0000103122001">MRK 11:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2122125220120003000004122212222224">MAT 21:21</Verse>
+    <Verse GRK="1222124202224111222222222300000000000011">MRK 11:22-23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0221111114000000000">MAT 21:22</Verse>
+    <Verse GRK="000022111100311">MRK 11:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21021141122222002522224222222">MAT 21:23</Verse>
+    <Verse GRK="2102002220041122222222210522225222222000">MRK 11:27-28</Verse>
+    <Verse GRK="000000100022200422222111202003022222521111222">LUK 20:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222252222301212222222">MAT 21:24</Verse>
+    <Verse GRK="22222422251212222222">MRK 11:29</Verse>
+    <Verse GRK="222115222512">LUK 20:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22220052222522112522220522222">MAT 21:25</Verse>
+    <Verse GRK="2222522222004222252222522222">MRK 11:30-31</Verse>
+    <Verse GRK="22252222252122205222252222">LUK 20:4-5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222224224211122">MAT 21:26</Verse>
+    <Verse GRK="12224224212211110">MRK 11:32</Verse>
+    <Verse GRK="2222241000421211">LUK 20:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222211142212222222222222222">MAT 21:27</Verse>
+    <Verse GRK="222211152212222222222">MRK 11:33</Verse>
+    <Verse GRK="2111052212222222222222222222222">LUK 20:7-8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="121500122520252001522522222">MAT 21:33</Verse>
+    <Verse GRK="000111522522521522522222">MRK 12:1</Verse>
+    <Verse GRK="000001121512252222200">LUK 20:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000100500022241115222111302000000">MAT 21:34-35</Verse>
+    <Verse GRK="0222202150001211225222012">MRK 12:2-3</Verse>
+    <Verse GRK="0222221521122115121212">LUK 20:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22110003000">MAT 21:36</Verse>
+    <Verse GRK="2220011512151130300300300">MRK 12:4-5</Verse>
+    <Verse GRK="21111302121305111300000">LUK 20:11-12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1022211125222">MAT 21:37</Verse>
+    <Verse GRK="0011220122205222">MRK 12:6</Verse>
+    <Verse GRK="00000030022202312">LUK 20:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222211111522252221110">MAT 21:38</Verse>
+    <Verse GRK="02221110522252222122">MRK 12:7</Verse>
+    <Verse GRK="22122111152225212122">LUK 20:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222300222222111300021522121300000000">MAT 21:39-41</Verse>
+    <Verse GRK="222022222252222225222252222">MRK 12:8-9</Verse>
+    <Verse GRK="2122222522122225222205222230000">LUK 20:15-16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11001211122222222222222222222">MAT 21:42</Verse>
+    <Verse GRK="1111122222222222222222222">MRK 12:10-11</Verse>
+    <Verse GRK="000110000112222222222">LUK 20:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="022222125222222">MAT 21:44</Verse>
+    <Verse GRK="022212225222222">LUK 20:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="002200011052111512221130000">MAT 21:45-46</Verse>
+    <Verse GRK="21225221522222223000">MRK 12:12</Verse>
+    <Verse GRK="21000221121100005221522222220">LUK 20:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10200200103000010011000">MAT 22:1-2</Verse>
+    <Verse GRK="212140110000">LUK 14:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="221121110000000">MAT 22:3</Verse>
+    <Verse GRK="22112000011110000">LUK 14:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00003000013000003000000000">MAT 22:5-6</Verse>
+    <Verse GRK="00000030001000000000000300000000000000030000000000">LUK 14:18-20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111000003000000003111230000000000401111130001111310002224000000031111">MAT 22:7-10</Verse>
+    <Verse GRK="0000000004111111240111110030000000011300000000000300000042220031131011">LUK 14:21-23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22100012255222252222112522222522222000000522222">MAT 22:16-17</Verse>
+    <Verse GRK="22110001225111301052222522222522222522222225222223000">MRK 12:13-14</Verse>
+    <Verse GRK="2000000051110000000000300252200005212522222225021222">LUK 20:20-22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="122021225220421111521015222222222422412512222222225010000">MAT 22:18-22</Verse>
+    <Verse GRK="22122121522422005215222222222522225202252222222225111">MRK 12:15-17</Verse>
+    <Verse GRK="1222121142221121522252211422222222223000000005111110">LUK 20:23-26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000212222222222212122121222220212222">MAT 22:23-24</Verse>
+    <Verse GRK="0121102222222222220222201222122222222222222">MRK 12:18-19</Verse>
+    <Verse GRK="2000201222222222222221220102222222222222">LUK 20:27-28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2000225221101110000000">MAT 22:25</Verse>
+    <Verse GRK="2225221201111">MRK 12:20</Verse>
+    <Verse GRK="20225221211">LUK 20:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1222522311502222">MAT 22:26-27</Verse>
+    <Verse GRK="22222000005222522111422222">MRK 12:21-22</Verse>
+    <Verse GRK="22222222502221110052222">LUK 20:30-32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2220211224222">MAT 22:28</Verse>
+    <Verse GRK="222002222522222">MRK 12:23</Verse>
+    <Verse GRK="0002222212522222">LUK 20:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0122205222222222">MAT 22:29</Verse>
+    <Verse GRK="12223002222222222">MRK 12:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111122225222112">MAT 22:30</Verse>
+    <Verse GRK="1122122225222211">MRK 12:25</Verse>
+    <Verse GRK="000000030002252223000041200000000">LUK 20:35-36</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22112222111122120222222222222202221">MAT 22:31-32</Verse>
+    <Verse GRK="22221122000222211122122222222222222222200">MRK 12:26-27</Verse>
+    <Verse GRK="1212202022200022222222220222220000">LUK 20:37-38</Verse>
+    <Verse GRK="222222222222222100000000000000000">ACT 3:13</Verse>
+    <Verse GRK="000000000000000020020000000011122222122222220000000">ACT 7:30-32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222112125221111">MAT 22:35-36</Verse>
+    <Verse GRK="20211000300002050211">MRK 12:28</Verse>
+    <Verse GRK="20200120500000">LUK 10:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000110210002">MAT 22:42</Verse>
+    <Verse GRK="0000000005200011221">MRK 12:35</Verse>
+    <Verse GRK="00005211121">LUK 20:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000022200002222222222222222222">MAT 22:43-44</Verse>
+    <Verse GRK="221202002222222222222222222">MRK 12:36</Verse>
+    <Verse GRK="20212002222222222222222222">LUK 20:42-43</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0222225222">MAT 22:45</Verse>
+    <Verse GRK="021223122230000002222222222">MRK 12:37</Verse>
+    <Verse GRK="222223222222222222222">LUK 20:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000001100000222">MAT 22:46</Verse>
+    <Verse GRK="0000000000300000003121222222222222">MRK 12:34</Verse>
+    <Verse GRK="2011212222222222">LUK 20:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0020020111111511112111">MAT 23:4</Verse>
+    <Verse GRK="000000003111224211112111">LUK 11:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111222502222522222511111">MAT 23:6-7</Verse>
+    <Verse GRK="000000422222222522225222252222">MRK 12:38-39</Verse>
+    <Verse GRK="00000411222522222">LUK 11:43</Verse>
+    <Verse GRK="1222222225122225222252222">LUK 20:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1012251122">MAT 23:12</Verse>
+    <Verse GRK="22222252222">LUK 14:11</Verse>
+    <Verse GRK="0000000000052222251222">LUK 18:14</Verse>
+    <Verse GRK="2114120">JAS 4:10</Verse>
+    <Verse GRK="2011111142100">1PE 5:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2021110510000000402112211">MAT 23:13</Verse>
+    <Verse GRK="22115001004211221">LUK 11:52</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0">MAT 23:14</Verse>
+    <Verse GRK="00000000000000000000000000000000000000000000">MRK 12:38-40</Verse>
+    <Verse GRK="000000000000000000000000000000000000000">LUK 20:46-47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2200105222221211510000222000005222221">MAT 23:23</Verse>
+    <Verse GRK="0220152222212115122200005222221">LUK 11:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0100103222222115010211300000003000000">MAT 23:25-26</Verse>
+    <Verse GRK="00000001015222211230201211300000000030000000000">LUK 11:39-41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22000051113000030000000">MAT 23:27</Verse>
+    <Verse GRK="22211111130000000">LUK 11:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="220000520022302200">MAT 23:29</Verse>
+    <Verse GRK="22522222300000">LUK 11:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0110000111">MAT 23:31</Verse>
+    <Verse GRK="011000000000011000">LUK 11:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000111200005210030000000510000">MAT 23:34</Verse>
+    <Verse GRK="00000000411200322151">LUK 11:49</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01111212000042200202200412112224221001111">MAT 23:35-36</Verse>
+    <Verse GRK="01121111230000004222224122221142211111">LUK 11:50-51</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222225222225212225220111222522">MAT 23:37</Verse>
+    <Verse GRK="222222522222521222522111222522">LUK 13:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222220512222200202522222">MAT 23:38-39</Verse>
+    <Verse GRK="22222251222222002522222">LUK 13:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1000122030112320122">MAT 24:1</Verse>
+    <Verse GRK="0001224201123011001">MRK 13:1</Verse>
+    <Verse GRK="0010223110000">LUK 21:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2002101203005222222222">MAT 24:2</Verse>
+    <Verse GRK="020214100052222222211">MRK 13:2</Verse>
+    <Verse GRK="012003000000000300000000000032111200300000000">LUK 19:43-44</Verse>
+    <Verse GRK="211120051221222">LUK 21:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2121112230112224222222220000111">MAT 24:3</Verse>
+    <Verse GRK="122111223001022411111142222222222211">MRK 13:3-4</Verse>
+    <Verse GRK="10023202222222220">LUK 21:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10202252222522222225200222">MAT 24:4-5</Verse>
+    <Verse GRK="220012522225222222052222">MRK 13:5-6</Verse>
+    <Verse GRK="222221522222225200000000">LUK 21:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="021222232222222022">MAT 24:6</Verse>
+    <Verse GRK="222222252222222">MRK 13:7</Verse>
+    <Verse GRK="222221512202021022">LUK 21:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222422222200222">MAT 24:7-8</Verse>
+    <Verse GRK="222222222522202222">MRK 13:8</Verse>
+    <Verse GRK="00022222222510222200230000000">LUK 21:10-11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222">MAT 24:13</Verse>
+    <Verse GRK="000000000522222222222222">MRK 13:13</Verse>
+    <Verse GRK="11111111222222222">LUK 21:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="020220000002022200000">MAT 24:14</Verse>
+    <Verse GRK="0222200222">MRK 13:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222223000004110522222222222">MAT 24:15-16</Verse>
+    <Verse GRK="21222224100522222222222">MRK 13:14</Verse>
+    <Verse GRK="222222222300000300000000">LUK 21:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222202222522122222222">MAT 24:17-18</Verse>
+    <Verse GRK="20222220020222252111222222222">MRK 13:15-16</Verse>
+    <Verse GRK="000010222000000052202222022222">LUK 17:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222222">MAT 24:19</Verse>
+    <Verse GRK="2222222222222">MRK 13:17</Verse>
+    <Verse GRK="222222222222300000000000">LUK 21:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222000200">MAT 24:20</Verse>
+    <Verse GRK="222222">MRK 13:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111205222212221222">MAT 24:21</Verse>
+    <Verse GRK="111112522022111112221222">MRK 13:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22211115222251221111">MAT 24:22</Verse>
+    <Verse GRK="222101152222422200111">MRK 13:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222212220122">MAT 24:23</Verse>
+    <Verse GRK="02222212220122">MRK 13:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222225220221152022">MAT 24:24</Verse>
+    <Verse GRK="22222522221113222">MRK 13:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="122">MAT 24:25</Verse>
+    <Verse GRK="00222000000000000">MRK 13:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222111111152001122">MAT 24:27</Verse>
+    <Verse GRK="2222111111111115211220000">LUK 17:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20011212200000000000">MAT 24:28</Verse>
+    <Verse GRK="000000000051120221">LUK 17:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00222111522222222225221122522222">MAT 24:29</Verse>
+    <Verse GRK="001112220522222222225221122152201112">MRK 13:24-25</Verse>
+    <Verse GRK="0000101013000000000003000000000512222">LUK 21:25-26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000000000000052222222222222222">MAT 24:30</Verse>
+    <Verse GRK="1011000003022222111221222222">MAT 26:64</Verse>
+    <Verse GRK="222222222222222">MRK 13:26</Verse>
+    <Verse GRK="101100522222111221212222">MRK 14:62</Verse>
+    <Verse GRK="222222222222222">LUK 21:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22220000312222222511211122222222222">MAT 24:31</Verse>
+    <Verse GRK="2022231222222251121122222222222">MRK 13:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222225222222222252222">MAT 24:32</Verse>
+    <Verse GRK="222222252222222222522222">MRK 13:28</Verse>
+    <Verse GRK="000031100000003002202222">LUK 21:29-30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222202522222">MAT 24:33</Verse>
+    <Verse GRK="2222222522222">MRK 13:29</Verse>
+    <Verse GRK="222222252220000">LUK 21:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222222">MAT 24:34</Verse>
+    <Verse GRK="222222222211222">MRK 13:30</Verse>
+    <Verse GRK="22222222222222">LUK 21:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222122222212222222222">MAT 24:35</Verse>
+    <Verse GRK="222222222222222222222">MRK 13:31</Verse>
+    <Verse GRK="22222222222222222">LUK 21:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222212225221122222220">MAT 24:36</Verse>
+    <Verse GRK="2222210222522112222222">MRK 13:32</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11110252002222">MAT 24:37</Verse>
+    <Verse GRK="11011125200002222">LUK 17:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000040110152222222">MAT 24:38</Verse>
+    <Verse GRK="1111522222223000000">LUK 17:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000420111111">MAT 24:39</Verse>
+    <Verse GRK="11121111110">LUK 17:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11200051211">MAT 24:40</Verse>
+    <Verse GRK="00111210003212111">LUK 17:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2200051111">MAT 24:41</Verse>
+    <Verse GRK="0220030211111">LUK 17:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22122112202">MAT 24:42</Verse>
+    <Verse GRK="2222112200230000000">MRK 13:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12222222212223002212112">MAT 24:43</Verse>
+    <Verse GRK="12222222212225212112">LUK 12:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="002222522222222200000000">MAT 24:44</Verse>
+    <Verse GRK="22225222222222">LUK 12:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222102512222125201122">MAT 24:45</Verse>
+    <Verse GRK="00005222210251222212522211">LUK 12:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222">MAT 24:46</Verse>
+    <Verse GRK="222222222222">LUK 12:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12222222222">MAT 24:47</Verse>
+    <Verse GRK="12222222222">LUK 12:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222022222252225222114111111">MAT 24:48-49</Verse>
+    <Verse GRK="22222222225222052221111411111">LUK 12:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222222222252222222212300000000">MAT 24:50-51</Verse>
+    <Verse GRK="2222222222222222252222222212">LUK 12:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10122111110000000">MAT 25:13</Verse>
+    <Verse GRK="012211111">MRK 13:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1021411251200030001100000050000000">MAT 25:14-15</Verse>
+    <Verse GRK="121000051111005000300000">MRK 13:34</Verse>
+    <Verse GRK="0020000003000041121421100003000">LUK 19:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000030000">MAT 25:19</Verse>
+    <Verse GRK="000000000300000000003000">LUK 19:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111111300025110030111">MAT 25:20</Verse>
+    <Verse GRK="111125110111">LUK 19:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222522222225222222">MAT 25:21</Verse>
+    <Verse GRK="2222222222222222222222222">MAT 25:23</Verse>
+    <Verse GRK="01212231121300000">LUK 19:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="110111115110030111">MAT 25:22</Verse>
+    <Verse GRK="112114112111">LUK 19:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1100000000000000003000000">MAT 25:23</Verse>
+    <Verse GRK="1001000000">LUK 19:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="110111111502212241222111130011122111111">MAT 25:24-25</Verse>
+    <Verse GRK="1111151112001213022212411121122">LUK 19:20-21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000012520052112251111">MAT 25:26</Verse>
+    <Verse GRK="1230000022520000411151122">LUK 19:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000111211522121122">MAT 25:27</Verse>
+    <Verse GRK="00001211115222211">LUK 19:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2022112222121">MAT 25:28</Verse>
+    <Verse GRK="0000522112221212">LUK 19:24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00222221300000000302222111300000005101121025122221121111222222222">MAT 26:2-5</Verse>
+    <Verse GRK="1222011222522222222021252222211211222222222">MRK 14:1-2</Verse>
+    <Verse GRK="120011002522222202123211">LUK 22:1-2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111222222240222213202220">MAT 26:6-7</Verse>
+    <Verse GRK="1112222222241122222204112222">MRK 14:3</Verse>
+    <Verse GRK="00000000030012221142200002223000000052200210022200003000000002220">LUK 7:37-38,46</Verse>
+    <Verse GRK="0001122215221121222222300000000">JHN 12:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0111105222242221222">MAT 26:8-9</Verse>
+    <Verse GRK="111100522220004222221112202300">MRK 14:4-5</Verse>
+    <Verse GRK="00111111100000302220111212">JHN 12:4-5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02222032211502211522222252222411111111111111">MAT 26:10-12</Verse>
+    <Verse GRK="222212512252211522222230000005222241111111111">MRK 14:6-8</Verse>
+    <Verse GRK="2122124111111115222222522220000">JHN 12:7-8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222201111522222222222222222">MAT 26:13</Verse>
+    <Verse GRK="2022222221111522222222222222222">MRK 14:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112221121222">MAT 26:14</Verse>
+    <Verse GRK="121022212221212">MRK 14:10</Verse>
+    <Verse GRK="00001111111111010000011212">LUK 22:3-4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000300001500221212222222222222">MAT 26:15-16</Verse>
+    <Verse GRK="0102212225212112222222222222">MRK 14:11</Verse>
+    <Verse GRK="122122230222112000222222222222">LUK 22:5-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222220221115221122">MAT 26:17</Verse>
+    <Verse GRK="12212212211122052021122">MRK 14:12</Verse>
+    <Verse GRK="02112211112230000030000003000222">LUK 22:7-9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222200002152230000000222222">MAT 26:18</Verse>
+    <Verse GRK="0000004122222312222252111121105222222022222222">MRK 14:13-14</Verse>
+    <Verse GRK="2222011222422222521111111122005022222222222222">LUK 22:10-11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2022112002222">MAT 26:19</Verse>
+    <Verse GRK="212200000122122222">MRK 14:16</Verse>
+    <Verse GRK="11221222220000000000000">LUK 22:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2121222">MAT 26:20</Verse>
+    <Verse GRK="1221222">MRK 14:17</Verse>
+    <Verse GRK="10111111111">LUK 22:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222222">MAT 26:21</Verse>
+    <Verse GRK="202020022222222220000">MRK 14:18</Verse>
+    <Verse GRK="000000000022022222222">JHN 13:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="010222212221">MAT 26:22</Verse>
+    <Verse GRK="0000000222100000000000000000">MAT 26:25</Verse>
+    <Verse GRK="2102221122">MRK 14:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2212112211111111">MAT 26:23</Verse>
+    <Verse GRK="22200001122111">MRK 14:20</Verse>
+    <Verse GRK="001111022111">LUK 22:21</Verse>
+    <Verse GRK="10010001000000000000000">JHN 13:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222222222222222202222222">MAT 26:24</Verse>
+    <Verse GRK="22222222222222222222222222222220000000000000">MRK 14:21</Verse>
+    <Verse GRK="222222111112222222">LUK 22:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2122002322200025022222">MAT 26:26</Verse>
+    <Verse GRK="222225222222522222">MRK 14:22</Verse>
+    <Verse GRK="222522221522222220522222">LUK 22:19</Verse>
+    <Verse GRK="0000000003000000000123222250222222522222">1CO 11:23-24</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222022224222502222225122000">MAT 26:27-28</Verse>
+    <Verse GRK="2222223122200052222225221">MRK 14:23-24</Verse>
+    <Verse GRK="2220222252222222215212">LUK 22:20</Verse>
+    <Verse GRK="0222222252222202212300000000">1CO 11:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212222112022222222222002222211">MAT 26:29</Verse>
+    <Verse GRK="02220222222222222222222222">MRK 14:25</Verse>
+    <Verse GRK="2122222111122222111221">LUK 22:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222222222">MAT 26:30</Verse>
+    <Verse GRK="222222222222222222">MRK 14:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0222220200000020522222200">MAT 26:31</Verse>
+    <Verse GRK="02222022325222222">MRK 14:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2122222222">MAT 26:32</Verse>
+    <Verse GRK="1222222222">MRK 14:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02222252200510">MAT 26:33</Verse>
+    <Verse GRK="222125022412">MRK 14:29</Verse>
+    <Verse GRK="2222500000003111">LUK 22:33</Verse>
+    <Verse GRK="122250000000411111">JHN 13:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="122222250222222222">MAT 26:34</Verse>
+    <Verse GRK="1122222250222220022222">MRK 14:30</Verse>
+    <Verse GRK="1112232121222200000">LUK 22:34</Verse>
+    <Verse GRK="120000000222501120122">JHN 13:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10201221215222122111222222222">MAT 26:35</Verse>
+    <Verse GRK="200112212522210211222222222">MRK 14:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="110000221252222020002">MAT 26:36</Verse>
+    <Verse GRK="11221112522202022">MRK 14:32</Verse>
+    <Verse GRK="00000000000300000300000030000">LUK 22:39-40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2122211115122">MAT 26:37</Verse>
+    <Verse GRK="21222111110032122">MRK 14:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1222222222522200">MAT 26:38</Verse>
+    <Verse GRK="12222222225222">MRK 14:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22212001025022212222251122212">MAT 26:39</Verse>
+    <Verse GRK="2221200023222100110030200002222241122212">MRK 14:35-36</Verse>
+    <Verse GRK="000000005111225211222225111121100">LUK 22:41-42</Verse>
+    <Verse GRK="00000000500011030000000">JHN 12:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222522202122200">MAT 26:40</Verse>
+    <Verse GRK="22222252220021222">MRK 14:37</Verse>
+    <Verse GRK="000000222412000">LUK 22:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222252222222">MAT 26:41</Verse>
+    <Verse GRK="2222212252222222">MRK 14:38</Verse>
+    <Verse GRK="000002252122">LUK 22:40</Verse>
+    <Verse GRK="022003222222000000000000">LUK 22:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="200221300000000003000">MAT 26:42</Verse>
+    <Verse GRK="02220001">MRK 14:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222221">MAT 26:43</Verse>
+    <Verse GRK="222222222221300000">MRK 14:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12000222522223122022222222">MAT 26:45</Verse>
+    <Verse GRK="120022252222042202222220202">MRK 14:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222222222222222">MAT 26:46</Verse>
+    <Verse GRK="22222222222222222222">MRK 14:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222215222022224222200">MAT 26:47</Verse>
+    <Verse GRK="202221222252222222422200002">MRK 14:43</Verse>
+    <Verse GRK="22220000222210300000">LUK 22:47</Verse>
+    <Verse GRK="00201130222000030000011">JHN 18:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222211125222222">MAT 26:48</Verse>
+    <Verse GRK="122221125222222300">MRK 14:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21211132222">MAT 26:49</Verse>
+    <Verse GRK="2012115222">MRK 14:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02222400030222111222">MAT 26:50</Verse>
+    <Verse GRK="002221222">MRK 14:46</Verse>
+    <Verse GRK="22224000000">LUK 22:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000012205122222221">MAT 26:51</Verse>
+    <Verse GRK="000001225222222222">MRK 14:47</Verse>
+    <Verse GRK="21000022220221222">LUK 22:50</Verse>
+    <Verse GRK="00002005222222122222300000">JHN 18:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="011224220211030000000">MAT 26:52</Verse>
+    <Verse GRK="1022114222113000000000000000000000">JHN 18:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000022211522222222252222022222300022220040022222222222222222">MAT 26:55-56</Verse>
+    <Verse GRK="002221522222222252111222222223222242222222222">MRK 14:48-50</Verse>
+    <Verse GRK="20211111300000052222222521111222211111300000000002222222222222">LUK 22:52-53</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02122220220222221">MAT 26:57</Verse>
+    <Verse GRK="122222201000022222">MRK 14:53</Verse>
+    <Verse GRK="1212000001100000">LUK 22:54</Verse>
+    <Verse GRK="000000000001220000221000000000000">JHN 18:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222211222002222000">MAT 26:58</Verse>
+    <Verse GRK="1222212200112221122200000">MRK 14:54</Verse>
+    <Verse GRK="000000000002222200000000020011">LUK 22:54-55</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222212224212211014111">MAT 26:59-60</Verse>
+    <Verse GRK="2222222222214112221101003000004110000">MRK 14:55-57</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01131220052221">MAT 26:61</Verse>
+    <Verse GRK="00011031220005222001">MRK 14:58</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222210522222">MAT 26:62</Verse>
+    <Verse GRK="22220000015222222">MRK 14:60</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2202522123000000322222222222">MAT 26:63</Verse>
+    <Verse GRK="22250003221111252222221">MRK 14:61</Verse>
+    <Verse GRK="15222212300300000">LUK 22:67</Verse>
+    <Verse GRK="11150222223000030000">LUK 22:70</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1022000000022222222222212222">MAT 26:64</Verse>
+    <Verse GRK="202100022222222222212222">MRK 14:62</Verse>
+    <Verse GRK="0000200101111112211">MRK 16:19</Verse>
+    <Verse GRK="0000122222222211">LUK 22:69</Verse>
+    <Verse GRK="1101110001111000000000000">ACT 2:33</Verse>
+    <Verse GRK="011000111100000000">ACT 5:31</Verse>
+    <Verse GRK="0001100110000212211">ACT 7:55</Verse>
+    <Verse GRK="00001100222222111">ACT 7:56</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02211121022222002112212210121">MAT 26:65-66</Verse>
+    <Verse GRK="212111212222221122122010112">MRK 14:63-64</Verse>
+    <Verse GRK="111222120000000">LUK 22:71</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="011221212010120022222222222222222">MAT 26:67-68</Verse>
+    <Verse GRK="00011211222121102000000222222222222">MRK 14:65</Verse>
+    <Verse GRK="00000000021101222222">LUK 22:63-64</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1111122201022122222112220022222111110000000000000">MAT 26:69-71</Verse>
+    <Verse GRK="11111222121100121111212221121222221200022110111000">MRK 14:66-68</Verse>
+    <Verse GRK="21120111101212111122222200">LUK 22:56-57</Verse>
+    <Verse GRK="1011020011100000000000">JHN 18:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000012001212100001220000000">MAT 26:71-72</Verse>
+    <Verse GRK="000120011102000222100000000002220000">MRK 14:69-70</Verse>
+    <Verse GRK="0000121222222201022">LUK 22:58</Verse>
+    <Verse GRK="000000000002211112201122">JHN 18:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22101112222122222000000">MAT 26:73</Verse>
+    <Verse GRK="000012201112222222221">MRK 14:70</Verse>
+    <Verse GRK="00000000111211112221">LUK 22:59</Verse>
+    <Verse GRK="00000000000000000000000">JHN 18:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12121222222222">MAT 26:74</Verse>
+    <Verse GRK="012121222220002100220000000000000000000000">MRK 14:71-72</Verse>
+    <Verse GRK="0002022002100022">LUK 22:60</Verse>
+    <Verse GRK="000222220000000000">JHN 18:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222210222222222222">MAT 26:75</Verse>
+    <Verse GRK="0000002122112221122220222211">MRK 14:72</Verse>
+    <Verse GRK="0000000212222112222222022222222">LUK 22:61-62</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1112132212222000300522252200">MAT 27:1-2</Verse>
+    <Verse GRK="11121521222200225111522">MRK 15:1</Verse>
+    <Verse GRK="11114222220225220000">LUK 22:66</Verse>
+    <Verse GRK="00111042111">LUK 23:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000522212522222522122">MAT 27:11</Verse>
+    <Verse GRK="222215222225222122">MRK 15:2</Verse>
+    <Verse GRK="1111225222225222222">LUK 23:3</Verse>
+    <Verse GRK="000000005111010522222300000000422220003000000000030003000000000">JHN 18:33,37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000100110022">MAT 27:12</Verse>
+    <Verse GRK="012220">MRK 15:3</Verse>
+    <Verse GRK="000000002203022000012">LUK 23:9-10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0212250221322200005221022222222222">MAT 27:13-14</Verse>
+    <Verse GRK="20200115000221522112522122222222222">MRK 15:4-5</Verse>
+    <Verse GRK="00000032110005221212">JHN 19:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2220001211221">MAT 27:15</Verse>
+    <Verse GRK="222112221">MRK 15:6</Verse>
+    <Verse GRK="00020012">LUK 23:17</Verse>
+    <Verse GRK="0000021100030000000">JHN 18:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00010101">MAT 27:16</Verse>
+    <Verse GRK="000110001311120">MRK 15:7</Verse>
+    <Verse GRK="00003000001301100000320000">LUK 23:18-19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1222212">MAT 27:18</Verse>
+    <Verse GRK="122221200">MRK 15:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22200011150220000300000300000030122">MAT 27:20-21</Verse>
+    <Verse GRK="222111502211">MRK 15:11</Verse>
+    <Verse GRK="10023010122">LUK 23:18</Verse>
+    <Verse GRK="10023002230000">JHN 18:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22225220000402">MAT 27:22</Verse>
+    <Verse GRK="00000125202000000300122">MRK 15:12-13</Verse>
+    <Verse GRK="000000000030001123001110000030000000003000000030000">LUK 23:20-23</Verse>
+    <Verse GRK="00000000040215222000003000000">JHN 19:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2212222522101">MAT 27:23</Verse>
+    <Verse GRK="220112222522122">MRK 15:14</Verse>
+    <Verse GRK="2201112222030000000005201110130000">LUK 23:22-23</Verse>
+    <Verse GRK="00000000041110000411002230000000300000000">JHN 19:14-15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222225222222222222222">MAT 27:26</Verse>
+    <Verse GRK="00200000052223222222222222222">MRK 15:15</Verse>
+    <Verse GRK="0200000501111111100522200022222222222">LUK 23:24-25</Verse>
+    <Verse GRK="202102230002222222000">JHN 19:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12200111002100222">MAT 27:27</Verse>
+    <Verse GRK="2121100000201222">MRK 15:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0001112522225111230000030001005222">MAT 27:28-29</Verse>
+    <Verse GRK="000101251230005222">MRK 15:17-18</Verse>
+    <Verse GRK="0000000000311113000">LUK 23:11</Verse>
+    <Verse GRK="0002222521100111300000501223000">JHN 19:2-3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2111301221111">MAT 27:30</Verse>
+    <Verse GRK="121111511300000">MRK 15:19</Verse>
+    <Verse GRK="000000300005111">JHN 19:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222152222221211122222222222">MAT 27:31</Verse>
+    <Verse GRK="2222222152222221211122222222222">MRK 15:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00012020122222">MAT 27:32</Verse>
+    <Verse GRK="0102222220000022222">MRK 15:21</Verse>
+    <Verse GRK="0000022222200000000">LUK 23:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01221222221">MAT 27:33</Verse>
+    <Verse GRK="000001222122">MRK 15:22</Verse>
+    <Verse GRK="00111211100000000000000">LUK 23:33</Verse>
+    <Verse GRK="000001211222102">JHN 19:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="120200010211">MAT 27:34</Verse>
+    <Verse GRK="012020121">MRK 15:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112122222">MAT 27:35</Verse>
+    <Verse GRK="112112222200000">MRK 15:24</Verse>
+    <Verse GRK="000000000000112221100">LUK 23:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="01000011010022222">MAT 27:37</Verse>
+    <Verse GRK="000211012222">MRK 15:26</Verse>
+    <Verse GRK="00020022220">LUK 23:38</Verse>
+    <Verse GRK="100100010000012002222">JHN 19:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0122221222122">MAT 27:38</Verse>
+    <Verse GRK="02212212221220">MRK 15:27</Verse>
+    <Verse GRK="00000000002200011121111">LUK 23:33</Verse>
+    <Verse GRK="022011021210000">JHN 19:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21222222222222222222220000001222">MAT 27:39-40</Verse>
+    <Verse GRK="122222222220222222222221222">MRK 15:29-30</Verse>
+    <Verse GRK="000000000022000000022">LUK 23:36-37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222002522222520222222100">MAT 27:41-42</Verse>
+    <Verse GRK="222220022225222225202222222002130000000000000000">MRK 15:31-32</Verse>
+    <Verse GRK="000003021115212000220000">LUK 23:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00021111222222222222222">MAT 27:44</Verse>
+    <Verse GRK="22000000003000511222222222222222">MRK 15:32</Verse>
+    <Verse GRK="11111120300220000">LUK 23:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0011221122222">MAT 27:45</Verse>
+    <Verse GRK="0011221122222">MRK 15:33</Verse>
+    <Verse GRK="0000110221122222">LUK 23:44</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="002221222202222122222122">MAT 27:46</Verse>
+    <Verse GRK="02221222222221202222221122">MRK 15:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21211220220">MAT 27:47</Verse>
+    <Verse GRK="122122022">MRK 15:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1021000020020222200001222202">MAT 27:48-49</Verse>
+    <Verse GRK="2110022222201222202">MRK 15:36</Verse>
+    <Verse GRK="0000000111">LUK 23:36</Verse>
+    <Verse GRK="000020002011111">JHN 19:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2220122122">MAT 27:50</Verse>
+    <Verse GRK="2221111">MRK 15:37</Verse>
+    <Verse GRK="0122220000000000001">LUK 23:46</Verse>
+    <Verse GRK="0000022000000122">JHN 19:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="202222222222200000000">MAT 27:51</Verse>
+    <Verse GRK="222222222222">MRK 15:38</Verse>
+    <Verse GRK="0002022220">LUK 23:45</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222000000010000000022202">MAT 27:54</Verse>
+    <Verse GRK="12210000000002200222">MRK 15:39</Verse>
+    <Verse GRK="1222000000100212">LUK 23:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2202022241112221252022222202212211111">MAT 27:55-56</Verse>
+    <Verse GRK="2202222521222222200212214001111201230000000">MRK 15:40-41</Verse>
+    <Verse GRK="110000220211222110">LUK 23:49</Verse>
+    <Verse GRK="110000000000000020111222">JHN 19:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000220222200022222222202211">MAT 27:57-58</Verse>
+    <Verse GRK="000000000002022002220000000111102222220200000100000000000010000">MRK 15:42-45</Verse>
+    <Verse GRK="000020000000000000000022000200000222222222">LUK 23:50-52</Verse>
+    <Verse GRK="00000020220000000000000222200220000000">JHN 19:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212200211202222010221111212011220">MAT 27:59-60</Verse>
+    <Verse GRK="00001112222222111121211122">MRK 15:46</Verse>
+    <Verse GRK="20202222210111111">LUK 23:53</Verse>
+    <Verse GRK="102200000000000000000000000000011111111">JHN 19:40-41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02022220020000">MAT 27:61</Verse>
+    <Verse GRK="022222200100">MRK 15:47</Verse>
+    <Verse GRK="00000000000100000000">LUK 23:55</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1121111212222112111">MAT 28:1</Verse>
+    <Verse GRK="1122222222110002000001122221122111">MRK 16:1-2</Verse>
+    <Verse GRK="222221112210002">LUK 24:1</Verse>
+    <Verse GRK="222222221111112200000022">JHN 20:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000000001220000">MAT 28:2</Verse>
+    <Verse GRK="0000010222002211001220000">MRK 16:3-4</Verse>
+    <Verse GRK="11221122">LUK 24:2</Verse>
+    <Verse GRK="000000000000002211221222">JHN 20:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000110200000001000000">MAT 28:3-4</Verse>
+    <Verse GRK="0000000000001201">MRK 16:5</Verse>
+    <Verse GRK="00000000000001000000000011">LUK 24:3-4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="022111121000022222222000022221">MAT 28:5-6</Verse>
+    <Verse GRK="2211212200222222222211">MRK 16:6</Verse>
+    <Verse GRK="00000000000111020000022202000000000">LUK 24:5-6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0012222200000022222222012">MAT 28:7</Verse>
+    <Verse GRK="012222000222222222012">MRK 16:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0102220000002111">MAT 28:8</Verse>
+    <Verse GRK="010222000000000000">MRK 16:8</Verse>
+    <Verse GRK="01222211110000">LUK 24:9</Verse>
+    <Verse GRK="1000111111110000000000122000000">JHN 20:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2000120000000000020022200000000000000000000000000000000000">MAT 28:18-20</Verse>
+    <Verse GRK="21220000000111">MRK 16:15</Verse>
+    <Verse GRK="212000000000000000000000000222000000">LUK 24:46-48</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2022220211122022222222222222222">MRK 1:23-24</Verse>
+    <Verse GRK="22222211012200022222222222222222">LUK 4:33-34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222221251221110000112">MRK 1:25-26</Verse>
+    <Verse GRK="2222222221251221000112000">LUK 4:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="211012113000011502222000">MRK 1:27</Verse>
+    <Verse GRK="2111101211300001150222200">LUK 4:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2111201211100">MRK 1:28</Verse>
+    <Verse GRK="2111221111">LUK 4:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000005211221200222">MRK 1:34</Verse>
+    <Verse GRK="1022010000000000502102220020">LUK 4:41</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000010122200000000000000000110">MRK 1:35-37</Verse>
+    <Verse GRK="0001122201111000000000000">LUK 4:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11100111100011211">MRK 1:38</Verse>
+    <Verse GRK="111110011110000001121">LUK 4:43</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2211022200000000000000">MRK 2:4</Verse>
+    <Verse GRK="221110222000000000000000000">LUK 5:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1121222225222">MRK 3:3</Verse>
+    <Verse GRK="000000412122222500222300">LUK 6:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="012220000000000022222000000000000000">MRK 3:13-15</Verse>
+    <Verse GRK="0000001122200000000000000000000022222">LUK 6:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112222410200210">MRK 5:9</Verse>
+    <Verse GRK="1120022204112200100">LUK 8:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21202211000">MRK 5:10</Verse>
+    <Verse GRK="21222110000">LUK 8:31</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122220110000">MRK 5:16</Verse>
+    <Verse GRK="112222011">LUK 8:36</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000011111111">MRK 5:18</Verse>
+    <Verse GRK="11111111111110000">LUK 8:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000004222200051022121000520010002222230022222222222222">MRK 5:19-20</Verse>
+    <Verse GRK="12222512212152000012222252222222222222">LUK 8:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000001200200000">MRK 5:21</Verse>
+    <Verse GRK="000000120200000">LUK 8:40</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20220000000000001221000000000111200000000000">MRK 5:30-32</Verse>
+    <Verse GRK="21222012000000011120000000000000000">LUK 8:45-46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20200000002212000000">MRK 5:33</Verse>
+    <Verse GRK="00220000221200000000000000">LUK 8:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222112212222111122">MRK 5:35</Verse>
+    <Verse GRK="222111221212221122">LUK 8:49</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22210001112221">MRK 5:36</Verse>
+    <Verse GRK="222111222100">LUK 8:50</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="120220120220000">MRK 6:15</Verse>
+    <Verse GRK="11222012220000">LUK 9:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02021022200">MRK 6:16</Verse>
+    <Verse GRK="122222000000000000">LUK 9:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0022000012022000">MRK 6:30</Verse>
+    <Verse GRK="002212220000000000">LUK 9:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2212222220000000032222205222222012202">MRK 8:38</Verse>
+    <Verse GRK="2212222223222225222200221222">LUK 9:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222225221222222222">MRK 9:32</Verse>
+    <Verse GRK="22222200122111152120000222222222">LUK 9:45</Verse>
+    <Verse GRK="001110022212201111">LUK 18:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10021222222222222200">MRK 9:38</Verse>
+    <Verse GRK="002112222222222222000">LUK 9:49</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000220000000000000000222221212">MRK 9:39-40</Verse>
+    <Verse GRK="00000022222221212">LUK 9:50</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222202222220222222202022200000">MRK 9:43</Verse>
+    <Verse GRK="22202222222222220222022222">MRK 9:45</Verse>
+    <Verse GRK="222022202222022200022022222">MRK 9:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222222">MRK 9:44</Verse>
+    <Verse GRK="22222222222">MRK 9:46</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222222002222222">MRK 10:19</Verse>
+    <Verse GRK="222222222222222222">LUK 18:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000222202121300000000000">MRK 11:18</Verse>
+    <Verse GRK="00000000030222222100000">LUK 19:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000042222222252222522225222241222252225222">MRK 12:38-40</Verse>
+    <Verse GRK="122222222502222522225222241222252225222">LUK 20:46-47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222225222">MRK 12:40</Verse>
+    <Verse GRK="22222222225222">LUK 20:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000010111022200000">MRK 12:41</Verse>
+    <Verse GRK="001112220000">LUK 21:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00111122000">MRK 12:42</Verse>
+    <Verse GRK="001111022">LUK 21:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="200002012222222222200000">MRK 12:43</Verse>
+    <Verse GRK="22122222222222">LUK 21:3</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222211221220220">MRK 12:44</Verse>
+    <Verse GRK="22022222000222112222122">LUK 21:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000021114111100001130000000000">MRK 13:11</Verse>
+    <Verse GRK="00000021141111003000000000">LUK 21:14-15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112222203220">MRK 14:15</Verse>
+    <Verse GRK="12222252">LUK 22:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000003000004222222">MRK 15:8-9</Verse>
+    <Verse GRK="00000000000">LUK 23:13</Verse>
+    <Verse GRK="0000001000040222222">JHN 18:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0011111000000000011">MRK 16:10-11</Verse>
+    <Verse GRK="002220000000000011110000000000011">LUK 24:10-11</Verse>
+    <Verse GRK="022211100000000">JHN 20:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000011111222000000">MRK 16:19</Verse>
+    <Verse GRK="001111100001222">LUK 24:51</Verse>
+    <Verse GRK="11100101110000">ACT 1:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222220300000000000">LUK 1:80</Verse>
+    <Verse GRK="22222212511000">LUK 2:40</Verse>
+    <Verse GRK="11111200510100">LUK 2:52</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2000112200010111212">LUK 7:3</Verse>
+    <Verse GRK="02010000000122111111221000">JHN 4:47</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222222222">LUK 20:43</Verse>
+    <Verse GRK="2222222222">ACT 2:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000011051110100000">LUK 21:24</Verse>
+    <Verse GRK="000000000000000115111110000">REV 11:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0001000">LUK 23:54</Verse>
+    <Verse GRK="000010000000000">JHN 19:42</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="001011222222200000000">LUK 24:12</Verse>
+    <Verse GRK="1000000000001000122222022000">JHN 20:4-5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000100012230000000000000">LUK 24:21</Verse>
+    <Verse GRK="000001003000010022">ACT 1:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000211022222">LUK 24:36</Verse>
+    <Verse GRK="00000000000000000000000000211122222">JHN 20:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222022000">LUK 24:40</Verse>
+    <Verse GRK="22222200000000000">JHN 20:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20002222000301111000000">LUK 24:49</Verse>
+    <Verse GRK="20001111302222000">ACT 1:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000221">JHN 1:13</Verse>
+    <Verse GRK="0000000011111212">1JN 2:29</Verse>
+    <Verse GRK="222222111000000011102222">1JN 3:9</Verse>
+    <Verse GRK="0000000000000022220000">1JN 4:7</Verse>
+    <Verse GRK="000000002222000000000000">1JN 5:1</Verse>
+    <Verse GRK="0222222000000000000000">1JN 5:4</Verse>
+    <Verse GRK="002222221100122200000000">1JN 5:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000211212212222222">JHN 1:15</Verse>
+    <Verse GRK="211112221012222222">JHN 1:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000012000220000000">JHN 3:3</Verse>
+    <Verse GRK="000120022">JHN 3:7</Verse>
+    <Verse GRK="000000000000000010000000000">1PE 1:3</Verse>
+    <Verse GRK="1000000000000">1PE 1:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00002221200000">JHN 4:29</Verse>
+    <Verse GRK="00000000000000000022212">JHN 4:39</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000222220000002222200">JHN 6:32</Verse>
+    <Verse GRK="2020022222200000">JHN 6:33</Verse>
+    <Verse GRK="00000000002202222">JHN 6:41</Verse>
+    <Verse GRK="02222222200001101">JHN 6:50</Verse>
+    <Verse GRK="00220022222001000000000000000000000000">JHN 6:51</Verse>
+    <Verse GRK="022222220010011000000000">JHN 6:58</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00002222220000000000000000">JHN 6:35</Verse>
+    <Verse GRK="222222">JHN 6:48</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222252222222">JHN 7:34</Verse>
+    <Verse GRK="000000052222252222222">JHN 7:36</Verse>
+    <Verse GRK="0000300220000005212222">JHN 8:21</Verse>
+    <Verse GRK="0000005200000052122220000">JHN 13:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02000200000113000005200221222000000">JHN 11:49-50</Verse>
+    <Verse GRK="022111152221222">JHN 18:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000200001222222000000">JHN 12:38</Verse>
+    <Verse GRK="000000201222222">ROM 10:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111111011111522200002000000050002221111522">JHN 13:23-25</Verse>
+    <Verse GRK="00201122220302000222101522000">JHN 21:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00003000000300000000003022222222212">JHN 15:16</Verse>
+    <Verse GRK="000000000300052222222212">JHN 16:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000001112">JHN 19:37</Verse>
+    <Verse GRK="0000031100011230000000000">REV 1:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0022222222">ACT 2:21</Verse>
+    <Verse GRK="222222222">ROM 10:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="212000224222222">ACT 2:27</Verse>
+    <Verse GRK="000000051222411122">ACT 2:31</Verse>
+    <Verse GRK="000004222222">ACT 13:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0111111510122222">ACT 2:45</Verse>
+    <Verse GRK="00000003000000411111500000040122222">ACT 4:34-35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20105220220222222300000000">ACT 3:22</Verse>
+    <Verse GRK="00020100052222222222">ACT 7:37</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000112222222222222">ACT 4:24</Verse>
+    <Verse GRK="0000000000000000000000112222222222222">ACT 14:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000152222200">ACT 7:27</Verse>
+    <Verse GRK="00000152222230000000000000000">ACT 7:35</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000002200000001112000000000">ACT 7:58-59</Verse>
+    <Verse GRK="1111120000000000022000">ACT 22:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00011000011222122">ACT 8:3</Verse>
+    <Verse GRK="0000000111222222">ACT 22:4</Verse>
+    <Verse GRK="000000001110111111">ACT 22:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000022000222111000011111112122">ACT 9:1-2</Verse>
+    <Verse GRK="0022000000000201112201011122200">ACT 22:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="20112112220022222">ACT 9:3</Verse>
+    <Verse GRK="2001112211222222001">ACT 22:6</Verse>
+    <Verse GRK="2110220000000110000010000011200000">ACT 26:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11122222022222">ACT 9:4</Verse>
+    <Verse GRK="111110222122222">ACT 22:7</Verse>
+    <Verse GRK="0110122222110002222200000">ACT 26:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1122222222222">ACT 9:5</Verse>
+    <Verse GRK="221222200022200222">ACT 22:8</Verse>
+    <Verse GRK="2212222202222222">ACT 26:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="220111112211111">ACT 9:6</Verse>
+    <Verse GRK="000000000001111022111111">ACT 22:10</Verse>
+    <Verse GRK="22000000000000000000000000">ACT 26:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="111111001011000">ACT 9:7</Verse>
+    <Verse GRK="11111000000001110">ACT 22:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000011100122">ACT 9:8</Verse>
+    <Verse GRK="001100000010000122">ACT 22:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00110002000000000000000">ACT 9:10</Verse>
+    <Verse GRK="20011000000000">ACT 22:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000002010112252">ACT 9:12</Verse>
+    <Verse GRK="00201111211122252000000000000052000031000000050021">ACT 9:17-18</Verse>
+    <Verse GRK="10011205214111100000051000000000">ACT 22:13,16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000022210121">ACT 9:25</Verse>
+    <Verse GRK="00021122200000">2CO 11:33</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000022002000000202000000000000002222222111122">ACT 10:3-4</Verse>
+    <Verse GRK="0000000000200202220001100000002122222221122">ACT 10:30-31</Verse>
+    <Verse GRK="00000022220102000000000">ACT 11:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="112022222122222002211222">ACT 10:5-6</Verse>
+    <Verse GRK="212221222222122222">ACT 10:32</Verse>
+    <Verse GRK="00000000000000122222122">ACT 11:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000010000000000001111111100222222222111">ACT 10:9-11</Verse>
+    <Verse GRK="000001011112222222221110111">ACT 11:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11032252222222">ACT 10:12</Verse>
+    <Verse GRK="110030222200050220222">ACT 11:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2111152222">ACT 10:13</Verse>
+    <Verse GRK="10211152222">ACT 11:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0201222210212">ACT 10:14</Verse>
+    <Verse GRK="12222212211111">ACT 11:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12022005222222">ACT 10:15</Verse>
+    <Verse GRK="012220005222222">ACT 11:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222220111222">ACT 10:16</Verse>
+    <Verse GRK="222222101222">ACT 11:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000000202111000002211">ACT 10:17</Verse>
+    <Verse GRK="00002221100021100">ACT 11:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000002022000000111111210000">ACT 10:19-20</Verse>
+    <Verse GRK="2022011210000000000000000">ACT 11:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="110011122222210000">ACT 10:44</Verse>
+    <Verse GRK="1111012222221000000">ACT 11:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000000000000022222222">ACT 13:33</Verse>
+    <Verse GRK="000000222222220000000000000">HEB 1:5</Verse>
+    <Verse GRK="0000000000000022222222">HEB 5:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="010021111212212212">ACT 15:20</Verse>
+    <Verse GRK="212222220000000">ACT 15:29</Verse>
+    <Verse GRK="0000001010001222222">ACT 21:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2112213011030000000">ACT 19:32</Verse>
+    <Verse GRK="212210113000000000300000">ACT 21:34</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000022122000000000">ACT 20:25</Verse>
+    <Verse GRK="00000005202201300000">ACT 20:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0002111111000000000000220100021">ACT 22:30</Verse>
+    <Verse GRK="20111111112220">ACT 23:28</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000000000421130111115202222">ACT 23:6</Verse>
+    <Verse GRK="101110000030000003000001211052222000">ACT 24:15,21</Verse>
+    <Verse GRK="00000030000000113011000001111111300000000000051200003000001111">ACT 26:5-8</Verse>
+    <Verse GRK="00000000004011000000">ACT 28:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000200222522222222222">ROM 1:7</Verse>
+    <Verse GRK="222222222222">1CO 1:3</Verse>
+    <Verse GRK="222222222222">2CO 1:2</Verse>
+    <Verse GRK="222222222222">GAL 1:3</Verse>
+    <Verse GRK="222222222222">EPH 1:2</Verse>
+    <Verse GRK="222222222222">PHP 1:2</Verse>
+    <Verse GRK="00000000022222222">COL 1:2</Verse>
+    <Verse GRK="0000000002222222222">1TH 1:1</Verse>
+    <Verse GRK="222222222222">2TH 1:2</Verse>
+    <Verse GRK="00000202222222121">1TI 1:2</Verse>
+    <Verse GRK="000502222222121">2TI 1:2</Verse>
+    <Verse GRK="000000222222222111">TIT 1:4</Verse>
+    <Verse GRK="222222222222">PHM 1:3</Verse>
+    <Verse GRK="0000000000000022221">1PE 1:2</Verse>
+    <Verse GRK="22221000202121">2PE 1:2</Verse>
+    <Verse GRK="111202022212200000000">2JN 1:3</Verse>
+    <Verse GRK="0000000022222111111110000000000">REV 1:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="002222022222000000000">ROM 1:8</Verse>
+    <Verse GRK="222222200000000000">1CO 1:4</Verse>
+    <Verse GRK="2222111122111111100000">PHP 1:3-4</Verse>
+    <Verse GRK="2220000222221">COL 1:3</Verse>
+    <Verse GRK="22222221000101">1TH 1:2</Verse>
+    <Verse GRK="22222222000000000000000000">2TH 1:3</Verse>
+    <Verse GRK="002222222200000000000000000">2TH 2:13</Verse>
+    <Verse GRK="1122000000001111111111000">2TI 1:3</Verse>
+    <Verse GRK="222221111111">PHM 1:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000030522222">ROM 1:17</Verse>
+    <Verse GRK="0000000000322222">GAL 3:11</Verse>
+    <Verse GRK="22202223003000000">HEB 10:38</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="021112222222222">ROM 4:3</Verse>
+    <Verse GRK="000000000000122121122">ROM 4:9</Verse>
+    <Verse GRK="022222">ROM 4:22</Verse>
+    <Verse GRK="0222222222">GAL 3:6</Verse>
+    <Verse GRK="00111120222222220000">JAS 2:23</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000000000000000000000022">ROM 7:7</Verse>
+    <Verse GRK="0000000022000000000000000000">ROM 13:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0002000000212222200000">ROM 8:34</Verse>
+    <Verse GRK="00002000011221111">EPH 1:20</Verse>
+    <Verse GRK="00002110002222221">COL 3:1</Verse>
+    <Verse GRK="000000000000000000000001221111">HEB 1:3</Verse>
+    <Verse GRK="0000000021221111111">HEB 8:1</Verse>
+    <Verse GRK="000000000200000000022011221">HEB 12:2</Verse>
+    <Verse GRK="2222221110000000">1PE 3:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000022222">ROM 9:7</Verse>
+    <Verse GRK="000022222">HEB 11:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000100000122221222">ROM 9:21</Verse>
+    <Verse GRK="0000000200000001012221222">2TI 2:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000001102222222">ROM 10:5</Verse>
+    <Verse GRK="10100000222222">GAL 3:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222211110">ROM 11:34</Verse>
+    <Verse GRK="2222211100000">1CO 2:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000002222222">ROM 11:36</Verse>
+    <Verse GRK="122222222">GAL 1:5</Verse>
+    <Verse GRK="2220000000000022222">EPH 3:21</Verse>
+    <Verse GRK="11111122222222">PHP 4:20</Verse>
+    <Verse GRK="111110000112222222">1TI 1:17</Verse>
+    <Verse GRK="0000000000000000122222222">2TI 4:18</Verse>
+    <Verse GRK="000000000000000000000122222222">HEB 13:21</Verse>
+    <Verse GRK="00000000000000000000000001122000222222">1PE 4:11</Verse>
+    <Verse GRK="2112222">1PE 5:11</Verse>
+    <Verse GRK="0000000000222111222222">REV 1:6</Verse>
+    <Verse GRK="00000000000000000000000000000000000000002211122222">REV 5:13</Verse>
+    <Verse GRK="0000022000000000000000111222222">REV 7:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000012222200">ROM 12:19</Verse>
+    <Verse GRK="021122220000000">HEB 10:30</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222211100">ROM 16:16</Verse>
+    <Verse GRK="2211122222">1CO 16:20</Verse>
+    <Verse GRK="2222222111">2CO 13:12</Verse>
+    <Verse GRK="2111222">1TH 5:26</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000022222222">ROM 16:20</Verse>
+    <Verse GRK="2222222222200">GAL 6:18</Verse>
+    <Verse GRK="2222222222">PHP 4:23</Verse>
+    <Verse GRK="222222222">1TH 5:28</Verse>
+    <Verse GRK="2222222212">2TH 3:18</Verse>
+    <Verse GRK="2222222222">PHM 1:25</Verse>
+    <Verse GRK="2222221">REV 22:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00052222">1CO 1:31</Verse>
+    <Verse GRK="202222">2CO 10:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000222222">1CO 5:6</Verse>
+    <Verse GRK="222222">GAL 5:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="1211112122000000">1CO 9:9</Verse>
+    <Verse GRK="121122210000000">1TI 5:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="201122200002100000000">1CO 15:27</Verse>
+    <Verse GRK="2112220001002000000000000">HEB 2:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222">1CO 16:21</Verse>
+    <Verse GRK="22222200000000">COL 4:18</Verse>
+    <Verse GRK="22222200000000">2TH 3:17</Verse>
+    <Verse GRK="12122200000000000">PHM 1:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="020022212221110">GAL 5:6</Verse>
+    <Verse GRK="2222122211">GAL 6:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="11111002221111200010">GAL 5:13</Verse>
+    <Verse GRK="110211111222001">1PE 2:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000012222200">EPH 1:4</Verse>
+    <Verse GRK="0111000000000000001222">EPH 5:27</Verse>
+    <Verse GRK="000000000000112220022">COL 1:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2222200002221000000">EPH 1:7</Verse>
+    <Verse GRK="222222221">COL 1:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000012211121221222200">EPH 1:10</Verse>
+    <Verse GRK="011122000000000001222212122">COL 1:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00012112211222212222">EPH 1:15</Verse>
+    <Verse GRK="1221212222112222">COL 1:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="21122111111500000000000411101111">EPH 1:16-17</Verse>
+    <Verse GRK="1000000001122">COL 1:3</Verse>
+    <Verse GRK="0000000021222005111000001001">COL 1:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0222200000000000000000000000000000202220022022000000">EPH 1:21-23</Verse>
+    <Verse GRK="00000000022220000000000000000000000022000000">EPH 4:15-16</Verse>
+    <Verse GRK="012222222000000000000000002220">COL 1:18-19</Verse>
+    <Verse GRK="0000122222222">COL 2:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222200232222221140100">EPH 2:1,5</Verse>
+    <Verse GRK="2222022200002501140111">COL 2:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000002130000000000030000000012241100">EPH 2:15-16</Verse>
+    <Verse GRK="100000200103010000022">COL 2:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00022222222222">EPH 3:2</Verse>
+    <Verse GRK="1122212222222000000">EPH 3:7</Verse>
+    <Verse GRK="1102222221122200000">COL 1:25</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000222112">EPH 3:7</Verse>
+    <Verse GRK="000000000002112220">EPH 3:20</Verse>
+    <Verse GRK="000002222222000">COL 1:29</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00202025200">EPH 4:2</Verse>
+    <Verse GRK="00300000030022252000000000300000000">COL 3:12-13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="10111122200000004011111311111211300000">EPH 4:22-24</Verse>
+    <Verse GRK="0000422211113111111121111">COL 3:9-10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0002020002111012">EPH 4:31</Verse>
+    <Verse GRK="0011101222200000">COL 3:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000200001122200000">EPH 5:15-16</Verse>
+    <Verse GRK="112000222">COL 4:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="12020202250022221">EPH 5:19</Verse>
+    <Verse GRK="00000000300001252220002022221">COL 3:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="200122020202202">EPH 5:20</Verse>
+    <Verse GRK="2220000000000000">COL 1:12</Verse>
+    <Verse GRK="0000000000012222222200">COL 3:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22202202">EPH 5:22</Verse>
+    <Verse GRK="220022002">COL 3:18</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222000000000000">EPH 5:25</Verse>
+    <Verse GRK="2222200000">COL 3:19</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222221002211">EPH 6:1</Verse>
+    <Verse GRK="2222211221111">COL 3:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="2112220001111111">EPH 6:6</Verse>
+    <Verse GRK="000000000211222111111">COL 3:22</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000022200222222222222">EPH 6:21</Verse>
+    <Verse GRK="22222222222220022">COL 4:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222222222222222">EPH 6:22</Verse>
+    <Verse GRK="22222222222222222">COL 4:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000000000000111222">PHP 4:3</Verse>
+    <Verse GRK="000000000002211222200000000000000">REV 3:5</Verse>
+    <Verse GRK="000000000101221222222200000">REV 13:8</Verse>
+    <Verse GRK="000000000000000000000000010122112220000000000000">REV 17:8</Verse>
+    <Verse GRK="00000000000000000020111200000111110000">REV 20:12</Verse>
+    <Verse GRK="00100222221000000">REV 20:15</Verse>
+    <Verse GRK="0000000000000000112222222">REV 21:27</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000052222222">COL 1:2</Verse>
+    <Verse GRK="0000000032222225222">1TH 1:1</Verse>
+    <Verse GRK="000502222222222">2TI 1:2</Verse>
+    <Verse GRK="000000522222222212">TIT 1:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22202221">COL 1:19</Verse>
+    <Verse GRK="2221222000">COL 2:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000022220001">1TH 5:2</Verse>
+    <Verse GRK="00000000020220">1TH 5:4</Verse>
+    <Verse GRK="102222000000000000000000">2PE 3:10</Verse>
+    <Verse GRK="00000000000001122000000000">REV 3:3</Verse>
+    <Verse GRK="012200100000000000000">REV 16:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000012110211">1TI 6:15</Verse>
+    <Verse GRK="00000000000220222000000000">REV 17:14</Verse>
+    <Verse GRK="00000000000022222">REV 19:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="021111122222222222222200000000">HEB 3:7-8</Verse>
+    <Verse GRK="111222222222222222">HEB 3:15</Verse>
+    <Verse GRK="000001110002122222222222">HEB 4:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222">HEB 3:11</Verse>
+    <Verse GRK="0000000002222222222220000000">HEB 4:3</Verse>
+    <Verse GRK="0000222222">HEB 4:5</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000122220000">HEB 3:18</Verse>
+    <Verse GRK="000001222200000">HEB 4:1</Verse>
+    <Verse GRK="00122220000000000000">HEB 4:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000212222222">HEB 5:6</Verse>
+    <Verse GRK="000022221">HEB 5:10</Verse>
+    <Verse GRK="000000222220222">HEB 6:20</Verse>
+    <Verse GRK="00000000000000000022220010000000">HEB 7:11</Verse>
+    <Verse GRK="000222222222">HEB 7:17</Verse>
+    <Verse GRK="0000000000000021222">HEB 7:21</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="022222111222222222122222222200000000000">HEB 8:10</Verse>
+    <Verse GRK="22222112222222222222122222">HEB 10:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000022222212">HEB 8:12</Verse>
+    <Verse GRK="222200002212">HEB 10:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="002002200000000200022">2PE 1:1</Verse>
+    <Verse GRK="02220000020002200">JUD 1:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02222000000000">2PE 1:2</Verse>
+    <Verse GRK="0222002">JUD 1:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000000000000000220000">2PE 2:1</Verse>
+    <Verse GRK="000000000000000000000002000002">JUD 1:4</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000200001200222">2PE 2:4</Verse>
+    <Verse GRK="2000000000000220010022">JUD 1:6</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000020010021002002">2PE 2:10</Verse>
+    <Verse GRK="00000201201202">JUD 1:8</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222220000000012000002">2PE 2:12</Verse>
+    <Verse GRK="220011200020220002">JUD 1:10</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000002000000021">2PE 2:13</Verse>
+    <Verse GRK="00000012200000000000000">JUD 1:12</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000222222">2PE 2:17</Verse>
+    <Verse GRK="00000000022222002">JUD 1:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000000220222">2PE 3:3</Verse>
+    <Verse GRK="0000222220000000000">JUD 1:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222220002221">1JN 2:3</Verse>
+    <Verse GRK="0000000000000002222000">1JN 2:5</Verse>
+    <Verse GRK="000000000000000022000">1JN 2:18</Verse>
+    <Verse GRK="011222000000022222111222121">1JN 3:24</Verse>
+    <Verse GRK="00000000000000000000112000000000">1JN 4:6</Verse>
+    <Verse GRK="222200001110222112">1JN 4:13</Verse>
+    <Verse GRK="222200000000002221">1JN 5:2</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000000000002212222">1JN 4:1</Verse>
+    <Verse GRK="2212222000000000000000">2JN 1:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="000000002222">1JN 4:8</Verse>
+    <Verse GRK="000000000000022220000000000000000">1JN 4:16</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22122121221211122222000000">2JN 1:12</Verse>
+    <Verse GRK="22211212221012111122222">3JN 1:13-14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000222222220000000000">REV 1:4</Verse>
+    <Verse GRK="000000000002222222200">REV 1:8</Verse>
+    <Verse GRK="00000000000000000000000000000000022222222">REV 4:8</Verse>
+    <Verse GRK="0000000022222000000000">REV 11:17</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222200001111111100">REV 1:8</Verse>
+    <Verse GRK="0000222222200000000000000000">REV 21:6</Verse>
+    <Verse GRK="2222221111111111">REV 22:13</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222202222200000000000000000">REV 2:1</Verse>
+    <Verse GRK="22222022222000000000">REV 2:8</Verse>
+    <Verse GRK="222220222222000000">REV 2:12</Verse>
+    <Verse GRK="2222202222200000000000000000">REV 2:18</Verse>
+    <Verse GRK="222220222222000000000000000000000">REV 3:1</Verse>
+    <Verse GRK="22222022222000000000000000000">REV 3:7</Verse>
+    <Verse GRK="222220222220000000000000">REV 3:14</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222200000000000000000000000000">REV 2:2</Verse>
+    <Verse GRK="22000000000000000000000000">REV 2:9</Verse>
+    <Verse GRK="20000000000000000000000000000000000000">REV 2:13</Verse>
+    <Verse GRK="22220000000000000000000000">REV 2:19</Verse>
+    <Verse GRK="000000000000000000000222220000000">REV 3:1</Verse>
+    <Verse GRK="222200000000000000000000000000">REV 3:8</Verse>
+    <Verse GRK="222220000000000">REV 3:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22222000000">REV 2:4</Verse>
+    <Verse GRK="22220200000000000000000000">REV 2:14</Verse>
+    <Verse GRK="222220000000000000000000">REV 2:20</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="222222222222220000000000000">REV 2:7</Verse>
+    <Verse GRK="22222222222200000000">REV 2:11</Verse>
+    <Verse GRK="2222222222222200000000000000000000000">REV 2:17</Verse>
+    <Verse GRK="02200000000220000">REV 2:26</Verse>
+    <Verse GRK="2222222222">REV 2:29</Verse>
+    <Verse GRK="2200000000000000000000000000000002222222222">REV 3:5-6</Verse>
+    <Verse GRK="22000000000000000000000000000000000000000000000000002222222222">REV 3:12-13</Verse>
+    <Verse GRK="2222000000000000000000002222222222">REV 3:21-22</Verse>
+    <Verse GRK="2200000000000">REV 21:7</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="00000000000000222222222222">REV 2:9</Verse>
+    <Verse GRK="0000222222222222000000000000000000">REV 3:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="02110111">REV 2:25</Verse>
+    <Verse GRK="11121000000">REV 3:11</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000000000000000222222222">REV 5:9</Verse>
+    <Verse GRK="00000000000022222222200000000000000000">REV 7:9</Verse>
+    <Verse GRK="002122222220000000000000000">REV 11:9</Verse>
+    <Verse GRK="000000000000000222222222">REV 13:7</Verse>
+    <Verse GRK="000000000000000000222222222">REV 14:6</Verse>
+    <Verse GRK="0000000000022002222">REV 17:15</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="22220222200000000000000000000000">REV 10:1</Verse>
+    <Verse GRK="00222222200000000000">REV 18:1</Verse>
+    <Verse GRK="2222222000000000000">REV 20:1</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="0000000000000000222200022">REV 13:10</Verse>
+    <Verse GRK="22120000000000000000000">REV 13:18</Verse>
+    <Verse GRK="2222220000000000">REV 14:12</Verse>
+    <Verse GRK="2211110000000000000000">REV 17:9</Verse>
+  </Passage>
+  <Passage>
+    <Verse GRK="200012222221222222221222">REV 14:8</Verse>
+    <Verse GRK="21000222222000000000000000000000122222222122200000000000000000000">REV 18:2-3</Verse>
+  </Passage>
+</Passages>

--- a/data/parallel-passages/ubs-paratext/README.md
+++ b/data/parallel-passages/ubs-paratext/README.md
@@ -1,0 +1,21 @@
+# UBS/Paratext Parallel Passages snapshot
+
+This directory vendors the exact `ParallelPassages.xml` snapshot from the
+United Bible Societies (UBS) open-license repository. The XML is retained
+byte-for-byte and is the source of truth for the generated local corpus.
+
+- Source: [UBS open-license repository](https://github.com/ubsicap/ubs-open-license/tree/fd7bcf88b20a1522d3916f437f012c561466fe7b/parallel%20passages)
+- Resource description: [UBS Paratext Parallel Passages Database](https://translation.bible/tools-resources/paratext-parallel-passages-database/)
+- License: [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
+- Copyright: © 2023 United Bible Societies
+
+TheologAI's compiler validates the pinned bytes, parses only the expected
+`Passages`/`Passage`/`Verse` XML shape, preserves source group/member order,
+retains raw references and alignment strings, and writes a deterministic
+derived JSON artifact. The generated artifact is an adapted database under
+the same CC BY-SA 4.0 license. The transformation does not select, classify,
+or infer directionality for UBS passage groups.
+
+The pinned source metadata, including byte size, SHA-256, Git blob, and source
+commit, is in `SOURCE.json`. Normal builds and tests use these local files and
+do not fetch from the network.

--- a/data/parallel-passages/ubs-paratext/SOURCE.json
+++ b/data/parallel-passages/ubs-paratext/SOURCE.json
@@ -1,0 +1,16 @@
+{
+  "sourceId": "ubs_paratext_parallel_passages",
+  "title": "UBS Parallel Passage Database",
+  "publisher": "United Bible Societies",
+  "copyright": "© 2023 United Bible Societies",
+  "license": "CC BY-SA 4.0",
+  "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0/",
+  "sourceUrl": "https://github.com/ubsicap/ubs-open-license/tree/fd7bcf88b20a1522d3916f437f012c561466fe7b/parallel%20passages",
+  "sourcePath": "parallel passages/ParallelPassages.xml",
+  "sourceCommit": "fd7bcf88b20a1522d3916f437f012c561466fe7b",
+  "sourceCommitDate": "2023-07-10",
+  "sourceBlob": "b30af22e9ee4740f6c339eb267a59b8fdb9f83f7",
+  "sourceBytes": 336250,
+  "sourceSha256": "d43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394",
+  "transformVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc && mkdir -p dist/data && cp src/data/parallel-passages.json dist/data/",
+    "build": "tsc && mkdir -p dist/data && cp src/data/parallel-passages.json src/data/ubs-parallel-passages.generated.json dist/data/",
+    "build:ubs-parallel-passages": "tsx scripts/build-ubs-parallel-passages.ts",
     "build:strongs": "tsx scripts/build-strongs-json.ts",
     "build:stepbible": "tsx scripts/build-stepbible-json.ts",
     "build:stepbible:lexicons": "tsx scripts/build-stepbible-lexicons.ts",

--- a/scripts/build-ubs-parallel-passages.ts
+++ b/scripts/build-ubs-parallel-passages.ts
@@ -1,0 +1,534 @@
+#!/usr/bin/env tsx
+
+/** Compile the pinned UBS/Paratext XML snapshot into deterministic JSON. */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  findBookByHelloaoCode,
+  getBibleBookBounds,
+  type BibleBook,
+} from '../src/kernel/books.js';
+
+export const TRANSFORM_VERSION = 1;
+export const LABEL = 'source_attested_parallel' as const;
+export const DIRECTIONALITY = 'unspecified' as const;
+
+export interface SourceMetadata {
+  sourceId: string;
+  title: string;
+  publisher: string;
+  copyright: string;
+  license: string;
+  licenseUrl: string;
+  sourceUrl: string;
+  sourcePath: string;
+  sourceCommit: string;
+  sourceCommitDate: string;
+  sourceBlob: string;
+  sourceBytes: number;
+  sourceSha256: string;
+  transformVersion: number;
+}
+
+export const PROVENANCE_FIELDS = [
+  'sourceId',
+  'title',
+  'publisher',
+  'copyright',
+  'license',
+  'licenseUrl',
+  'sourceUrl',
+  'sourcePath',
+  'sourceCommit',
+  'sourceCommitDate',
+  'sourceBlob',
+  'sourceBytes',
+  'sourceSha256',
+  'transformVersion',
+] as const satisfies readonly (keyof SourceMetadata)[];
+
+export function assertProvenanceMatches(left: SourceMetadata, right: SourceMetadata): void {
+  const canonicalFields = [...PROVENANCE_FIELDS].sort();
+  for (const [label, value] of [['left', left], ['right', right]] as const) {
+    if (JSON.stringify(Object.keys(value).sort()) !== JSON.stringify(canonicalFields)) {
+      throw new Error(`[ubs-provenance] ${label} metadata contains noncanonical fields`);
+    }
+  }
+  for (const field of PROVENANCE_FIELDS) {
+    if (left[field] !== right[field]) {
+      throw new Error(`[ubs-provenance] ${field} differs between canonical metadata records`);
+    }
+  }
+}
+
+export interface ReferenceSegment {
+  bookNumber: number;
+  chapter: number;
+  startVerse: number;
+  endVerse: number;
+}
+
+export type LanguageMarker = 'HEB' | 'GRK';
+export type AlignmentBasis = 'BHS' | 'LXX' | 'UBSGNT5';
+export interface SourceParallelMember {
+  sourceOrder: number;
+  sourceReference: string;
+  normalizedReference: string;
+  segments: ReferenceSegment[];
+  languageMarker: LanguageMarker;
+  alignmentBasis: AlignmentBasis;
+  alignmentRaw: string;
+}
+
+export interface ParallelSourceProvenance extends SourceMetadata {
+  modified: true;
+  modificationNote: string;
+}
+
+export interface SourceAttestedParallelGroup {
+  groupId: string;
+  sourceOrdinal: number;
+  label: typeof LABEL;
+  directionality: typeof DIRECTIONALITY;
+  members: SourceParallelMember[];
+  provenance: ParallelSourceProvenance;
+}
+
+export interface ReferenceIndexEntry {
+  groupId: string;
+  memberOrder: number;
+  segmentOrder: number;
+  startVerse: number;
+  endVerse: number;
+}
+
+export interface GeneratedUbsCorpus {
+  schemaVersion: 'ubs-parallel-passages.v1';
+  transformVersion: typeof TRANSFORM_VERSION;
+  label: typeof LABEL;
+  directionality: typeof DIRECTIONALITY;
+  license: {
+    name: 'CC BY-SA 4.0';
+    url: string;
+  };
+  provenance: ParallelSourceProvenance;
+  groups: SourceAttestedParallelGroup[];
+  referenceIndex: Record<string, ReferenceIndexEntry[]>;
+}
+
+interface XmlNode {
+  name: string;
+  attributes: Record<string, string>;
+  text: string;
+  children: XmlNode[];
+}
+
+interface ParsedVerse {
+  marker: LanguageMarker;
+  alignmentRaw: string;
+  sourceReference: string;
+}
+
+interface ParsedPassage {
+  verses: ParsedVerse[];
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+export const DEFAULT_SOURCE_PATH = join(ROOT, 'data/parallel-passages/ubs-paratext/ParallelPassages.xml');
+export const DEFAULT_METADATA_PATH = join(ROOT, 'data/parallel-passages/ubs-paratext/SOURCE.json');
+export const DEFAULT_OUTPUT_PATH = join(ROOT, 'src/data/ubs-parallel-passages.generated.json');
+
+const MODIFICATION_NOTE =
+  'References and alignment metadata normalized for local lookup; UBS group membership and member order preserved.';
+
+function fail(message: string): never {
+  throw new Error(`[ubs-compiler] ${message}`);
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function gitBlobSha(bytes: Buffer): string {
+  const header = Buffer.from(`blob ${bytes.length}\0`, 'utf8');
+  return createHash('sha1').update(Buffer.concat([header, bytes])).digest('hex');
+}
+
+function isWhitespace(char: string): boolean {
+  return char === ' ' || char === '\t' || char === '\r' || char === '\n';
+}
+
+function isXml10CodePoint(codePoint: number): boolean {
+  return codePoint === 0x9 || codePoint === 0xa || codePoint === 0xd
+    || (codePoint >= 0x20 && codePoint <= 0xd7ff)
+    || (codePoint >= 0xe000 && codePoint <= 0xfffd)
+    || (codePoint >= 0x10000 && codePoint <= 0x10ffff);
+}
+
+function assertXml10Characters(input: string): void {
+  let offset = 0;
+  for (const character of input) {
+    const codePoint = character.codePointAt(0)!;
+    if (!isXml10CodePoint(codePoint)) {
+      fail(`disallowed XML 1.0 literal character U+${codePoint.toString(16).toUpperCase().padStart(4, '0')} at offset ${offset}`);
+    }
+    offset += character.length;
+  }
+}
+
+function isXmlWhitespaceOnly(value: string): boolean {
+  for (const character of value) {
+    if (!isWhitespace(character)) return false;
+  }
+  return true;
+}
+
+function decodeXmlEntities(value: string): string {
+  if (!value.includes('&')) return value;
+
+  let cursor = 0;
+  let decoded = '';
+  while (cursor < value.length) {
+    const ampersand = value.indexOf('&', cursor);
+    if (ampersand < 0) {
+      decoded += value.slice(cursor);
+      break;
+    }
+    decoded += value.slice(cursor, ampersand);
+    const semicolon = value.indexOf(';', ampersand + 1);
+    if (semicolon < 0) fail('unterminated XML entity');
+    const entity = value.slice(ampersand + 1, semicolon);
+    if (entity.includes('&')) fail(`invalid XML entity &${entity};`);
+
+    if (entity === 'amp') decoded += '&';
+    else if (entity === 'lt') decoded += '<';
+    else if (entity === 'gt') decoded += '>';
+    else if (entity === 'apos') decoded += "'";
+    else if (entity === 'quot') decoded += '"';
+    else {
+      const hexadecimal = /^#x([0-9A-Fa-f]+)$/.exec(entity);
+      const decimal = /^#([0-9]+)$/.exec(entity);
+      if (!hexadecimal && !decimal) fail(`invalid XML entity &${entity};`);
+      const digits = hexadecimal?.[1] ?? decimal?.[1] ?? '';
+      const codePoint = Number.parseInt(digits, hexadecimal ? 16 : 10);
+      if (!Number.isSafeInteger(codePoint) || !isXml10CodePoint(codePoint)) {
+        fail(`disallowed XML 1.0 character entity &${entity};`);
+      }
+      decoded += String.fromCodePoint(codePoint);
+    }
+    cursor = semicolon + 1;
+  }
+  return decoded;
+}
+
+function parseXmlDocument(input: string): XmlNode {
+  assertXml10Characters(input);
+  if (input.includes('<!')) fail('unsafe XML construct rejected (DOCTYPE, entity declaration, comment, or CDATA)');
+
+  let index = input.charCodeAt(0) === 0xfeff ? 1 : 0;
+  if (!input.startsWith('<?xml', index)) fail('XML declaration is required');
+  const declarationEnd = input.indexOf('?>', index + 5);
+  if (declarationEnd < 0) fail('unterminated XML declaration');
+  const declaration = input.slice(index, declarationEnd + 2);
+  if (!/^<\?xml[ \t\r\n]+version[ \t\r\n]*=[ \t\r\n]*["']1\.0["'][ \t\r\n]+encoding[ \t\r\n]*=[ \t\r\n]*["']utf-8["'][ \t\r\n]*\?>$/.test(declaration)) {
+    fail('XML declaration must specify version 1.0 and UTF-8 encoding');
+  }
+  index = declarationEnd + 2;
+
+  const readName = (): string => {
+    const start = index;
+    if (!/[A-Za-z_]/.test(input[index] ?? '')) fail(`invalid XML name at offset ${index}`);
+    index++;
+    while (/[A-Za-z0-9_.:-]/.test(input[index] ?? '')) index++;
+    return input.slice(start, index);
+  };
+
+  const skipWhitespace = (): void => {
+    while (isWhitespace(input[index] ?? '')) index++;
+  };
+
+  const parseElement = (): XmlNode => {
+    if (input[index] !== '<') fail(`expected '<' at offset ${index}`);
+    index++;
+    if (input[index] === '/' || input[index] === '?' || input[index] === '!') {
+      fail(`unexpected XML token at offset ${index - 1}`);
+    }
+
+    const name = readName();
+    const attributes: Record<string, string> = {};
+    skipWhitespace();
+    while (input[index] !== '>') {
+      if (input[index] === '/' || input[index] == null) fail(`self-closing or unterminated <${name}> is not allowed`);
+      const attributeName = readName();
+      if (attributes[attributeName] !== undefined) fail(`duplicate attribute ${attributeName} on <${name}>`);
+      skipWhitespace();
+      if (input[index] !== '=') fail(`attribute ${attributeName} on <${name}> lacks '='`);
+      index++;
+      skipWhitespace();
+      const quote = input[index];
+      if (quote !== '"' && quote !== "'") fail(`attribute ${attributeName} on <${name}> must be quoted`);
+      index++;
+      const valueStart = index;
+      const valueEnd = input.indexOf(quote, index);
+      if (valueEnd < 0) fail(`unterminated attribute ${attributeName} on <${name}>`);
+      const rawValue = input.slice(valueStart, valueEnd);
+      if (rawValue.includes('<')) fail(`'<\u003c' is not allowed in attribute ${attributeName}`);
+      attributes[attributeName] = decodeXmlEntities(rawValue);
+      index = valueEnd + 1;
+      skipWhitespace();
+    }
+    index++;
+
+    const textParts: string[] = [];
+    const children: XmlNode[] = [];
+    while (true) {
+      if (index >= input.length) fail(`unterminated <${name}> element`);
+      if (input.startsWith('</', index)) {
+        index += 2;
+        const closingName = readName();
+        skipWhitespace();
+        if (input[index] !== '>') fail(`invalid closing tag for <${name}>`);
+        index++;
+        if (closingName !== name) fail(`closing tag </${closingName}> does not match <${name}>`);
+        return { name, attributes, text: textParts.join(''), children };
+      }
+      if (input[index] === '<') {
+        children.push(parseElement());
+      } else {
+        const textStart = index;
+        const nextTag = input.indexOf('<', index);
+        index = nextTag < 0 ? input.length : nextTag;
+        textParts.push(decodeXmlEntities(input.slice(textStart, index)));
+      }
+    }
+  };
+
+  while (isWhitespace(input[index] ?? '')) index++;
+  const root = parseElement();
+  while (isWhitespace(input[index] ?? '')) index++;
+  if (index !== input.length) fail(`unexpected content after root at offset ${index}`);
+  return root;
+}
+
+export function parseUbsXml(xml: string | Buffer): ParsedPassage[] {
+  const input = Buffer.isBuffer(xml) ? new TextDecoder('utf-8', { fatal: true }).decode(xml) : xml;
+  const root = parseXmlDocument(input);
+  if (root.name !== 'Passages' || Object.keys(root.attributes).length !== 0 || !isXmlWhitespaceOnly(root.text)) {
+    fail('XML must contain exactly one empty-text <Passages> root');
+  }
+
+  return root.children.map((passage, passageIndex) => {
+    if (passage.name !== 'Passage' || Object.keys(passage.attributes).length !== 0 || !isXmlWhitespaceOnly(passage.text)) {
+      fail(`passage ${passageIndex + 1} has an unexpected element or attribute`);
+    }
+    if (passage.children.length < 2) fail(`passage ${passageIndex + 1} must contain at least two Verse members`);
+    return {
+      verses: passage.children.map((verse, verseIndex) => {
+        if (verse.name !== 'Verse' || verse.children.length !== 0 || verse.text.length === 0) {
+          fail(`passage ${passageIndex + 1} member ${verseIndex + 1} is not a nonempty Verse`);
+        }
+        const attributes = Object.entries(verse.attributes);
+        if (attributes.length !== 1 || (attributes[0][0] !== 'HEB' && attributes[0][0] !== 'GRK')) {
+          fail(`passage ${passageIndex + 1} member ${verseIndex + 1} must have exactly one HEB or GRK attribute`);
+        }
+        const [marker, alignmentRaw] = attributes[0] as [LanguageMarker, string];
+        if (!alignmentRaw || !/^[0-8]+$/.test(alignmentRaw)) {
+          fail(`passage ${passageIndex + 1} member ${verseIndex + 1} has invalid alignment digits`);
+        }
+        return { marker, alignmentRaw, sourceReference: verse.text };
+      }),
+    };
+  });
+}
+
+function assertSourceMetadata(metadata: SourceMetadata): void {
+  if (metadata.transformVersion !== TRANSFORM_VERSION) fail(`unsupported transform version ${metadata.transformVersion}`);
+  if (!/^[0-9a-f]{40}$/.test(metadata.sourceCommit) || !/^[0-9a-f]{40}$/.test(metadata.sourceBlob)) {
+    fail('source commit and blob must be lowercase SHA-1 values');
+  }
+  if (!/^https:\/\//.test(metadata.sourceUrl) || metadata.license !== 'CC BY-SA 4.0') {
+    fail('source metadata must retain the pinned HTTPS source and CC BY-SA 4.0 license');
+  }
+}
+
+function verifySourceBytes(bytes: Buffer, metadata: SourceMetadata): void {
+  assertSourceMetadata(metadata);
+  if (bytes.length !== metadata.sourceBytes) fail(`source byte size drift: expected ${metadata.sourceBytes}, received ${bytes.length}`);
+  const actualSha256 = sha256(bytes);
+  if (actualSha256 !== metadata.sourceSha256) fail(`source SHA-256 drift: expected ${metadata.sourceSha256}, received ${actualSha256}`);
+  const actualBlob = gitBlobSha(bytes);
+  if (actualBlob !== metadata.sourceBlob) fail(`source Git blob drift: expected ${metadata.sourceBlob}, received ${actualBlob}`);
+}
+
+function validateBounds(book: BibleBook, chapter: number, startVerse: number, endVerse: number): void {
+  const bounds = getBibleBookBounds(book).maxVerseByChapter;
+  if (!Number.isSafeInteger(chapter) || !bounds[chapter - 1]) fail(`reference uses out-of-range chapter ${book.name} ${chapter}`);
+  // UBS locators use their source-language versification. Do not apply the
+  // current translation-oriented verse maxima here (for example, UBS has
+  // Psalm 18:51 where this repository's English bounds stop at 18:50).
+  if (!Number.isSafeInteger(startVerse) || !Number.isSafeInteger(endVerse)
+    || startVerse < 1 || endVerse < startVerse) {
+    fail(`reference uses out-of-range verse ${book.name} ${chapter}:${startVerse}-${endVerse}`);
+  }
+}
+
+function parseSafeInteger(raw: string, label: string): number {
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) fail(`${label} is outside the safe integer range`);
+  return value;
+}
+
+function parseVersePart(part: string, label: string): { startVerse: number; endVerse: number } {
+  const match = /^(\d+)(?:-(\d+))?$/.exec(part);
+  if (!match) fail(`invalid ${label} verse segment ${JSON.stringify(part)}`);
+  const startVerse = parseSafeInteger(match[1], `${label} start verse`);
+  const endVerse = match[2] ? parseSafeInteger(match[2], `${label} end verse`) : startVerse;
+  return { startVerse, endVerse };
+}
+
+function parseSourceReference(sourceReference: string): { book: BibleBook; segments: ReferenceSegment[]; normalizedReference: string } {
+  if (!sourceReference || isWhitespace(sourceReference[0]) || isWhitespace(sourceReference.at(-1)!)
+    || !/^[A-Z0-9]{3} [^ \t\r\n].*$/.test(sourceReference)) {
+    fail(`reference is not losslessly normalized: ${JSON.stringify(sourceReference)}`);
+  }
+  const match = /^([A-Z0-9]{3}) (.+)$/.exec(sourceReference);
+  if (!match) fail(`invalid UBS reference ${JSON.stringify(sourceReference)}`);
+  const [, code, body] = match;
+  const book = findBookByHelloaoCode(code);
+  if (!book) fail(`unknown UBS book code ${code}`);
+  const parts = body.split(',');
+  const first = /^(\d+):(\d+(?:-\d+)?)$/.exec(parts[0]);
+  if (!first) fail(`invalid UBS reference ${JSON.stringify(sourceReference)}`);
+  const firstChapter = parseSafeInteger(first[1], 'reference chapter');
+  const firstVerse = parseVersePart(first[2], 'reference');
+  const segments: ReferenceSegment[] = [{
+    bookNumber: book.number,
+    chapter: firstChapter,
+    startVerse: firstVerse.startVerse,
+    endVerse: firstVerse.endVerse,
+  }];
+  validateBounds(book, firstChapter, firstVerse.startVerse, firstVerse.endVerse);
+
+  for (const [index, part] of parts.slice(1).entries()) {
+    const full = /^(\d+):(\d+(?:-\d+)?)$/.exec(part);
+    const chapter = full ? parseSafeInteger(full[1], 'discontinuous segment chapter') : firstChapter;
+    const verse = parseVersePart(full ? full[2] : part, `discontinuous segment ${index + 2}`);
+    validateBounds(book, chapter, verse.startVerse, verse.endVerse);
+    segments.push({ bookNumber: book.number, chapter, startVerse: verse.startVerse, endVerse: verse.endVerse });
+  }
+
+  const normalizedParts = segments.map((segment, index) => {
+    const verse = segment.startVerse === segment.endVerse
+      ? String(segment.startVerse)
+      : `${segment.startVerse}-${segment.endVerse}`;
+    if (index === 0) return `${book.name} ${segment.chapter}:${verse}`;
+    return segment.chapter === segments[0].chapter ? verse : `${segment.chapter}:${verse}`;
+  });
+  return { book, segments, normalizedReference: normalizedParts.join(',') };
+}
+
+function provenance(metadata: SourceMetadata): ParallelSourceProvenance {
+  return { ...metadata, modified: true, modificationNote: MODIFICATION_NOTE };
+}
+
+export function compileUbsParallelPassages(xml: string | Buffer, metadata: SourceMetadata): string {
+  const bytes = Buffer.isBuffer(xml) ? xml : Buffer.from(xml, 'utf8');
+  verifySourceBytes(bytes, metadata);
+  const parsed = parseUbsXml(bytes);
+  const sourceProvenance = provenance(metadata);
+  const seenGroups = new Set<string>();
+  const groups: SourceAttestedParallelGroup[] = [];
+  const index = new Map<string, ReferenceIndexEntry[]>();
+
+  parsed.forEach((passage, passageIndex) => {
+    const markers = new Set(passage.verses.map(verse => verse.marker));
+    const mixed = markers.size === 2;
+    const canonicalMembers = passage.verses.map(verse => [verse.marker, verse.sourceReference, verse.alignmentRaw]);
+    const canonical = JSON.stringify(canonicalMembers);
+    const groupId = `ubs-pp-${sha256(Buffer.from(canonical, 'utf8'))}`;
+    if (seenGroups.has(canonical) || seenGroups.has(groupId)) fail(`duplicate UBS group at source ordinal ${passageIndex + 1}`);
+    seenGroups.add(canonical);
+    seenGroups.add(groupId);
+
+    const members = passage.verses.map((verse, verseIndex): SourceParallelMember => {
+      const parsedReference = parseSourceReference(verse.sourceReference);
+      const alignmentBasis: AlignmentBasis = mixed
+        ? verse.marker === 'HEB' ? 'LXX' : 'UBSGNT5'
+        : verse.marker === 'HEB' ? 'BHS' : 'UBSGNT5';
+      parsedReference.segments.forEach((segment, segmentIndex) => {
+        const key = `${segment.bookNumber}:${segment.chapter}`;
+        const entries = index.get(key) ?? [];
+        entries.push({
+          groupId,
+          memberOrder: verseIndex + 1,
+          segmentOrder: segmentIndex + 1,
+          startVerse: segment.startVerse,
+          endVerse: segment.endVerse,
+        });
+        index.set(key, entries);
+      });
+      return {
+        sourceOrder: verseIndex + 1,
+        sourceReference: verse.sourceReference,
+        normalizedReference: parsedReference.normalizedReference,
+        segments: parsedReference.segments,
+        languageMarker: verse.marker,
+        alignmentBasis,
+        alignmentRaw: verse.alignmentRaw,
+      };
+    });
+
+    groups.push({
+      groupId,
+      sourceOrdinal: passageIndex + 1,
+      label: LABEL,
+      directionality: DIRECTIONALITY,
+      members,
+      provenance: sourceProvenance,
+    });
+  });
+
+  const referenceIndex: Record<string, ReferenceIndexEntry[]> = {};
+  for (const key of [...index.keys()].sort()) referenceIndex[key] = index.get(key)!;
+
+  const output: GeneratedUbsCorpus = {
+    schemaVersion: 'ubs-parallel-passages.v1',
+    transformVersion: TRANSFORM_VERSION,
+    label: LABEL,
+    directionality: DIRECTIONALITY,
+    license: { name: 'CC BY-SA 4.0', url: metadata.licenseUrl },
+    provenance: sourceProvenance,
+    groups,
+    referenceIndex,
+  };
+  // Object insertion order is fixed above; compact output keeps the shared
+  // Node/Worker artifact practical without changing its deterministic bytes.
+  return `${JSON.stringify(output)}\n`;
+}
+
+function readMetadata(path: string): SourceMetadata {
+  return JSON.parse(readFileSync(path, 'utf8')) as SourceMetadata;
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const valueFor = (name: string, fallback: string): string => {
+    const equals = args.find(arg => arg.startsWith(`${name}=`));
+    if (equals) return equals.slice(name.length + 1);
+    const position = args.indexOf(name);
+    return position >= 0 && args[position + 1] ? args[position + 1] : fallback;
+  };
+  const inputPath = resolve(ROOT, valueFor('--input', DEFAULT_SOURCE_PATH));
+  const metadataPath = resolve(ROOT, valueFor('--metadata', DEFAULT_METADATA_PATH));
+  const outputPath = resolve(ROOT, valueFor('--output', DEFAULT_OUTPUT_PATH));
+  const output = compileUbsParallelPassages(readFileSync(inputPath), readMetadata(metadataPath));
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, output, 'utf8');
+  console.error(`[ubs-compiler] wrote ${outputPath} (${Buffer.byteLength(output, 'utf8')} bytes)`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) main();

--- a/scripts/verify-data-manifest.ts
+++ b/scripts/verify-data-manifest.ts
@@ -5,6 +5,7 @@ import { createHash } from 'crypto';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { assertProvenanceMatches, type SourceMetadata } from './build-ubs-parallel-passages.js';
 
 interface ManifestFile {
   path: string;
@@ -17,6 +18,7 @@ interface DataManifest {
   algorithm: 'sha256';
   files: ManifestFile[];
   expectedCounts: Record<string, number>;
+  sources?: Record<string, SourceMetadata>;
 }
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -41,12 +43,24 @@ function discoverCanonicalFiles(): string[] {
     ...relativeDataFiles('data/biblical-languages/stepbible/greek', '.json.gz'),
     ...relativeDataFiles('data/biblical-languages/stepbible/hebrew', '.json.gz'),
     ...relativeDataFiles('data/historical-documents', '.json'),
+    'data/parallel-passages/ubs-paratext/LICENSE.md',
+    'data/parallel-passages/ubs-paratext/ParallelPassages.xml',
+    'data/parallel-passages/ubs-paratext/README.md',
+    'data/parallel-passages/ubs-paratext/SOURCE.json',
     'src/data/parallel-passages.json',
+    'src/data/ubs-parallel-passages.generated.json',
   ].sort();
 }
 
 function checksum(path: string): string {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function gitBlobChecksum(bytes: Buffer): string {
+  return createHash('sha1').update(Buffer.concat([
+    Buffer.from(`blob ${bytes.length}\0`, 'utf8'),
+    bytes,
+  ])).digest('hex');
 }
 
 const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf-8')) as DataManifest;
@@ -57,6 +71,27 @@ if (manifest.manifestVersion !== 1 || manifest.algorithm !== 'sha256') {
 const schemaPath = join(ROOT, 'migrations', `${manifest.schemaVersion}.sql`);
 if (!existsSync(schemaPath)) {
   throw new Error(`Manifest schema migration does not exist: ${schemaPath}`);
+}
+
+const ubsSource = manifest.sources?.ubs_paratext_parallel_passages;
+if (!ubsSource) throw new Error('Manifest is missing UBS/Paratext source provenance');
+const ubsMetadata = JSON.parse(readFileSync(
+  join(ROOT, 'data/parallel-passages/ubs-paratext/SOURCE.json'),
+  'utf-8',
+)) as SourceMetadata;
+assertProvenanceMatches(ubsMetadata, ubsSource);
+const ubsXml = readFileSync(join(ROOT, 'data/parallel-passages/ubs-paratext/ParallelPassages.xml'));
+if (ubsXml.length !== ubsSource.sourceBytes) {
+  throw new Error(`UBS source byte size mismatch: expected ${ubsSource.sourceBytes}, received ${ubsXml.length}`);
+}
+if (checksum(join(ROOT, 'data/parallel-passages/ubs-paratext/ParallelPassages.xml')) !== ubsSource.sourceSha256) {
+  throw new Error('UBS source SHA-256 does not match manifest provenance');
+}
+if (gitBlobChecksum(ubsXml) !== ubsSource.sourceBlob) {
+  throw new Error('UBS source Git blob does not match manifest provenance');
+}
+if (!/^[0-9a-f]{40}$/.test(ubsSource.sourceCommit)) {
+  throw new Error('UBS source commit provenance is not a Git SHA-1');
 }
 
 const discovered = discoverCanonicalFiles();

--- a/test/unit/scripts/buildUbsParallelPassages.test.ts
+++ b/test/unit/scripts/buildUbsParallelPassages.test.ts
@@ -1,0 +1,227 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  assertProvenanceMatches,
+  compileUbsParallelPassages,
+  type GeneratedUbsCorpus,
+  type SourceMetadata,
+} from '../../../scripts/build-ubs-parallel-passages.js';
+
+const sourceDir = new URL('../../../data/parallel-passages/ubs-paratext/', import.meta.url);
+const sourcePath = new URL('ParallelPassages.xml', sourceDir);
+const metadataPath = new URL('SOURCE.json', sourceDir);
+const generatedPath = new URL('../../../src/data/ubs-parallel-passages.generated.json', import.meta.url);
+
+const sourceBytes = readFileSync(sourcePath);
+const metadata = JSON.parse(readFileSync(metadataPath, 'utf8')) as SourceMetadata;
+const manifest = JSON.parse(readFileSync(new URL('../../../data/data-manifest.json', import.meta.url), 'utf8')) as {
+  sources: { ubs_paratext_parallel_passages: SourceMetadata };
+};
+const generatedBytes = readFileSync(generatedPath, 'utf8');
+const generated = JSON.parse(generatedBytes) as GeneratedUbsCorpus;
+
+function sha256(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function gitBlobSha(bytes: Buffer): string {
+  return createHash('sha1').update(Buffer.concat([
+    Buffer.from(`blob ${bytes.length}\0`, 'utf8'),
+    bytes,
+  ])).digest('hex');
+}
+
+function fixtureMetadata(xml: string): SourceMetadata {
+  const bytes = Buffer.from(xml, 'utf8');
+  return {
+    ...metadata,
+    sourceBytes: bytes.length,
+    sourceSha256: sha256(bytes),
+    sourceBlob: gitBlobSha(bytes),
+  };
+}
+
+function fixtureXml(groups: string[]): string {
+  return `<?xml version="1.0" encoding="utf-8"?><Passages>${groups.join('')}</Passages>`;
+}
+
+function passage(members: string[]): string {
+  return `<Passage>${members.join('')}</Passage>`;
+}
+
+function verse(attribute: string, reference: string): string {
+  return `<Verse ${attribute}>${reference}</Verse>`;
+}
+
+describe('UBS/Paratext deterministic compiler', () => {
+  it('matches the pinned snapshot and exact published invariants', () => {
+    expect(sourceBytes.byteLength).toBe(336250);
+    expect(sha256(sourceBytes)).toBe('d43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394');
+    expect(gitBlobSha(sourceBytes)).toBe('b30af22e9ee4740f6c339eb267a59b8fdb9f83f7');
+    expect(metadata.sourceCommit).toBe('fd7bcf88b20a1522d3916f437f012c561466fe7b');
+    expect(manifest.sources.ubs_paratext_parallel_passages).toEqual(metadata);
+
+    const groups = generated.groups;
+    const members = groups.flatMap(group => group.members);
+    const markers = groups.map(group => new Set(group.members.map(member => member.languageMarker)));
+    const groupSizes = new Map<number, number>();
+    for (const group of groups) groupSizes.set(group.members.length, (groupSizes.get(group.members.length) ?? 0) + 1);
+
+    expect(groups).toHaveLength(2193);
+    expect(members).toHaveLength(5266);
+    expect(markers.filter(set => set.size === 1 && set.has('HEB'))).toHaveLength(1184);
+    expect(markers.filter(set => set.size === 1 && set.has('GRK'))).toHaveLength(760);
+    expect(markers.filter(set => set.size === 2)).toHaveLength(249);
+    expect(groupSizes.get(2)).toBe(1699);
+    expect([...groupSizes.entries()].filter(([size]) => size >= 3).reduce((sum, [, count]) => sum + count, 0)).toBe(494);
+    expect(Math.max(...groups.map(group => group.members.length))).toBe(39);
+
+    expect(members.filter(member => member.sourceReference.includes('-'))).toHaveLength(647);
+    expect(members.filter(member => member.sourceReference.includes(','))).toHaveLength(10);
+    expect(new Set(members.map(member => member.sourceReference.split(' ')[0]))).toHaveLength(60);
+    expect(new Set(members.flatMap(member => [...member.alignmentRaw]))).toEqual(new Set(['0', '1', '2', '3', '4', '5']));
+    expect(new Set(groups.map(group => group.groupId)).size).toBe(groups.length);
+    expect(groups.every((group, index) => group.sourceOrdinal === index + 1
+      && group.members.every((member, memberIndex) => member.sourceOrder === memberIndex + 1))).toBe(true);
+    expect(groups.every(group => group.label === 'source_attested_parallel')).toBe(true);
+    expect(groups.every(group => group.directionality === 'unspecified')).toBe(true);
+    expect(generated.provenance.license).toBe('CC BY-SA 4.0');
+    expect(generated.provenance.modified).toBe(true);
+    expect(generated.provenance.sourceSha256).toBe(metadata.sourceSha256);
+  });
+
+  it('is byte-identical when compiled twice and matches the checked-in artifact', () => {
+    const first = compileUbsParallelPassages(sourceBytes, metadata);
+    const second = compileUbsParallelPassages(sourceBytes, metadata);
+    expect(first).toBe(second);
+    expect(first).toBe(generatedBytes);
+    expect(first.endsWith('\n')).toBe(true);
+  });
+
+  it('preserves discontinuous segments without widening ranges', () => {
+    const member = generated.groups
+      .flatMap(group => group.members)
+      .find(candidate => candidate.sourceReference === 'LUK 6:27-28,35');
+    expect(member).toBeDefined();
+    expect(member?.normalizedReference).toBe('Luke 6:27-28,35');
+    expect(member?.segments).toEqual([
+      { bookNumber: 42, chapter: 6, startVerse: 27, endVerse: 28 },
+      { bookNumber: 42, chapter: 6, startVerse: 35, endVerse: 35 },
+    ]);
+    const indexEntries = generated.referenceIndex['42:6'];
+    expect(indexEntries.some(entry => entry.startVerse === 27 && entry.endVerse === 28)).toBe(true);
+    expect(indexEntries.some(entry => entry.startVerse === 35 && entry.endVerse === 35)).toBe(true);
+    expect(indexEntries.some(entry => entry.startVerse === 27 && entry.endVerse === 35)).toBe(false);
+  });
+
+  it('derives alignment basis from testament composition while preserving raw codes', () => {
+    const mixed = generated.groups.find(group => group.members.some(member => member.sourceReference === 'ISA 40:3'));
+    expect(mixed?.members.find(member => member.sourceReference === 'ISA 40:3')?.alignmentBasis).toBe('LXX');
+    expect(mixed?.members.filter(member => member.languageMarker === 'GRK').every(member => member.alignmentBasis === 'UBSGNT5')).toBe(true);
+    expect(generated.groups.filter(group => group.members.every(member => member.languageMarker === 'HEB'))
+      .every(group => group.members.every(member => member.alignmentBasis === 'BHS'))).toBe(true);
+  });
+});
+
+describe('UBS/Paratext compiler rejection and security gates', () => {
+  function compileFixture(xml: string): GeneratedUbsCorpus {
+    return JSON.parse(compileUbsParallelPassages(xml, fixtureMetadata(xml))) as GeneratedUbsCorpus;
+  }
+
+  it.each([
+    ['DOCTYPE/entity declarations', '<!DOCTYPE Passages [<!ENTITY x SYSTEM "file:///tmp/x">]><Passages />'],
+    ['unknown element', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), '<Other>GEN 1:2</Other>'])])],
+    ['unknown attribute', fixtureXml([passage([verse('HEB="0" foo="1"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['one member group', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1')])])],
+    ['both language attributes', fixtureXml([passage([verse('HEB="0" GRK="1"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['missing language attribute', fixtureXml([passage([verse('', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['invalid alignment digit', fixtureXml([passage([verse('HEB="9"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['unknown book code', fixtureXml([passage([verse('HEB="0"', 'ZZZ 1:1'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['reversed range', fixtureXml([passage([verse('HEB="0"', 'GEN 1:2-1'), verse('HEB="2"', 'GEN 1:3')])])],
+    ['unsafe integer verse', fixtureXml([passage([verse('HEB="0"', 'GEN 1:9007199254740993'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['overflow chapter', fixtureXml([passage([verse('HEB="0"', 'GEN 999999999999999999999999:1'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['reference whitespace drift', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1 '), verse('HEB="2"', 'GEN 1:2')])])],
+    ['unsupported entity', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1&evil;'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['literal vertical tab', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])]).replace('<Passages>', '<Passages>\u000b')],
+    ['literal C0 control', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])]).replace('<Passages>', '<Passages>\u001f')],
+    ['literal XML noncharacter', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])]).replace('<Passages>', '<Passages>\ufffe')],
+    ['NBSP structural whitespace', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])]).replace('<Passages>', '<Passages>\u00a0')],
+    ['missing XML declaration', '<Passages><Passage><Verse HEB="0">GEN 1:1</Verse><Verse HEB="2">GEN 1:2</Verse></Passage></Passages>'],
+    ['wrong XML version', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])]).replace('version="1.0"', 'version="1.1"')],
+    ['wrong XML encoding', fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')])]).replace('encoding="utf-8"', 'encoding="utf-16"')],
+    ['malformed numeric entity', fixtureXml([passage([verse('HEB="0"', 'GEN 1:&#49junk;'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['disallowed numeric entity code point', fixtureXml([passage([verse('HEB="0"', 'GEN 1:&#x1;'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['disallowed XML control code point', fixtureXml([passage([verse('HEB="0"', 'GEN 1:&#xB;'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['disallowed XML non-character code point', fixtureXml([passage([verse('HEB="0"', 'GEN 1:&#xFFFE;'), verse('HEB="2"', 'GEN 1:2')])])],
+    ['surrogate numeric entity', fixtureXml([passage([verse('HEB="0"', 'GEN 1:&#xD800;'), verse('HEB="2"', 'GEN 1:2')])])],
+  ])('rejects %s', (_label, xml) => {
+    expect(() => compileFixture(xml)).toThrow('[ubs-compiler]');
+  });
+
+  it('accepts documented alignment digits 6–8 without interpreting or discarding them', () => {
+    const xml = fixtureXml([passage([
+      verse('HEB="678"', 'GEN 1:1'),
+      verse('HEB="012"', 'GEN 1:2'),
+    ])]);
+    const result = compileFixture(xml);
+    expect(result.groups[0].members[0].alignmentRaw).toBe('678');
+    expect(result.groups[0].members[0]).not.toHaveProperty('confidence');
+  });
+
+  it('decodes standard XML character references before validating and retaining the reference', () => {
+    const xml = fixtureXml([passage([
+      verse('HEB="0"', 'GEN 1:1&#x2d;1'),
+      verse('HEB="2"', 'GEN 1:2'),
+    ])]);
+    const result = compileFixture(xml);
+    expect(result.groups[0].members[0].sourceReference).toBe('GEN 1:1-1');
+    expect(result.groups[0].members[0].segments[0]).toEqual({
+      bookNumber: 1, chapter: 1, startVerse: 1, endVerse: 1,
+    });
+  });
+
+  it('rejects exact duplicate groups and source drift', () => {
+    const oneGroup = passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')]);
+    const duplicateXml = fixtureXml([oneGroup, oneGroup]);
+    expect(() => compileFixture(duplicateXml)).toThrow(/duplicate UBS group/);
+    const drifted = Buffer.from(readFileSync(sourcePath));
+    drifted[drifted.length - 20] ^= 1;
+    expect(() => compileUbsParallelPassages(drifted, metadata)).toThrow(/source (byte size|SHA-256|Git blob) drift/);
+  });
+
+  it('rejects provenance drift between canonical metadata records', () => {
+    expect(() => assertProvenanceMatches(metadata, {
+      ...metadata,
+      licenseUrl: 'https://example.invalid/license',
+    })).toThrow(/licenseUrl/);
+    expect(() => assertProvenanceMatches(metadata, {
+      ...metadata,
+      sourceCommitDate: '2024-01-01',
+    })).toThrow(/sourceCommitDate/);
+    expect(() => assertProvenanceMatches(metadata, {
+      ...metadata,
+      extraField: 'drift',
+    } as SourceMetadata)).toThrow(/noncanonical fields/);
+    expect(() => assertProvenanceMatches({
+      ...metadata,
+      extraField: 'left',
+    } as SourceMetadata, {
+      ...metadata,
+      extraField: 'right',
+    } as SourceMetadata)).toThrow(/noncanonical fields/);
+  });
+
+  it('keeps IDs content-derived when group order changes and changes IDs when content changes', () => {
+    const first = passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="2"', 'GEN 1:2')]);
+    const second = passage([verse('GRK="1"', 'MAT 1:1'), verse('GRK="2"', 'MRK 1:1')]);
+    const xml = fixtureXml([first, second]);
+    const reorderedXml = fixtureXml([second, first]);
+    const originalIds = new Set(compileFixture(xml).groups.map(group => group.groupId));
+    const reorderedIds = new Set(compileFixture(reorderedXml).groups.map(group => group.groupId));
+    expect(reorderedIds).toEqual(originalIds);
+
+    const changedXml = fixtureXml([passage([verse('HEB="0"', 'GEN 1:1'), verse('HEB="1"', 'GEN 1:2')]), second]);
+    expect(compileFixture(changedXml).groups[0].groupId).not.toBe(compileFixture(xml).groups[0].groupId);
+  });
+});


### PR DESCRIPTION
## Summary

- Vendor the pinned official UBS/Paratext Parallel Passages XML snapshot under CC BY-SA 4.0 with license, attribution, and source provenance metadata.
- Add a secure offline deterministic XML compiler preserving all 2,193 source groups and 5,266 ordered members, raw references, discontinuous segments, raw alignment strings, neutral `source_attested_parallel` labels, and unspecified directionality.
- Add generated JSON, canonical manifest/build-copy verification, source-drift gates, and adversarial/determinism/fidelity tests.

## Scope

This is intentionally data/compiler-only. It does not change runtime services, MCP tools/schemas, defaults, public behavior, D1, Cloudflare, or deployment configuration. The existing legacy parallel corpus remains untouched. No deploy-preview was requested or run.

## Validation

- UBS compiler tests: 34 passed.
- Non-SQLite unit suites: 55 suites / 755 tests passed.
- Integration tests: 3 passed.
- Node and Worker typechecks passed.
- Compiler rebuild, normal build, deterministic output, source hash/blob verification, and data manifest verification passed.
- Sol approval reviews completed; the final approval was APPROVE.

The full SQLite-dependent test pipeline is environment-blocked by the unavailable `better-sqlite3` native binding under Node 26.