### PR TITLE
Preserve exact Strong's identities across runtimes

### DIFF
--- a/src/adapters/d1/D1MorphologyRepository.ts
+++ b/src/adapters/d1/D1MorphologyRepository.ts
@@ -8,6 +8,7 @@
 import type { IMorphologyRepository, MorphWord, WordOccurrence, BookDistribution } from '../../kernel/repositories.js';
 import { expandHebrewMorphCode } from '../shared/hebrewMorphExpander.js';
 import { CANONICAL_BOOK_ORDER_SQL, sortByCanonicalBook } from '../shared/repositoryUtils.js';
+import { parseStrongsIdentity } from '../../kernel/strongs.js';
 
 export class D1MorphologyRepository implements IMorphologyRepository {
   constructor(private db: D1Database) {}
@@ -41,21 +42,25 @@ export class D1MorphologyRepository implements IMorphologyRepository {
   }
 
   async getOccurrences(strongsNumber: string, limit: number = 100): Promise<WordOccurrence[]> {
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return [];
     const { results } = await this.db.prepare(
       `SELECT DISTINCT book, chapter, verse, word_text, gloss
        FROM morphology WHERE strongs_number = ?
        ORDER BY ${CANONICAL_BOOK_ORDER_SQL}, chapter, verse, word_text, gloss
        LIMIT ?`
-    ).bind(strongsNumber, limit).all<WordOccurrence>();
+    ).bind(identity.morphologyKey, limit).all<WordOccurrence>();
     return results;
   }
 
   async getDistribution(strongsNumber: string): Promise<BookDistribution[]> {
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return [];
     const { results } = await this.db.prepare(
       `SELECT book, COUNT(DISTINCT chapter || ':' || verse) as verse_count
        FROM morphology WHERE strongs_number = ? GROUP BY book
        ORDER BY ${CANONICAL_BOOK_ORDER_SQL}, book`
-    ).bind(strongsNumber).all<BookDistribution>();
+    ).bind(identity.morphologyKey).all<BookDistribution>();
     return sortByCanonicalBook(results);
   }
 }

--- a/src/adapters/d1/D1StrongsRepository.ts
+++ b/src/adapters/d1/D1StrongsRepository.ts
@@ -11,27 +11,34 @@ import {
   normalizeTransliteration,
   normalizedTransliterationSql,
 } from '../../kernel/transliteration.js';
+import { baseStrongsId, parseStrongsIdentity } from '../../kernel/strongs.js';
 
 export class D1StrongsRepository implements IStrongsRepository {
   constructor(private db: D1Database) {}
 
   async lookup(strongsNumber: string): Promise<StrongsEntry | undefined> {
-    const normalized = strongsNumber.toUpperCase().trim();
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return undefined;
 
-    // Try exact match first
+    // Try the suffix-preserving public identity first.
     let row = await this.db.prepare(
       'SELECT * FROM strongs WHERE strongs_number = ?'
-    ).bind(normalized).first<StrongsEntry>();
+    ).bind(identity.publicId).first<StrongsEntry>();
     if (row) return row;
 
-    // Try padded: G25 → G0025
-    const padded = normalized.replace(/^([GH])(\d+)$/, (_, prefix, num) =>
-      prefix + num.padStart(4, '0')
-    );
-    if (padded !== normalized) {
+    const basePublicId = baseStrongsId(identity.publicId);
+    if (basePublicId !== identity.publicId) {
       row = await this.db.prepare(
         'SELECT * FROM strongs WHERE strongs_number = ?'
-      ).bind(padded).first<StrongsEntry>();
+      ).bind(basePublicId).first<StrongsEntry>();
+      if (row) return row;
+    }
+
+    const baseMorphologyKey = baseStrongsId(identity.morphologyKey);
+    if (baseMorphologyKey !== identity.publicId && baseMorphologyKey !== basePublicId) {
+      row = await this.db.prepare(
+        'SELECT * FROM strongs WHERE strongs_number = ?'
+      ).bind(baseMorphologyKey).first<StrongsEntry>();
     }
     return row ?? undefined;
   }
