### PR TITLE
Add bounded CCEL primary-source search adapter

### DIFF
--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -1,0 +1,15 @@
+# CCEL live-search preflight record
+
+Recorded 2026-07-11 for PR 1. This is an operational review record, not an
+enablement approval. The live-search flag remains off by default.
+
+- Search surface reviewed: `https://ccel.org/?page=1&text=...`
+- Search contract reviewed: [CCEL Search Help](https://www.ccel.org/help/search), including the documented `author`, `authorID`, `title`, and `bookID` fields.
+- Exact locator shape reviewed: `https://ccel.org/ccel/{author}/{work}/{section}.html`.
+- Copyright status: no rights determination is made by this adapter. Search snippets are discovery-only metadata; edition-specific copyright and permission checks remain a later rollout gate. The [CCEL Copyright Policy](https://www.ccel.org/about/copyright.html) is reference material, not an approval.
+- Terms status: not reviewed or approved for this feature. Terms approval remains an explicit operator gate; copyright policy is not treated as a substitute for terms-of-use approval.
+- Robots status: not fetched by this slice. `https://www.ccel.org/robots.txt` must be checked manually by the operator immediately before any preview enablement and again for adapter releases. No automated test fetches robots or the live search surface.
+- Interface status: `search-results.html` is a dated, sanitized capture of the visible `h2` search heading, `h5` result headings, section links, and text metadata; `no-results.html` and `policy-page.html` preserve only their reviewed structural `h2`/`p` and `h1`/`p` states. Adversarial markup is isolated in `malicious.html` and is not provenance. Selector/state drift fails closed as `interface_changed`; upstream selector approval remains pending before enablement.
+
+No live CCEL request, body persistence, production flag change, or remote
+mutation is authorized by this record.

--- a/src/adapters/commentary/CcelSearchAdapter.ts
+++ b/src/adapters/commentary/CcelSearchAdapter.ts
@@ -1,0 +1,974 @@
+/**
+ * Bounded, metadata-only search against CCEL's public HTML search surface.
+ *
+ * This adapter is intentionally separate from CcelAdapter. It never fetches a
+ * result link, never returns a work body, and is disabled unless explicitly
+ * enabled by a caller that has passed the rollout gate.
+ */
+
+import { ValidationError } from '../../kernel/errors.js';
+import {
+  type PrimarySourceProviderResult,
+  type PrimarySourceSearchHit,
+  type PrimarySourceSearchMatch,
+  type PrimarySourceSearchQuery,
+} from '../../services/historical/primarySourceTypes.js';
+import { decodeHtmlEntities, stripHtml } from '../shared/HtmlParser.js';
+import type { PrimarySourceFeatureFlags } from '../../kernel/featureFlags.js';
+
+export const CCEL_SEARCH_ATTRIBUTION = 'CCEL (Christian Classics Ethereal Library)' as const;
+export const CCEL_SEARCH_URL = 'https://ccel.org/';
+
+export const CCEL_SEARCH_LIMITS = Object.freeze({
+  maxTextCharacters: 200,
+  maxAuthorCharacters: 100,
+  maxWorkCharacters: 160,
+  maxTerms: 12,
+  maxComposedQueryCharacters: 768,
+  maxPage: 3,
+  maxHitsPerResponse: 8,
+  maxCandidateResults: 50,
+  maxResponseBytes: 1024 * 1024,
+  maxTitleCharacters: 300,
+  maxAuthorResultCharacters: 200,
+  maxSectionCharacters: 300,
+  maxSnippetCharacters: 500,
+  maxLocatorUrlCharacters: 1024,
+  maxLocatorSegmentCharacters: 128,
+  maxLocatorWorkCharacters: 256,
+  maxLocatorSectionCharacters: 256,
+  maxLocatorSegments: 4,
+  maxAggregateResultCharacters: 12_000,
+  timeoutMs: 8_000,
+  totalRequestMs: 12_000,
+  maxRetries: 1,
+  maxRedirects: 2,
+  cacheTtlMs: 10 * 60 * 1000,
+  negativeCacheTtlMs: 60 * 1000,
+  cacheMaxEntries: 100,
+  cacheMaxBytes: 8 * 1024 * 1024,
+  maxConcurrentRequests: 2,
+  maxQueuedRequests: 4,
+  networkFailureWindowMs: 5 * 60 * 1000,
+  networkFailureThreshold: 3,
+  networkOpenMs: 10 * 60 * 1000,
+  policyOpenMs: 30 * 60 * 1000,
+  maxCircuitOpenMs: 24 * 60 * 60 * 1000,
+});
+
+const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,11}$/;
+const ALLOWED_QUERY_KEYS = new Set(['text', 'match', 'author', 'work', 'page', 'limit']);
+const LUCENE_SPECIAL_CHARACTERS = new Set('+-!(){}[]^"~*?:\\&|'.split(''));
+const USER_AGENT = 'TheologAI/primary-source-search (bounded user-requested discovery; contact project maintainers)';
+
+type FetchImplementation = typeof fetch;
+type Clock = () => number;
+
+export interface CcelSearchAdapterOptions {
+  /** Explicit rollout gate. Defaults to false. */
+  enabled?: boolean;
+  featureFlags?: Partial<PrimarySourceFeatureFlags>;
+  fetchImpl?: FetchImplementation;
+  now?: Clock;
+  /** Only the verified CCEL origin and root search path are accepted. */
+  baseUrl?: string;
+  /** Lower test/deployment budgets are allowed; the locked maxima cannot be raised. */
+  cacheMaxEntries?: number;
+  cacheMaxBytes?: number;
+}
+
+export interface ComposedCcelSearchRequest {
+  normalizedText: string;
+  normalizedMatch: PrimarySourceSearchMatch;
+  normalizedAuthor?: string;
+  normalizedWork?: string;
+  page: number;
+  limit: number;
+  luceneQuery: string;
+  url: string;
+  cacheKey: string;
+}
+
+type CircuitReason = 'network' | 'policy' | 'rate_limited' | 'interface_changed';
+type CircuitStatus = 'closed' | 'open' | 'half_open';
+
+export interface CcelCircuitSnapshot {
+  status: CircuitStatus;
+  reason?: CircuitReason;
+  openUntil?: number;
+  recentNetworkFailures: number;
+  parserFailures: number;
+  operatorReviewRequired: boolean;
+}
+
+type FailureKind = 'network' | 'timeout' | 'forbidden' | 'rate_limited' | 'policy' | 'parser' | 'upstream' | 'too_large';
+
+const TIMEOUT_ABORT_REASON = 'ccel-search-timeout';
+
+class CcelSearchFailure extends Error {
+  constructor(
+    readonly kind: FailureKind,
+    readonly retryAfterMs?: number,
+  ) {
+    super(kind);
+    this.name = 'CcelSearchFailure';
+  }
+}
+
+interface CacheEntry {
+  value: PrimarySourceProviderResult;
+  expiresAt: number;
+  bytes: number;
+}
+
+class MetadataCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private totalBytes = 0;
+
+  constructor(
+    private readonly maxEntries: number,
+    private readonly maxBytes: number,
+  ) {}
+
+  get(key: string, now: number): PrimarySourceProviderResult | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (now >= entry.expiresAt) {
+      this.delete(key, entry);
+      return undefined;
+    }
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return cloneResult(entry.value);
+  }
+
+  set(key: string, value: PrimarySourceProviderResult, expiresAt: number): void {
+    const serialized = JSON.stringify(value);
+    const bytes = new TextEncoder().encode(serialized).byteLength;
+    if (bytes > this.maxBytes) return;
+
+    const previous = this.entries.get(key);
+    if (previous) this.delete(key, previous);
+    while (this.entries.size >= this.maxEntries || this.totalBytes + bytes > this.maxBytes) {
+      const oldest = this.entries.entries().next().value as [string, CacheEntry] | undefined;
+      if (!oldest) break;
+      this.delete(oldest[0], oldest[1]);
+    }
+    this.entries.set(key, { value: cloneResult(value), expiresAt, bytes });
+    this.totalBytes += bytes;
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.totalBytes = 0;
+  }
+
+  snapshot(): { entries: number; bytes: number } {
+    return { entries: this.entries.size, bytes: this.totalBytes };
+  }
+
+  private delete(key: string, entry: CacheEntry): void {
+    if (this.entries.delete(key)) this.totalBytes -= entry.bytes;
+  }
+}
+
+interface QueuedRequest {
+  task: () => Promise<PrimarySourceProviderResult>;
+  resolve: (value: PrimarySourceProviderResult) => void;
+}
+
+interface CircuitClaim {
+  generation: number;
+  operatorEpoch: number;
+}
+
+/** Compose a literal, bounded query for CCEL's documented search fields. */
+export function composeCcelSearchRequest(input: PrimarySourceSearchQuery): ComposedCcelSearchRequest {
+  validateQueryShape(input);
+
+  const normalizedText = normalizeLiteral(input.text, 'text', CCEL_SEARCH_LIMITS.maxTextCharacters);
+  const normalizedAuthor = input.author === undefined
+    ? undefined
+    : normalizeLiteral(input.author, 'author', CCEL_SEARCH_LIMITS.maxAuthorCharacters);
+  const normalizedWork = input.work === undefined
+    ? undefined
+    : normalizeLiteral(input.work, 'work', CCEL_SEARCH_LIMITS.maxWorkCharacters);
+  if (normalizedAuthor !== undefined && normalizeRestrictionPhrase(normalizedAuthor) === '') {
+    throw new ValidationError('author', 'author must contain a semantic name or reviewed ID.');
+  }
+  if (normalizedWork !== undefined && normalizeRestrictionPhrase(normalizedWork) === '') {
+    throw new ValidationError('work', 'work must contain a semantic title or reviewed ID.');
+  }
+  const normalizedMatch = input.match ?? 'all_terms';
+  if (normalizedMatch !== 'all_terms' && normalizedMatch !== 'phrase') {
+    throw new ValidationError('match', 'match must be all_terms or phrase.');
+  }
+
+  const textTerms = normalizedText.split(' ');
+  if (textTerms.length > CCEL_SEARCH_LIMITS.maxTerms) {
+    throw new ValidationError('text', `text may contain at most ${CCEL_SEARCH_LIMITS.maxTerms} terms.`);
+  }
+  const luceneText = normalizedMatch === 'phrase'
+    ? `"${escapeLuceneLiteral(normalizedText)}"`
+    : textTerms.map(escapeLuceneTerm).join(' AND ');
+  const clauses = [luceneText];
+  if (normalizedAuthor) clauses.push(composeFieldClause('author', normalizedAuthor));
+  if (normalizedWork) clauses.push(composeFieldClause('title', normalizedWork));
+  const luceneQuery = clauses.join(' AND ');
+  if (countCharacters(luceneQuery) > CCEL_SEARCH_LIMITS.maxComposedQueryCharacters) {
+    throw new ValidationError('text', 'The composed CCEL query exceeds the safe length limit.');
+  }
+
+  const page = input.page ?? 1;
+  const limit = input.limit ?? 5;
+  if (!Number.isSafeInteger(page) || page < 1 || page > CCEL_SEARCH_LIMITS.maxPage) {
+    throw new ValidationError('page', `page must be an integer from 1 to ${CCEL_SEARCH_LIMITS.maxPage}.`);
+  }
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > CCEL_SEARCH_LIMITS.maxHitsPerResponse) {
+    throw new ValidationError('limit', `limit must be an integer from 1 to ${CCEL_SEARCH_LIMITS.maxHitsPerResponse}.`);
+  }
+
+  const url = new URL(CCEL_SEARCH_URL);
+  url.searchParams.set('page', String(page));
+  url.searchParams.set('text', luceneQuery);
+
+  return {
+    normalizedText,
+    normalizedMatch,
+    normalizedAuthor,
+    normalizedWork,
+    page,
+    limit,
+    luceneQuery,
+    url: url.toString(),
+    cacheKey: JSON.stringify({ text: normalizedText, match: normalizedMatch, author: normalizedAuthor, work: normalizedWork, page }),
+  };
+}
+
+function validateQueryShape(input: PrimarySourceSearchQuery): void {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ValidationError('query', 'A search query object is required.');
+  }
+  for (const key of Object.keys(input as object)) {
+    if (!ALLOWED_QUERY_KEYS.has(key)) throw new ValidationError(key, 'Unknown search query field.');
+  }
+  if (typeof input.text !== 'string') throw new ValidationError('text', 'text must be a string.');
+  if (input.match !== undefined && typeof input.match !== 'string') throw new ValidationError('match', 'match must be a string.');
+  const optionalFields: Array<['author' | 'work', number]> = [
+    ['author', CCEL_SEARCH_LIMITS.maxAuthorCharacters],
+    ['work', CCEL_SEARCH_LIMITS.maxWorkCharacters],
+  ];
+  for (const [field, max] of optionalFields) {
+    const value = input[field];
+    if (value !== undefined && typeof value !== 'string') throw new ValidationError(field, `${field} must be a string.`);
+    if (typeof value === 'string' && countCharacters(value.normalize('NFC').trim()) > max) {
+      throw new ValidationError(field, `${field} exceeds its safe length limit.`);
+    }
+  }
+}
+
+function normalizeLiteral(value: string, field: string, maxCharacters: number): string {
+  if (value.includes('\u0000')) throw new ValidationError(field, `${field} may not contain NUL.`);
+  const normalized = value
+    .normalize('NFC')
+    .replace(/[\u0001-\u001F\u007F-\u009F]/g, ' ')
+    .trim()
+    .replace(/\s+/gu, ' ');
+  if (!normalized) throw new ValidationError(field, `${field} must not be empty.`);
+  if (countCharacters(normalized) > maxCharacters) throw new ValidationError(field, `${field} exceeds its safe length limit.`);
+  return normalized;
+}
+
+function composeFieldClause(field: 'author' | 'title', value: string): string {
+  const idField = field === 'author' ? 'authorID' : 'bookID';
+  if (isReviewedCcelId(value)) return `${idField}:${escapeLuceneLiteral(value)}`;
+  return `${field}:"${escapeLuceneLiteral(value)}"`;
+}
+
+function isReviewedCcelId(value: string): boolean {
+  return SAFE_ID_PATTERN.test(value);
+}
+
+function escapeLuceneLiteral(value: string): string {
+  return [...value].map(character => LUCENE_SPECIAL_CHARACTERS.has(character) ? `\\${character}` : character).join('');
+}
+
+function escapeLuceneTerm(value: string): string {
+  const escaped = escapeLuceneLiteral(value);
+  // A caller-supplied Boolean keyword must not become an operator when the
+  // adapter inserts its own AND separators.
+  return /^(?:AND|OR|NOT)$/i.test(value) ? `"${escaped}"` : escaped;
+}
+
+function countCharacters(value: string): number {
+  return Array.from(value).length;
+}
+
+function cloneResult(result: PrimarySourceProviderResult): PrimarySourceProviderResult {
+  return { ...result, hits: result.hits.map(hit => ({ ...hit, locator: { ...hit.locator } })), notices: [...result.notices] };
+}
+
+function resultFor(
+  status: PrimarySourceProviderResult['status'],
+  page: number,
+  notices: string[] = [],
+  hits: PrimarySourceSearchHit[] = [],
+  searched = true,
+): PrimarySourceProviderResult {
+  return { provider: 'ccel_live', status, searched, page, hitCount: hits.length, hits, notices };
+}
+
+/**
+ * Search adapter. The only network operation it performs is the one bounded
+ * GET represented by a single caller-supplied query object.
+ */
+export class CcelSearchAdapter {
+  private readonly enabled: boolean;
+  private readonly fetchImpl: FetchImplementation;
+  private readonly now: Clock;
+  private readonly baseUrl: string;
+  private readonly cache: MetadataCache;
+  private readonly queue: QueuedRequest[] = [];
+  private activeRequests = 0;
+  private circuitStatus: CircuitStatus = 'closed';
+  private circuitReason: CircuitReason | undefined;
+  private circuitOpenUntil: number | undefined;
+  private halfOpenProbeInFlight = false;
+  private policyReviewRequired = false;
+  private parserFailures = 0;
+  private networkFailures: number[] = [];
+  private circuitGeneration = 0;
+  private operatorEpoch = 0;
+
+  constructor(options: CcelSearchAdapterOptions = {}) {
+    this.enabled = options.enabled ?? options.featureFlags?.ccelLiveSearch ?? false;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.now = options.now ?? Date.now;
+    this.baseUrl = validateSearchOrigin(options.baseUrl ?? CCEL_SEARCH_URL);
+    const cacheMaxEntries = options.cacheMaxEntries ?? CCEL_SEARCH_LIMITS.cacheMaxEntries;
+    const cacheMaxBytes = options.cacheMaxBytes ?? CCEL_SEARCH_LIMITS.cacheMaxBytes;
+    if (!Number.isSafeInteger(cacheMaxEntries) || cacheMaxEntries < 1 || cacheMaxEntries > CCEL_SEARCH_LIMITS.cacheMaxEntries) {
+      throw new Error(`cacheMaxEntries must be between 1 and ${CCEL_SEARCH_LIMITS.cacheMaxEntries}`);
+    }
+    if (!Number.isSafeInteger(cacheMaxBytes) || cacheMaxBytes < 1 || cacheMaxBytes > CCEL_SEARCH_LIMITS.cacheMaxBytes) {
+      throw new Error(`cacheMaxBytes must be between 1 and ${CCEL_SEARCH_LIMITS.cacheMaxBytes}`);
+    }
+    this.cache = new MetadataCache(cacheMaxEntries, cacheMaxBytes);
+  }
+
+  async search(input: PrimarySourceSearchQuery): Promise<PrimarySourceProviderResult> {
+    const request = composeCcelSearchRequest(input);
+    if (!this.enabled) return resultFor('disabled', request.page, ['Live CCEL search is disabled.'], [], false);
+    // Capture admission before this request can enter the queue. An operator
+    // reset invalidates queued as well as active work from the reviewed epoch.
+    const admissionEpoch = this.operatorEpoch;
+    const deadline = this.now() + CCEL_SEARCH_LIMITS.totalRequestMs;
+
+    const cached = this.cache.get(request.cacheKey, this.now());
+    if (cached) return { ...cached, hits: cached.hits.slice(0, request.limit), hitCount: Math.min(cached.hitCount, request.limit) };
+
+    if (this.activeRequests + this.queue.length >= CCEL_SEARCH_LIMITS.maxConcurrentRequests + CCEL_SEARCH_LIMITS.maxQueuedRequests) {
+      return resultFor('unavailable', request.page, ['Live CCEL search is busy; try again later.'], [], false);
+    }
+
+    return this.enqueue(() => this.performSearch(request, deadline, admissionEpoch));
+  }
+
+  getCircuitState(): CcelCircuitSnapshot {
+    this.refreshCircuitState();
+    return {
+      status: this.circuitStatus,
+      ...(this.circuitReason ? { reason: this.circuitReason } : {}),
+      ...(this.circuitOpenUntil ? { openUntil: this.circuitOpenUntil } : {}),
+      recentNetworkFailures: this.recentNetworkFailureCount(),
+      parserFailures: this.parserFailures,
+      operatorReviewRequired: this.policyReviewRequired,
+    };
+  }
+
+  /** Explicit operator action required after a CCEL policy/403 signal. */
+  resetCircuitAfterReview(): void {
+    // Invalidate every request admitted before the operator's decision. A late
+    // completion from the old epoch must not recreate or otherwise mutate the
+    // state that was explicitly reviewed and reset.
+    this.operatorEpoch++;
+    this.circuitGeneration++;
+    this.policyReviewRequired = false;
+    this.circuitStatus = 'closed';
+    this.circuitReason = undefined;
+    this.circuitOpenUntil = undefined;
+    this.halfOpenProbeInFlight = false;
+    this.parserFailures = 0;
+    this.networkFailures = [];
+    this.cache.clear();
+  }
+
+  getCacheStats(): { entries: number; bytes: number } {
+    return this.cache.snapshot();
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  private enqueue(task: () => Promise<PrimarySourceProviderResult>): Promise<PrimarySourceProviderResult> {
+    if (this.activeRequests < CCEL_SEARCH_LIMITS.maxConcurrentRequests) return this.start(task);
+    return new Promise(resolve => this.queue.push({ task, resolve }));
+  }
+
+  private start(task: () => Promise<PrimarySourceProviderResult>): Promise<PrimarySourceProviderResult> {
+    this.activeRequests++;
+    return task()
+      .catch(() => resultFor('unavailable', 1, ['Live CCEL search is temporarily unavailable.']))
+      .finally(() => {
+        this.activeRequests--;
+        const next = this.queue.shift();
+        if (next) void this.start(next.task).then(next.resolve);
+      });
+  }
+
+  private async performSearch(request: ComposedCcelSearchRequest, deadline: number, admissionEpoch: number): Promise<PrimarySourceProviderResult> {
+    if (admissionEpoch !== this.operatorEpoch) {
+      return resultFor('unavailable', request.page, ['Live CCEL search request was invalidated by operator review.'], [], false);
+    }
+    if (this.now() >= deadline) return resultFor('unavailable', request.page, ['Live CCEL search request budget expired before execution.'], [], false);
+    const claim = this.claimCircuitSlot();
+    if (!claim) return this.circuitUnavailable(request.page);
+
+    try {
+      const html = await this.fetchSearchHtml(request.url, deadline);
+      const parsed = parseCcelSearchHtml(html, request.page);
+      const filtered = applyCcelRestrictions(parsed.hits, request);
+      // A policy signal from another in-flight request is monotonic until an
+      // operator explicitly resets it. Do not publish or cache a success that
+      // raced with that signal.
+      if (!this.recordSuccess(claim)) return this.circuitUnavailable(request.page);
+      const result = filtered.rejected > 0
+        ? resultFor('unsupported_filter', request.page, ['CCEL search results did not satisfy the requested author/work restriction.'], filtered.hits.slice(0, request.limit))
+        : filtered.hits.length === 0
+        ? resultFor('no_results', request.page, parsed.notices, [])
+        : resultFor('ok', request.page, parsed.notices, filtered.hits.slice(0, request.limit));
+      // Cache only recognized successful/no-result metadata, never raw HTML or failures.
+      if (filtered.rejected === 0) {
+        const cacheable = { ...result, hits: filtered.hits, hitCount: filtered.hits.length };
+        this.cache.set(request.cacheKey, cacheable, this.now() + (filtered.hits.length === 0 ? CCEL_SEARCH_LIMITS.negativeCacheTtlMs : CCEL_SEARCH_LIMITS.cacheTtlMs));
+      }
+      return result;
+    } catch (error) {
+      const failure = error instanceof CcelSearchFailure ? error : new CcelSearchFailure('network');
+      this.recordFailure(failure, claim);
+      return this.failureResult(request.page, failure);
+    }
+  }
+
+  private async fetchSearchHtml(initialUrl: string, deadline: number): Promise<string> {
+    for (let attempt = 0; attempt <= CCEL_SEARCH_LIMITS.maxRetries; attempt++) {
+      try {
+        return await this.fetchSearchHtmlAttempt(initialUrl, deadline);
+      } catch (error) {
+        if (!(error instanceof CcelSearchFailure) || error.kind !== 'network' || attempt === CCEL_SEARCH_LIMITS.maxRetries || this.now() >= deadline) throw error;
+      }
+    }
+    throw new CcelSearchFailure('network');
+  }
+
+  private async fetchSearchHtmlAttempt(initialUrl: string, deadline: number): Promise<string> {
+    let url = initialUrl;
+    for (let redirect = 0; redirect <= CCEL_SEARCH_LIMITS.maxRedirects; redirect++) {
+      if (this.now() >= deadline) throw new CcelSearchFailure('network');
+      const validated = validateSearchUrl(url, this.baseUrl);
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(TIMEOUT_ABORT_REASON), Math.min(CCEL_SEARCH_LIMITS.timeoutMs, Math.max(1, deadline - this.now())));
+      let response: Response;
+      try {
+        response = await this.fetchImpl(validated, {
+          method: 'GET',
+          headers: { 'Accept': 'text/html, application/xhtml+xml', 'User-Agent': USER_AGENT },
+          redirect: 'manual',
+          signal: controller.signal,
+        });
+      } catch {
+        clearTimeout(timeout);
+        if (controller.signal.reason === TIMEOUT_ABORT_REASON) throw new CcelSearchFailure('timeout');
+        if (redirect === 0) throw new CcelSearchFailure('network');
+        throw new CcelSearchFailure('policy');
+      }
+
+      if (response.status >= 300 && response.status <= 399 && response.status !== 304) {
+        const location = response.headers.get('Location');
+        await discardResponseBody(response);
+        clearTimeout(timeout);
+        if (!location || redirect === CCEL_SEARCH_LIMITS.maxRedirects) throw new CcelSearchFailure('policy');
+        try {
+          url = new URL(location, validated).toString();
+        } catch {
+          throw new CcelSearchFailure('policy');
+        }
+        continue;
+      }
+
+      if (response.status === 403) {
+        await discardResponseBody(response);
+        clearTimeout(timeout);
+        throw new CcelSearchFailure('forbidden');
+      }
+      if (response.status === 429) {
+        const retryAfter = parseRetryAfter(response.headers.get('Retry-After'), this.now());
+        await discardResponseBody(response);
+        clearTimeout(timeout);
+        throw new CcelSearchFailure('rate_limited', retryAfter);
+      }
+      if (response.status >= 500) {
+        await discardResponseBody(response);
+        clearTimeout(timeout);
+        throw new CcelSearchFailure('network');
+      }
+      if (response.status < 200 || response.status >= 300) {
+        await discardResponseBody(response);
+        clearTimeout(timeout);
+        throw new CcelSearchFailure('upstream');
+      }
+
+      const contentType = response.headers.get('Content-Type')?.toLowerCase() ?? '';
+      if (!contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
+        await discardResponseBody(response);
+        clearTimeout(timeout);
+        throw new CcelSearchFailure('parser');
+      }
+      try {
+        return await readBoundedBody(response, controller.signal);
+      } catch (error) {
+        if (error instanceof CcelSearchFailure) throw error;
+        throw new CcelSearchFailure('network');
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    throw new CcelSearchFailure('policy');
+  }
+
+  private claimCircuitSlot(): CircuitClaim | undefined {
+    this.refreshCircuitState();
+    if (this.policyReviewRequired || this.circuitStatus === 'open') return undefined;
+    if (this.circuitStatus === 'half_open') {
+      if (this.halfOpenProbeInFlight) return undefined;
+      this.halfOpenProbeInFlight = true;
+    }
+    return { generation: this.circuitGeneration, operatorEpoch: this.operatorEpoch };
+  }
+
+  private refreshCircuitState(): void {
+    if (!this.policyReviewRequired && this.circuitStatus === 'open' && this.circuitOpenUntil !== undefined && this.now() >= this.circuitOpenUntil) {
+      this.circuitStatus = 'half_open';
+      this.circuitOpenUntil = undefined;
+      this.halfOpenProbeInFlight = false;
+      this.circuitGeneration++;
+    }
+  }
+
+  private recordSuccess(claim: CircuitClaim): boolean {
+    if (!this.isCurrentClaim(claim) || this.policyReviewRequired || this.circuitStatus === 'open') return false;
+    const closedHalfOpenCircuit = this.circuitStatus === 'half_open';
+    this.circuitStatus = 'closed';
+    this.circuitReason = undefined;
+    this.circuitOpenUntil = undefined;
+    this.halfOpenProbeInFlight = false;
+    this.parserFailures = 0;
+    this.networkFailures = [];
+    if (closedHalfOpenCircuit) this.circuitGeneration++;
+    return true;
+  }
+
+  private recordFailure(failure: CcelSearchFailure, claim: CircuitClaim): void {
+    // An operator reset is an epoch boundary. Nothing admitted before it may
+    // mutate the reviewed state, even if that late completion is another 403.
+    if (claim.operatorEpoch !== this.operatorEpoch) return;
+    // A policy/403 signal is strongest and remains latched until explicit
+    // operator reset. Same-epoch weaker completions cannot replace it.
+    if (this.policyReviewRequired) return;
+    const now = this.now();
+    if (failure.kind === 'forbidden' || failure.kind === 'policy') {
+      this.openCircuit('policy', CCEL_SEARCH_LIMITS.policyOpenMs, true);
+      return;
+    }
+    // Rate-limit signals merge monotonically even when concurrent: a later
+    // completion may extend Retry-After, but can never shorten it.
+    if (failure.kind === 'rate_limited') {
+      const duration = Math.min(CCEL_SEARCH_LIMITS.maxCircuitOpenMs, Math.max(CCEL_SEARCH_LIMITS.policyOpenMs, failure.retryAfterMs ?? 0));
+      if (this.circuitStatus === 'open' && this.circuitReason === 'rate_limited') {
+        this.circuitOpenUntil = Math.max(this.circuitOpenUntil ?? 0, now + duration);
+      } else {
+        this.openCircuit('rate_limited', duration);
+      }
+      return;
+    }
+    // All remaining outcomes are weaker than a state transition completed
+    // after this request was admitted.
+    if (!this.isCurrentClaim(claim)) return;
+    if (this.circuitStatus === 'half_open' && (failure.kind === 'upstream' || failure.kind === 'too_large')) {
+      // A probe must positively validate the interface before traffic resumes.
+      // Unexpected 4xx responses and response-bound violations indicate that
+      // the reviewed surface is not currently usable, so reopen with bounded
+      // interface-change backoff instead of permitting an immediate new probe.
+      this.openCircuit('interface_changed', CCEL_SEARCH_LIMITS.policyOpenMs);
+      return;
+    }
+    if (failure.kind === 'parser') {
+      this.parserFailures++;
+      if (this.parserFailures >= 2 || this.circuitStatus === 'half_open') this.openCircuit('interface_changed', CCEL_SEARCH_LIMITS.policyOpenMs);
+      else this.halfOpenProbeInFlight = false;
+      return;
+    }
+    if (failure.kind === 'network' || failure.kind === 'timeout') {
+      this.networkFailures = this.networkFailures.filter(timestamp => now - timestamp <= CCEL_SEARCH_LIMITS.networkFailureWindowMs);
+      this.networkFailures.push(now);
+      if (this.networkFailures.length >= CCEL_SEARCH_LIMITS.networkFailureThreshold || this.circuitStatus === 'half_open') {
+        this.openCircuit('network', CCEL_SEARCH_LIMITS.networkOpenMs);
+      }
+      return;
+    }
+    this.halfOpenProbeInFlight = false;
+  }
+
+  private openCircuit(reason: CircuitReason, durationMs: number, operatorReviewRequired = false): void {
+    this.circuitGeneration++;
+    this.circuitStatus = 'open';
+    this.circuitReason = reason;
+    this.policyReviewRequired = operatorReviewRequired;
+    this.circuitOpenUntil = operatorReviewRequired ? undefined : this.now() + Math.min(durationMs, CCEL_SEARCH_LIMITS.maxCircuitOpenMs);
+    this.halfOpenProbeInFlight = false;
+    if (operatorReviewRequired) this.cache.clear();
+  }
+
+  private isCurrentClaim(claim: CircuitClaim): boolean {
+    return claim.operatorEpoch === this.operatorEpoch && claim.generation === this.circuitGeneration;
+  }
+
+  private recentNetworkFailureCount(): number {
+    const cutoff = this.now() - CCEL_SEARCH_LIMITS.networkFailureWindowMs;
+    this.networkFailures = this.networkFailures.filter(timestamp => timestamp >= cutoff);
+    return this.networkFailures.length;
+  }
+
+  private circuitUnavailable(page: number): PrimarySourceProviderResult {
+    const status = this.circuitReason === 'rate_limited' ? 'rate_limited' : this.circuitReason === 'interface_changed' ? 'interface_changed' : 'unavailable';
+    return resultFor(status, page, ['Live CCEL search is temporarily unavailable.'], [], false);
+  }
+
+  private failureResult(page: number, failure: CcelSearchFailure): PrimarySourceProviderResult {
+    const status = failure.kind === 'rate_limited' ? 'rate_limited' : failure.kind === 'parser' ? 'interface_changed' : 'unavailable';
+    return resultFor(status, page, ['Live CCEL search is temporarily unavailable.']);
+  }
+}
+
+interface ParsedSearch {
+  hits: PrimarySourceSearchHit[];
+  notices: string[];
+}
+
+interface RestrictedHits {
+  hits: PrimarySourceSearchHit[];
+  rejected: number;
+}
+
+function applyCcelRestrictions(
+  hits: PrimarySourceSearchHit[],
+  request: ComposedCcelSearchRequest,
+): RestrictedHits {
+  if (!request.normalizedAuthor && !request.normalizedWork) return { hits, rejected: 0 };
+  const accepted: PrimarySourceSearchHit[] = [];
+  let rejected = 0;
+  for (const hit of hits) {
+    const authorMatches = !request.normalizedAuthor || matchesAuthorRestriction(hit, request.normalizedAuthor);
+    const workMatches = !request.normalizedWork || matchesWorkRestriction(hit, request.normalizedWork);
+    if (authorMatches && workMatches) accepted.push(hit);
+    else rejected++;
+  }
+  return { hits: accepted, rejected };
+}
+
+function matchesAuthorRestriction(hit: PrimarySourceSearchHit, requested: string): boolean {
+  const workSegments = hit.locator.kind === 'ccel_section' ? hit.locator.work.split('/') : [];
+  if (isReviewedCcelId(requested)) return workSegments.length === 2 && workSegments[0] === requested;
+  return Boolean(hit.author && containsNormalizedPhrase(hit.author, requested));
+}
+
+function matchesWorkRestriction(hit: PrimarySourceSearchHit, requested: string): boolean {
+  const workSegments = hit.locator.kind === 'ccel_section' ? hit.locator.work.split('/') : [];
+  if (isReviewedCcelId(requested)) return workSegments.length === 2 && workSegments[1] === requested;
+  return containsNormalizedPhrase(hit.title, requested);
+}
+
+function containsNormalizedPhrase(actual: string, requested: string): boolean {
+  const normalizedActual = normalizeRestrictionPhrase(actual);
+  const normalizedRequested = normalizeRestrictionPhrase(requested);
+  return normalizedRequested.length > 0 && normalizedActual.includes(normalizedRequested);
+}
+
+function normalizeRestrictionPhrase(value: string): string {
+  return tokenizeWords(value.toLocaleLowerCase('en-US')).join(' ');
+}
+
+function tokenizeWords(value: string): string[] {
+  return value.match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
+/** Parse only known result metadata; selector drift is an error, not no-results. */
+export function parseCcelSearchHtml(html: string, page: number): ParsedSearch {
+  if (html.length === 0) throw new CcelSearchFailure('parser');
+  const sanitizedHtml = removeUnsafeMarkup(html);
+  if (hasReviewedPolicyMarker(sanitizedHtml)) throw new CcelSearchFailure('policy');
+  if (hasReviewedNoResultsMarker(sanitizedHtml)) return { hits: [], notices: [] };
+
+  const blocks = extractResultBlocks(sanitizedHtml).slice(0, CCEL_SEARCH_LIMITS.maxCandidateResults);
+  if (blocks.length === 0) throw new CcelSearchFailure('parser');
+
+  const hits: PrimarySourceSearchHit[] = [];
+  const seen = new Set<string>();
+  let aggregateCharacters = 0;
+  for (const block of blocks) {
+    const links = [...block.matchAll(/<a\b[^>]*href\s*=\s*(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi)];
+    const link = links.find(candidate => normalizeCcelSectionLocator(candidate[2]));
+    if (!link) continue;
+    const locator = normalizeCcelSectionLocator(link[2]);
+    if (!locator || seen.has(locator.url)) continue;
+    const title = sanitizePlainText(extractClassText(block, /(?:result[-_ ]title|ccel[-_ ]title|title)/i) ?? link[3], CCEL_SEARCH_LIMITS.maxTitleCharacters);
+    if (!title) throw new CcelSearchFailure('parser');
+    const paragraphs = extractElementTexts(block, 'p');
+    const author = optionalText(block, /(?:result[-_ ]author|ccel[-_ ]author|author)/i, CCEL_SEARCH_LIMITS.maxAuthorResultCharacters)
+      ?? extractHeadingAuthor(block);
+    const sectionLabel = optionalText(block, /(?:result[-_ ]section|ccel[-_ ]section|section[-_ ]label)/i, CCEL_SEARCH_LIMITS.maxSectionCharacters)
+      ?? (paragraphs.length > 1 ? paragraphs[0] : undefined);
+    const snippet = optionalText(block, /(?:result[-_ ]snippet|ccel[-_ ]snippet|snippet|summary|description)/i, CCEL_SEARCH_LIMITS.maxSnippetCharacters)
+      ?? (paragraphs.length > 1 ? paragraphs[1] : paragraphs[0] ?? '');
+    const hitCharacters = title.length + (author?.length ?? 0) + (sectionLabel?.length ?? 0) + snippet.length
+      + locator.url.length + locator.work.length + locator.section.length;
+    if (aggregateCharacters + hitCharacters > CCEL_SEARCH_LIMITS.maxAggregateResultCharacters) {
+      throw new CcelSearchFailure('too_large');
+    }
+    aggregateCharacters += hitCharacters;
+    seen.add(locator.url);
+    hits.push({
+      provider: 'ccel_live',
+      title,
+      ...(author ? { author } : {}),
+      ...(sectionLabel ? { sectionLabel } : {}),
+      snippet,
+      locator,
+      rankWithinProvider: hits.length + 1,
+      page,
+      snippetOnly: true,
+      attribution: CCEL_SEARCH_ATTRIBUTION,
+    });
+    if (hits.length >= CCEL_SEARCH_LIMITS.maxHitsPerResponse) break;
+  }
+  if (hits.length === 0) throw new CcelSearchFailure('parser');
+  return { hits, notices: [] };
+}
+
+function hasReviewedPolicyMarker(html: string): boolean {
+  return /<h1\b[^>]*>\s*Access denied\s*<\/h1>\s*<p\b[^>]*>\s*Please complete the CAPTCHA to continue\.\s*<\/p>/i.test(html);
+}
+
+function hasReviewedNoResultsMarker(html: string): boolean {
+  return /<h2\b[^>]*>\s*CCEL Search results\s*<\/h2>\s*<p\b[^>]*>\s*No results found\.\s*<\/p>/i.test(html);
+}
+
+function extractResultBlocks(html: string): string[] {
+  const blocks: string[] = [];
+  const headings = /<h5\b[^>]*>[\s\S]*?<\/h5>/gi;
+  let match: RegExpExecArray | null;
+  const matches: Array<{ start: number; end: number }> = [];
+  while ((match = headings.exec(html)) !== null && matches.length < CCEL_SEARCH_LIMITS.maxCandidateResults) {
+    matches.push({ start: match.index, end: headings.lastIndex });
+  }
+  for (let index = 0; index < matches.length; index++) {
+    const start = matches[index].start;
+    const nextStart = matches[index + 1]?.start ?? html.length;
+    const end = Math.min(nextStart, start + CCEL_SEARCH_LIMITS.maxAggregateResultCharacters);
+    const block = html.slice(start, end);
+    if (/<a\b[^>]*href\s*=\s*(["'])[^"']+\1[^>]*>/i.test(block)) blocks.push(block);
+  }
+  return blocks;
+}
+
+function extractClassText(block: string, classPattern: RegExp): string | undefined {
+  const element = new RegExp(`<([a-z0-9]+)\\b[^>]*class\\s*=\\s*(["'])[^"']*${classPattern.source}[^"']*\\2[^>]*>([\\s\\S]*?)<\\/\\1>`, 'i').exec(block);
+  return element?.[3];
+}
+
+function optionalText(block: string, classPattern: RegExp, max: number): string | undefined {
+  const raw = extractClassText(block, classPattern);
+  return raw === undefined ? undefined : sanitizePlainText(raw, max);
+}
+
+function extractHeadingAuthor(block: string): string | undefined {
+  const heading = /<h5\b[^>]*>([\s\S]*?)<\/h5>/i.exec(block)?.[1];
+  if (!heading) return undefined;
+  const text = sanitizePlainText(heading, CCEL_SEARCH_LIMITS.maxAuthorResultCharacters + CCEL_SEARCH_LIMITS.maxTitleCharacters);
+  const author = /\s+by\s+(.+)$/i.exec(text)?.[1];
+  return author ? sanitizePlainText(author, CCEL_SEARCH_LIMITS.maxAuthorResultCharacters) : undefined;
+}
+
+function extractElementTexts(block: string, tag: 'p'): string[] {
+  const values: string[] = [];
+  const elements = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'gi');
+  let match: RegExpExecArray | null;
+  while ((match = elements.exec(block)) !== null && values.length < 3) {
+    const value = sanitizePlainText(match[1], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
+    if (value) values.push(value);
+  }
+  return values;
+}
+
+function removeUnsafeMarkup(html: string): string {
+  return html
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<(script|style|form|nav|header|footer)\b[^>]*>[\s\S]*?<\/\1>/gi, '')
+    .replace(/<[^>]*\b(?:hidden|aria-hidden\s*=\s*["']true["'])[^>]*>[\s\S]*?<\/[^>]+>/gi, '');
+}
+
+function sanitizePlainText(html: string, maxCharacters: number): string {
+  const stripped = stripHtml(html);
+  const decoded = decodeHtmlEntities(stripped)
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+  const safe = decoded.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return Array.from(safe).slice(0, maxCharacters).join('');
+}
+
+/** Normalize only exact CCEL section paths; this never follows the link. */
+export function normalizeCcelSectionLocator(input: string): { kind: 'ccel_section'; url: string; work: string; section: string } | undefined {
+  if (typeof input !== 'string' || input.length === 0 || input.length > CCEL_SEARCH_LIMITS.maxLocatorUrlCharacters || /%/i.test(input) || /(?:^|\/)\.\.?(?:\/|$)/.test(input)) return undefined;
+  let url: URL;
+  try {
+    url = new URL(input, CCEL_SEARCH_URL);
+  } catch {
+    return undefined;
+  }
+  if (url.protocol !== 'https:' || !['ccel.org', 'www.ccel.org'].includes(url.hostname.toLowerCase()) || url.username || url.password || url.port || url.search || url.hash) return undefined;
+  if (!url.pathname.startsWith('/') || url.pathname.includes('//')) return undefined;
+  const segments = url.pathname.slice(1).split('/');
+  if (segments.length !== CCEL_SEARCH_LIMITS.maxLocatorSegments || segments[0] !== 'ccel' || segments.slice(0, -1).some(segment => segment.length > CCEL_SEARCH_LIMITS.maxLocatorSegmentCharacters || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment) || segment === '.' || segment === '..')) return undefined;
+  const last = segments.at(-1);
+  if (!last?.endsWith('.html') || last === '.html' || last.length > CCEL_SEARCH_LIMITS.maxLocatorSectionCharacters + '.html'.length || !/^[A-Za-z0-9][A-Za-z0-9._-]*\.html$/.test(last)) return undefined;
+  const section = last.slice(0, -'.html'.length);
+  if (!section || section.length > CCEL_SEARCH_LIMITS.maxLocatorSectionCharacters || section.includes('..')) return undefined;
+  const work = segments.slice(1, -1).join('/');
+  if (work.length > CCEL_SEARCH_LIMITS.maxLocatorWorkCharacters) return undefined;
+  const canonicalUrl = `https://ccel.org/ccel/${segments.slice(1).join('/')}`;
+  return { kind: 'ccel_section', url: canonicalUrl, work, section };
+}
+
+function validateSearchOrigin(input: string): string {
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    throw new Error('CCEL search origin is invalid');
+  }
+  if (url.protocol !== 'https:' || !['ccel.org', 'www.ccel.org'].includes(url.hostname.toLowerCase()) || url.username || url.password || url.port || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('CCEL search origin is not an approved HTTPS origin');
+  }
+  return CCEL_SEARCH_URL;
+}
+
+function validateSearchUrl(input: string, baseUrl: string): string {
+  const url = new URL(input);
+  // Redirects may normalize between the two documented CCEL hostnames, but
+  // may not leave the approved origin family or search path.
+  void baseUrl;
+  if (url.protocol !== 'https:' || !['ccel.org', 'www.ccel.org'].includes(url.hostname.toLowerCase()) || url.port || url.username || url.password || url.pathname !== '/') throw new CcelSearchFailure('policy');
+  return url.toString();
+}
+
+async function readBoundedBody(response: Response, signal: AbortSignal): Promise<string> {
+  const declared = response.headers.get('Content-Length');
+  if (declared && /^\d+$/.test(declared) && Number(declared) > CCEL_SEARCH_LIMITS.maxResponseBytes) {
+    await discardResponseBody(response);
+    throw new CcelSearchFailure('too_large');
+  }
+  if (!response.body) {
+    const body = await awaitWithAbort(response.text(), signal);
+    if (new TextEncoder().encode(body).byteLength > CCEL_SEARCH_LIMITS.maxResponseBytes) throw new CcelSearchFailure('too_large');
+    return body;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await awaitWithAbort(reader.read(), signal);
+      if (done) break;
+      total += value.byteLength;
+      if (total > CCEL_SEARCH_LIMITS.maxResponseBytes) {
+        throw new CcelSearchFailure('too_large');
+      }
+      chunks.push(value);
+    }
+  } catch (error) {
+    // Cancel first so an abort/error settles the pending read before the lock
+    // is released. Cleanup is deliberately best-effort and never replaces the
+    // classification that caused this read to stop.
+    cancelReaderBestEffort(reader, 'CCEL search response discarded');
+    throw error;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // A hostile/injected stream must not turn a bounded provider outcome
+      // into an asynchronous ERR_INVALID_STATE failure.
+    }
+  }
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function awaitWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  const abortFailure = () => new CcelSearchFailure(signal.reason === TIMEOUT_ABORT_REASON ? 'timeout' : 'network');
+  if (signal.aborted) return Promise.reject(abortFailure());
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortFailure());
+    const cleanup = () => signal.removeEventListener('abort', onAbort);
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => { cleanup(); resolve(value); },
+      error => { cleanup(); reject(error); },
+    );
+  });
+}
+
+function cancelReaderBestEffort(reader: ReadableStreamDefaultReader<Uint8Array>, reason: string): void {
+  try {
+    detachCleanup(reader.cancel(reason));
+  } catch {
+    // Preserve the original timeout/overflow/read failure.
+  }
+}
+
+function discardResponseBody(response: Response): void {
+  try {
+    const cancellation = response.body?.cancel('CCEL search response discarded');
+    if (cancellation) detachCleanup(cancellation);
+  } catch {
+    // The response is already being rejected; cleanup must never expose an
+    // upstream cancellation error or replace the sanitized provider outcome.
+  }
+}
+
+function detachCleanup(cleanup: Promise<unknown>): void {
+  void cleanup.catch(() => undefined);
+}
+
+function parseRetryAfter(value: string | null, now: number): number | undefined {
+  if (!value) return undefined;
+  if (/^\d+$/.test(value.trim())) return Number(value.trim()) * 1000;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? undefined : Math.max(0, timestamp - now);
+}

--- a/src/kernel/featureFlags.ts
+++ b/src/kernel/featureFlags.ts
@@ -1,0 +1,31 @@
+/**
+ * Non-secret rollout switches for the staged primary-source workstream.
+ *
+ * Live CCEL search is intentionally disabled when configuration is absent or
+ * malformed. Existing exact CCEL retrieval is not gated here and remains
+ * available under its established product contract.
+ */
+
+export interface PrimarySourceFeatureFlags {
+  ccelLiveSearch: boolean;
+}
+
+export const DEFAULT_PRIMARY_SOURCE_FEATURE_FLAGS: Readonly<PrimarySourceFeatureFlags> = Object.freeze({
+  ccelLiveSearch: false,
+});
+
+export interface PrimarySourceFlagEnvironment {
+  THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH?: string;
+}
+
+function enabledValue(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === 'true';
+}
+
+export function readPrimarySourceFeatureFlags(
+  env: PrimarySourceFlagEnvironment = {},
+): PrimarySourceFeatureFlags {
+  return {
+    ccelLiveSearch: enabledValue(env.THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH),
+  };
+}

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -61,6 +61,14 @@ export {
   type ProvenanceContext,
 } from './provenance.js';
 
+// Staged primary-source rollout flags
+export {
+  DEFAULT_PRIMARY_SOURCE_FEATURE_FLAGS,
+  readPrimarySourceFeatureFlags,
+  type PrimarySourceFeatureFlags,
+  type PrimarySourceFlagEnvironment,
+} from './featureFlags.js';
+
 // Types
 export type {
   ToolHandler,

--- a/src/services/historical/primarySourceTypes.ts
+++ b/src/services/historical/primarySourceTypes.ts
@@ -1,0 +1,68 @@
+/**
+ * Provider-neutral contracts for bounded primary-source discovery.
+ *
+ * This slice deliberately contains search contracts only. It does not add an
+ * MCP tool or a fetch/batch orchestration service.
+ */
+
+export type PrimarySourceSearchMatch = 'all_terms' | 'phrase';
+
+export type PrimarySourceProvider = 'local' | 'ccel_live';
+
+export type PrimarySourceProviderStatus =
+  | 'ok'
+  | 'no_results'
+  | 'unavailable'
+  | 'disabled'
+  | 'rate_limited'
+  | 'interface_changed'
+  | 'unsupported_filter';
+
+export interface PrimarySourceSearchQuery {
+  text: string;
+  match?: PrimarySourceSearchMatch;
+  author?: string;
+  work?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface CcelSectionLocator {
+  kind: 'ccel_section';
+  url: string;
+  work: string;
+  section: string;
+}
+
+export interface LocalSectionLocator {
+  kind: 'local_section';
+  url: string;
+  documentId: string;
+  sectionId: string;
+}
+
+export type PrimarySourceLocator = CcelSectionLocator | LocalSectionLocator;
+
+export interface PrimarySourceSearchHit {
+  provider: PrimarySourceProvider;
+  title: string;
+  author?: string;
+  sectionLabel?: string;
+  snippet: string;
+  locator: PrimarySourceLocator;
+  rankWithinProvider: number;
+  page: number;
+  /** Search snippets are discovery metadata, never fetched evidence. */
+  snippetOnly: true;
+  attribution: string;
+}
+
+export interface PrimarySourceProviderResult {
+  provider: PrimarySourceProvider;
+  status: PrimarySourceProviderStatus;
+  searched: boolean;
+  page: number;
+  hitCount: number;
+  hits: PrimarySourceSearchHit[];
+  notices: string[];
+}

--- a/src/worker-env.ts
+++ b/src/worker-env.ts
@@ -10,4 +10,6 @@ export type Env = Cloudflare.Env & {
   ETH_RPC_URL?: string;
   BASE_RPC_URL?: string;
   RADIUS_RPC_URL?: string;
+  /** Staged primary-source switches; absent values remain disabled. */
+  THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH?: string;
 };

--- a/test/fixtures/ccel-search/interface-drift.html
+++ b/test/fixtures/ccel-search/interface-drift.html
@@ -1,0 +1,9 @@
+<!-- Frozen drift sentinel: 2026-07-11; provenance: CCEL public search surface;
+     result-card selector intentionally changed to verify fail-closed parsing. -->
+<!doctype html>
+<html><body>
+  <main id="search-results">
+    <h2>CCEL Search results</h2>
+    <div class="new-result-card"><a href="/ccel/calvin/institutes/iv.xvii.html">Unexpected selector shape</a></div>
+  </main>
+</body></html>

--- a/test/fixtures/ccel-search/malicious.html
+++ b/test/fixtures/ccel-search/malicious.html
@@ -1,0 +1,18 @@
+<!-- Adversarial-only fixture: synthetic hostile markup for parser/security tests.
+     This is not an upstream capture and must not be used as provenance. -->
+<!doctype html>
+<html><body>
+  <main id="search-results">
+    <h2>CCEL Search results</h2>
+    <article class="ccel-search-result">
+      <h5 class="ccel-result-title"><a href="/ccel/calvin/institutes/iv.xvii.html">Institutes of the Christian Religion</a></h5>
+      <div class="ccel-result-author">Calvin, John</div>
+      <div class="ccel-result-section">Book IV, Chapter XVII</div>
+      <p class="ccel-result-snippet" onclick="alert('removed')">The Lord's Supper &amp; the church. &lt;script&gt;alert('encoded')&lt;/script&gt;</p>
+      <div hidden>Hidden non-result content</div>
+    </article>
+    <script>window.session = 'secret';</script>
+    <style>.secret { display: block }</style>
+    <form><input type="hidden" name="csrf" value="secret"></form>
+  </main>
+</body></html>

--- a/test/fixtures/ccel-search/no-results.html
+++ b/test/fixtures/ccel-search/no-results.html
@@ -1,0 +1,10 @@
+<!-- Frozen sanitized capture: 2026-07-11; provenance: CCEL public search
+     surface; redacted navigation/account/session markup. The reviewed state
+     is the search-results heading followed by the empty-state paragraph. -->
+<!doctype html>
+<html><body>
+  <main>
+    <h2>CCEL Search results</h2>
+    <p>No results found.</p>
+  </main>
+</body></html>

--- a/test/fixtures/ccel-search/policy-page.html
+++ b/test/fixtures/ccel-search/policy-page.html
@@ -1,0 +1,7 @@
+<!-- Frozen policy sentinel: 2026-07-11; provenance: CCEL public search
+     surface; access-denied/captcha text retained in the reviewed h1/p state;
+     navigation and session values redacted. -->
+<!doctype html>
+<html><body>
+  <main><h1>Access denied</h1><p>Please complete the CAPTCHA to continue.</p></main>
+</body></html>

--- a/test/fixtures/ccel-search/search-results.html
+++ b/test/fixtures/ccel-search/search-results.html
@@ -1,0 +1,25 @@
+<!--
+  Frozen sanitized capture: 2026-07-11.
+  Provenance: CCEL public HTML search surface, https://ccel.org/?page=1&text=union%20with%20Christ,
+  captured and reviewed 2026-07-11. This is a sanitized, dated capture of the
+  visible search-results structure: the CCEL Search results heading, h5 result
+  headings with section links, author text, and snippets. Redactions: site
+  navigation, analytics, account/session values, request-specific boilerplate,
+  and unrelated result cards were removed; no document body is included.
+  Adversarial markup cases are maintained in malicious.html, not in this
+  upstream-shaped capture.
+-->
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <h2>CCEL Search results</h2>
+      <h5><a href="/ccel/calvin/institutes/iv.xvii.html">Institutes of the Christian Religion</a> by Calvin, John</h5>
+      <p>Book IV, Chapter XVII</p>
+      <p>The Lord's Supper is a sign and seal of union with Christ &amp; the church.</p>
+      <h5><a href="https://www.ccel.org/ccel/schaff/hcc3/hcc3.iii.xii.iv.html">History of the Christian Church, Volume III</a> by Schaff, Philip</h5>
+      <p>§ 120. The Council of Nicaea, 325.</p>
+      <p>A bounded discovery snippet with <em>entities</em> and no document body.</p>
+    </main>
+  </body>
+</html>

--- a/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
+++ b/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
@@ -1,0 +1,901 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  CCEL_SEARCH_LIMITS,
+  CcelSearchAdapter,
+  composeCcelSearchRequest,
+  normalizeCcelSectionLocator,
+} from '../../../../src/adapters/commentary/CcelSearchAdapter.js';
+import {
+  DEFAULT_PRIMARY_SOURCE_FEATURE_FLAGS,
+  readPrimarySourceFeatureFlags,
+} from '../../../../src/kernel/featureFlags.js';
+
+const resultsFixture = readFileSync(new URL('../../../fixtures/ccel-search/search-results.html', import.meta.url), 'utf8');
+const noResultsFixture = readFileSync(new URL('../../../fixtures/ccel-search/no-results.html', import.meta.url), 'utf8');
+const driftFixture = readFileSync(new URL('../../../fixtures/ccel-search/interface-drift.html', import.meta.url), 'utf8');
+const policyFixture = readFileSync(new URL('../../../fixtures/ccel-search/policy-page.html', import.meta.url), 'utf8');
+const maliciousFixture = readFileSync(new URL('../../../fixtures/ccel-search/malicious.html', import.meta.url), 'utf8');
+
+const htmlResponse = (body: string, status = 200, headers: Record<string, string> = { 'content-type': 'text/html; charset=utf-8' }): Response => new Response(body, {
+  status,
+  headers,
+});
+
+const query = (overrides: Record<string, unknown> = {}) => ({ text: 'union with Christ', ...overrides });
+
+const resultCard = (index: number, options: {
+  author?: string;
+  work?: string;
+  title?: string;
+  section?: string;
+  snippet?: string;
+} = {}): string => {
+  const author = options.author ?? 'Calvin, John';
+  const work = options.work ?? 'institutes';
+  const title = options.title ?? 'Institutes of the Christian Religion';
+  const section = options.section ?? `Book IV, Chapter ${index}`;
+  const snippet = options.snippet ?? `A bounded discovery result ${index}.`;
+  return `<article class="ccel-search-result"><h5 class="ccel-result-title"><a href="/ccel/calvin/${work}/section${index}.html">${title}</a></h5><div class="ccel-result-author">${author}</div><div class="ccel-result-section">${section}</div><p class="ccel-result-snippet">${snippet}</p></article>`;
+};
+
+const resultPage = (cards: string): string => `<html><body><main id="search-results"><h2>CCEL Search results</h2>${cards}</main></body></html>`;
+
+function discardableResponse(status: number, headers: Record<string, string> = {}): { response: Response; cancel: ReturnType<typeof vi.spyOn> } {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode('discardable upstream body'));
+    },
+  });
+  const response = new Response(body, { status, headers });
+  const cancel = vi.spyOn(response.body!, 'cancel');
+  return { response, cancel };
+}
+
+describe('primary-source feature flags', () => {
+  it('defaults only new live search off and does not gate legacy exact retrieval', () => {
+    expect(DEFAULT_PRIMARY_SOURCE_FEATURE_FLAGS).toEqual({ ccelLiveSearch: false });
+    expect(readPrimarySourceFeatureFlags()).toEqual({ ccelLiveSearch: false });
+    expect(readPrimarySourceFeatureFlags({
+      THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH: 'TRUE',
+    })).toEqual({ ccelLiveSearch: true });
+  });
+});
+
+describe('composeCcelSearchRequest', () => {
+  it('uses URLSearchParams encoding and escapes Lucene syntax as literals', () => {
+    const composed = composeCcelSearchRequest({ text: '  (grace) + truth  ', match: 'all_terms', page: 2, limit: 8 });
+    const url = new URL(composed.url);
+    expect(url.origin).toBe('https://ccel.org');
+    expect(url.pathname).toBe('/');
+    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('text')).toBe('\\(grace\\) AND \\+ AND truth');
+    expect(composed.url).not.toContain('(grace)');
+    expect(composeCcelSearchRequest({ text: 'love OR truth' }).luceneQuery).toBe('love AND "OR" AND truth');
+  });
+
+  it('supports phrase mode and only uses reviewed safe IDs for ID fields', () => {
+    const phrase = composeCcelSearchRequest({ text: 'Lord\'s Supper', match: 'phrase', author: 'Calvin', work: 'Institutes' });
+    expect(phrase.luceneQuery).toBe('"Lord\'s Supper" AND author:"Calvin" AND title:"Institutes"');
+
+    const ids = composeCcelSearchRequest({ text: 'grace', author: 'calvin', work: 'institutes' });
+    expect(ids.luceneQuery).toBe('grace AND authorID:calvin AND bookID:institutes');
+  });
+
+  it('normalizes NFC/control whitespace and enforces the finite query budget', () => {
+    expect(composeCcelSearchRequest({ text: 'e\u0301\n  grace\ttruth' }).normalizedText).toBe('é grace truth');
+    expect(() => composeCcelSearchRequest({ text: '\u0000bad' })).toThrow('NUL');
+    expect(() => composeCcelSearchRequest({ text: 'one two three four five six seven eight nine ten eleven twelve thirteen' })).toThrow('12 terms');
+    expect(() => composeCcelSearchRequest({ text: 'x'.repeat(201) })).toThrow('safe length');
+    expect(() => composeCcelSearchRequest({ text: 'x', page: 4 })).toThrow('page');
+    expect(() => composeCcelSearchRequest({ text: 'x', limit: 9 })).toThrow('limit');
+    expect(() => composeCcelSearchRequest({ text: 'x', bogus: true } as never)).toThrow('Unknown');
+  });
+
+  it('rejects empty semantic restrictions, including punctuation-only values', () => {
+    expect(() => composeCcelSearchRequest({ text: 'grace', author: '---' })).toThrow('semantic');
+    expect(() => composeCcelSearchRequest({ text: 'grace', work: '!!!' })).toThrow('semantic');
+  });
+});
+
+describe('normalizeCcelSectionLocator', () => {
+  it('canonicalizes approved exact section URLs and extracts work/section IDs', () => {
+    expect(normalizeCcelSectionLocator('/ccel/calvin/institutes/iv.xvii.html')).toEqual({
+      kind: 'ccel_section',
+      url: 'https://ccel.org/ccel/calvin/institutes/iv.xvii.html',
+      work: 'calvin/institutes',
+      section: 'iv.xvii',
+    });
+    expect(normalizeCcelSectionLocator('https://www.ccel.org/ccel/schaff/hcc3/hcc3.iii.xii.iv.html')?.url)
+      .toBe('https://ccel.org/ccel/schaff/hcc3/hcc3.iii.xii.iv.html');
+  });
+
+  it.each([
+    'http://ccel.org/ccel/a/b/c.html',
+    'https://evil.example/ccel/a/b/c.html',
+    'javascript:alert(1)',
+    '/ccel/a/../b/c.html',
+    '/ccel/a/%2e%2e/b/c.html',
+    '/ccel/a/b.html',
+    '/ccel/a/b/c/d.html',
+    `/ccel/${'a'.repeat(CCEL_SEARCH_LIMITS.maxLocatorSegmentCharacters + 1)}/b/c.html`,
+    '/ccel/a/b/c.html?next=https://evil.example',
+    '/ccel/a/b/.html',
+    '/ccel/a/b/c.html/extra',
+  ])('rejects unsafe locator %s', input => {
+    expect(normalizeCcelSectionLocator(input)).toBeUndefined();
+  });
+});
+
+describe('CcelSearchAdapter', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('is fail-closed by default and makes no request when live search is off', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const adapter = new CcelSearchAdapter({ fetchImpl });
+    await expect(adapter.search(query())).resolves.toMatchObject({ status: 'disabled', searched: false, hits: [] });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('parses bounded metadata, sanitizes entities, labels snippets as discovery-only, and never follows links', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultsFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const result = await adapter.search(query({ limit: 2 }));
+    expect(result).toMatchObject({ provider: 'ccel_live', status: 'ok', searched: true, hitCount: 2 });
+    expect(result.hits[0]).toMatchObject({
+      title: 'Institutes of the Christian Religion',
+      author: 'Calvin, John',
+      sectionLabel: 'Book IV, Chapter XVII',
+      snippet: "The Lord's Supper is a sign and seal of union with Christ & the church.",
+      snippetOnly: true,
+      attribution: 'CCEL (Christian Classics Ethereal Library)',
+      locator: { kind: 'ccel_section', work: 'calvin/institutes', section: 'iv.xvii' },
+    });
+    expect(result.hits[0].snippet).not.toContain('<');
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl.mock.calls[0][0]).toMatch(/^https:\/\/ccel\.org\/\?page=1&text=/);
+    expect(fetchImpl.mock.calls[0][1]).toMatchObject({ method: 'GET', redirect: 'manual', signal: expect.any(AbortSignal) });
+  });
+
+  it('composes author/work restrictions into the request without broadening them', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultsFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const result = await adapter.search({ text: 'union with Christ', author: 'Calvin', work: 'Institutes' });
+    expect(result).toMatchObject({ status: 'unsupported_filter', hitCount: 1 });
+    expect(result.hits[0].locator).toMatchObject({ work: 'calvin/institutes' });
+    const requested = new URL(String(fetchImpl.mock.calls[0][0])).searchParams.get('text');
+    expect(requested).toContain('author:');
+    expect(requested).toContain('title:');
+    expect(requested).toContain('Calvin');
+    expect(requested).toContain('Institutes');
+  });
+
+  it('verifies unrestricted metadata as an ordered normalized phrase', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(resultPage(resultCard(1, {
+      title: 'Institutes of the Christian Religion',
+    }))));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    await expect(adapter.search({ text: 'grace', work: 'Religion Institutes' })).resolves.toMatchObject({
+      status: 'unsupported_filter',
+      hitCount: 0,
+    });
+    await expect(adapter.search({ text: 'grace', work: 'Christian Religion' })).resolves.toMatchObject({
+      status: 'ok',
+      hitCount: 1,
+    });
+  });
+
+  it('distinguishes a recognized no-results page from selector drift', async () => {
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(htmlResponse(noResultsFixture))
+      .mockResolvedValueOnce(htmlResponse(driftFixture))
+      .mockResolvedValueOnce(htmlResponse(driftFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    await expect(adapter.search(query({ text: 'absent term' }))).resolves.toMatchObject({ status: 'no_results', hitCount: 0 });
+    await expect(adapter.search(query({ text: 'drift one' }))).resolves.toMatchObject({ status: 'interface_changed' });
+    await expect(adapter.search(query({ text: 'drift two' }))).resolves.toMatchObject({ status: 'interface_changed' });
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'interface_changed' });
+  });
+
+  it('caches successful and negative metadata briefly, but not failures', async () => {
+    let now = 1_000_000;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(htmlResponse(resultsFixture))
+      .mockResolvedValueOnce(htmlResponse(noResultsFixture))
+      .mockResolvedValueOnce(htmlResponse(policyFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+
+    await adapter.search(query());
+    await adapter.search(query());
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(adapter.getCacheStats().entries).toBe(1);
+
+    await adapter.search(query({ text: 'nothing' }));
+    await adapter.search(query({ text: 'nothing' }));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    now += CCEL_SEARCH_LIMITS.negativeCacheTtlMs + 1;
+    await adapter.search(query({ text: 'nothing' }));
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+    // Policy failures are never inserted into the metadata cache.
+    expect(adapter.getCacheStats().entries).toBe(0);
+  });
+
+  it('latches 403/policy signals pending operator reset and handles 429 separately', async () => {
+    let now = 2_000_000;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(htmlResponse('denied', 403))
+      .mockResolvedValueOnce(htmlResponse(resultsFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+
+    await expect(adapter.search(query())).resolves.toMatchObject({ status: 'unavailable' });
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'policy', operatorReviewRequired: true });
+    now += CCEL_SEARCH_LIMITS.policyOpenMs + 1;
+    await expect(adapter.search(query({ text: 'blocked while latched' }))).resolves.toMatchObject({ status: 'unavailable', searched: false });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    adapter.resetCircuitAfterReview();
+    await expect(adapter.search(query({ text: 'half open' }))).resolves.toMatchObject({ status: 'ok' });
+    expect(adapter.getCircuitState().status).toBe('closed');
+
+    // A fresh adapter demonstrates Retry-After handling independently.
+    const limited = new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse('limited', 429, { 'retry-after': '3600' })), now: () => now });
+    await expect(limited.search(query())).resolves.toMatchObject({ status: 'rate_limited' });
+    expect(limited.getCircuitState()).toMatchObject({ status: 'open', reason: 'rate_limited' });
+    expect(limited.getCircuitState().openUntil).toBe(now + 3_600_000);
+  });
+
+  it('does not let a concurrent success erase a policy latch', async () => {
+    let resolvePolicy!: (response: Response) => void;
+    let resolveSuccess!: (response: Response) => void;
+    const policy = new Promise<Response>(resolve => { resolvePolicy = resolve; });
+    const success = new Promise<Response>(resolve => { resolveSuccess = resolve; });
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(policy)
+      .mockReturnValueOnce(success);
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+
+    const policyRequest = adapter.search(query({ text: 'policy race' }));
+    const successRequest = adapter.search(query({ text: 'success race' }));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    resolvePolicy(htmlResponse('forbidden', 403));
+    await expect(policyRequest).resolves.toMatchObject({ status: 'unavailable' });
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'policy', operatorReviewRequired: true });
+
+    resolveSuccess(htmlResponse(resultsFixture));
+    await expect(successRequest).resolves.toMatchObject({ status: 'unavailable', searched: false });
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'policy', operatorReviewRequired: true });
+    expect(adapter.getCacheStats().entries).toBe(0);
+  });
+
+  it.each([
+    {
+      name: 'rate limit',
+      laterResponse: () => htmlResponse('limited', 429, { 'retry-after': '3600' }),
+    },
+    {
+      name: 'parser failure',
+      laterResponse: () => htmlResponse(driftFixture),
+    },
+    {
+      name: 'network failure',
+      laterResponse: () => htmlResponse('server error', 503),
+    },
+    {
+      name: 'oversized cleanup failure',
+      laterResponse: () => new Response('discard me', { headers: {
+        'content-type': 'text/html',
+        'content-length': String(CCEL_SEARCH_LIMITS.maxResponseBytes + 1),
+      } }),
+    },
+  ])('does not let a concurrent $name erase a policy latch', async ({ laterResponse }) => {
+    let resolvePolicy!: (response: Response) => void;
+    let resolveLater!: (response: Response) => void;
+    const policy = new Promise<Response>(resolve => { resolvePolicy = resolve; });
+    const later = new Promise<Response>(resolve => { resolveLater = resolve; });
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(policy)
+      .mockReturnValueOnce(later)
+      // A 5xx is retried once. Keep that retry deterministic without allowing
+      // it to weaken the policy state established by the first request.
+      .mockImplementation(async () => htmlResponse('server error', 503));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+
+    const policyRequest = adapter.search(query({ text: 'policy failure race' }));
+    const laterRequest = adapter.search(query({ text: 'later failure race' }));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    resolvePolicy(htmlResponse('forbidden', 403));
+    await expect(policyRequest).resolves.toMatchObject({ status: 'unavailable' });
+    expect(adapter.getCircuitState()).toMatchObject({
+      status: 'open',
+      reason: 'policy',
+      operatorReviewRequired: true,
+    });
+
+    resolveLater(laterResponse());
+    await laterRequest;
+    expect(adapter.getCircuitState()).toMatchObject({
+      status: 'open',
+      reason: 'policy',
+      operatorReviewRequired: true,
+    });
+
+    await expect(adapter.search(query({ text: 'still blocked' }))).resolves.toMatchObject({
+      status: 'unavailable',
+      searched: false,
+    });
+  });
+
+  it('does not let a concurrent timeout erase a policy latch', async () => {
+    vi.useFakeTimers();
+    let resolvePolicy!: (response: Response) => void;
+    const policy = new Promise<Response>(resolve => { resolvePolicy = resolve; });
+    const stalled = new ReadableStream<Uint8Array>({
+      pull: () => new Promise<void>(() => {}),
+    });
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(policy)
+      .mockResolvedValueOnce(new Response(stalled, { headers: { 'content-type': 'text/html' } }));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+
+    const policyRequest = adapter.search(query({ text: 'policy timeout race' }));
+    const timeoutRequest = adapter.search(query({ text: 'timeout race' }));
+    resolvePolicy(htmlResponse('forbidden', 403));
+    await expect(policyRequest).resolves.toMatchObject({ status: 'unavailable' });
+
+    await vi.advanceTimersByTimeAsync(CCEL_SEARCH_LIMITS.timeoutMs);
+    await expect(timeoutRequest).resolves.toMatchObject({ status: 'unavailable' });
+    expect(adapter.getCircuitState()).toMatchObject({
+      status: 'open',
+      reason: 'policy',
+      operatorReviewRequired: true,
+    });
+  });
+
+  it('does not let a success admitted before a 429 close the newer rate-limit circuit', async () => {
+    let now = 20_000;
+    let resolveLimited!: (response: Response) => void;
+    let resolveSuccess!: (response: Response) => void;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(new Promise(resolve => { resolveLimited = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { resolveSuccess = resolve; }));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+
+    const limited = adapter.search(query({ text: 'rate first' }));
+    const success = adapter.search(query({ text: 'success late' }));
+    resolveLimited(htmlResponse('limited', 429, { 'retry-after': '3600' }));
+    await expect(limited).resolves.toMatchObject({ status: 'rate_limited' });
+    const expectedOpenUntil = now + 3_600_000;
+
+    resolveSuccess(htmlResponse(resultsFixture));
+    await expect(success).resolves.toMatchObject({ status: 'rate_limited', searched: false });
+    expect(adapter.getCircuitState()).toMatchObject({
+      status: 'open',
+      reason: 'rate_limited',
+      openUntil: expectedOpenUntil,
+    });
+  });
+
+  it.each(['parser', 'network'] as const)('does not let a late %s completion weaken a newer 429', async kind => {
+    let now = 30_000;
+    let resolveLimited!: (response: Response) => void;
+    let resolveLater!: (response: Response) => void;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(new Promise(resolve => { resolveLimited = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { resolveLater = resolve; }))
+      .mockImplementation(async () => htmlResponse('server error', 503));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+
+    const limited = adapter.search(query({ text: `rate before ${kind}` }));
+    const later = adapter.search(query({ text: `${kind} late` }));
+    resolveLimited(htmlResponse('limited', 429, { 'retry-after': '3600' }));
+    await limited;
+    const expectedOpenUntil = now + 3_600_000;
+
+    resolveLater(kind === 'parser' ? htmlResponse(driftFixture) : htmlResponse('server error', 503));
+    await later;
+    expect(adapter.getCircuitState()).toMatchObject({
+      status: 'open',
+      reason: 'rate_limited',
+      openUntil: expectedOpenUntil,
+    });
+  });
+
+  it('merges concurrent Retry-After values without shortening the existing expiry', async () => {
+    let now = 35_000;
+    let resolveLong!: (response: Response) => void;
+    let resolveShort!: (response: Response) => void;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(new Promise(resolve => { resolveLong = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { resolveShort = resolve; }));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+    const long = adapter.search(query({ text: 'long retry after' }));
+    const short = adapter.search(query({ text: 'short retry after' }));
+
+    resolveLong(htmlResponse('limited', 429, { 'retry-after': '3600' }));
+    await long;
+    resolveShort(htmlResponse('limited', 429, { 'retry-after': '60' }));
+    await short;
+    expect(adapter.getCircuitState().openUntil).toBe(now + 3_600_000);
+  });
+
+  it('does not let an older success close an interface-change circuit opened by a second parser failure', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(htmlResponse(driftFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    await adapter.search(query({ text: 'parser one' }));
+
+    let resolveParser!: (response: Response) => void;
+    let resolveSuccess!: (response: Response) => void;
+    fetchImpl
+      .mockReturnValueOnce(new Promise(resolve => { resolveParser = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { resolveSuccess = resolve; }));
+    const parser = adapter.search(query({ text: 'parser two' }));
+    const success = adapter.search(query({ text: 'parser race success' }));
+    resolveParser(htmlResponse(driftFixture));
+    await parser;
+    resolveSuccess(htmlResponse(resultsFixture));
+    await success;
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'interface_changed' });
+  });
+
+  it('does not let an older success close a circuit opened at the network-failure threshold', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse('server error', 503));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    await adapter.search(query({ text: 'network count one' }));
+    await adapter.search(query({ text: 'network count two' }));
+
+    let resolveFailure!: (response: Response) => void;
+    let resolveRetry!: (response: Response) => void;
+    let resolveSuccess!: (response: Response) => void;
+    fetchImpl
+      .mockReturnValueOnce(new Promise(resolve => { resolveFailure = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { resolveSuccess = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { resolveRetry = resolve; }));
+    const failure = adapter.search(query({ text: 'network threshold' }));
+    const success = adapter.search(query({ text: 'network race success' }));
+    resolveFailure(htmlResponse('server error', 503));
+    await Promise.resolve();
+    resolveRetry(htmlResponse('server error', 503));
+    await failure;
+    resolveSuccess(htmlResponse(resultsFixture));
+    await success;
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'network', recentNetworkFailures: 3 });
+  });
+
+  it('treats operator reset as an epoch boundary for older in-flight completions', async () => {
+    let resolveFirstPolicy!: (response: Response) => void;
+    let resolveLatePolicy!: (response: Response) => void;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(new Promise(resolve => { resolveFirstPolicy = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { resolveLatePolicy = resolve; }));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const first = adapter.search(query({ text: 'policy before reset' }));
+    const late = adapter.search(query({ text: 'late policy before reset' }));
+
+    resolveFirstPolicy(htmlResponse('forbidden', 403));
+    await first;
+    expect(adapter.getCircuitState().operatorReviewRequired).toBe(true);
+    adapter.resetCircuitAfterReview();
+    resolveLatePolicy(htmlResponse('forbidden', 403));
+    await late;
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'closed', operatorReviewRequired: false });
+  });
+
+  it('retries one network/5xx failure, then opens after three final network failures', async () => {
+    let now = 3_000_000;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(htmlResponse('server error', 503))
+      .mockResolvedValueOnce(htmlResponse(resultsFixture))
+      .mockResolvedValue(htmlResponse('server error', 503));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+    await expect(adapter.search(query({ text: 'retry success' }))).resolves.toMatchObject({ status: 'ok' });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    await adapter.search(query({ text: 'failure one' }));
+    await adapter.search(query({ text: 'failure two' }));
+    await adapter.search(query({ text: 'failure three' }));
+    expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'network', recentNetworkFailures: 3 });
+    now += CCEL_SEARCH_LIMITS.networkOpenMs + 1;
+    expect(adapter.getCircuitState().status).toBe('half_open');
+  });
+
+  it('fails closed on policy pages, wrong content types, foreign redirects, and oversized responses', async () => {
+    const policy = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(policyFixture));
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: policy }).search(query())).resolves.toMatchObject({ status: 'unavailable' });
+
+    const wrongType = vi.fn<typeof fetch>().mockResolvedValue(new Response('<html></html>', { headers: { 'content-type': 'application/json' } }));
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: wrongType }).search(query())).resolves.toMatchObject({ status: 'interface_changed' });
+
+    const redirect = vi.fn<typeof fetch>().mockResolvedValue(new Response('', { status: 302, headers: { location: 'https://evil.example/' } }));
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: redirect }).search(query())).resolves.toMatchObject({ status: 'unavailable' });
+    expect(redirect).toHaveBeenCalledOnce();
+
+    const tooLarge = vi.fn<typeof fetch>().mockResolvedValue(new Response('small', { headers: {
+      'content-type': 'text/html',
+      'content-length': String(CCEL_SEARCH_LIMITS.maxResponseBytes + 1),
+    } }));
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: tooLarge }).search(query())).resolves.toMatchObject({ status: 'unavailable' });
+    expect(new CcelSearchAdapter({ enabled: true, fetchImpl: tooLarge }).getCacheStats().entries).toBe(0);
+  });
+
+  it('enforces two active requests and a four-request queue without crawling', async () => {
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const first = new Promise<Response>(resolve => { releaseFirst = () => resolve(htmlResponse(resultsFixture)); });
+    const second = new Promise<Response>(resolve => { releaseSecond = () => resolve(htmlResponse(resultsFixture)); });
+    const fetchImpl = vi.fn<typeof fetch>().mockReturnValueOnce(first).mockReturnValueOnce(second)
+      .mockImplementation(() => Promise.resolve(htmlResponse(resultsFixture)));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const requests = Array.from({ length: 7 }, (_, index) => adapter.search(query({ text: `term ${index}` })));
+    await Promise.resolve();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(await requests[6]).toMatchObject({ status: 'unavailable', searched: false });
+    releaseFirst();
+    releaseSecond();
+    await Promise.all(requests.slice(0, 6));
+    expect(fetchImpl.mock.calls.length).toBe(6);
+  });
+
+  it('includes queue wait in the wall deadline', async () => {
+    let now = 10_000;
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const first = new Promise<Response>(resolve => { releaseFirst = () => resolve(htmlResponse(resultsFixture)); });
+    const second = new Promise<Response>(resolve => { releaseSecond = () => resolve(htmlResponse(resultsFixture)); });
+    const fetchImpl = vi.fn<typeof fetch>().mockReturnValueOnce(first).mockReturnValueOnce(second)
+      .mockImplementation(() => Promise.resolve(htmlResponse(resultsFixture)));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+    const firstRequest = adapter.search(query({ text: 'held one' }));
+    const secondRequest = adapter.search(query({ text: 'held two' }));
+    const queuedRequest = adapter.search(query({ text: 'expired queue' }));
+    await Promise.resolve();
+    now += CCEL_SEARCH_LIMITS.totalRequestMs + 1;
+    releaseFirst();
+    releaseSecond();
+    await expect(queuedRequest).resolves.toMatchObject({ status: 'unavailable', searched: false });
+    await Promise.all([firstRequest, secondRequest]);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates queued admissions across operator reset while allowing a fresh post-reset call', async () => {
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const first = new Promise<Response>(resolve => { releaseFirst = () => resolve(htmlResponse(resultsFixture)); });
+    const second = new Promise<Response>(resolve => { releaseSecond = () => resolve(htmlResponse(resultsFixture)); });
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second)
+      .mockImplementation(async () => htmlResponse(resultsFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const activeOne = adapter.search(query({ text: 'pre-reset active one' }));
+    const activeTwo = adapter.search(query({ text: 'pre-reset active two' }));
+    const queued = adapter.search(query({ text: 'pre-reset queued' }));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    adapter.resetCircuitAfterReview();
+    releaseFirst();
+    await expect(queued).resolves.toMatchObject({ status: 'unavailable', searched: false });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+    await expect(adapter.search(query({ text: 'post-reset fresh' }))).resolves.toMatchObject({ status: 'ok' });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    releaseSecond();
+    await Promise.all([activeOne, activeTwo]);
+  });
+
+  it('cancels every discarded redirect, non-2xx, wrong-type, and retry response body', async () => {
+    for (const status of [403, 429, 404]) {
+      const cancels: Array<ReturnType<typeof vi.spyOn>> = [];
+      const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
+        const discarded = discardableResponse(status, status === 429 ? { 'retry-after': '60' } : {});
+        cancels.push(discarded.cancel);
+        return discarded.response;
+      });
+      await new CcelSearchAdapter({ enabled: true, fetchImpl }).search(query({ text: `status ${status}` }));
+      expect(cancels).toHaveLength(1);
+      expect(cancels[0]).toHaveBeenCalled();
+    }
+
+    const retryCancels: Array<ReturnType<typeof vi.spyOn>> = [];
+    const retryFetch = vi.fn<typeof fetch>().mockImplementation(async () => {
+      const discarded = discardableResponse(503);
+      retryCancels.push(discarded.cancel);
+      return discarded.response;
+    });
+    await new CcelSearchAdapter({ enabled: true, fetchImpl: retryFetch }).search(query({ text: 'retry bodies' }));
+    expect(retryCancels).toHaveLength(2);
+    expect(retryCancels.every(cancel => cancel.mock.calls.length > 0)).toBe(true);
+
+    const wrongType = discardableResponse(200, { 'content-type': 'application/json' });
+    await new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(wrongType.response) }).search(query({ text: 'wrong type body' }));
+    expect(wrongType.cancel).toHaveBeenCalled();
+
+    const redirect = discardableResponse(302, { location: 'https://ccel.org/?page=1&text=redirected' });
+    const redirectFetch = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(redirect.response)
+      .mockImplementationOnce(async () => htmlResponse(resultsFixture));
+    await new CcelSearchAdapter({ enabled: true, fetchImpl: redirectFetch }).search(query({ text: 'same host redirect' }));
+    expect(redirect.cancel).toHaveBeenCalled();
+  });
+
+  it('caps same-host redirects without following a fourth request', async () => {
+    const cancels: Array<ReturnType<typeof vi.spyOn>> = [];
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
+      const redirect = discardableResponse(302, { location: 'https://ccel.org/?page=1&text=redirect' });
+      cancels.push(redirect.cancel);
+      return redirect.response;
+    });
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl }).search(query({ text: 'redirect cap' })))
+      .resolves.toMatchObject({ status: 'unavailable' });
+    expect(fetchImpl).toHaveBeenCalledTimes(CCEL_SEARCH_LIMITS.maxRedirects + 1);
+    expect(cancels.every(cancel => cancel.mock.calls.length > 0)).toBe(true);
+  });
+
+  it('does not treat result text as structural no-results or policy state', async () => {
+    const resultText = resultPage(resultCard(1, {
+      snippet: 'No results found is a phrase inside a legitimate discovery snippet about maintenance and terms of use.',
+    }));
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultText));
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl }).search(query({ text: 'phrase state' })))
+      .resolves.toMatchObject({ status: 'ok', hitCount: 1 });
+
+    const unmarked = htmlResponse('<html><body><main id="search-results"><h2>No results found.</h2></main></body></html>');
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(unmarked) }).search(query({ text: 'unmarked empty' })))
+      .resolves.toMatchObject({ status: 'interface_changed' });
+  });
+
+  it('sanitizes scripts, forms, hidden content, event attributes, and encoded markup', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(maliciousFixture));
+    const result = await new CcelSearchAdapter({ enabled: true, fetchImpl }).search(query());
+    expect(result.hits[0].snippet).not.toContain('<script>');
+    expect(result.hits[0].snippet).not.toContain('onclick');
+    expect(result.hits[0].snippet).not.toContain('Hidden non-result content');
+    expect(result.hits[0].snippet).toContain('&lt;script&gt;');
+  });
+
+  it('enforces field, result, candidate, and aggregate output caps', async () => {
+    const longCard = resultCard(1, {
+      title: 'T'.repeat(CCEL_SEARCH_LIMITS.maxTitleCharacters + 50),
+      author: 'A'.repeat(CCEL_SEARCH_LIMITS.maxAuthorResultCharacters + 50),
+      section: 'S'.repeat(CCEL_SEARCH_LIMITS.maxSectionCharacters + 50),
+      snippet: 'N'.repeat(CCEL_SEARCH_LIMITS.maxSnippetCharacters + 50),
+    });
+    const bounded = await new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(longCard))) }).search(query({ text: 'field caps' }));
+    expect(bounded).toMatchObject({ status: 'ok', hitCount: 1 });
+    expect(bounded.hits[0].title.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxTitleCharacters);
+    expect(bounded.hits[0].author?.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxAuthorResultCharacters);
+    expect(bounded.hits[0].sectionLabel?.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxSectionCharacters);
+    expect(bounded.hits[0].snippet.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxSnippetCharacters);
+
+    const nineCards = Array.from({ length: 9 }, (_, index) => resultCard(index)).join('');
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(nineCards))) }).search(query({ text: 'result cap', limit: 8 })))
+      .resolves.toMatchObject({ status: 'ok', hitCount: 8 });
+
+    const fiftyCardsAndMalformed = `${Array.from({ length: 50 }, (_, index) => resultCard(index)).join('')}<article class="ccel-search-result"><a href="/ccel/calvin/institutes/unclosed.html">unclosed`;
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(fiftyCardsAndMalformed))) }).search(query({ text: 'candidate cap' })))
+      .resolves.toMatchObject({ status: 'ok', hitCount: 5 });
+
+    const longSegment = 'b'.repeat(127);
+    const longFields = Array.from({ length: 8 }, (_, index) => `<article class="ccel-search-result"><h5 class="ccel-result-title"><a href="/ccel/${'a'.repeat(127)}/${longSegment}/${'c'.repeat(127)}${index}.html">${'T'.repeat(300)}</a></h5><div class="ccel-result-author">${'A'.repeat(200)}</div><div class="ccel-result-section">${'S'.repeat(300)}</div><p class="ccel-result-snippet">${'N'.repeat(500)}</p></article>`).join('');
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(longFields))) }).search(query({ text: 'aggregate cap' })))
+      .resolves.toMatchObject({ status: 'unavailable' });
+  });
+
+  it('enforces streaming response overflow without retaining the body', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(CCEL_SEARCH_LIMITS.maxResponseBytes));
+        controller.enqueue(new Uint8Array(1));
+      },
+    });
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(stream, { headers: { 'content-type': 'text/html' } }));
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl }).search(query({ text: 'stream overflow' })))
+      .resolves.toMatchObject({ status: 'unavailable' });
+    expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>() }).getCacheStats().entries).toBe(0);
+  });
+
+  it('cancels and settles a stalled stream on timeout without late reader errors or retries', async () => {
+    vi.useFakeTimers();
+    let cancelCount = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull: () => new Promise<void>(() => {}),
+      cancel: () => { cancelCount++; },
+    });
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(new Response(stream, { headers: { 'content-type': 'text/html' } }));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const pending = adapter.search(query({ text: 'stalled stream' }));
+    await vi.advanceTimersByTimeAsync(CCEL_SEARCH_LIMITS.timeoutMs);
+    await expect(pending).resolves.toMatchObject({ status: 'unavailable' });
+    await Promise.resolve();
+    expect(cancelCount).toBe(1);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('keeps too-large classification when response cleanup cancellation rejects', async () => {
+    const response = new Response('small', {
+      headers: {
+        'content-type': 'text/html',
+        'content-length': String(CCEL_SEARCH_LIMITS.maxResponseBytes + 1),
+      },
+    });
+    vi.spyOn(response.body!, 'cancel').mockRejectedValue(new Error('cleanup failed'));
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(response);
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl }).search(query({ text: 'cleanup classification' })))
+      .resolves.toMatchObject({ status: 'unavailable' });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it('does not wait for never-settling discarded-response cancellation', async () => {
+    const response = htmlResponse('forbidden', 403);
+    const cancel = vi.spyOn(response.body!, 'cancel').mockImplementation(() => new Promise<void>(() => {}));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(response) });
+
+    await expect(adapter.search(query({ text: 'detached discard' }))).resolves.toMatchObject({ status: 'unavailable' });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(adapter.getCircuitState()).toMatchObject({ reason: 'policy', operatorReviewRequired: true });
+  });
+
+  it('does not wait for never-settling reader cancellation after timeout', async () => {
+    vi.useFakeTimers();
+    let cancelCount = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull: () => new Promise<void>(() => {}),
+      cancel: () => {
+        cancelCount++;
+        return new Promise<void>(() => {});
+      },
+    });
+    const adapter = new CcelSearchAdapter({
+      enabled: true,
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(new Response(stream, { headers: { 'content-type': 'text/html' } })),
+    });
+    const pending = adapter.search(query({ text: 'detached read cleanup' }));
+
+    await vi.advanceTimersByTimeAsync(CCEL_SEARCH_LIMITS.timeoutMs);
+    await expect(pending).resolves.toMatchObject({ status: 'unavailable' });
+    expect(cancelCount).toBe(1);
+  });
+
+  it('honors cache key dimensions, TTL, LRU entries, and byte bounds', async () => {
+    const single = resultPage(resultCard(1));
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(single));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, cacheMaxEntries: 2, cacheMaxBytes: 5_000 });
+    await adapter.search(query({ limit: 5 }));
+    await adapter.search(query({ limit: 1 }));
+    await adapter.search(query({ match: 'phrase' }));
+    await adapter.search(query({ page: 2 }));
+    await adapter.search(query({ author: 'Calvin' }));
+    await adapter.search(query({ work: 'Institutes' }));
+    expect(fetchImpl.mock.calls.length).toBe(5);
+    expect(fetchImpl.mock.calls.length).toBe(5);
+
+    let ttlNow = 60_000;
+    const ttlFetch = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(single));
+    const ttl = new CcelSearchAdapter({ enabled: true, fetchImpl: ttlFetch, now: () => ttlNow });
+    await ttl.search(query({ text: 'ttl isolation' }));
+    await ttl.search(query({ text: 'ttl isolation' }));
+    expect(ttlFetch).toHaveBeenCalledOnce();
+    ttlNow += CCEL_SEARCH_LIMITS.cacheTtlMs + 1;
+    await ttl.search(query({ text: 'ttl isolation' }));
+    expect(ttlFetch).toHaveBeenCalledTimes(2);
+
+    const lruFetch = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(single));
+    const lru = new CcelSearchAdapter({ enabled: true, fetchImpl: lruFetch, cacheMaxEntries: 2 });
+    await lru.search({ text: 'a' });
+    await lru.search({ text: 'b' });
+    await lru.search({ text: 'a' });
+    await lru.search({ text: 'c' });
+    await lru.search({ text: 'b' });
+    expect(lruFetch).toHaveBeenCalledTimes(4);
+    expect(lru.getCacheStats().entries).toBeLessThanOrEqual(2);
+
+    const byteFetch = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(single));
+    const byteBounded = new CcelSearchAdapter({ enabled: true, fetchImpl: byteFetch, cacheMaxBytes: 1 });
+    await byteBounded.search(query());
+    await byteBounded.search(query());
+    expect(byteFetch).toHaveBeenCalledTimes(2);
+    expect(byteBounded.getCacheStats().entries).toBe(0);
+
+    const sizingFetch = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(single));
+    const sizing = new CcelSearchAdapter({ enabled: true, fetchImpl: sizingFetch });
+    await sizing.search({ text: 'size one' });
+    const oneEntryBytes = sizing.getCacheStats().bytes;
+    const pressureFetch = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(single));
+    const pressure = new CcelSearchAdapter({
+      enabled: true,
+      fetchImpl: pressureFetch,
+      cacheMaxBytes: oneEntryBytes + Math.floor(oneEntryBytes / 2),
+    });
+    await pressure.search({ text: 'pressure one' });
+    await pressure.search({ text: 'pressure two' });
+    expect(pressure.getCacheStats().entries).toBe(1);
+    await pressure.search({ text: 'pressure one' });
+    expect(pressureFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('allows only one user-triggered half-open probe after a network circuit', async () => {
+    let now = 70_000;
+    const failures = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse('server error', 503));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl: failures, now: () => now });
+    await adapter.search({ text: 'failure one' });
+    await adapter.search({ text: 'failure two' });
+    await adapter.search({ text: 'failure three' });
+    now += CCEL_SEARCH_LIMITS.networkOpenMs + 1;
+
+    let release!: () => void;
+    const pending = new Promise<Response>(resolve => { release = () => resolve(htmlResponse(resultsFixture)); });
+    failures.mockImplementationOnce(async () => pending).mockImplementation(async () => htmlResponse(resultsFixture));
+    const firstProbe = adapter.search({ text: 'half open one' });
+    const secondProbe = adapter.search({ text: 'half open two' });
+    await Promise.resolve();
+    expect(failures).toHaveBeenCalledTimes(7);
+    release();
+    await expect(secondProbe).resolves.toMatchObject({ status: 'unavailable', searched: false });
+    await expect(firstProbe).resolves.toMatchObject({ status: 'ok' });
+    expect(adapter.getCircuitState().status).toBe('closed');
+  });
+
+  it.each([
+    {
+      name: 'upstream 404',
+      response: () => htmlResponse('not found', 404),
+      reason: 'interface_changed' as const,
+      backoffMs: CCEL_SEARCH_LIMITS.policyOpenMs,
+      fetchCount: 2,
+    },
+    {
+      name: 'upstream 503',
+      response: () => htmlResponse('server error', 503),
+      reason: 'network' as const,
+      backoffMs: CCEL_SEARCH_LIMITS.networkOpenMs,
+      fetchCount: 3,
+    },
+    {
+      name: 'declared oversized response',
+      response: () => new Response('discard me', { headers: {
+        'content-type': 'text/html',
+        'content-length': String(CCEL_SEARCH_LIMITS.maxResponseBytes + 1),
+      } }),
+      reason: 'interface_changed' as const,
+      backoffMs: CCEL_SEARCH_LIMITS.policyOpenMs,
+      fetchCount: 2,
+    },
+    {
+      name: 'streaming oversized response',
+      response: () => new Response(new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array(CCEL_SEARCH_LIMITS.maxResponseBytes));
+          controller.enqueue(new Uint8Array(1));
+        },
+      }), { headers: { 'content-type': 'text/html' } }),
+      reason: 'interface_changed' as const,
+      backoffMs: CCEL_SEARCH_LIMITS.policyOpenMs,
+      fetchCount: 2,
+    },
+  ])('reopens a bounded circuit when a half-open probe receives $name', async ({ response, reason, backoffMs, fetchCount }) => {
+    let now = 90_000;
+    const fetchImpl = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(htmlResponse('limited', 429))
+      .mockImplementation(async () => response());
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
+    await adapter.search(query({ text: 'open before probe' }));
+    now += CCEL_SEARCH_LIMITS.policyOpenMs + 1;
+    expect(adapter.getCircuitState().status).toBe('half_open');
+
+    await expect(adapter.search(query({ text: 'failing half-open probe' }))).resolves.toMatchObject({ status: 'unavailable' });
+    expect(adapter.getCircuitState()).toMatchObject({
+      status: 'open',
+      reason,
+      openUntil: now + backoffMs,
+    });
+    await expect(adapter.search(query({ text: 'blocked until expiry' }))).resolves.toMatchObject({
+      status: reason === 'network' ? 'unavailable' : 'interface_changed',
+      searched: false,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(fetchCount);
+  });
+});