@@ -66,13 +73,16 @@ export class D1StrongsRepository implements IStrongsRepository {
   }
 
   async getLexiconEntry(strongsNumber: string): Promise<LexiconEntry | undefined> {
-    const padded = strongsNumber.toUpperCase().trim().replace(
-      /^([GH])(\d+)$/,
-      (_, prefix, num) => prefix + num.padStart(4, '0')
-    );
-    const row = await this.db.prepare(
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return undefined;
+    let row = await this.db.prepare(
       'SELECT * FROM stepbible_lexicons WHERE strongs_number = ?'
-    ).bind(padded).first<{ strongs_number: string; source: string; extended_data: string }>();
+    ).bind(identity.morphologyKey).first<{ strongs_number: string; source: string; extended_data: string }>();
+    if (!row && /[a-z]$/.test(identity.morphologyKey)) {
+      row = await this.db.prepare(
+        'SELECT * FROM stepbible_lexicons WHERE strongs_number = ?'
+      ).bind(baseStrongsId(identity.morphologyKey)).first<{ strongs_number: string; source: string; extended_data: string }>();
+    }
     if (!row) return undefined;
 
     return {

--- a/src/adapters/d1/D1StrongsRepository.ts
+++ b/src/adapters/d1/D1StrongsRepository.ts
@@ -11,7 +11,7 @@ import {
   normalizeTransliteration,
   normalizedTransliterationSql,
 } from '../../kernel/transliteration.js';
-import { baseStrongsId, parseStrongsIdentity } from '../../kernel/strongs.js';
+import { parseStrongsIdentity } from '../../kernel/strongs.js';
 
 export class D1StrongsRepository implements IStrongsRepository {
   constructor(private db: D1Database) {}
@@ -26,19 +26,10 @@ export class D1StrongsRepository implements IStrongsRepository {
     ).bind(identity.publicId).first<StrongsEntry>();
     if (row) return row;
 
-    const basePublicId = baseStrongsId(identity.publicId);
-    if (basePublicId !== identity.publicId) {
+    if (identity.morphologyKey !== identity.publicId) {
       row = await this.db.prepare(
         'SELECT * FROM strongs WHERE strongs_number = ?'
-      ).bind(basePublicId).first<StrongsEntry>();
-      if (row) return row;
-    }
-
-    const baseMorphologyKey = baseStrongsId(identity.morphologyKey);
-    if (baseMorphologyKey !== identity.publicId && baseMorphologyKey !== basePublicId) {
-      row = await this.db.prepare(
-        'SELECT * FROM strongs WHERE strongs_number = ?'
-      ).bind(baseMorphologyKey).first<StrongsEntry>();
+      ).bind(identity.morphologyKey).first<StrongsEntry>();
     }
     return row ?? undefined;
   }
@@ -75,14 +66,9 @@ export class D1StrongsRepository implements IStrongsRepository {
   async getLexiconEntry(strongsNumber: string): Promise<LexiconEntry | undefined> {
     const identity = parseStrongsIdentity(strongsNumber);
     if (!identity) return undefined;
-    let row = await this.db.prepare(
+    const row = await this.db.prepare(
       'SELECT * FROM stepbible_lexicons WHERE strongs_number = ?'
     ).bind(identity.morphologyKey).first<{ strongs_number: string; source: string; extended_data: string }>();
-    if (!row && /[a-z]$/.test(identity.morphologyKey)) {
-      row = await this.db.prepare(
-        'SELECT * FROM stepbible_lexicons WHERE strongs_number = ?'
-      ).bind(baseStrongsId(identity.morphologyKey)).first<{ strongs_number: string; source: string; extended_data: string }>();
-    }
     if (!row) return undefined;
 
     return {

--- a/src/adapters/data/MorphologyRepository.ts
+++ b/src/adapters/data/MorphologyRepository.ts
@@ -15,6 +15,7 @@ import type {
 } from '../../kernel/repositories.js';
 import { expandHebrewMorphCode } from '../shared/hebrewMorphExpander.js';
 import { CANONICAL_BOOK_ORDER_SQL, sortByCanonicalBook } from '../shared/repositoryUtils.js';
+import { parseStrongsIdentity } from '../../kernel/strongs.js';
 
 export type { MorphWord } from '../../kernel/repositories.js';
 
@@ -74,11 +75,15 @@ export class MorphologyRepository implements IMorphologyRepository {
 
   /** Find verse occurrences for a Strong's number */
   getOccurrences(strongsNumber: string, limit: number = 100): WordOccurrence[] {
-    return this.stmtOccurrences.all(strongsNumber, limit) as WordOccurrence[];
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return [];
+    return this.stmtOccurrences.all(identity.morphologyKey, limit) as WordOccurrence[];
   }
 
   /** Count distinct verse occurrences by book for a Strong's number */
   getDistribution(strongsNumber: string): BookDistribution[] {
-    return sortByCanonicalBook(this.stmtDistribution.all(strongsNumber) as BookDistribution[]);
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return [];
+    return sortByCanonicalBook(this.stmtDistribution.all(identity.morphologyKey) as BookDistribution[]);
   }
 }

--- a/src/adapters/data/StrongsRepository.ts
+++ b/src/adapters/data/StrongsRepository.ts
@@ -13,6 +13,7 @@ import {
   normalizeTransliteration,
   normalizedTransliterationSql,
 } from '../../kernel/transliteration.js';
+import { baseStrongsId, parseStrongsIdentity } from '../../kernel/strongs.js';
 
 export type { StrongsEntry, LexiconEntry } from '../../kernel/repositories.js';
 
@@ -43,17 +44,24 @@ export class StrongsRepository implements IStrongsRepository {
 
   /** Look up a Strong's number (e.g. "G25", "H430") */
   lookup(strongsNumber: string): StrongsEntry | undefined {
-    const normalized = strongsNumber.toUpperCase().trim();
-    // Try exact match first
-    let row = this.stmtLookup.get(normalized) as StrongsEntry | undefined;
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return undefined;
+
+    // Preserve sense suffixes for data sets that contain them, then fall back
+    // to the base concordance entry when the source only provides that entry.
+    let row = this.stmtLookup.get(identity.publicId) as StrongsEntry | undefined;
     if (row) return row;
 
-    // Try padded: G25 → G0025 (for lexicon lookup)
-    const padded = normalized.replace(/^([GH])(\d+)$/, (_, prefix, num) =>
-      prefix + num.padStart(4, '0')
-    );
-    if (padded !== normalized) {
-      row = this.stmtLookup.get(padded) as StrongsEntry | undefined;
+    const basePublicId = baseStrongsId(identity.publicId);
+    if (basePublicId !== identity.publicId) {
+      row = this.stmtLookup.get(basePublicId) as StrongsEntry | undefined;
+      if (row) return row;
+    }
+
+    // Compatibility with databases that stored concordance keys padded.
+    const baseMorphologyKey = baseStrongsId(identity.morphologyKey);
+    if (baseMorphologyKey !== identity.publicId && baseMorphologyKey !== basePublicId) {
+      row = this.stmtLookup.get(baseMorphologyKey) as StrongsEntry | undefined;
     }
     return row;
   }
@@ -86,11 +94,12 @@ export class StrongsRepository implements IStrongsRepository {
 
   /** Get STEPBible lexicon data for a Strong's number */
   getLexiconEntry(strongsNumber: string): LexiconEntry | undefined {
-    const padded = strongsNumber.toUpperCase().trim().replace(
-      /^([GH])(\d+)$/,
-      (_, prefix, num) => prefix + num.padStart(4, '0')
-    );
-    const row = this.stmtLexicon.get(padded) as { strongs_number: string; source: string; extended_data: string } | undefined;
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) return undefined;
+    let row = this.stmtLexicon.get(identity.morphologyKey) as { strongs_number: string; source: string; extended_data: string } | undefined;
+    if (!row && /[a-z]$/.test(identity.morphologyKey)) {
+      row = this.stmtLexicon.get(baseStrongsId(identity.morphologyKey)) as typeof row;
+    }
     if (!row) return undefined;
 
     return {

--- a/src/adapters/data/StrongsRepository.ts
+++ b/src/adapters/data/StrongsRepository.ts
@@ -13,7 +13,7 @@ import {
   normalizeTransliteration,
   normalizedTransliterationSql,
 } from '../../kernel/transliteration.js';
-import { baseStrongsId, parseStrongsIdentity } from '../../kernel/strongs.js';
+import { parseStrongsIdentity } from '../../kernel/strongs.js';
 
 export type { StrongsEntry, LexiconEntry } from '../../kernel/repositories.js';
 
@@ -47,21 +47,13 @@ export class StrongsRepository implements IStrongsRepository {
     const identity = parseStrongsIdentity(strongsNumber);
     if (!identity) return undefined;
 
-    // Preserve sense suffixes for data sets that contain them, then fall back
-    // to the base concordance entry when the source only provides that entry.
+    // A suffixed identity is exact: never silently substitute the base entry.
     let row = this.stmtLookup.get(identity.publicId) as StrongsEntry | undefined;
     if (row) return row;
 
-    const basePublicId = baseStrongsId(identity.publicId);
-    if (basePublicId !== identity.publicId) {
-      row = this.stmtLookup.get(basePublicId) as StrongsEntry | undefined;
-      if (row) return row;
-    }
-
     // Compatibility with databases that stored concordance keys padded.
-    const baseMorphologyKey = baseStrongsId(identity.morphologyKey);
-    if (baseMorphologyKey !== identity.publicId && baseMorphologyKey !== basePublicId) {
-      row = this.stmtLookup.get(baseMorphologyKey) as StrongsEntry | undefined;
+    if (identity.morphologyKey !== identity.publicId) {
+      row = this.stmtLookup.get(identity.morphologyKey) as StrongsEntry | undefined;
     }
     return row;
   }
@@ -96,10 +88,7 @@ export class StrongsRepository implements IStrongsRepository {
   getLexiconEntry(strongsNumber: string): LexiconEntry | undefined {
     const identity = parseStrongsIdentity(strongsNumber);
     if (!identity) return undefined;
-    let row = this.stmtLexicon.get(identity.morphologyKey) as { strongs_number: string; source: string; extended_data: string } | undefined;
-    if (!row && /[a-z]$/.test(identity.morphologyKey)) {
-      row = this.stmtLexicon.get(baseStrongsId(identity.morphologyKey)) as typeof row;
-    }
+    const row = this.stmtLexicon.get(identity.morphologyKey) as { strongs_number: string; source: string; extended_data: string } | undefined;
     if (!row) return undefined;
 
     return {

--- a/src/formatters/languagesFormatter.ts
+++ b/src/formatters/languagesFormatter.ts
@@ -4,6 +4,8 @@
 
 import type { EnhancedStrongsResult, VerseMorphologyResult, VerseWord } from '../kernel/types.js';
 import type { StrongsEntry } from '../kernel/repositories.js';
+import { normalizeLexiconText } from '../kernel/lexiconText.js';
+export { normalizeLexiconText } from '../kernel/lexiconText.js';
 
 /** Format a Strong's lookup result */
 export function formatStrongsResult(result: EnhancedStrongsResult, detailLevel: string = 'simple'): string {
@@ -49,35 +51,6 @@ export function formatStrongsResult(result: EnhancedStrongsResult, detailLevel: 
 }
 
 /** Normalize STEPBible markup before exposing it in either result view. */
-export function normalizeLexiconText(value: string): string {
-  return decodeLexiconEntities(value)
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<ref=['"][^'"]*['"]>/gi, '')
-    .replace(/<\/ref>/gi, '')
-    .replace(/<[^>]+>/g, '')
-    .replace(/[ \t]+/g, ' ')
-    .replace(/\n\s+/g, '\n')
-    .trim();
-}
-
-function decodeLexiconEntities(value: string): string {
-  return value.replace(/&(#x[\da-f]+|#\d+|nbsp|amp|lt|gt|quot|apos);/gi, (_match, entity: string) => {
-    const normalized = entity.toLowerCase();
-    if (normalized === 'nbsp') return ' ';
-    if (normalized === 'amp') return '&';
-    if (normalized === 'lt') return '<';
-    if (normalized === 'gt') return '>';
-    if (normalized === 'quot') return '"';
-    if (normalized === 'apos') return "'";
-    const code = normalized.startsWith('#x')
-      ? Number.parseInt(normalized.slice(2), 16)
-      : Number.parseInt(normalized.slice(1), 10);
-    return !Number.isInteger(code) || code < 0 || code > 0x10FFFF
-      ? _match
-      : String.fromCodePoint(code);
-  });
-}
-
 /** Produce the bounded discovery summary used by Markdown and structured search. */
 export function summarizeDefinition(value: string, maxLength = 240): string {
   const definition = normalizeLexiconText(value).replace(/\s+/g, ' ').trim();

--- a/src/formatters/languagesFormatter.ts
+++ b/src/formatters/languagesFormatter.ts
@@ -9,7 +9,8 @@ export { normalizeLexiconText } from '../kernel/lexiconText.js';
 
 /** Format a Strong's lookup result */
 export function formatStrongsResult(result: EnhancedStrongsResult, detailLevel: string = 'simple'): string {
-  const testament = result.testament === 'NT' ? 'Greek' : 'Hebrew';
+  const testament = result.language
+    ?? (result.testament === 'NT' ? 'Greek' : result.testament === 'OT' ? 'Hebrew' : 'Source language');
 
   let s = `**${result.strongs_number}** (${testament})\n\n`;
   s += `**Lemma:** ${result.lemma}\n`;

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -54,7 +54,6 @@ export { Cache } from './cache.js';
 // Strong's identity
 export {
   parseStrongsIdentity,
-  baseStrongsId,
   type CanonicalStrongsIdentity,
 } from './strongs.js';
 

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -51,6 +51,13 @@ export {
 // Cache
 export { Cache } from './cache.js';
 
+// Strong's identity
+export {
+  parseStrongsIdentity,
+  baseStrongsId,
+  type CanonicalStrongsIdentity,
+} from './strongs.js';
+
 // Provenance
 export {
   provenanceFromCitation,

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -54,6 +54,8 @@ export { Cache } from './cache.js';
 // Strong's identity
 export {
   parseStrongsIdentity,
+  STRONGS_IDENTITY_MAX_DIGITS,
+  STRONGS_IDENTITY_MAX_NUMBER,
   type CanonicalStrongsIdentity,
 } from './strongs.js';
 

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -56,6 +56,7 @@ export {
   parseStrongsIdentity,
   STRONGS_IDENTITY_MAX_DIGITS,
   STRONGS_IDENTITY_MAX_NUMBER,
+  STRONGS_IDENTITY_PATTERN,
   type CanonicalStrongsIdentity,
 } from './strongs.js';
 

--- a/src/kernel/lexiconText.ts
+++ b/src/kernel/lexiconText.ts
@@ -1,0 +1,29 @@
+/** Normalize the limited HTML-like markup embedded in STEPBible lexicons. */
+export function normalizeLexiconText(value: string): string {
+  return decodeLexiconEntities(value)
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<ref=['"][^'"]*['"]>/gi, '')
+    .replace(/<\/ref>/gi, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n\s+/g, '\n')
+    .trim();
+}
+
+function decodeLexiconEntities(value: string): string {
+  return value.replace(/&(#x[\da-f]+|#\d+|nbsp|amp|lt|gt|quot|apos);/gi, (_match, entity: string) => {
+    const normalized = entity.toLowerCase();
+    if (normalized === 'nbsp') return ' ';
+    if (normalized === 'amp') return '&';
+    if (normalized === 'lt') return '<';
+    if (normalized === 'gt') return '>';
+    if (normalized === 'quot') return '"';
+    if (normalized === 'apos') return "'";
+    const code = normalized.startsWith('#x')
+      ? Number.parseInt(normalized.slice(2), 16)
+      : Number.parseInt(normalized.slice(1), 10);
+    return !Number.isInteger(code) || code < 0 || code > 0x10FFFF
+      ? _match
+      : String.fromCodePoint(code);
+  });
+}

--- a/src/kernel/strongs.ts
+++ b/src/kernel/strongs.ts
@@ -1,12 +1,16 @@
 /** Canonical identities used by the public Strong's API and STEPBible data. */
 export interface CanonicalStrongsIdentity {
-  /** Unpadded public identifier, preserving an optional lowercase sense suffix. */
+  prefix: 'G' | 'H';
+  number: number;
+  suffix?: string;
+  /** Unpadded public identifier, preserving an optional uppercase STEPBible suffix. */
   publicId: string;
   /** Four-digit STEPBible/morphology identifier, preserving the same suffix. */
   morphologyKey: string;
 }
 
-const STRONGS_ID = /^([GH])(\d+)([a-z]?)$/i;
+const STRONGS_ID = /^([GH])(\d+)([A-Z]?)$/i;
+const MAX_NUMBER = { G: 5624, H: 8674 } as const;
 
 /**
  * Parse a Strong's identifier once at the kernel boundary.
@@ -19,17 +23,17 @@ export function parseStrongsIdentity(input: string): CanonicalStrongsIdentity | 
   const match = STRONGS_ID.exec(input.trim());
   if (!match) return undefined;
 
-  const prefix = match[1].toUpperCase();
-  const digits = match[2].replace(/^0+(?=\d)/, '');
-  const suffix = match[3].toLowerCase();
+  const prefix = match[1].toUpperCase() as 'G' | 'H';
+  const number = Number(match[2]);
+  if (!Number.isSafeInteger(number) || number < 1 || number > MAX_NUMBER[prefix]) return undefined;
+  const digits = String(number);
+  const suffix = match[3].toUpperCase() || undefined;
 
   return {
-    publicId: `${prefix}${digits}${suffix}`,
-    morphologyKey: `${prefix}${digits.padStart(4, '0')}${suffix}`,
+    prefix,
+    number,
+    suffix,
+    publicId: `${prefix}${digits}${suffix ?? ''}`,
+    morphologyKey: `${prefix}${digits.padStart(4, '0')}${suffix ?? ''}`,
   };
-}
-
-/** Remove an optional sense suffix while retaining the chosen key format. */
-export function baseStrongsId(id: string): string {
-  return id.replace(/[a-z]$/, '');
 }

--- a/src/kernel/strongs.ts
+++ b/src/kernel/strongs.ts
@@ -1,0 +1,35 @@
+/** Canonical identities used by the public Strong's API and STEPBible data. */
+export interface CanonicalStrongsIdentity {
+  /** Unpadded public identifier, preserving an optional lowercase sense suffix. */
+  publicId: string;
+  /** Four-digit STEPBible/morphology identifier, preserving the same suffix. */
+  morphologyKey: string;
+}
+
+const STRONGS_ID = /^([GH])(\d+)([a-z]?)$/i;
+
+/**
+ * Parse a Strong's identifier once at the kernel boundary.
+ *
+ * Public concordance data uses unpadded numbers (G25), while STEPBible data
+ * uses four-digit keys (G0025). Optional sense suffixes are semantic and must
+ * survive conversion between those two representations.
+ */
+export function parseStrongsIdentity(input: string): CanonicalStrongsIdentity | undefined {
+  const match = STRONGS_ID.exec(input.trim());
+  if (!match) return undefined;
+
+  const prefix = match[1].toUpperCase();
+  const digits = match[2].replace(/^0+(?=\d)/, '');
+  const suffix = match[3].toLowerCase();
+
+  return {
+    publicId: `${prefix}${digits}${suffix}`,
+    morphologyKey: `${prefix}${digits.padStart(4, '0')}${suffix}`,
+  };
+}
+
+/** Remove an optional sense suffix while retaining the chosen key format. */
+export function baseStrongsId(id: string): string {
+  return id.replace(/[a-z]$/, '');
+}

--- a/src/kernel/strongs.ts
+++ b/src/kernel/strongs.ts
@@ -19,6 +19,7 @@ const STRONGS_ID = /^([GH])(\d+)([A-Z]?)$/i;
  */
 export const STRONGS_IDENTITY_MAX_DIGITS = 5;
 export const STRONGS_IDENTITY_MAX_NUMBER = 99_999;
+export const STRONGS_IDENTITY_PATTERN = '^[GHgh](?:[1-9]\\d{0,4}|0[1-9]\\d{0,3}|00[1-9]\\d{0,2}|000[1-9]\\d?|0000[1-9])[A-Za-z]?$';
 
 /**
  * Parse a Strong's identifier once at the kernel boundary.

--- a/src/kernel/strongs.ts
+++ b/src/kernel/strongs.ts
@@ -10,7 +10,15 @@ export interface CanonicalStrongsIdentity {
 }
 
 const STRONGS_ID = /^([GH])(\d+)([A-Z]?)$/i;
-const MAX_NUMBER = { G: 5624, H: 8674 } as const;
+
+/**
+ * STEPBible extends classical dictionary numbering with morphology particles,
+ * proper names, and other source identities (for example H9001 and G21502).
+ * Five decimal digits is the reviewed, storage-safe interchange domain. It is
+ * identity grammar, not a claim that every number exists in every repository.
+ */
+export const STRONGS_IDENTITY_MAX_DIGITS = 5;
+export const STRONGS_IDENTITY_MAX_NUMBER = 99_999;
 
 /**
  * Parse a Strong's identifier once at the kernel boundary.
@@ -24,8 +32,9 @@ export function parseStrongsIdentity(input: string): CanonicalStrongsIdentity | 
   if (!match) return undefined;
 
   const prefix = match[1].toUpperCase() as 'G' | 'H';
+  if (match[2].length > STRONGS_IDENTITY_MAX_DIGITS) return undefined;
   const number = Number(match[2]);
-  if (!Number.isSafeInteger(number) || number < 1 || number > MAX_NUMBER[prefix]) return undefined;
+  if (!Number.isSafeInteger(number) || number < 1 || number > STRONGS_IDENTITY_MAX_NUMBER) return undefined;
   const digits = String(number);
   const suffix = match[3].toUpperCase() || undefined;
 

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -201,6 +201,8 @@ export interface SenseInfo {
 }
 
 export interface EnhancedStrongsResult extends StrongsResult {
+  /** Identifies the source of the base fields without changing public output. */
+  sourceKind?: 'strongs_concordance' | 'stepbible_lexicon';
   extendedCitation?: Citation;
   extended?: {
     strongsExtended?: string;

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -185,7 +185,7 @@ export type StrongsLookupParams =
 
 export interface StrongsResult {
   strongs_number: string;
-  testament: 'OT' | 'NT';
+  testament: 'OT' | 'NT' | null;
   lemma: string;
   transliteration?: string;
   pronunciation?: string;
@@ -203,6 +203,8 @@ export interface SenseInfo {
 export interface EnhancedStrongsResult extends StrongsResult {
   /** Identifies the source of the base fields without changing public output. */
   sourceKind?: 'strongs_concordance' | 'stepbible_lexicon';
+  /** Known source language does not imply a biblical testament classification. */
+  language?: 'Greek' | 'Hebrew';
   extendedCitation?: Citation;
   extended?: {
     strongsExtended?: string;

--- a/src/mcp/schemas/originalLanguage.ts
+++ b/src/mcp/schemas/originalLanguage.ts
@@ -22,7 +22,7 @@ export interface OriginalLanguageExtendedV1 {
 export interface OriginalLanguageEntryV1 {
   strongsNumber: string;
   language: 'Greek' | 'Hebrew';
-  testament: 'NT' | 'OT';
+  testament: 'NT' | 'OT' | null;
   lemma: string | null;
   transliteration?: string;
   pronunciation?: string;
@@ -55,7 +55,7 @@ const entrySchema: Schema = {
   properties: {
     strongsNumber: { type: 'string', minLength: 2, maxLength: 7, pattern: STRONGS_IDENTITY_PATTERN },
     language: { type: 'string', enum: ['Greek', 'Hebrew'] },
-    testament: { type: 'string', enum: ['NT', 'OT'] },
+    testament: { type: ['string', 'null'], enum: ['NT', 'OT', null] },
     lemma: { type: ['string', 'null'], minLength: 1, maxLength: 500 },
     transliteration: { type: 'string', minLength: 1, maxLength: 500 },
     pronunciation: { type: 'string', minLength: 1, maxLength: 500 },

--- a/src/mcp/schemas/originalLanguage.ts
+++ b/src/mcp/schemas/originalLanguage.ts
@@ -52,7 +52,7 @@ export interface OriginalLanguageOutputV1 {
 const entrySchema: Schema = {
   type: 'object',
   properties: {
-    strongsNumber: { type: 'string', minLength: 2, maxLength: 16, pattern: '^[GHgh]\\d+[a-z]?$' },
+    strongsNumber: { type: 'string', minLength: 2, maxLength: 6, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
     language: { type: 'string', enum: ['Greek', 'Hebrew'] },
     testament: { type: 'string', enum: ['NT', 'OT'] },
     lemma: { type: ['string', 'null'], minLength: 1, maxLength: 500 },
@@ -110,7 +110,7 @@ export const originalLanguageOutputSchema = {
         arguments: {
           type: 'object',
           properties: {
-            strongs_number: { type: 'string', minLength: 2, maxLength: 16, pattern: '^[GHgh]\\d+[a-z]?$' },
+            strongs_number: { type: 'string', minLength: 2, maxLength: 6, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
             detail_level: { const: 'detailed' },
             include_extended: { const: true },
           },

--- a/src/mcp/schemas/originalLanguage.ts
+++ b/src/mcp/schemas/originalLanguage.ts
@@ -52,7 +52,7 @@ export interface OriginalLanguageOutputV1 {
 const entrySchema: Schema = {
   type: 'object',
   properties: {
-    strongsNumber: { type: 'string', minLength: 2, maxLength: 6, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
+    strongsNumber: { type: 'string', minLength: 2, maxLength: 7, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
     language: { type: 'string', enum: ['Greek', 'Hebrew'] },
     testament: { type: 'string', enum: ['NT', 'OT'] },
     lemma: { type: ['string', 'null'], minLength: 1, maxLength: 500 },
@@ -110,7 +110,7 @@ export const originalLanguageOutputSchema = {
         arguments: {
           type: 'object',
           properties: {
-            strongs_number: { type: 'string', minLength: 2, maxLength: 6, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
+            strongs_number: { type: 'string', minLength: 2, maxLength: 7, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
             detail_level: { const: 'detailed' },
             include_extended: { const: true },
           },

--- a/src/mcp/schemas/originalLanguage.ts
+++ b/src/mcp/schemas/originalLanguage.ts
@@ -2,6 +2,7 @@ import type { Schema } from '@cfworker/json-schema';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import type { ProvenanceRecord } from '../../kernel/provenance.js';
 import { createProvenanceRecordSchema } from './provenance.js';
+import { STRONGS_IDENTITY_PATTERN } from '../../kernel/strongs.js';
 
 export interface OriginalLanguageSenseV1 {
   gloss: string;
@@ -52,7 +53,7 @@ export interface OriginalLanguageOutputV1 {
 const entrySchema: Schema = {
   type: 'object',
   properties: {
-    strongsNumber: { type: 'string', minLength: 2, maxLength: 7, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
+    strongsNumber: { type: 'string', minLength: 2, maxLength: 7, pattern: STRONGS_IDENTITY_PATTERN },
     language: { type: 'string', enum: ['Greek', 'Hebrew'] },
     testament: { type: 'string', enum: ['NT', 'OT'] },
     lemma: { type: ['string', 'null'], minLength: 1, maxLength: 500 },
@@ -110,7 +111,7 @@ export const originalLanguageOutputSchema = {
         arguments: {
           type: 'object',
           properties: {
-            strongs_number: { type: 'string', minLength: 2, maxLength: 7, pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$' },
+            strongs_number: { type: 'string', minLength: 2, maxLength: 7, pattern: STRONGS_IDENTITY_PATTERN },
             detail_level: { const: 'detailed' },
             include_extended: { const: true },
           },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -213,7 +213,11 @@ export function createTheologAiMcpServer(
           `# ${entry.strongs_number} — ${entry.lemma}\n`,
           entry.transliteration ? `**Transliteration:** ${entry.transliteration}` : '',
           entry.pronunciation ? `**Pronunciation:** ${entry.pronunciation}` : '',
-          `**Testament:** ${entry.testament === 'OT' ? 'Old Testament (Hebrew)' : 'New Testament (Greek)'}`,
+          `**Testament:** ${entry.testament === 'OT'
+            ? 'Old Testament (Hebrew)'
+            : entry.testament === 'NT'
+              ? 'New Testament (Greek)'
+              : 'Not classified (source-language lexicon identity)'}`,
           `\n## Definition\n`,
           entry.definition,
         ];

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -13,6 +13,7 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { NotFoundError } from '../kernel/errors.js';
+import { parseStrongsIdentity } from '../kernel/strongs.js';
 import { LOCAL_HISTORICAL_SOURCE } from '../formatters/historicalFormatter.js';
 import type { ToolHandler } from '../kernel/types.js';
 import type { BibleService } from '../services/bible/BibleService.js';
@@ -202,11 +203,11 @@ export function createTheologAiMcpServer(
     }
 
     // theologai://strongs/{number}
-    const strongsMatch = uri.match(/^theologai:\/\/strongs\/([GHgh]\d+[a-z]?)$/);
-    if (strongsMatch) {
+    const strongsMatch = uri.match(/^theologai:\/\/strongs\/([^/]+)$/);
+    const strongsIdentity = strongsMatch ? parseStrongsIdentity(strongsMatch[1]) : undefined;
+    if (strongsIdentity) {
       try {
-        const number = strongsMatch[1].toUpperCase();
-        const entry = await services.strongsService.lookup(number, true);
+        const entry = await services.strongsService.lookup(strongsIdentity.publicId, true);
 
         const lines = [
           `# ${entry.strongs_number} — ${entry.lemma}\n`,

--- a/src/presenters/originalLanguageStructured.ts
+++ b/src/presenters/originalLanguageStructured.ts
@@ -9,7 +9,8 @@ import type {
   OriginalLanguageExtendedV1,
   OriginalLanguageOutputV1,
 } from '../mcp/schemas/originalLanguage.js';
-import { normalizeLexiconText, summarizeDefinition } from '../formatters/languagesFormatter.js';
+import { summarizeDefinition } from '../formatters/languagesFormatter.js';
+import { normalizeLexiconText } from '../kernel/lexiconText.js';
 
 const STRONGS_CITATION = {
   source: "Strong's Concordance",
@@ -60,12 +61,16 @@ export function presentOriginalLanguageEntry(
   result: EnhancedStrongsResult,
   detailLevel: 'simple' | 'detailed',
 ): OriginalLanguageOutputV1 {
+  const stepBibleBase = result.sourceKind === 'stepbible_lexicon';
   const base = provenanceFromCitation(result.citation, {
     id: 'src-1',
     kind: 'lexicon',
     status: 'verified_source',
-    license: { label: 'Public Domain' },
-    attribution: 'OpenScriptures',
+    license: stepBibleBase ? {
+      label: 'CC BY 4.0',
+      url: 'https://creativecommons.org/licenses/by/4.0/',
+    } : { label: 'Public Domain' },
+    attribution: stepBibleBase ? 'Tyndale House, Cambridge' : 'OpenScriptures',
   });
   const provenance: ProvenanceRecord[] = [base];
   const provenanceIds = [base.id];

--- a/src/presenters/originalLanguageStructured.ts
+++ b/src/presenters/originalLanguageStructured.ts
@@ -93,7 +93,7 @@ export function presentOriginalLanguageEntry(
   const extended = result.extended;
   const entry: OriginalLanguageEntryV1 = {
     strongsNumber: result.strongs_number,
-    language: languageFor(result.testament),
+    language: result.language ?? languageFor(result.testament, result.strongs_number),
     testament: result.testament,
     lemma: nullableText(result.lemma),
     ...(result.transliteration ? { transliteration: result.transliteration } : {}),
@@ -146,8 +146,10 @@ function strongsProvenance(): ProvenanceRecord {
   });
 }
 
-function languageFor(testament: 'OT' | 'NT'): 'Greek' | 'Hebrew' {
-  return testament === 'NT' ? 'Greek' : 'Hebrew';
+function languageFor(testament: 'OT' | 'NT' | null, strongsNumber?: string): 'Greek' | 'Hebrew' {
+  if (testament === 'NT') return 'Greek';
+  if (testament === 'OT') return 'Hebrew';
+  return strongsNumber?.startsWith('H') ? 'Hebrew' : 'Greek';
 }
 
 function nullableText(value: string | null | undefined): string | null {

--- a/src/services/languages/StrongsService.ts
+++ b/src/services/languages/StrongsService.ts
@@ -104,7 +104,8 @@ function resultFromStepBible(
   const definition = normalizeLexiconText(rawDefinition);
   const result: EnhancedStrongsResult = {
     strongs_number: publicId,
-    testament: prefix === 'G' ? 'NT' : 'OT',
+    testament: null,
+    language: prefix === 'G' ? 'Greek' : 'Hebrew',
     lemma,
     transliteration: stringValue(data.translit),
     definition,

--- a/src/services/languages/StrongsService.ts
+++ b/src/services/languages/StrongsService.ts
@@ -5,6 +5,7 @@
 import type { IStrongsRepository, StrongsEntry } from '../../kernel/repositories.js';
 import type { StrongsResult, EnhancedStrongsResult, Citation } from '../../kernel/types.js';
 import { ValidationError, NotFoundError } from '../../kernel/errors.js';
+import { parseStrongsIdentity } from '../../kernel/strongs.js';
 
 const CITATION: Citation = {
   source: "Strong's Concordance",
@@ -32,14 +33,14 @@ export class StrongsService {
 
   /** Look up a Strong's number */
   async lookup(strongsNumber: string, includeExtended?: boolean): Promise<EnhancedStrongsResult> {
-    const normalized = strongsNumber.toUpperCase().trim();
-    if (!/^[GH]\d+[a-z]?$/i.test(normalized)) {
+    const identity = parseStrongsIdentity(strongsNumber);
+    if (!identity) {
       throw new ValidationError('strongs_number', `Invalid Strong's number format: ${strongsNumber}. Expected G#### or H####.`);
     }
 
-    const entry = await this.repo.lookup(normalized);
+    const entry = await this.repo.lookup(identity.publicId);
     if (!entry) {
-      throw new NotFoundError('strongs', `Strong's number ${normalized} not found`);
+      throw new NotFoundError('strongs', `Strong's number ${identity.publicId} not found`);
     }
 
     const result: EnhancedStrongsResult = {
@@ -54,7 +55,7 @@ export class StrongsService {
     };
 
     if (includeExtended) {
-      const lexicon = await this.repo.getLexiconEntry(normalized);
+      const lexicon = await this.repo.getLexiconEntry(identity.publicId);
       if (lexicon) {
         const data = lexicon.extended_data as StepBibleLexiconData;
         result.extended = {

--- a/src/services/languages/StrongsService.ts
+++ b/src/services/languages/StrongsService.ts
@@ -6,6 +6,7 @@ import type { IStrongsRepository, StrongsEntry } from '../../kernel/repositories
 import type { StrongsResult, EnhancedStrongsResult, Citation } from '../../kernel/types.js';
 import { ValidationError, NotFoundError } from '../../kernel/errors.js';
 import { parseStrongsIdentity } from '../../kernel/strongs.js';
+import { normalizeLexiconText } from '../../kernel/lexiconText.js';
 
 const CITATION: Citation = {
   source: "Strong's Concordance",
@@ -26,6 +27,8 @@ interface StepBibleLexiconData {
   morph?: unknown;
   source?: unknown;
   senses?: unknown;
+  lemma?: unknown;
+  translit?: unknown;
 }
 
 export class StrongsService {
@@ -39,9 +42,12 @@ export class StrongsService {
     }
 
     const entry = await this.repo.lookup(identity.publicId);
-    if (!entry) {
-      throw new NotFoundError('strongs', `Strong's number ${identity.publicId} not found`);
-    }
+    const lexicon = !entry || includeExtended
+      ? await this.repo.getLexiconEntry(identity.publicId)
+      : undefined;
+    if (!entry && !lexicon) throw new NotFoundError('strongs', `Strong's number ${identity.publicId} not found`);
+
+    if (!entry) return resultFromStepBible(identity.publicId, identity.prefix, lexicon!, includeExtended === true);
 
     const result: EnhancedStrongsResult = {
       strongs_number: entry.strongs_number,
@@ -55,17 +61,9 @@ export class StrongsService {
     };
 
     if (includeExtended) {
-      const lexicon = await this.repo.getLexiconEntry(identity.publicId);
       if (lexicon) {
         const data = lexicon.extended_data as StepBibleLexiconData;
-        result.extended = {
-          strongsExtended: stringValue(data.extendedStrongs),
-          gloss: stringValue(data.gloss),
-          definition: stringValue(data.definition),
-          morphologyCode: stringValue(data.morph),
-          source: stringValue(data.source) ?? lexicon.source,
-          senses: isSenseRecord(data.senses) ? data.senses : undefined,
-        };
+        result.extended = extendedFromLexicon(data, lexicon.source);
         result.extendedCitation = STEP_BIBLE_CITATION;
       }
     }
@@ -89,6 +87,43 @@ export class StrongsService {
   async getStats() {
     return await this.repo.getStats();
   }
+}
+
+function resultFromStepBible(
+  publicId: string,
+  prefix: 'G' | 'H',
+  lexicon: NonNullable<Awaited<ReturnType<IStrongsRepository['getLexiconEntry']>>>,
+  includeExtended: boolean,
+): EnhancedStrongsResult {
+  const data = lexicon.extended_data as StepBibleLexiconData;
+  const lemma = stringValue(data.lemma);
+  const rawDefinition = stringValue(data.definition) ?? stringValue(data.gloss);
+  if (!lemma || !rawDefinition) {
+    throw new NotFoundError('strongs', `Strong's number ${publicId} has no complete lexicon entry`);
+  }
+  const definition = normalizeLexiconText(rawDefinition);
+  const result: EnhancedStrongsResult = {
+    strongs_number: publicId,
+    testament: prefix === 'G' ? 'NT' : 'OT',
+    lemma,
+    transliteration: stringValue(data.translit),
+    definition,
+    citation: STEP_BIBLE_CITATION,
+    sourceKind: 'stepbible_lexicon',
+  };
+  if (includeExtended) result.extended = extendedFromLexicon(data, lexicon.source);
+  return result;
+}
+
+function extendedFromLexicon(data: StepBibleLexiconData, fallbackSource: string): NonNullable<EnhancedStrongsResult['extended']> {
+  return {
+    strongsExtended: stringValue(data.extendedStrongs),
+    gloss: stringValue(data.gloss),
+    definition: stringValue(data.definition),
+    morphologyCode: stringValue(data.morph),
+    source: stringValue(data.source) ?? fallbackSource,
+    senses: isSenseRecord(data.senses) ? data.senses : undefined,
+  };
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/src/tools/v2/strongsLookup.ts
+++ b/src/tools/v2/strongsLookup.ts
@@ -25,9 +25,9 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
         strongs_number: {
           type: 'string',
           minLength: 2,
-          maxLength: 16,
+          maxLength: 6,
           description: "Strong's number (e.g., G25 for Greek agapaō, H430 for Hebrew Elohim)",
-          pattern: '^[GHgh]\\d+[a-z]?$',
+          pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$',
         },
         detail_level: { type: 'string', enum: ['simple', 'detailed'], description: 'Exact strongs_number lookups only; choose the amount of entry detail. Defaults to simple when omitted.' },
         include_extended: { type: 'boolean', description: 'Exact strongs_number lookups only; include STEPBible extended data. Defaults to false when omitted.' },
@@ -113,7 +113,7 @@ function validateLookupMode(params: Record<string, unknown>): void {
 
   if (typeof params.strongs_number !== 'string'
     || params.strongs_number.length < 2
-    || params.strongs_number.length > 16
+    || params.strongs_number.length > 6
     || params.strongs_number !== params.strongs_number.trim()
     || !parseStrongsIdentity(params.strongs_number)) {
     throw new ValidationError('strongs_number', "strongs_number must match a Strong's number such as G25 or H430.");

--- a/src/tools/v2/strongsLookup.ts
+++ b/src/tools/v2/strongsLookup.ts
@@ -11,7 +11,7 @@ import {
   presentOriginalLanguageEntry,
   presentOriginalLanguageSearch,
 } from '../../presenters/originalLanguageStructured.js';
-import { parseStrongsIdentity } from '../../kernel/strongs.js';
+import { parseStrongsIdentity, STRONGS_IDENTITY_PATTERN } from '../../kernel/strongs.js';
 import type { CanonicalStrongsIdentity } from '../../kernel/strongs.js';
 
 export function createStrongsLookupHandler(service: StrongsService): ToolHandler {
@@ -28,7 +28,7 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
           minLength: 2,
           maxLength: 7,
           description: "Strong's number (e.g., G25 for Greek agapaō, H430 for Hebrew Elohim)",
-          pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$',
+          pattern: STRONGS_IDENTITY_PATTERN,
         },
         detail_level: { type: 'string', enum: ['simple', 'detailed'], description: 'Exact strongs_number lookups only; choose the amount of entry detail. Defaults to simple when omitted.' },
         include_extended: { type: 'boolean', description: 'Exact strongs_number lookups only; include STEPBible extended data. Defaults to false when omitted.' },

--- a/src/tools/v2/strongsLookup.ts
+++ b/src/tools/v2/strongsLookup.ts
@@ -12,6 +12,7 @@ import {
   presentOriginalLanguageSearch,
 } from '../../presenters/originalLanguageStructured.js';
 import { parseStrongsIdentity } from '../../kernel/strongs.js';
+import type { CanonicalStrongsIdentity } from '../../kernel/strongs.js';
 
 export function createStrongsLookupHandler(service: StrongsService): ToolHandler {
   return {
@@ -25,7 +26,7 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
         strongs_number: {
           type: 'string',
           minLength: 2,
-          maxLength: 6,
+          maxLength: 7,
           description: "Strong's number (e.g., G25 for Greek agapaō, H430 for Hebrew Elohim)",
           pattern: '^[GHgh]0*[1-9]\\d*[A-Za-z]?$',
         },
@@ -51,7 +52,7 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
 
     handler: async (params) => {
       try {
-        validateLookupMode(params);
+        const exactIdentity = validateLookupMode(params);
 
         if (Object.prototype.hasOwnProperty.call(params, 'query')) {
           const limit = typeof params.limit === 'number' ? params.limit : 10;
@@ -64,7 +65,7 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
         }
 
         const result = await service.lookup(
-          params.strongs_number as string,
+          exactIdentity!.publicId,
           params.include_extended === true,
         );
         const text = formatStrongsResult(result, params.detail_level as string);
@@ -82,7 +83,7 @@ export function createStrongsLookupHandler(service: StrongsService): ToolHandler
   };
 }
 
-function validateLookupMode(params: Record<string, unknown>): void {
+function validateLookupMode(params: Record<string, unknown>): CanonicalStrongsIdentity | undefined {
   const keys = Object.keys(params);
   const allowed = new Set(['strongs_number', 'detail_level', 'include_extended', 'query', 'limit']);
   const unknown = keys.find(key => !allowed.has(key));
@@ -108,14 +109,17 @@ function validateLookupMode(params: Record<string, unknown>): void {
     if (has('limit') && (!Number.isInteger(params.limit) || (params.limit as number) < 1 || (params.limit as number) > 20)) {
       throw new ValidationError('limit', 'limit must be an integer between 1 and 20.');
     }
-    return;
+    return undefined;
   }
 
+  const identity = typeof params.strongs_number === 'string'
+    ? parseStrongsIdentity(params.strongs_number)
+    : undefined;
   if (typeof params.strongs_number !== 'string'
     || params.strongs_number.length < 2
-    || params.strongs_number.length > 6
+    || params.strongs_number.length > 7
     || params.strongs_number !== params.strongs_number.trim()
-    || !parseStrongsIdentity(params.strongs_number)) {
+    || !identity) {
     throw new ValidationError('strongs_number', "strongs_number must match a Strong's number such as G25 or H430.");
   }
   if (has('limit')) {
@@ -127,4 +131,5 @@ function validateLookupMode(params: Record<string, unknown>): void {
   if (has('include_extended') && typeof params.include_extended !== 'boolean') {
     throw new ValidationError('include_extended', 'include_extended must be true or false.');
   }
+  return identity;
 }

--- a/src/tools/v2/strongsLookup.ts
+++ b/src/tools/v2/strongsLookup.ts
@@ -11,6 +11,7 @@ import {
   presentOriginalLanguageEntry,
   presentOriginalLanguageSearch,
 } from '../../presenters/originalLanguageStructured.js';
+import { parseStrongsIdentity } from '../../kernel/strongs.js';
 
 export function createStrongsLookupHandler(service: StrongsService): ToolHandler {
   return {
@@ -110,7 +111,11 @@ function validateLookupMode(params: Record<string, unknown>): void {
     return;
   }
 
-  if (typeof params.strongs_number !== 'string' || params.strongs_number.length < 2 || params.strongs_number.length > 16 || !/^[GHgh]\d+[a-z]?$/.test(params.strongs_number)) {
+  if (typeof params.strongs_number !== 'string'
+    || params.strongs_number.length < 2
+    || params.strongs_number.length > 16
+    || params.strongs_number !== params.strongs_number.trim()
+    || !parseStrongsIdentity(params.strongs_number)) {
     throw new ValidationError('strongs_number', "strongs_number must match a Strong's number such as G25 or H430.");
   }
   if (has('limit')) {

--- a/test/fixtures/stepbible-extended-strongs.json
+++ b/test/fixtures/stepbible-extended-strongs.json
@@ -1,0 +1,13 @@
+{
+  "source": "STEPBible-Data TBESG/TBESH checked-in source extracts",
+  "sourceFiles": [
+    "data/biblical-languages/stepbible-lexicons/tbesg-greek.json",
+    "data/biblical-languages/stepbible-lexicons/tbesh-hebrew.json"
+  ],
+  "identities": [
+    { "id": "G6000", "lemma": "ἀγγέλλω", "kind": "extended_greek_lexicon" },
+    { "id": "G21502", "lemma": "Ηνια", "kind": "five_digit_lxx_proper_name" },
+    { "id": "H9001", "lemma": "/וַ", "kind": "hebrew_morphology_particle" },
+    { "id": "H9049", "lemma": "ינה", "kind": "hebrew_morphology_suffix" }
+  ]
+}

--- a/test/tools/strongs-lookup-enhanced.test.ts
+++ b/test/tools/strongs-lookup-enhanced.test.ts
@@ -40,35 +40,31 @@ describe('original_language_lookup - Enhanced Features (STEPBible)', () => {
   });
 
   describe('extended Strong\'s numbers', () => {
-    it('should accept extended Strong\'s format (G1722a)', async () => {
+    it('should preserve an extended Strong\'s identity without joining it to the base', async () => {
       const result = await originalLanguageLookupHandler.handler({
         strongs_number: 'G1722a',
         include_extended: true
       });
 
-      expect(result.isError).toBeUndefined();
-      const text = result.content[0].text;
-      expect(text).toContain('1722');
+      expect(result.isError).toBe(true);
     });
 
-    it('should fall back to base number when extended variant not found', async () => {
+    it('should not fall back to a base number when an extended variant is absent', async () => {
       const result = await originalLanguageLookupHandler.handler({
         strongs_number: 'G25z',
         include_extended: true
       });
 
-      expect(result.isError).toBeUndefined();
-      const text = result.content[0].text;
-      expect(text).toContain('G25');
+      expect(result.isError).toBe(true);
     });
 
-    it('should normalize input (lowercase, whitespace)', async () => {
+    it('should reject surrounding whitespace at the exact handler boundary', async () => {
       const result = await originalLanguageLookupHandler.handler({
         strongs_number: '  g25a  ',
         include_extended: true
       });
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError).toBe(true);
     });
   });
 

--- a/test/unit/adapters/d1/D1MorphologyRepository.test.ts
+++ b/test/unit/adapters/d1/D1MorphologyRepository.test.ts
@@ -91,6 +91,12 @@ describe('D1MorphologyRepository', () => {
       expect(result).toEqual([occurrence]);
     });
 
+    it.each(['G6000', 'H9001', 'H9049', 'G21502'])('uses extended morphology identity %s unchanged', async identity => {
+      const db = createSimpleD1([]);
+      await expect(new D1MorphologyRepository(db as any).getOccurrences(identity)).resolves.toEqual([]);
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith(identity, 100);
+    });
+
     it('passes strongsNumber and limit to .bind()', async () => {
       const db = createSimpleD1([]);
       const repo = new D1MorphologyRepository(db as any);

--- a/test/unit/adapters/d1/D1MorphologyRepository.test.ts
+++ b/test/unit/adapters/d1/D1MorphologyRepository.test.ts
@@ -95,7 +95,11 @@ describe('D1MorphologyRepository', () => {
       const db = createSimpleD1([]);
       const repo = new D1MorphologyRepository(db as any);
       await repo.getOccurrences('G25', 50);
-      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('G25', 50);
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('G0025', 50);
+
+      await repo.getOccurrences('g25i');
+      expect(db.prepare.mock.results[1].value.bind).toHaveBeenCalledWith('G0025I', 100);
+      expect(await repo.getOccurrences('G0')).toEqual([]);
     });
   });
 
@@ -117,7 +121,7 @@ describe('D1MorphologyRepository', () => {
       const db = createSimpleD1([]);
       const repo = new D1MorphologyRepository(db as any);
       await repo.getDistribution('G25');
-      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('G25');
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('G0025');
     });
   });
 });

--- a/test/unit/adapters/d1/D1StrongsRepository.test.ts
+++ b/test/unit/adapters/d1/D1StrongsRepository.test.ts
@@ -45,6 +45,20 @@ describe('D1StrongsRepository', () => {
       expect(db.prepare).toHaveBeenCalledTimes(2);
     });
 
+    it('preserves suffix identity before falling back to the base entry', async () => {
+      const binds: unknown[] = [];
+      const db = {
+        prepare: vi.fn().mockImplementation(() => ({
+          bind: vi.fn().mockImplementation((value: unknown) => {
+            binds.push(value);
+            return { first: vi.fn().mockResolvedValue(value === 'G1722' ? sampleEntry : null) };
+          }),
+        })),
+      };
+      expect(await new D1StrongsRepository(db as any).lookup('g01722A')).toEqual(sampleEntry);
+      expect(binds).toEqual(['G1722a', 'G1722']);
+    });
+
     it('returns undefined when both exact and padded fail', async () => {
       const db = createSimpleD1([], null);
       const repo = new D1StrongsRepository(db as any);
@@ -52,12 +66,13 @@ describe('D1StrongsRepository', () => {
       expect(result).toBeUndefined();
     });
 
-    it('skips padding when padded equals normalized', async () => {
+    it('canonicalizes padded input and retains padded-database compatibility', async () => {
       const db = createSimpleD1([], null);
       const repo = new D1StrongsRepository(db as any);
       await repo.lookup('G0025');
-      // G0025 padded is still G0025, so only 1 query
-      expect(db.prepare).toHaveBeenCalledTimes(1);
+      expect(db.prepare).toHaveBeenCalledTimes(2);
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('G25');
+      expect(db.prepare.mock.results[1].value.bind).toHaveBeenCalledWith('G0025');
     });
   });
 
@@ -119,6 +134,21 @@ describe('D1StrongsRepository', () => {
       expect(result).toBeDefined();
       expect(result!.extended_data).toEqual({ senses: { '1': { gloss: 'love', count: 100 } } });
       expect(typeof result!.extended_data).toBe('object');
+    });
+
+    it('preserves suffix identity before falling back to the base morphology key', async () => {
+      const binds: unknown[] = [];
+      const row = { strongs_number: 'H0430', source: 'BDB', extended_data: '{}' };
+      const db = {
+        prepare: vi.fn().mockImplementation(() => ({
+          bind: vi.fn().mockImplementation((value: unknown) => {
+            binds.push(value);
+            return { first: vi.fn().mockResolvedValue(value === 'H0430' ? row : null) };
+          }),
+        })),
+      };
+      expect(await new D1StrongsRepository(db as any).getLexiconEntry('h430A')).toMatchObject({ strongs_number: 'H0430' });
+      expect(binds).toEqual(['H0430a', 'H0430']);
     });
 
     it('returns undefined when row is null', async () => {

--- a/test/unit/adapters/d1/D1StrongsRepository.test.ts
+++ b/test/unit/adapters/d1/D1StrongsRepository.test.ts
@@ -151,6 +151,13 @@ describe('D1StrongsRepository', () => {
       expect(binds).toEqual(['G2385I']);
     });
 
+    it.each(['G6000', 'H9001', 'H9049', 'G21502'])('queries extended STEPBible lexicon identity %s exactly', async identity => {
+      const row = { strongs_number: identity, source: 'STEPBible', extended_data: '{}' };
+      const db = createSimpleD1([], row);
+      await expect(new D1StrongsRepository(db as any).getLexiconEntry(identity)).resolves.toMatchObject({ strongs_number: identity });
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith(identity);
+    });
+
     it('returns undefined when row is null', async () => {
       const db = createSimpleD1([], null);
       const repo = new D1StrongsRepository(db as any);

--- a/test/unit/adapters/d1/D1StrongsRepository.test.ts
+++ b/test/unit/adapters/d1/D1StrongsRepository.test.ts
@@ -45,18 +45,18 @@ describe('D1StrongsRepository', () => {
       expect(db.prepare).toHaveBeenCalledTimes(2);
     });
 
-    it('preserves suffix identity before falling back to the base entry', async () => {
+    it('treats a suffixed public identity as exact', async () => {
       const binds: unknown[] = [];
       const db = {
         prepare: vi.fn().mockImplementation(() => ({
           bind: vi.fn().mockImplementation((value: unknown) => {
             binds.push(value);
-            return { first: vi.fn().mockResolvedValue(value === 'G1722' ? sampleEntry : null) };
+            return { first: vi.fn().mockResolvedValue(value === 'G2385I' ? sampleEntry : null) };
           }),
         })),
       };
-      expect(await new D1StrongsRepository(db as any).lookup('g01722A')).toEqual(sampleEntry);
-      expect(binds).toEqual(['G1722a', 'G1722']);
+      expect(await new D1StrongsRepository(db as any).lookup('g02385i')).toEqual(sampleEntry);
+      expect(binds).toEqual(['G2385I']);
     });
 
     it('returns undefined when both exact and padded fail', async () => {
@@ -136,19 +136,19 @@ describe('D1StrongsRepository', () => {
       expect(typeof result!.extended_data).toBe('object');
     });
 
-    it('preserves suffix identity before falling back to the base morphology key', async () => {
+    it('uses the source-grounded uppercase suffixed morphology key exactly', async () => {
       const binds: unknown[] = [];
-      const row = { strongs_number: 'H0430', source: 'BDB', extended_data: '{}' };
+      const row = { strongs_number: 'G2385I', source: 'STEPBible', extended_data: '{}' };
       const db = {
         prepare: vi.fn().mockImplementation(() => ({
           bind: vi.fn().mockImplementation((value: unknown) => {
             binds.push(value);
-            return { first: vi.fn().mockResolvedValue(value === 'H0430' ? row : null) };
+            return { first: vi.fn().mockResolvedValue(value === 'G2385I' ? row : null) };
           }),
         })),
       };
-      expect(await new D1StrongsRepository(db as any).getLexiconEntry('h430A')).toMatchObject({ strongs_number: 'H0430' });
-      expect(binds).toEqual(['H0430a', 'H0430']);
+      expect(await new D1StrongsRepository(db as any).getLexiconEntry('g2385i')).toMatchObject({ strongs_number: 'G2385I' });
+      expect(binds).toEqual(['G2385I']);
     });
 
     it('returns undefined when row is null', async () => {

--- a/test/unit/adapters/data/MorphologyRepository.test.ts
+++ b/test/unit/adapters/data/MorphologyRepository.test.ts
@@ -56,16 +56,23 @@ describe('MorphologyRepository', () => {
     expect(repo.getOccurrences('G1722', 3)).toEqual(occurrences);
     expect(db.statement('SELECT DISTINCT book, chapter, verse').all).toHaveBeenNthCalledWith(1, 'G1722', 100);
     expect(db.statement('SELECT DISTINCT book, chapter, verse').all).toHaveBeenNthCalledWith(2, 'G1722', 3);
+
+    repo.getOccurrences('g25i');
+    expect(db.statement('SELECT DISTINCT book, chapter, verse').all).toHaveBeenNthCalledWith(3, 'G0025I', 100);
+    expect(repo.getOccurrences('G0')).toEqual([]);
   });
 
   it('returns per-book verse distribution rows unchanged', () => {
     const distribution = [{ book: 'Romans', verse_count: 4 }, { book: 'John', verse_count: 9 }];
     const db = new FakeSqliteDatabase([{ match: 'COUNT(DISTINCT', all: distribution }]);
-    expect(new MorphologyRepository(db.asDatabase()).getDistribution('G1722')).toEqual([
+    const repo = new MorphologyRepository(db.asDatabase());
+    expect(repo.getDistribution('G1722')).toEqual([
       { book: 'John', verse_count: 9 },
       { book: 'Romans', verse_count: 4 },
     ]);
     expect(db.statement('COUNT(DISTINCT').all).toHaveBeenCalledWith('G1722');
+    repo.getDistribution('h430a');
+    expect(db.statement('COUNT(DISTINCT').all).toHaveBeenLastCalledWith('H0430A');
   });
 
   it('propagates database failures', () => {

--- a/test/unit/adapters/data/MorphologyRepository.test.ts
+++ b/test/unit/adapters/data/MorphologyRepository.test.ts
@@ -62,6 +62,13 @@ describe('MorphologyRepository', () => {
     expect(repo.getOccurrences('G0')).toEqual([]);
   });
 
+  it.each(['G6000', 'H9001', 'H9049', 'G21502'])('uses extended morphology identity %s unchanged', identity => {
+    const db = new FakeSqliteDatabase([{ match: 'SELECT DISTINCT book, chapter, verse', all: [] }]);
+    const repo = new MorphologyRepository(db.asDatabase());
+    expect(repo.getOccurrences(identity)).toEqual([]);
+    expect(db.statement('SELECT DISTINCT book, chapter, verse').all).toHaveBeenCalledWith(identity, 100);
+  });
+
   it('returns per-book verse distribution rows unchanged', () => {
     const distribution = [{ book: 'Romans', verse_count: 4 }, { book: 'John', verse_count: 9 }];
     const db = new FakeSqliteDatabase([{ match: 'COUNT(DISTINCT', all: distribution }]);

--- a/test/unit/adapters/data/StrongsRepository.test.ts
+++ b/test/unit/adapters/data/StrongsRepository.test.ts
@@ -20,12 +20,12 @@ describe('StrongsRepository', () => {
     expect(db.statement('strongs_fts MATCH').sql).toMatch(/ORDER BY rank, s\.strongs_number\s+LIMIT \?/);
   });
 
-  it('normalizes exact lookups and does not perform an unnecessary padded lookup', () => {
+  it('canonicalizes padded input to the public identity', () => {
     const db = new FakeSqliteDatabase([{ match: 'strongs WHERE strongs_number', get: entry }]);
     const repo = new StrongsRepository(db.asDatabase());
     expect(repo.lookup(' g0025 ')).toEqual(entry);
     expect(db.statement('strongs WHERE strongs_number').get).toHaveBeenCalledOnce();
-    expect(db.statement('strongs WHERE strongs_number').get).toHaveBeenCalledWith('G0025');
+    expect(db.statement('strongs WHERE strongs_number').get).toHaveBeenCalledWith('G25');
   });
 
   it('falls back to a four-digit padded Strong number', () => {
@@ -37,6 +37,16 @@ describe('StrongsRepository', () => {
     expect(repo.lookup('g25')).toEqual(entry);
     expect(db.statement('strongs WHERE strongs_number').get.mock.calls).toEqual([['G25'], ['G0025']]);
     expect(repo.lookup('invalid')).toBeUndefined();
+  });
+
+  it('preserves a suffix before falling back to the base public identity', () => {
+    const db = new FakeSqliteDatabase([{
+      match: 'strongs WHERE strongs_number',
+      get: (number: unknown) => number === 'G1722' ? entry : undefined,
+    }]);
+    const repo = new StrongsRepository(db.asDatabase());
+    expect(repo.lookup('g01722A')).toEqual(entry);
+    expect(db.statement('strongs WHERE strongs_number').get.mock.calls).toEqual([['G1722a'], ['G1722']]);
   });
 
   it('sanitizes FTS input and applies default and explicit limits', () => {
@@ -61,6 +71,16 @@ describe('StrongsRepository', () => {
       extended_data: { definition: 'God' },
     });
     expect(db.statement('stepbible_lexicons').get).toHaveBeenCalledWith('H0430');
+  });
+
+  it('tries a suffix-preserving morphology key before its base key', () => {
+    const row = { strongs_number: 'H0430', source: 'STEPBible', extended_data: '{}' };
+    const db = new FakeSqliteDatabase([{
+      match: 'stepbible_lexicons',
+      get: (number: unknown) => number === 'H0430' ? row : undefined,
+    }]);
+    expect(new StrongsRepository(db.asDatabase()).getLexiconEntry('h430A')).toMatchObject({ strongs_number: 'H0430' });
+    expect(db.statement('stepbible_lexicons').get.mock.calls).toEqual([['H0430a'], ['H0430']]);
   });
 
   it('returns undefined for a missing lexicon row', () => {

--- a/test/unit/adapters/data/StrongsRepository.test.ts
+++ b/test/unit/adapters/data/StrongsRepository.test.ts
@@ -39,14 +39,15 @@ describe('StrongsRepository', () => {
     expect(repo.lookup('invalid')).toBeUndefined();
   });
 
-  it('preserves a suffix before falling back to the base public identity', () => {
+  it('treats a suffixed public identity as exact', () => {
+    const suffixedEntry = { ...entry, strongs_number: 'G2385I' };
     const db = new FakeSqliteDatabase([{
       match: 'strongs WHERE strongs_number',
-      get: (number: unknown) => number === 'G1722' ? entry : undefined,
+      get: (number: unknown) => number === 'G2385I' ? suffixedEntry : undefined,
     }]);
     const repo = new StrongsRepository(db.asDatabase());
-    expect(repo.lookup('g01722A')).toEqual(entry);
-    expect(db.statement('strongs WHERE strongs_number').get.mock.calls).toEqual([['G1722a'], ['G1722']]);
+    expect(repo.lookup('g02385i')).toEqual(suffixedEntry);
+    expect(db.statement('strongs WHERE strongs_number').get.mock.calls).toEqual([['G2385I']]);
   });
 
   it('sanitizes FTS input and applies default and explicit limits', () => {
@@ -73,14 +74,14 @@ describe('StrongsRepository', () => {
     expect(db.statement('stepbible_lexicons').get).toHaveBeenCalledWith('H0430');
   });
 
-  it('tries a suffix-preserving morphology key before its base key', () => {
-    const row = { strongs_number: 'H0430', source: 'STEPBible', extended_data: '{}' };
+  it('uses the source-grounded uppercase suffixed morphology key exactly', () => {
+    const row = { strongs_number: 'G2385I', source: 'STEPBible', extended_data: '{}' };
     const db = new FakeSqliteDatabase([{
       match: 'stepbible_lexicons',
-      get: (number: unknown) => number === 'H0430' ? row : undefined,
+      get: (number: unknown) => number === 'G2385I' ? row : undefined,
     }]);
-    expect(new StrongsRepository(db.asDatabase()).getLexiconEntry('h430A')).toMatchObject({ strongs_number: 'H0430' });
-    expect(db.statement('stepbible_lexicons').get.mock.calls).toEqual([['H0430a'], ['H0430']]);
+    expect(new StrongsRepository(db.asDatabase()).getLexiconEntry('g2385i')).toMatchObject({ strongs_number: 'G2385I' });
+    expect(db.statement('stepbible_lexicons').get.mock.calls).toEqual([['G2385I']]);
   });
 
   it('returns undefined for a missing lexicon row', () => {

--- a/test/unit/adapters/data/StrongsRepository.test.ts
+++ b/test/unit/adapters/data/StrongsRepository.test.ts
@@ -84,6 +84,13 @@ describe('StrongsRepository', () => {
     expect(db.statement('stepbible_lexicons').get.mock.calls).toEqual([['G2385I']]);
   });
 
+  it.each(['G6000', 'H9001', 'H9049', 'G21502'])('queries extended STEPBible lexicon identity %s exactly', identity => {
+    const row = { strongs_number: identity, source: 'STEPBible', extended_data: '{}' };
+    const db = new FakeSqliteDatabase([{ match: 'stepbible_lexicons', get: row }]);
+    expect(new StrongsRepository(db.asDatabase()).getLexiconEntry(identity)).toMatchObject({ strongs_number: identity });
+    expect(db.statement('stepbible_lexicons').get).toHaveBeenCalledWith(identity);
+  });
+
   it('returns undefined for a missing lexicon row', () => {
     const db = new FakeSqliteDatabase([{ match: 'stepbible_lexicons', get: undefined }]);
     expect(new StrongsRepository(db.asDatabase()).getLexiconEntry('G25')).toBeUndefined();

--- a/test/unit/adapters/repositoryParity.test.ts
+++ b/test/unit/adapters/repositoryParity.test.ts
@@ -88,14 +88,22 @@ describe('SQLite and D1 repository parity with identical real data', () => {
       INSERT INTO strongs_fts
         SELECT strongs_number, lemma, transliteration, definition FROM strongs;
       INSERT INTO stepbible_lexicons VALUES
-        ('G0025', 'STEPBible', '{"gloss":"love"}');
+        ('G0025', 'STEPBible', '{"gloss":"love"}'),
+        ('G6000', 'STEPBible', '{"gloss":"to report"}'),
+        ('G21502', 'STEPBible', '{"gloss":"Heneia"}'),
+        ('H9001', 'STEPBible', '{"gloss":"&"}'),
+        ('H9049', 'STEPBible', '{"gloss":"they"}');
 
       INSERT INTO morphology VALUES
         ('Romans', 8, 28, 1, 'οἴδαμεν', 'οἶδα', 'G1492', 'V-RAI-1P', 'we know'),
         ('John', 3, 16, 1, 'ἠγάπησεν', 'ἀγαπάω', 'G0025', 'V-AAI-3S', 'loved'),
         ('Genesis', 1, 1, 1, 'בְּרֵאשִׁית', 'רֵאשִׁית', 'H7225', 'HNcfsa', 'in beginning'),
         ('Romans', 5, 8, 1, 'συνίστησιν', 'συνίστημι', 'G4921', 'V-PAI-3S', 'demonstrates'),
-        ('Romans', 8, 35, 1, 'ἀγάπης', 'ἀγάπη', 'G0025', 'N-GSF', 'love');
+        ('Romans', 8, 35, 1, 'ἀγάπης', 'ἀγάπη', 'G0025', 'N-GSF', 'love'),
+        ('John', 1, 1, 1, 'fixture-g6000', 'fixture', 'G6000', 'G:V', 'report'),
+        ('John', 1, 1, 2, 'fixture-g21502', 'fixture', 'G21502', 'G:N-PRI', 'Heneia'),
+        ('John', 1, 1, 3, 'fixture-h9001', 'fixture', 'H9001', 'H:Conj', '&'),
+        ('John', 1, 1, 4, 'fixture-h9049', 'fixture', 'H9049', 'Sp3f', 'they');
       INSERT INTO morph_codes VALUES ('V-AAI-3S', 'Verb Aorist Active Indicative 3rd Singular');
 
       INSERT INTO documents VALUES
@@ -185,6 +193,14 @@ describe('SQLite and D1 repository parity with identical real data', () => {
     await expect(d1Strongs.getLexiconEntry('G25'))
       .resolves.toEqual(sqliteStrongs.getLexiconEntry('G25'));
     await expect(d1Strongs.getStats()).resolves.toEqual(sqliteStrongs.getStats());
+  });
+
+  it.each(['G6000', 'H9001', 'H9049', 'G21502'])('preserves extended identity %s across SQLite and D1 lexicon/morphology repositories', async identity => {
+    await expect(d1Strongs.getLexiconEntry(identity)).resolves.toEqual(sqliteStrongs.getLexiconEntry(identity));
+    await expect(d1Morphology.getOccurrences(identity)).resolves.toEqual(sqliteMorphology.getOccurrences(identity));
+    await expect(d1Morphology.getDistribution(identity)).resolves.toEqual(sqliteMorphology.getDistribution(identity));
+    expect(sqliteStrongs.getLexiconEntry(identity)?.strongs_number).toBe(identity);
+    expect(sqliteMorphology.getOccurrences(identity)).toHaveLength(1);
   });
 
   it('normalizes ASCII transliteration search identically in SQLite and D1', async () => {

--- a/test/unit/formatters/languagesFormatter.test.ts
+++ b/test/unit/formatters/languagesFormatter.test.ts
@@ -83,6 +83,20 @@ describe('formatStrongsResult', () => {
     expect(out).toContain('**H430** (Hebrew)');
   });
 
+  it('renders a lexicon-only Greek identity without assigning a testament', () => {
+    const out = formatStrongsResult(makeStrongsResult({
+      strongs_number: 'G21502',
+      testament: null,
+      language: 'Greek',
+      sourceKind: 'stepbible_lexicon',
+      lemma: 'Ηνια',
+      definition: 'Heneia, man occurring at LXX in 1Ch.25.9',
+      citation: { source: 'STEPBible lexicon data', copyright: 'CC BY 4.0 (Tyndale House, Cambridge)' },
+    }));
+    expect(out).toContain('**G21502** (Greek)');
+    expect(out).not.toContain('New Testament');
+  });
+
   it('shows lemma, transliteration, pronunciation, definition', () => {
     const out = formatStrongsResult(makeStrongsResult());
     expect(out).toContain('**Lemma:** ἀγάπη');

--- a/test/unit/kernel/strongs.test.ts
+++ b/test/unit/kernel/strongs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { parseStrongsIdentity } from '../../../src/kernel/strongs.js';
 
 describe('parseStrongsIdentity', () => {
@@ -15,11 +16,23 @@ describe('parseStrongsIdentity', () => {
 
   it.each([
     '', '25', 'X25', 'G', 'G 25', 'G25aa', 'G-25',
-    'G0', 'H0000', 'G5625', 'H8675', 'G9007199254740993',
+    'G0', 'H0000', 'G100000', 'H999999', 'G9007199254740993',
   ])('rejects %s', input => {
     expect(parseStrongsIdentity(input)).toBeUndefined();
   });
-  it.each(['G5624', 'H8674'])('accepts the reviewed corpus boundary %s', input => {
+  it.each(['G5624', 'H8674', 'G6000', 'H9001', 'H9049', 'G21502', 'G99999'])('accepts bounded classical and extended identity %s', input => {
     expect(parseStrongsIdentity(input)?.publicId).toBe(input);
+  });
+
+  it('keeps the reviewed fixture grounded in checked-in STEPBible lexicons', () => {
+    const fixture = JSON.parse(readFileSync(new URL('../../fixtures/stepbible-extended-strongs.json', import.meta.url), 'utf8')) as {
+      identities: Array<{ id: string; lemma: string }>;
+    };
+    const greek = JSON.parse(readFileSync(new URL('../../../data/biblical-languages/stepbible-lexicons/tbesg-greek.json', import.meta.url), 'utf8')) as Record<string, { lemma: string }>;
+    const hebrew = JSON.parse(readFileSync(new URL('../../../data/biblical-languages/stepbible-lexicons/tbesh-hebrew.json', import.meta.url), 'utf8')) as Record<string, { lemma: string }>;
+    for (const item of fixture.identities) {
+      expect(parseStrongsIdentity(item.id)?.morphologyKey).toBe(item.id);
+      expect((item.id.startsWith('G') ? greek : hebrew)[item.id]?.lemma.normalize('NFC')).toBe(item.lemma.normalize('NFC'));
+    }
   });
 });

--- a/test/unit/kernel/strongs.test.ts
+++ b/test/unit/kernel/strongs.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { baseStrongsId, parseStrongsIdentity } from '../../../src/kernel/strongs.js';
+
+describe('parseStrongsIdentity', () => {
+  it.each([
+    ['G25', { publicId: 'G25', morphologyKey: 'G0025' }],
+    [' g0025 ', { publicId: 'G25', morphologyKey: 'G0025' }],
+    ['H430', { publicId: 'H430', morphologyKey: 'H0430' }],
+    ['g1722A', { publicId: 'G1722a', morphologyKey: 'G1722a' }],
+    ['h25b', { publicId: 'H25b', morphologyKey: 'H0025b' }],
+  ])('canonicalizes %s without losing a suffix', (input, expected) => {
+    expect(parseStrongsIdentity(input)).toEqual(expected);
+  });
+
+  it.each(['', '25', 'X25', 'G', 'G 25', 'G25aa', 'G-25'])('rejects %s', input => {
+    expect(parseStrongsIdentity(input)).toBeUndefined();
+  });
+});
+
+describe('baseStrongsId', () => {
+  it('removes only an optional sense suffix', () => {
+    expect(baseStrongsId('G1722a')).toBe('G1722');
+    expect(baseStrongsId('H0430')).toBe('H0430');
+  });
+});

--- a/test/unit/kernel/strongs.test.ts
+++ b/test/unit/kernel/strongs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { parseStrongsIdentity } from '../../../src/kernel/strongs.js';
+import { parseStrongsIdentity, STRONGS_IDENTITY_PATTERN } from '../../../src/kernel/strongs.js';
 
 describe('parseStrongsIdentity', () => {
   it.each([
@@ -34,5 +34,17 @@ describe('parseStrongsIdentity', () => {
       expect(parseStrongsIdentity(item.id)?.morphologyKey).toBe(item.id);
       expect((item.id.startsWith('G') ? greek : hebrew)[item.id]?.lemma.normalize('NFC')).toBe(item.lemma.normalize('NFC'));
     }
+  });
+});
+
+describe('STRONGS_IDENTITY_PATTERN', () => {
+  const schemaPattern = new RegExp(STRONGS_IDENTITY_PATTERN);
+
+  it.each(['G1', 'G0025', 'H9001', 'G21502', 'g2385i', 'G99999Z'])('accepts schema identity %s', identity => {
+    expect(schemaPattern.test(identity)).toBe(true);
+  });
+
+  it.each(['G0', 'G00000', 'G000001', 'G100000', 'H999999A', 'G25AA'])('rejects schema identity %s', identity => {
+    expect(schemaPattern.test(identity)).toBe(false);
   });
 });

--- a/test/unit/kernel/strongs.test.ts
+++ b/test/unit/kernel/strongs.test.ts
@@ -1,25 +1,25 @@
 import { describe, expect, it } from 'vitest';
-import { baseStrongsId, parseStrongsIdentity } from '../../../src/kernel/strongs.js';
+import { parseStrongsIdentity } from '../../../src/kernel/strongs.js';
 
 describe('parseStrongsIdentity', () => {
   it.each([
-    ['G25', { publicId: 'G25', morphologyKey: 'G0025' }],
-    [' g0025 ', { publicId: 'G25', morphologyKey: 'G0025' }],
-    ['H430', { publicId: 'H430', morphologyKey: 'H0430' }],
-    ['g1722A', { publicId: 'G1722a', morphologyKey: 'G1722a' }],
-    ['h25b', { publicId: 'H25b', morphologyKey: 'H0025b' }],
+    ['G25', { prefix: 'G', number: 25, suffix: undefined, publicId: 'G25', morphologyKey: 'G0025' }],
+    [' g0025 ', { prefix: 'G', number: 25, suffix: undefined, publicId: 'G25', morphologyKey: 'G0025' }],
+    ['H430', { prefix: 'H', number: 430, suffix: undefined, publicId: 'H430', morphologyKey: 'H0430' }],
+    // STEPBible extended identities use uppercase suffixes (for example G2385I).
+    ['g2385i', { prefix: 'G', number: 2385, suffix: 'I', publicId: 'G2385I', morphologyKey: 'G2385I' }],
+    ['h25b', { prefix: 'H', number: 25, suffix: 'B', publicId: 'H25B', morphologyKey: 'H0025B' }],
   ])('canonicalizes %s without losing a suffix', (input, expected) => {
     expect(parseStrongsIdentity(input)).toEqual(expected);
   });
 
-  it.each(['', '25', 'X25', 'G', 'G 25', 'G25aa', 'G-25'])('rejects %s', input => {
+  it.each([
+    '', '25', 'X25', 'G', 'G 25', 'G25aa', 'G-25',
+    'G0', 'H0000', 'G5625', 'H8675', 'G9007199254740993',
+  ])('rejects %s', input => {
     expect(parseStrongsIdentity(input)).toBeUndefined();
   });
-});
-
-describe('baseStrongsId', () => {
-  it('removes only an optional sense suffix', () => {
-    expect(baseStrongsId('G1722a')).toBe('G1722');
-    expect(baseStrongsId('H0430')).toBe('H0430');
+  it.each(['G5624', 'H8674'])('accepts the reviewed corpus boundary %s', input => {
+    expect(parseStrongsIdentity(input)?.publicId).toBe(input);
   });
 });

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -370,7 +370,7 @@ describe('shared MCP registration', () => {
     });
   });
 
-  it('canonicalizes Strong\'s resource identities and rejects invalid corpus numbers', async () => {
+  it('canonicalizes classical and extended Strong\'s resources and rejects invalid domain numbers', async () => {
     const root = makeMockRoot();
     const lookup = vi.fn(root.services.strongsService.lookup);
     root.services.strongsService.lookup = lookup;
@@ -379,10 +379,15 @@ describe('shared MCP registration', () => {
     await client.readResource({ uri: 'theologai://strongs/g02385i' });
     expect(lookup).toHaveBeenCalledWith('G2385I', true);
 
-    for (const uri of ['theologai://strongs/G0', 'theologai://strongs/G5625', 'theologai://strongs/H8675']) {
+    for (const identity of ['G6000', 'H9001', 'H9049', 'G21502']) {
+      await client.readResource({ uri: `theologai://strongs/${identity}` });
+      expect(lookup).toHaveBeenCalledWith(identity, true);
+    }
+
+    for (const uri of ['theologai://strongs/G0', 'theologai://strongs/G100000', 'theologai://strongs/H999999']) {
       await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32002, data: { uri } });
     }
-    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(lookup).toHaveBeenCalledTimes(5);
   });
 
   it.each([

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -408,6 +408,7 @@ describe('shared MCP registration', () => {
       text: expect.stringContaining('# H9001 — /וַ'),
     });
     expect(String(result.contents[0].text)).toContain('Verbal vav');
+    expect(String(result.contents[0].text)).toContain('Not classified (source-language lexicon identity)');
   });
 
   it.each([

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -370,6 +370,21 @@ describe('shared MCP registration', () => {
     });
   });
 
+  it('canonicalizes Strong\'s resource identities and rejects invalid corpus numbers', async () => {
+    const root = makeMockRoot();
+    const lookup = vi.fn(root.services.strongsService.lookup);
+    root.services.strongsService.lookup = lookup;
+    const client = await connect(createTheologAiMcpServer(root, '1.0.0-test').server);
+
+    await client.readResource({ uri: 'theologai://strongs/g02385i' });
+    expect(lookup).toHaveBeenCalledWith('G2385I', true);
+
+    for (const uri of ['theologai://strongs/G0', 'theologai://strongs/G5625', 'theologai://strongs/H8675']) {
+      await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32002, data: { uri } });
+    }
+    expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     ['document', 'theologai://documents/nicene-creed'],
     ['strongs', 'theologai://strongs/G26'],

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -9,6 +9,8 @@ import { createTheologAiMcpServer, STATELESS_HTTP_CAPABILITIES } from '../../../
 import { BibleMCPServer } from '../../../src/server.js';
 import { createWorkerMcpServer } from '../../../src/worker-server.js';
 import type { WorkerCompositionRoot } from '../../../src/tools/worker/index.js';
+import { StrongsService } from '../../../src/services/languages/StrongsService.js';
+import { readFileSync } from 'node:fs';
 
 const TOOL_NAMES = [
   'bible_lookup',
@@ -388,6 +390,24 @@ describe('shared MCP registration', () => {
       await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32002, data: { uri } });
     }
     expect(lookup).toHaveBeenCalledTimes(5);
+  });
+
+  it('serves a source-grounded lexicon-only STEPBible resource', async () => {
+    const source = JSON.parse(readFileSync(new URL('../../../data/biblical-languages/stepbible-lexicons/tbesh-hebrew.json', import.meta.url), 'utf8')) as Record<string, Record<string, unknown>>;
+    const root = makeMockRoot();
+    root.services.strongsService = new StrongsService({
+      lookup: async () => undefined,
+      getLexiconEntry: async identity => ({ strongs_number: identity, source: 'STEPBible', extended_data: source[identity] }),
+      search: async () => [],
+      getStats: async () => ({ greek: 0, hebrew: 0, total: 0 }),
+    });
+    const client = await connect(createTheologAiMcpServer(root, '1.0.0-test').server);
+    const result = await client.readResource({ uri: 'theologai://strongs/H9001' });
+    expect(result.contents[0]).toMatchObject({
+      uri: 'theologai://strongs/H9001',
+      text: expect.stringContaining('# H9001 — /וַ'),
+    });
+    expect(String(result.contents[0].text)).toContain('Verbal vav');
   });
 
   it.each([

--- a/test/unit/presenters/originalLanguageStructured.test.ts
+++ b/test/unit/presenters/originalLanguageStructured.test.ts
@@ -84,4 +84,29 @@ describe('original-language structured presenter', () => {
       },
     ]);
   });
+
+  it('uses STEPBible as the sole base provenance for a lexicon-only identity', () => {
+    const result = presentOriginalLanguageEntry({
+      strongs_number: 'G21502',
+      testament: 'NT',
+      lemma: 'Ηνια',
+      transliteration: 'Henia',
+      definition: 'Heneia, man occurring at LXX in 1Ch.25.9',
+      citation: {
+        source: 'STEPBible lexicon data',
+        copyright: 'CC BY 4.0 (Tyndale House, Cambridge)',
+        url: 'https://github.com/STEPBible/STEPBible-Data',
+      },
+      sourceKind: 'stepbible_lexicon',
+    }, 'simple');
+
+    expect(result.entries[0]).toMatchObject({ strongsNumber: 'G21502', provenanceIds: ['src-1'] });
+    expect(result.provenance).toEqual([expect.objectContaining({
+      id: 'src-1',
+      label: 'STEPBible lexicon data',
+      rightsNotice: 'CC BY 4.0 (Tyndale House, Cambridge)',
+      license: { label: 'CC BY 4.0', url: 'https://creativecommons.org/licenses/by/4.0/' },
+      attribution: 'Tyndale House, Cambridge',
+    })]);
+  });
 });

--- a/test/unit/presenters/originalLanguageStructured.test.ts
+++ b/test/unit/presenters/originalLanguageStructured.test.ts
@@ -38,7 +38,6 @@ describe('original-language structured presenter', () => {
   it('maps detailed and extended exact fields to linked provenance', () => {
     const result = presentOriginalLanguageEntry({
       strongs_number: 'G25',
-      testament: 'NT',
       lemma: 'ἀγαπάω',
       transliteration: 'agapaō',
       pronunciation: 'ag-ap-ah-o',
@@ -98,9 +97,11 @@ describe('original-language structured presenter', () => {
         url: 'https://github.com/STEPBible/STEPBible-Data',
       },
       sourceKind: 'stepbible_lexicon',
+      language: 'Greek',
+      testament: null,
     }, 'simple');
 
-    expect(result.entries[0]).toMatchObject({ strongsNumber: 'G21502', provenanceIds: ['src-1'] });
+    expect(result.entries[0]).toMatchObject({ strongsNumber: 'G21502', language: 'Greek', testament: null, provenanceIds: ['src-1'] });
     expect(result.provenance).toEqual([expect.objectContaining({
       id: 'src-1',
       label: 'STEPBible lexicon data',

--- a/test/unit/services/languages/StrongsService.test.ts
+++ b/test/unit/services/languages/StrongsService.test.ts
@@ -51,9 +51,9 @@ describe('StrongsService', () => {
     it('canonicalizes padding while preserving a sense suffix', async () => {
       const repo = makeMockRepo();
       const service = new StrongsService(repo as any);
-      await service.lookup(' g01722A ', true);
-      expect(repo.lookup).toHaveBeenCalledWith('G1722a');
-      expect(repo.getLexiconEntry).toHaveBeenCalledWith('G1722a');
+      await service.lookup(' g02385i ', true);
+      expect(repo.lookup).toHaveBeenCalledWith('G2385I');
+      expect(repo.getLexiconEntry).toHaveBeenCalledWith('G2385I');
     });
 
     it('throws ValidationError for invalid format', async () => {
@@ -68,11 +68,17 @@ describe('StrongsService', () => {
       await expect(service.lookup('')).rejects.toThrow(ValidationError);
     });
 
+    it.each(['G0', 'G5625', 'H8675', 'G9007199254740993'])('rejects unsafe or out-of-corpus identity %s', async input => {
+      const repo = makeMockRepo();
+      await expect(new StrongsService(repo as any).lookup(input)).rejects.toThrow(ValidationError);
+      expect(repo.lookup).not.toHaveBeenCalled();
+    });
+
     it('throws NotFoundError when repo returns undefined', async () => {
       const repo = makeMockRepo();
       repo.lookup.mockReturnValue(undefined);
       const service = new StrongsService(repo as any);
-      await expect(service.lookup('G9999')).rejects.toThrow(NotFoundError);
+      await expect(service.lookup('G5624')).rejects.toThrow(NotFoundError);
     });
 
     it('maps repo entry to EnhancedStrongsResult with citation', async () => {

--- a/test/unit/services/languages/StrongsService.test.ts
+++ b/test/unit/services/languages/StrongsService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { StrongsService } from '../../../../src/services/languages/StrongsService.js';
 import { ValidationError, NotFoundError } from '../../../../src/kernel/errors.js';
+import { readFileSync } from 'node:fs';
 
 // ── Mock repository ──
 
@@ -22,6 +23,17 @@ const mockLexicon = {
     senses: { '1': { gloss: 'love', count: 85, usage: 'divine love' } },
   },
 };
+
+const stepBibleGreek = JSON.parse(readFileSync(new URL('../../../../data/biblical-languages/stepbible-lexicons/tbesg-greek.json', import.meta.url), 'utf8')) as Record<string, Record<string, unknown>>;
+const stepBibleHebrew = JSON.parse(readFileSync(new URL('../../../../data/biblical-languages/stepbible-lexicons/tbesh-hebrew.json', import.meta.url), 'utf8')) as Record<string, Record<string, unknown>>;
+
+function sourceLexicon(id: string) {
+  return {
+    strongs_number: id,
+    source: 'STEPBible',
+    extended_data: (id.startsWith('G') ? stepBibleGreek : stepBibleHebrew)[id],
+  };
+}
 
 function makeMockRepo() {
   return {
@@ -74,11 +86,38 @@ describe('StrongsService', () => {
       expect(repo.lookup).not.toHaveBeenCalled();
     });
 
-    it.each(['G6000', 'H9001', 'H9049', 'G21502'])('delegates representable extended identity %s to repository presence', async input => {
+    it.each(['G6000', 'H9001', 'H9049', 'G21502'])('returns source-backed lexicon-only identity %s without a classical row', async input => {
       const repo = makeMockRepo();
-      await new StrongsService(repo as any).lookup(input, true);
+      repo.lookup.mockReturnValue(undefined);
+      repo.getLexiconEntry.mockReturnValue(sourceLexicon(input));
+      const result = await new StrongsService(repo as any).lookup(input, true);
       expect(repo.lookup).toHaveBeenCalledWith(input);
       expect(repo.getLexiconEntry).toHaveBeenCalledWith(input);
+      expect(result).toMatchObject({
+        strongs_number: input,
+        sourceKind: 'stepbible_lexicon',
+        citation: { source: 'STEPBible lexicon data' },
+        lemma: sourceLexicon(input).extended_data.lemma,
+        extended: { strongsExtended: input },
+      });
+      expect(result.definition).not.toMatch(/<[^>]+>/);
+    });
+
+    it('keeps lexicon-only summary source-backed without forcing extended detail', async () => {
+      const repo = makeMockRepo();
+      repo.lookup.mockReturnValue(undefined);
+      repo.getLexiconEntry.mockReturnValue(sourceLexicon('G6000'));
+      const result = await new StrongsService(repo as any).lookup('G6000', false);
+      expect(result.extended).toBeUndefined();
+      expect(result.citation).toEqual(expect.objectContaining({ source: 'STEPBible lexicon data', copyright: expect.stringContaining('CC BY 4.0') }));
+    });
+
+    it('does not base-join a missing suffixed identity when only the base lexicon exists', async () => {
+      const repo = makeMockRepo();
+      repo.lookup.mockReturnValue(undefined);
+      repo.getLexiconEntry.mockReturnValue(undefined);
+      await expect(new StrongsService(repo as any).lookup('G6000A')).rejects.toThrow(NotFoundError);
+      expect(repo.getLexiconEntry).toHaveBeenCalledWith('G6000A');
     });
 
     it('throws NotFoundError when repo returns undefined', async () => {

--- a/test/unit/services/languages/StrongsService.test.ts
+++ b/test/unit/services/languages/StrongsService.test.ts
@@ -95,12 +95,23 @@ describe('StrongsService', () => {
       expect(repo.getLexiconEntry).toHaveBeenCalledWith(input);
       expect(result).toMatchObject({
         strongs_number: input,
+        testament: null,
+        language: input.startsWith('G') ? 'Greek' : 'Hebrew',
         sourceKind: 'stepbible_lexicon',
         citation: { source: 'STEPBible lexicon data' },
         lemma: sourceLexicon(input).extended_data.lemma,
         extended: { strongsExtended: input },
       });
       expect(result.definition).not.toMatch(/<[^>]+>/);
+    });
+
+    it('does not infer New Testament classification for the LXX-only G21502 identity', async () => {
+      const repo = makeMockRepo();
+      repo.lookup.mockReturnValue(undefined);
+      repo.getLexiconEntry.mockReturnValue(sourceLexicon('G21502'));
+      const result = await new StrongsService(repo as any).lookup('G21502');
+      expect(result).toMatchObject({ strongs_number: 'G21502', language: 'Greek', testament: null });
+      expect(result.definition).toContain('LXX');
     });
 
     it('keeps lexicon-only summary source-backed without forcing extended detail', async () => {

--- a/test/unit/services/languages/StrongsService.test.ts
+++ b/test/unit/services/languages/StrongsService.test.ts
@@ -48,6 +48,14 @@ describe('StrongsService', () => {
       expect(repo.lookup).toHaveBeenCalledWith('G26');
     });
 
+    it('canonicalizes padding while preserving a sense suffix', async () => {
+      const repo = makeMockRepo();
+      const service = new StrongsService(repo as any);
+      await service.lookup(' g01722A ', true);
+      expect(repo.lookup).toHaveBeenCalledWith('G1722a');
+      expect(repo.getLexiconEntry).toHaveBeenCalledWith('G1722a');
+    });
+
     it('throws ValidationError for invalid format', async () => {
       const repo = makeMockRepo();
       const service = new StrongsService(repo as any);

--- a/test/unit/services/languages/StrongsService.test.ts
+++ b/test/unit/services/languages/StrongsService.test.ts
@@ -68,10 +68,17 @@ describe('StrongsService', () => {
       await expect(service.lookup('')).rejects.toThrow(ValidationError);
     });
 
-    it.each(['G0', 'G5625', 'H8675', 'G9007199254740993'])('rejects unsafe or out-of-corpus identity %s', async input => {
+    it.each(['G0', 'G100000', 'H999999', 'G9007199254740993'])('rejects zero or out-of-domain identity %s', async input => {
       const repo = makeMockRepo();
       await expect(new StrongsService(repo as any).lookup(input)).rejects.toThrow(ValidationError);
       expect(repo.lookup).not.toHaveBeenCalled();
+    });
+
+    it.each(['G6000', 'H9001', 'H9049', 'G21502'])('delegates representable extended identity %s to repository presence', async input => {
+      const repo = makeMockRepo();
+      await new StrongsService(repo as any).lookup(input, true);
+      expect(repo.lookup).toHaveBeenCalledWith(input);
+      expect(repo.getLexiconEntry).toHaveBeenCalledWith(input);
     });
 
     it('throws NotFoundError when repo returns undefined', async () => {

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -697,9 +697,10 @@ describe('original_language_lookup handler', () => {
     expect(textOf(result)).toContain('**G21502**');
     expect(textOf(result)).toContain('*Source: STEPBible lexicon data* - CC BY 4.0');
     expect(result.structuredContent).toMatchObject({
-      entries: [{ strongsNumber: 'G21502', lemma: 'Ηνια', provenanceIds: ['src-1'] }],
+      entries: [{ strongsNumber: 'G21502', language: 'Greek', testament: null, lemma: 'Ηνια', provenanceIds: ['src-1'] }],
       provenance: [{ id: 'src-1', label: 'STEPBible lexicon data', license: { label: 'CC BY 4.0' } }],
     });
+    expect(textOf(result)).not.toContain('New Testament');
   });
 
   it('returns service validation failures as tool errors', async () => {

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -645,6 +645,25 @@ describe('original_language_lookup handler', () => {
     expect(lookup).not.toHaveBeenCalled();
   });
 
+  it('accepts a suffixed exact identity but rejects surrounding whitespace', async () => {
+    const lookup = vi.fn<StrongsService['lookup']>().mockResolvedValue({
+      strongs_number: 'G1722',
+      testament: 'NT',
+      lemma: 'ἐν',
+      definition: 'in',
+      citation,
+    });
+    const handler = createStrongsLookupHandler(serviceDouble({ lookup }));
+
+    const suffixed = await handler.handler({ strongs_number: 'g01722A' });
+    const spaced = await handler.handler({ strongs_number: ' G1722a ' });
+
+    expect(suffixed.isError).not.toBe(true);
+    expect(lookup).toHaveBeenCalledWith('g01722A', false);
+    expect(spaced.isError).toBe(true);
+    expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
   it('returns service validation failures as tool errors', async () => {
     const lookup = vi.fn<StrongsService['lookup']>().mockRejectedValue(
       new ValidationError('strongs_number', 'Expected G#### or H####'),

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -93,7 +93,7 @@ describe('v2 tool handler schemas', () => {
     });
     expect(originalLanguage).not.toHaveProperty('oneOf');
     expect(originalLanguage.properties).toMatchObject({
-      strongs_number: { minLength: 2, maxLength: 16 },
+      strongs_number: { minLength: 2, maxLength: 6 },
       query: { minLength: 2, maxLength: 100 },
       limit: { minimum: 1, maximum: 20 },
     });
@@ -655,11 +655,11 @@ describe('original_language_lookup handler', () => {
     });
     const handler = createStrongsLookupHandler(serviceDouble({ lookup }));
 
-    const suffixed = await handler.handler({ strongs_number: 'g01722A' });
-    const spaced = await handler.handler({ strongs_number: ' G1722a ' });
+    const suffixed = await handler.handler({ strongs_number: 'g2385i' });
+    const spaced = await handler.handler({ strongs_number: ' G2385I ' });
 
     expect(suffixed.isError).not.toBe(true);
-    expect(lookup).toHaveBeenCalledWith('g01722A', false);
+    expect(lookup).toHaveBeenCalledWith('g2385i', false);
     expect(spaced.isError).toBe(true);
     expect(lookup).toHaveBeenCalledTimes(1);
   });

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -20,6 +20,8 @@ import type { DonationService } from '../../../../src/services/donation/Donation
 import type { HistoricalDocumentService } from '../../../../src/services/historical/HistoricalDocumentService.js';
 import type { MorphologyService } from '../../../../src/services/languages/MorphologyService.js';
 import type { StrongsService } from '../../../../src/services/languages/StrongsService.js';
+import { StrongsService as StrongsServiceClass } from '../../../../src/services/languages/StrongsService.js';
+import { readFileSync } from 'node:fs';
 import type { ToolHandler, ToolResult } from '../../../../src/kernel/types.js';
 import type { DocumentInfo, DocumentSection } from '../../../../src/kernel/repositories.js';
 
@@ -600,6 +602,11 @@ describe('original_language_lookup handler', () => {
     expect(handler.inputSchema.properties?.detail_level).not.toHaveProperty('default');
     expect(handler.inputSchema.properties?.include_extended).not.toHaveProperty('default');
     expect(handler.inputSchema.properties?.limit).not.toHaveProperty('default');
+    const exact = handler.inputSchema.properties?.strongs_number as { pattern: string; maxLength: number };
+    expect(exact.maxLength).toBe(7);
+    expect(new RegExp(exact.pattern).test('G21502')).toBe(true);
+    expect(new RegExp(exact.pattern).test('G000001')).toBe(false);
+    expect(new RegExp(exact.pattern).test('G100000')).toBe(false);
   });
 
   it('accepts valid calls after mode-appropriate client default materialization', async () => {
@@ -675,6 +682,24 @@ describe('original_language_lookup handler', () => {
     const result = await createStrongsLookupHandler(serviceDouble({ lookup })).handler({ strongs_number: identity });
     expect(result.isError).not.toBe(true);
     expect(lookup).toHaveBeenCalledWith(identity, false);
+  });
+
+  it('presents a real lexicon-only STEPBible identity with CC BY provenance', async () => {
+    const source = JSON.parse(readFileSync(new URL('../../../../data/biblical-languages/stepbible-lexicons/tbesg-greek.json', import.meta.url), 'utf8')) as Record<string, Record<string, unknown>>;
+    const service = new StrongsServiceClass({
+      lookup: async () => undefined,
+      getLexiconEntry: async () => ({ strongs_number: 'G21502', source: 'STEPBible', extended_data: source.G21502 }),
+      search: async () => [],
+      getStats: async () => ({ greek: 0, hebrew: 0, total: 0 }),
+    });
+    const result = await createStrongsLookupHandler(service).handler({ strongs_number: 'g21502', include_extended: true });
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain('**G21502**');
+    expect(textOf(result)).toContain('*Source: STEPBible lexicon data* - CC BY 4.0');
+    expect(result.structuredContent).toMatchObject({
+      entries: [{ strongsNumber: 'G21502', lemma: 'Ηνια', provenanceIds: ['src-1'] }],
+      provenance: [{ id: 'src-1', label: 'STEPBible lexicon data', license: { label: 'CC BY 4.0' } }],
+    });
   });
 
   it('returns service validation failures as tool errors', async () => {

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -93,7 +93,7 @@ describe('v2 tool handler schemas', () => {
     });
     expect(originalLanguage).not.toHaveProperty('oneOf');
     expect(originalLanguage.properties).toMatchObject({
-      strongs_number: { minLength: 2, maxLength: 6 },
+      strongs_number: { minLength: 2, maxLength: 7 },
       query: { minLength: 2, maxLength: 100 },
       limit: { minimum: 1, maximum: 20 },
     });
@@ -659,9 +659,22 @@ describe('original_language_lookup handler', () => {
     const spaced = await handler.handler({ strongs_number: ' G2385I ' });
 
     expect(suffixed.isError).not.toBe(true);
-    expect(lookup).toHaveBeenCalledWith('g2385i', false);
+    expect(lookup).toHaveBeenCalledWith('G2385I', false);
     expect(spaced.isError).toBe(true);
     expect(lookup).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['G6000', 'H9001', 'H9049', 'G21502'])('accepts extended exact identity %s at the MCP boundary', async identity => {
+    const lookup = vi.fn<StrongsService['lookup']>().mockResolvedValue({
+      strongs_number: identity,
+      testament: identity.startsWith('G') ? 'NT' : 'OT',
+      lemma: 'fixture',
+      definition: 'fixture',
+      citation,
+    });
+    const result = await createStrongsLookupHandler(serviceDouble({ lookup })).handler({ strongs_number: identity });
+    expect(result.isError).not.toBe(true);
+    expect(lookup).toHaveBeenCalledWith(identity, false);
   });
 
   it('returns service validation failures as tool errors', async () => {


### PR DESCRIPTION
## Summary

- canonicalize Strong's identities through one shared parser and preserve exact suffix-bearing identities such as `G1234a`
- enforce exact identity matching across SQLite, D1, morphology, services, MCP resources, Markdown, and structured output
- resolve STEPBible lexicon-only identities without collapsing them onto a different base Strong's entry
- keep language provenance separate from biblical testament: lexicon-only entries may identify Greek or Hebrew while returning `testament: null` when no canonical OT/NT Strong's record establishes testament

## Compatibility and behavior

Existing canonical base-number lookups remain compatible. Extended identities are no longer silently truncated or confused with their base identity, and repository behavior remains aligned between local SQLite and Cloudflare D1. The output schema and presentation preserve exact requested/resolved identities while making lexicon-source provenance explicit.

This PR is independently based on current `main` at `4e025645` and does not depend on pending PR #15. It does not change deployment configuration, request routing, or rollout flags.

## Verification

Run with Node 22:

- targeted Strong's/repository/service/presenter/MCP suite: 237 tests passed
- full unit suite: 845 tests passed
- integration suite: 3 tests passed
- real workerd Worker runtime: 17 tests passed
- Node and Worker TypeScript checks passed
- production-like Worker bundle initialized without unsafe-eval privileges
- production build passed
- `git diff --check` passed

No deployment was performed and no `deploy-preview` label should be added as part of this draft.