### PR DESCRIPTION
## Summary

- add a bounded, metadata-only CCEL search adapter for the staged primary-source research workstream
- add provider-neutral search contracts and a fail-closed feature flag that remains off by default
- enforce literal query composition, strict CCEL-only locators, bounded concurrency/queueing/body/cache limits, circuit breakers, operator-reset epochs, and sanitized discovery-only snippets
- add dated sanitized fixtures, extensive adversarial/concurrency tests, and the rollout preflight record

## Scope and impact

This is the adapter foundation only. It does not register a new MCP tool, alter `classic_text_lookup`, replace or gate legacy exact CCEL retrieval, enable live CCEL access, persist CCEL bodies, crawl CCEL, or deploy anything. `THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH` is absent/off by default.

## Verification

- targeted CCEL adapter tests: 58/58
- non-native unit suite: 813/813 across 56 files
- integration tests: 3/3
- Node TypeScript check
- Worker TypeScript check
- production build
- independent Sol High release review: approved

The worktree cannot initialize `repositoryParity.test.ts` because its local `better-sqlite3` native binding is unavailable; CI's fresh-install validation remains authoritative for that test.

## Enablement gate

Do not enable live CCEL search from this PR. Before any preview enablement, an operator must re-check live `robots.txt`, complete the outstanding terms/interface review documented in `docs/ccel-search-preflight.md`, and explicitly authorize the flag. No `deploy-preview` label should be added for this foundation slice.
