### PR TITLE
Add strict UBS parallel-passage foundation

### DIFF
--- a/data/data-manifest.json
+++ b/data/data-manifest.json
@@ -118,7 +118,7 @@
       "sourceBlob": "b30af22e9ee4740f6c339eb267a59b8fdb9f83f7",
       "sourceBytes": 336250,
       "sourceSha256": "d43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394",
-      "transformVersion": 1
+      "transformVersion": 2
     }
   },
   "files": [
@@ -492,7 +492,7 @@
     },
     {
       "path": "data/parallel-passages/ubs-paratext/SOURCE.json",
-      "sha256": "ba0bbf93da809494a9e033e7047fd47bf04d905499a8b695f41e263b1c4239d9"
+      "sha256": "27f42912a62ac0af99eb56ef748f144171b17f294dbd7b1391f7b87f84ba37c8"
     },
     {
       "path": "src/data/parallel-passages.json",
@@ -500,7 +500,7 @@
     },
     {
       "path": "src/data/ubs-parallel-passages.generated.json",
-      "sha256": "164c1ab52366e1421b550ede91b3ac3d79f05eaf7bef054d065fb37d27006b4d"
+      "sha256": "948f324091974aee29b1f03f735c12555838ad49870ac4f0fecc11839c757aa4"
     }
   ],
   "expectedCounts": {

--- a/data/parallel-passages/ubs-paratext/SOURCE.json
+++ b/data/parallel-passages/ubs-paratext/SOURCE.json
@@ -12,5 +12,5 @@
   "sourceBlob": "b30af22e9ee4740f6c339eb267a59b8fdb9f83f7",
   "sourceBytes": 336250,
   "sourceSha256": "d43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394",
-  "transformVersion": 1
+  "transformVersion": 2
 }

--- a/scripts/build-ubs-parallel-passages.ts
+++ b/scripts/build-ubs-parallel-passages.ts
@@ -19,6 +19,7 @@ import type {
   SourceParallelMember as KernelSourceParallelMember,
   SourceParallelReferenceSegment,
 } from '../src/kernel/sourceAttestedParallels.js';
+import { deriveUbsParallelGroupId, UBS_PARALLEL_PASSAGE_PROVENANCE } from '../src/kernel/ubsParallelSource.js';
 
 export const TRANSFORM_VERSION = 1;
 export const LABEL = 'source_attested_parallel' as const;
@@ -124,8 +125,7 @@ export const DEFAULT_SOURCE_PATH = join(ROOT, 'data/parallel-passages/ubs-parate
 export const DEFAULT_METADATA_PATH = join(ROOT, 'data/parallel-passages/ubs-paratext/SOURCE.json');
 export const DEFAULT_OUTPUT_PATH = join(ROOT, 'src/data/ubs-parallel-passages.generated.json');
 
-const MODIFICATION_NOTE =
-  'References and alignment metadata normalized for local lookup; UBS group membership and member order preserved.';
+const MODIFICATION_NOTE = UBS_PARALLEL_PASSAGE_PROVENANCE.modificationNote;
 
 function fail(message: string): never {
   throw new Error(`[ubs-compiler] ${message}`);
@@ -431,7 +431,11 @@ export function compileUbsParallelPassages(xml: string | Buffer, metadata: Sourc
     const mixed = markers.size === 2;
     const canonicalMembers = passage.verses.map(verse => [verse.marker, verse.sourceReference, verse.alignmentRaw]);
     const canonical = JSON.stringify(canonicalMembers);
-    const groupId = `ubs-pp-${sha256(Buffer.from(canonical, 'utf8'))}`;
+    const groupId = deriveUbsParallelGroupId(passage.verses.map(verse => ({
+      languageMarker: verse.marker,
+      sourceReference: verse.sourceReference,
+      alignmentRaw: verse.alignmentRaw,
+    })));
     if (seenGroups.has(canonical) || seenGroups.has(groupId)) fail(`duplicate UBS group at source ordinal ${passageIndex + 1}`);
     seenGroups.add(canonical);
     seenGroups.add(groupId);

--- a/scripts/build-ubs-parallel-passages.ts
+++ b/scripts/build-ubs-parallel-passages.ts
@@ -19,9 +19,13 @@ import type {
   SourceParallelMember as KernelSourceParallelMember,
   SourceParallelReferenceSegment,
 } from '../src/kernel/sourceAttestedParallels.js';
-import { deriveUbsParallelGroupId, UBS_PARALLEL_PASSAGE_PROVENANCE } from '../src/kernel/ubsParallelSource.js';
+import {
+  computeUbsParallelArtifactIdentity,
+  deriveUbsParallelGroupId,
+  UBS_PARALLEL_PASSAGE_PROVENANCE,
+} from '../src/kernel/ubsParallelSource.js';
 
-export const TRANSFORM_VERSION = 1;
+export const TRANSFORM_VERSION = 2;
 export const LABEL = 'source_attested_parallel' as const;
 export const DIRECTIONALITY = 'unspecified' as const;
 
@@ -89,8 +93,9 @@ export interface ReferenceIndexEntry {
 }
 
 export interface GeneratedUbsCorpus {
-  schemaVersion: 'ubs-parallel-passages.v1';
+  schemaVersion: 'ubs-parallel-passages.v2';
   transformVersion: typeof TRANSFORM_VERSION;
+  artifactIdentity: string;
   label: typeof LABEL;
   directionality: typeof DIRECTIONALITY;
   license: {
@@ -481,8 +486,8 @@ export function compileUbsParallelPassages(xml: string | Buffer, metadata: Sourc
   const referenceIndex: Record<string, ReferenceIndexEntry[]> = {};
   for (const key of [...index.keys()].sort()) referenceIndex[key] = index.get(key)!;
 
-  const output: GeneratedUbsCorpus = {
-    schemaVersion: 'ubs-parallel-passages.v1',
+  const identityProjection = {
+    schemaVersion: 'ubs-parallel-passages.v2' as const,
     transformVersion: TRANSFORM_VERSION,
     label: LABEL,
     directionality: DIRECTIONALITY,
@@ -490,6 +495,17 @@ export function compileUbsParallelPassages(xml: string | Buffer, metadata: Sourc
     provenance: sourceProvenance,
     groups,
     referenceIndex,
+  };
+  const output: GeneratedUbsCorpus = {
+    schemaVersion: identityProjection.schemaVersion,
+    transformVersion: identityProjection.transformVersion,
+    artifactIdentity: computeUbsParallelArtifactIdentity(identityProjection),
+    label: identityProjection.label,
+    directionality: identityProjection.directionality,
+    license: identityProjection.license,
+    provenance: identityProjection.provenance,
+    groups: identityProjection.groups,
+    referenceIndex: identityProjection.referenceIndex,
   };
   // Object insertion order is fixed above; compact output keeps the shared
   // Node/Worker artifact practical without changing its deterministic bytes.

--- a/scripts/build-ubs-parallel-passages.ts
+++ b/scripts/build-ubs-parallel-passages.ts
@@ -11,6 +11,14 @@ import {
   getBibleBookBounds,
   type BibleBook,
 } from '../src/kernel/books.js';
+import type {
+  ParallelSourceProvenance as KernelParallelSourceProvenance,
+  SourceAttestedParallelGroup as KernelSourceAttestedParallelGroup,
+  SourceParallelAlignmentBasis,
+  SourceParallelLanguageMarker,
+  SourceParallelMember as KernelSourceParallelMember,
+  SourceParallelReferenceSegment,
+} from '../src/kernel/sourceAttestedParallels.js';
 
 export const TRANSFORM_VERSION = 1;
 export const LABEL = 'source_attested_parallel' as const;
@@ -64,38 +72,12 @@ export function assertProvenanceMatches(left: SourceMetadata, right: SourceMetad
   }
 }
 
-export interface ReferenceSegment {
-  bookNumber: number;
-  chapter: number;
-  startVerse: number;
-  endVerse: number;
-}
-
-export type LanguageMarker = 'HEB' | 'GRK';
-export type AlignmentBasis = 'BHS' | 'LXX' | 'UBSGNT5';
-export interface SourceParallelMember {
-  sourceOrder: number;
-  sourceReference: string;
-  normalizedReference: string;
-  segments: ReferenceSegment[];
-  languageMarker: LanguageMarker;
-  alignmentBasis: AlignmentBasis;
-  alignmentRaw: string;
-}
-
-export interface ParallelSourceProvenance extends SourceMetadata {
-  modified: true;
-  modificationNote: string;
-}
-
-export interface SourceAttestedParallelGroup {
-  groupId: string;
-  sourceOrdinal: number;
-  label: typeof LABEL;
-  directionality: typeof DIRECTIONALITY;
-  members: SourceParallelMember[];
-  provenance: ParallelSourceProvenance;
-}
+export type ReferenceSegment = SourceParallelReferenceSegment;
+export type LanguageMarker = SourceParallelLanguageMarker;
+export type AlignmentBasis = SourceParallelAlignmentBasis;
+export type SourceParallelMember = KernelSourceParallelMember;
+export type ParallelSourceProvenance = KernelParallelSourceProvenance;
+export type SourceAttestedParallelGroup = KernelSourceAttestedParallelGroup;
 
 export interface ReferenceIndexEntry {
   groupId: string;

--- a/src/adapters/data/loadUbsParallelPassages.ts
+++ b/src/adapters/data/loadUbsParallelPassages.ts
@@ -1,0 +1,12 @@
+/** Node-only loader for the generated UBS artifact copied into dist/data. */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { UbsParallelPassageRepository } from '../shared/UbsParallelPassageRepository.js';
+
+export function loadUbsParallelPassageRepository(path?: string): UbsParallelPassageRepository {
+  const currentDirectory = dirname(fileURLToPath(import.meta.url));
+  const artifactPath = path ?? join(currentDirectory, '..', '..', 'data', 'ubs-parallel-passages.generated.json');
+  return new UbsParallelPassageRepository(JSON.parse(readFileSync(artifactPath, 'utf8')) as unknown);
+}

--- a/src/adapters/shared/UbsParallelPassageRepository.ts
+++ b/src/adapters/shared/UbsParallelPassageRepository.ts
@@ -8,7 +8,12 @@
 
 import { findBookByHelloaoCode, findBookByNumber, getBibleBookBounds } from '../../kernel/books.js';
 import { parseSourceAttestedLookupReference } from '../../kernel/sourceAttestedReference.js';
-import { deriveUbsParallelGroupId, UBS_PARALLEL_PASSAGE_PROVENANCE } from '../../kernel/ubsParallelSource.js';
+import {
+  computeUbsParallelArtifactIdentity,
+  deriveUbsParallelGroupId,
+  UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY,
+  UBS_PARALLEL_PASSAGE_PROVENANCE,
+} from '../../kernel/ubsParallelSource.js';
 import type {
   ISourceAttestedParallelRepository,
   ParallelSourceProvenance,
@@ -32,7 +37,7 @@ interface ValidatedUbsCorpus {
 }
 
 const TOP_LEVEL_KEYS = [
-  'schemaVersion', 'transformVersion', 'label', 'directionality',
+  'schemaVersion', 'transformVersion', 'artifactIdentity', 'label', 'directionality',
   'license', 'provenance', 'groups', 'referenceIndex',
 ] as const;
 const PROVENANCE_KEYS = [
@@ -53,8 +58,8 @@ export class UbsParallelPassageRepository implements ISourceAttestedParallelRepo
   private readonly groupsById = new Map<string, SourceAttestedParallelGroup>();
   private readonly referenceIndex: Readonly<Record<string, readonly ReferenceIndexEntry[]>>;
 
-  constructor(artifact: unknown) {
-    const corpus = validateCorpus(artifact);
+  constructor(artifact: unknown, expectedArtifactIdentity = UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY) {
+    const corpus = validateCorpus(artifact, expectedArtifactIdentity);
     this.provenance = Object.freeze({ ...corpus.provenance });
     for (const group of corpus.groups) this.groupsById.set(group.groupId, deepFreezeGroup(group));
     this.referenceIndex = corpus.referenceIndex;
@@ -82,11 +87,16 @@ export class UbsParallelPassageRepository implements ISourceAttestedParallelRepo
   }
 }
 
-function validateCorpus(input: unknown): ValidatedUbsCorpus {
+function validateCorpus(input: unknown, expectedArtifactIdentity: string): ValidatedUbsCorpus {
   const corpus = record(input, 'artifact');
   exactKeys(corpus, TOP_LEVEL_KEYS, 'artifact');
-  equal(corpus.schemaVersion, 'ubs-parallel-passages.v1', 'artifact.schemaVersion');
-  equal(corpus.transformVersion, 1, 'artifact.transformVersion');
+  equal(corpus.schemaVersion, 'ubs-parallel-passages.v2', 'artifact.schemaVersion');
+  equal(corpus.transformVersion, 2, 'artifact.transformVersion');
+  const artifactIdentity = string(corpus.artifactIdentity, 'artifact.artifactIdentity');
+  if (!/^[0-9a-f]{64}$/.test(expectedArtifactIdentity)) fail('expected artifact identity is invalid');
+  equal(artifactIdentity, expectedArtifactIdentity, 'artifact.artifactIdentity pin');
+  const { artifactIdentity: _excludedIdentity, ...identityProjection } = corpus;
+  equal(artifactIdentity, computeUbsParallelArtifactIdentity(identityProjection), 'artifact.artifactIdentity derivation');
   equal(corpus.label, 'source_attested_parallel', 'artifact.label');
   equal(corpus.directionality, 'unspecified', 'artifact.directionality');
   const license = record(corpus.license, 'artifact.license');

--- a/src/adapters/shared/UbsParallelPassageRepository.ts
+++ b/src/adapters/shared/UbsParallelPassageRepository.ts
@@ -145,6 +145,7 @@ function validateMember(input: unknown, expectedOrder: number, groupOrdinal: num
   integer(member.sourceOrder, `${path}.sourceOrder`, 1);
   equal(member.sourceOrder, expectedOrder, `${path}.sourceOrder`);
   const sourceReference = string(member.sourceReference, `${path}.sourceReference`);
+  if (sourceReference !== sourceReference.trim()) fail(`${path}.sourceReference must preserve a canonical source locator without outer whitespace`);
   const normalizedReference = string(member.normalizedReference, `${path}.normalizedReference`);
   if (!Array.isArray(member.segments) || member.segments.length === 0) fail(`${path}.segments must be non-empty`);
   const segments = member.segments.map((segment, index) => validateSegment(segment, `${path}.segment ${index + 1}`));

--- a/src/adapters/shared/UbsParallelPassageRepository.ts
+++ b/src/adapters/shared/UbsParallelPassageRepository.ts
@@ -1,0 +1,298 @@
+/**
+ * Strict, runtime-neutral repository for the generated UBS/Paratext artifact.
+ *
+ * This module deliberately has no Node APIs and accepts injected data, so the
+ * same validated lookup implementation can be used with a Node file loader or
+ * a Worker JSON-module import.
+ */
+
+import { findBookByHelloaoCode, findBookByNumber, getBibleBookBounds } from '../../kernel/books.js';
+import { parseSourceAttestedLookupReference } from '../../kernel/sourceAttestedReference.js';
+import type {
+  ISourceAttestedParallelRepository,
+  ParallelSourceProvenance,
+  SourceAttestedParallelGroup,
+  SourceParallelMember,
+  SourceParallelReferenceSegment,
+} from '../../kernel/sourceAttestedParallels.js';
+
+interface ReferenceIndexEntry {
+  groupId: string;
+  memberOrder: number;
+  segmentOrder: number;
+  startVerse: number;
+  endVerse: number;
+}
+
+interface ValidatedUbsCorpus {
+  provenance: ParallelSourceProvenance;
+  groups: SourceAttestedParallelGroup[];
+  referenceIndex: Record<string, ReferenceIndexEntry[]>;
+}
+
+const TOP_LEVEL_KEYS = [
+  'schemaVersion', 'transformVersion', 'label', 'directionality',
+  'license', 'provenance', 'groups', 'referenceIndex',
+] as const;
+const PROVENANCE_KEYS = [
+  'sourceId', 'title', 'publisher', 'copyright', 'license', 'licenseUrl',
+  'sourceUrl', 'sourcePath', 'sourceCommit', 'sourceCommitDate', 'sourceBlob',
+  'sourceBytes', 'sourceSha256', 'transformVersion', 'modified', 'modificationNote',
+] as const;
+const GROUP_KEYS = ['groupId', 'sourceOrdinal', 'label', 'directionality', 'members', 'provenance'] as const;
+const MEMBER_KEYS = [
+  'sourceOrder', 'sourceReference', 'normalizedReference', 'segments',
+  'languageMarker', 'alignmentBasis', 'alignmentRaw',
+] as const;
+const SEGMENT_KEYS = ['bookNumber', 'chapter', 'startVerse', 'endVerse'] as const;
+const INDEX_KEYS = ['groupId', 'memberOrder', 'segmentOrder', 'startVerse', 'endVerse'] as const;
+
+export class UbsParallelPassageRepository implements ISourceAttestedParallelRepository {
+  private readonly provenance: Readonly<ParallelSourceProvenance>;
+  private readonly groupsById = new Map<string, SourceAttestedParallelGroup>();
+  private readonly referenceIndex: Readonly<Record<string, readonly ReferenceIndexEntry[]>>;
+
+  constructor(artifact: unknown) {
+    const corpus = validateCorpus(artifact);
+    this.provenance = Object.freeze({ ...corpus.provenance });
+    for (const group of corpus.groups) this.groupsById.set(group.groupId, deepFreezeGroup(group));
+    this.referenceIndex = corpus.referenceIndex;
+  }
+
+  findGroups(reference: string, maxGroups = Number.POSITIVE_INFINITY): readonly SourceAttestedParallelGroup[] {
+    if (maxGroups !== Number.POSITIVE_INFINITY && (!Number.isSafeInteger(maxGroups) || maxGroups < 1)) {
+      throw new Error('maxGroups must be a positive safe integer');
+    }
+    const groupIds = new Set<string>();
+    for (const segment of parseSourceAttestedLookupReference(reference).segments) {
+      const entries = this.referenceIndex[`${segment.bookNumber}:${segment.chapter}`] ?? [];
+      for (const entry of entries) {
+        if (entry.startVerse <= segment.endVerse && segment.startVerse <= entry.endVerse) groupIds.add(entry.groupId);
+      }
+    }
+    return [...groupIds]
+      .map(groupId => this.groupsById.get(groupId)!)
+      .sort((left, right) => left.sourceOrdinal - right.sourceOrdinal)
+      .slice(0, maxGroups);
+  }
+
+  getProvenance(): Readonly<ParallelSourceProvenance> {
+    return this.provenance;
+  }
+}
+
+function validateCorpus(input: unknown): ValidatedUbsCorpus {
+  const corpus = record(input, 'artifact');
+  exactKeys(corpus, TOP_LEVEL_KEYS, 'artifact');
+  equal(corpus.schemaVersion, 'ubs-parallel-passages.v1', 'artifact.schemaVersion');
+  equal(corpus.transformVersion, 1, 'artifact.transformVersion');
+  equal(corpus.label, 'source_attested_parallel', 'artifact.label');
+  equal(corpus.directionality, 'unspecified', 'artifact.directionality');
+  const license = record(corpus.license, 'artifact.license');
+  exactKeys(license, ['name', 'url'], 'artifact.license');
+  equal(license.name, 'CC BY-SA 4.0', 'artifact.license.name');
+  equal(license.url, 'https://creativecommons.org/licenses/by-sa/4.0/', 'artifact.license.url');
+  const provenance = validateProvenance(corpus.provenance, 'artifact.provenance');
+  equal(provenance.sourceId, 'ubs_paratext_parallel_passages', 'artifact.provenance.sourceId');
+  equal(provenance.license, license.name, 'artifact provenance/license');
+  equal(provenance.licenseUrl, license.url, 'artifact provenance/licenseUrl');
+  equal(provenance.transformVersion, corpus.transformVersion, 'artifact provenance/transformVersion');
+
+  if (!Array.isArray(corpus.groups) || corpus.groups.length === 0) fail('artifact.groups must be a non-empty array');
+  const groups = corpus.groups.map((group, index) => validateGroup(group, index + 1, provenance));
+  const groupIds = new Set<string>();
+  for (const group of groups) {
+    if (groupIds.has(group.groupId)) fail(`duplicate group ID ${group.groupId}`);
+    groupIds.add(group.groupId);
+  }
+
+  const referenceIndex = validateIndex(corpus.referenceIndex, groups);
+  return { provenance, groups, referenceIndex };
+}
+
+function validateGroup(input: unknown, expectedOrdinal: number, provenance: ParallelSourceProvenance): SourceAttestedParallelGroup {
+  const group = record(input, `group ${expectedOrdinal}`);
+  exactKeys(group, GROUP_KEYS, `group ${expectedOrdinal}`);
+  const groupId = string(group.groupId, `group ${expectedOrdinal}.groupId`);
+  if (!/^ubs-pp-[0-9a-f]{64}$/.test(groupId)) fail(`group ${expectedOrdinal}.groupId is invalid`);
+  integer(group.sourceOrdinal, `group ${expectedOrdinal}.sourceOrdinal`, 1);
+  equal(group.sourceOrdinal, expectedOrdinal, `group ${expectedOrdinal}.sourceOrdinal`);
+  equal(group.label, 'source_attested_parallel', `group ${expectedOrdinal}.label`);
+  equal(group.directionality, 'unspecified', `group ${expectedOrdinal}.directionality`);
+  const groupProvenance = validateProvenance(group.provenance, `group ${expectedOrdinal}.provenance`);
+  if (canonicalJson(groupProvenance) !== canonicalJson(provenance)) fail(`group ${expectedOrdinal} provenance differs from corpus provenance`);
+  if (!Array.isArray(group.members) || group.members.length < 2) fail(`group ${expectedOrdinal}.members must contain at least two members`);
+  const members = group.members.map((member, index) => validateMember(member, index + 1, expectedOrdinal));
+  const mixed = new Set(members.map(member => member.languageMarker)).size === 2;
+  for (const member of members) {
+    const expectedBasis = member.languageMarker === 'GRK' ? 'UBSGNT5' : mixed ? 'LXX' : 'BHS';
+    if (member.alignmentBasis !== expectedBasis) fail(`group ${expectedOrdinal}.member ${member.sourceOrder} alignment basis conflicts with group composition`);
+  }
+  return {
+    groupId,
+    sourceOrdinal: expectedOrdinal,
+    label: 'source_attested_parallel',
+    directionality: 'unspecified',
+    members,
+    provenance: groupProvenance,
+  };
+}
+
+function validateMember(input: unknown, expectedOrder: number, groupOrdinal: number): SourceParallelMember {
+  const path = `group ${groupOrdinal}.member ${expectedOrder}`;
+  const member = record(input, path);
+  exactKeys(member, MEMBER_KEYS, path);
+  integer(member.sourceOrder, `${path}.sourceOrder`, 1);
+  equal(member.sourceOrder, expectedOrder, `${path}.sourceOrder`);
+  const sourceReference = string(member.sourceReference, `${path}.sourceReference`);
+  const normalizedReference = string(member.normalizedReference, `${path}.normalizedReference`);
+  if (!Array.isArray(member.segments) || member.segments.length === 0) fail(`${path}.segments must be non-empty`);
+  const segments = member.segments.map((segment, index) => validateSegment(segment, `${path}.segment ${index + 1}`));
+  const sourceMatch = /^([A-Z0-9]{3}) ([^\s].*)$/.exec(sourceReference);
+  const sourceBook = sourceMatch ? findBookByHelloaoCode(sourceMatch[1]) : undefined;
+  if (!sourceMatch || !sourceBook) fail(`${path}.sourceReference is invalid`);
+  let parsedSource;
+  try {
+    parsedSource = parseSourceAttestedLookupReference(`${sourceBook.name} ${sourceMatch[2]}`);
+  } catch {
+    fail(`${path}.sourceReference is invalid`);
+  }
+  if (parsedSource.normalizedReference !== normalizedReference || canonicalJson(parsedSource.segments) !== canonicalJson(segments)) {
+    fail(`${path} source and normalized reference segments differ`);
+  }
+  equal(member.languageMarker === 'HEB' || member.languageMarker === 'GRK', true, `${path}.languageMarker`);
+  equal(['BHS', 'LXX', 'UBSGNT5'].includes(member.alignmentBasis as string), true, `${path}.alignmentBasis`);
+  if (member.languageMarker === 'GRK' && member.alignmentBasis !== 'UBSGNT5') fail(`${path} has an invalid Greek alignment basis`);
+  if (member.languageMarker === 'HEB' && !['BHS', 'LXX'].includes(member.alignmentBasis as string)) fail(`${path} has an invalid Hebrew alignment basis`);
+  const alignmentRaw = string(member.alignmentRaw, `${path}.alignmentRaw`);
+  if (!/^[0-8]+$/.test(alignmentRaw)) fail(`${path}.alignmentRaw contains an undocumented code`);
+  return {
+    sourceOrder: expectedOrder,
+    sourceReference,
+    normalizedReference,
+    segments,
+    languageMarker: member.languageMarker as 'HEB' | 'GRK',
+    alignmentBasis: member.alignmentBasis as 'BHS' | 'LXX' | 'UBSGNT5',
+    alignmentRaw,
+  };
+}
+
+function validateSegment(input: unknown, path: string): SourceParallelReferenceSegment {
+  const segment = record(input, path);
+  exactKeys(segment, SEGMENT_KEYS, path);
+  const bookNumber = integer(segment.bookNumber, `${path}.bookNumber`, 1);
+  const book = findBookByNumber(bookNumber);
+  if (!book) fail(`${path}.bookNumber is outside the canonical 66-book registry`);
+  const chapter = integer(segment.chapter, `${path}.chapter`, 1);
+  const startVerse = integer(segment.startVerse, `${path}.startVerse`, 1);
+  const endVerse = integer(segment.endVerse, `${path}.endVerse`, startVerse);
+  const bounds = getBibleBookBounds(book);
+  // UBS locators retain source-language versification, which can exceed the
+  // English-oriented verse maxima (for example Psalm 18:51). Chapter bounds
+  // remain canonical, while positive source verse numbers are preserved.
+  if (chapter > bounds.maxVerseByChapter.length) fail(`${path} is outside canonical chapter bounds`);
+  return { bookNumber, chapter, startVerse, endVerse };
+}
+
+function validateIndex(input: unknown, groups: SourceAttestedParallelGroup[]): Record<string, ReferenceIndexEntry[]> {
+  const actual = record(input, 'artifact.referenceIndex');
+  const expected: Record<string, ReferenceIndexEntry[]> = {};
+  for (const group of groups) {
+    for (const member of group.members) {
+      member.segments.forEach((segment, segmentIndex) => {
+        const key = `${segment.bookNumber}:${segment.chapter}`;
+        (expected[key] ??= []).push({
+          groupId: group.groupId,
+          memberOrder: member.sourceOrder,
+          segmentOrder: segmentIndex + 1,
+          startVerse: segment.startVerse,
+          endVerse: segment.endVerse,
+        });
+      });
+    }
+  }
+  const actualKeys = Object.keys(actual);
+  const expectedKeys = Object.keys(expected).sort();
+  if (canonicalJson(actualKeys) !== canonicalJson(expectedKeys)) fail('artifact.referenceIndex keys or source ordering are invalid');
+  const validated: Record<string, ReferenceIndexEntry[]> = {};
+  for (const key of expectedKeys) {
+    if (!/^([1-9]|[1-5]\d|6[0-6]):[1-9]\d*$/.test(key)) fail(`invalid reference index key ${key}`);
+    const entries = actual[key];
+    if (!Array.isArray(entries)) fail(`reference index ${key} must be an array`);
+    validated[key] = entries.map((entry, index) => {
+      const path = `reference index ${key}[${index}]`;
+      const row = record(entry, path);
+      exactKeys(row, INDEX_KEYS, path);
+      return {
+        groupId: string(row.groupId, `${path}.groupId`),
+        memberOrder: integer(row.memberOrder, `${path}.memberOrder`, 1),
+        segmentOrder: integer(row.segmentOrder, `${path}.segmentOrder`, 1),
+        startVerse: integer(row.startVerse, `${path}.startVerse`, 1),
+        endVerse: integer(row.endVerse, `${path}.endVerse`, 1),
+      };
+    });
+    if (canonicalJson(validated[key]) !== canonicalJson(expected[key])) fail(`reference index ${key} does not exactly represent group segments`);
+    Object.freeze(validated[key]);
+  }
+  return Object.freeze(validated);
+}
+
+function validateProvenance(input: unknown, path: string): ParallelSourceProvenance {
+  const value = record(input, path);
+  exactKeys(value, PROVENANCE_KEYS, path);
+  const result = Object.fromEntries(PROVENANCE_KEYS.map(key => [key, value[key]])) as unknown as ParallelSourceProvenance;
+  for (const key of PROVENANCE_KEYS) {
+    if (key === 'sourceBytes' || key === 'transformVersion') integer(result[key], `${path}.${key}`, 1);
+    else if (key === 'modified') equal(result.modified, true, `${path}.modified`);
+    else string(result[key], `${path}.${key}`);
+  }
+  if (!/^[0-9a-f]{40}$/.test(result.sourceCommit)) fail(`${path}.sourceCommit is invalid`);
+  if (!/^[0-9a-f]{40}$/.test(result.sourceBlob)) fail(`${path}.sourceBlob is invalid`);
+  if (!/^[0-9a-f]{64}$/.test(result.sourceSha256)) fail(`${path}.sourceSha256 is invalid`);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(result.sourceCommitDate)) fail(`${path}.sourceCommitDate is invalid`);
+  return result;
+}
+
+function deepFreezeGroup(group: SourceAttestedParallelGroup): SourceAttestedParallelGroup {
+  Object.freeze(group.provenance);
+  for (const member of group.members) {
+    for (const segment of member.segments) Object.freeze(segment);
+    Object.freeze(member.segments);
+    Object.freeze(member);
+  }
+  Object.freeze(group.members);
+  return Object.freeze(group);
+}
+
+function record(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${path} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[], path: string): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (canonicalJson(actual) !== canonicalJson(expected)) fail(`${path} contains missing or unknown fields`);
+}
+
+function string(value: unknown, path: string): string {
+  if (typeof value !== 'string' || value.length === 0) fail(`${path} must be a non-empty string`);
+  return value;
+}
+
+function integer(value: unknown, path: string, minimum: number): number {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) fail(`${path} must be a safe integer >= ${minimum}`);
+  return value as number;
+}
+
+function equal(actual: unknown, expected: unknown, path: string): void {
+  if (actual !== expected) fail(`${path} is invalid`);
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function fail(message: string): never {
+  throw new Error(`[ubs-repository] ${message}`);
+}

--- a/src/adapters/shared/UbsParallelPassageRepository.ts
+++ b/src/adapters/shared/UbsParallelPassageRepository.ts
@@ -8,6 +8,7 @@
 
 import { findBookByHelloaoCode, findBookByNumber, getBibleBookBounds } from '../../kernel/books.js';
 import { parseSourceAttestedLookupReference } from '../../kernel/sourceAttestedReference.js';
+import { deriveUbsParallelGroupId, UBS_PARALLEL_PASSAGE_PROVENANCE } from '../../kernel/ubsParallelSource.js';
 import type {
   ISourceAttestedParallelRepository,
   ParallelSourceProvenance,
@@ -93,7 +94,9 @@ function validateCorpus(input: unknown): ValidatedUbsCorpus {
   equal(license.name, 'CC BY-SA 4.0', 'artifact.license.name');
   equal(license.url, 'https://creativecommons.org/licenses/by-sa/4.0/', 'artifact.license.url');
   const provenance = validateProvenance(corpus.provenance, 'artifact.provenance');
-  equal(provenance.sourceId, 'ubs_paratext_parallel_passages', 'artifact.provenance.sourceId');
+  if (canonicalJson(provenance) !== canonicalJson(UBS_PARALLEL_PASSAGE_PROVENANCE)) {
+    fail('artifact.provenance differs from the reviewed UBS source descriptor');
+  }
   equal(provenance.license, license.name, 'artifact provenance/license');
   equal(provenance.licenseUrl, license.url, 'artifact provenance/licenseUrl');
   equal(provenance.transformVersion, corpus.transformVersion, 'artifact provenance/transformVersion');
@@ -123,6 +126,7 @@ function validateGroup(input: unknown, expectedOrdinal: number, provenance: Para
   if (canonicalJson(groupProvenance) !== canonicalJson(provenance)) fail(`group ${expectedOrdinal} provenance differs from corpus provenance`);
   if (!Array.isArray(group.members) || group.members.length < 2) fail(`group ${expectedOrdinal}.members must contain at least two members`);
   const members = group.members.map((member, index) => validateMember(member, index + 1, expectedOrdinal));
+  equal(groupId, deriveUbsParallelGroupId(members), `group ${expectedOrdinal}.groupId derivation`);
   const mixed = new Set(members.map(member => member.languageMarker)).size === 2;
   for (const member of members) {
     const expectedBasis = member.languageMarker === 'GRK' ? 'UBSGNT5' : mixed ? 'LXX' : 'BHS';

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -66,6 +66,10 @@ export {
   parseSourceAttestedLookupReference,
   type SourceAttestedLookupReference,
 } from './sourceAttestedReference.js';
+export {
+  UBS_PARALLEL_PASSAGE_PROVENANCE,
+  deriveUbsParallelGroupId,
+} from './ubsParallelSource.js';
 
 // Provenance
 export {

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -51,6 +51,22 @@ export {
 // Cache
 export { Cache } from './cache.js';
 
+// Source-attested parallel passage groups
+export type {
+  SourceParallelLanguageMarker,
+  SourceParallelAlignmentBasis,
+  SourceParallelReferenceSegment,
+  SourceParallelMember,
+  ParallelSourceProvenance,
+  SourceAttestedParallelGroup,
+  SourceAttestedParallelLookup,
+  ISourceAttestedParallelRepository,
+} from './sourceAttestedParallels.js';
+export {
+  parseSourceAttestedLookupReference,
+  type SourceAttestedLookupReference,
+} from './sourceAttestedReference.js';
+
 // Provenance
 export {
   provenanceFromCitation,

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -68,6 +68,8 @@ export {
 } from './sourceAttestedReference.js';
 export {
   UBS_PARALLEL_PASSAGE_PROVENANCE,
+  UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY,
+  computeUbsParallelArtifactIdentity,
   deriveUbsParallelGroupId,
 } from './ubsParallelSource.js';
 

--- a/src/kernel/sha256.ts
+++ b/src/kernel/sha256.ts
@@ -1,0 +1,65 @@
+/** Small synchronous SHA-256 for deterministic identities in Node and Workers. */
+export function sha256Hex(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const bitLength = bytes.length * 8;
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  const high = Math.floor(bitLength / 0x1_0000_0000);
+  const low = bitLength >>> 0;
+  view.setUint32(paddedLength - 8, high, false);
+  view.setUint32(paddedLength - 4, low, false);
+
+  const state = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const words = new Uint32Array(64);
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let index = 0; index < 16; index++) words[index] = view.getUint32(offset + index * 4, false);
+    for (let index = 16; index < 64; index++) {
+      const a = words[index - 15];
+      const b = words[index - 2];
+      const s0 = rotateRight(a, 7) ^ rotateRight(a, 18) ^ (a >>> 3);
+      const s1 = rotateRight(b, 17) ^ rotateRight(b, 19) ^ (b >>> 10);
+      words[index] = (words[index - 16] + s0 + words[index - 7] + s1) >>> 0;
+    }
+    let [a, b, c, d, e, f, g, h] = state;
+    for (let index = 0; index < 64; index++) {
+      const s1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choice = (e & f) ^ (~e & g);
+      const temp1 = (h + s1 + choice + ROUND_CONSTANTS[index] + words[index]) >>> 0;
+      const s0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + majority) >>> 0;
+      h = g; g = f; f = e; e = (d + temp1) >>> 0;
+      d = c; c = b; b = a; a = (temp1 + temp2) >>> 0;
+    }
+    state[0] = (state[0] + a) >>> 0;
+    state[1] = (state[1] + b) >>> 0;
+    state[2] = (state[2] + c) >>> 0;
+    state[3] = (state[3] + d) >>> 0;
+    state[4] = (state[4] + e) >>> 0;
+    state[5] = (state[5] + f) >>> 0;
+    state[6] = (state[6] + g) >>> 0;
+    state[7] = (state[7] + h) >>> 0;
+  }
+  return [...state].map(word => word.toString(16).padStart(8, '0')).join('');
+}
+
+function rotateRight(value: number, count: number): number {
+  return (value >>> count) | (value << (32 - count));
+}
+
+const ROUND_CONSTANTS = new Uint32Array([
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]);

--- a/src/kernel/sourceAttestedParallels.ts
+++ b/src/kernel/sourceAttestedParallels.ts
@@ -1,0 +1,59 @@
+/** Source-neutral domain contracts for externally attested parallel-passage groups. */
+
+export type SourceParallelLanguageMarker = 'HEB' | 'GRK';
+export type SourceParallelAlignmentBasis = 'BHS' | 'LXX' | 'UBSGNT5';
+
+export interface SourceParallelReferenceSegment {
+  bookNumber: number;
+  chapter: number;
+  startVerse: number;
+  endVerse: number;
+}
+
+export interface SourceParallelMember {
+  sourceOrder: number;
+  sourceReference: string;
+  normalizedReference: string;
+  segments: SourceParallelReferenceSegment[];
+  languageMarker: SourceParallelLanguageMarker;
+  alignmentBasis: SourceParallelAlignmentBasis;
+  alignmentRaw: string;
+}
+
+export interface ParallelSourceProvenance {
+  sourceId: string;
+  title: string;
+  publisher: string;
+  copyright: string;
+  license: string;
+  licenseUrl: string;
+  sourceUrl: string;
+  sourcePath: string;
+  sourceCommit: string;
+  sourceCommitDate: string;
+  sourceBlob: string;
+  sourceBytes: number;
+  sourceSha256: string;
+  transformVersion: number;
+  modified: boolean;
+  modificationNote: string;
+}
+
+export interface SourceAttestedParallelGroup {
+  groupId: string;
+  sourceOrdinal: number;
+  label: 'source_attested_parallel';
+  directionality: 'unspecified';
+  members: SourceParallelMember[];
+  provenance: ParallelSourceProvenance;
+}
+
+export interface SourceAttestedParallelLookup {
+  reference: string;
+  groups: readonly SourceAttestedParallelGroup[];
+}
+
+export interface ISourceAttestedParallelRepository {
+  findGroups(reference: string, maxGroups?: number): readonly SourceAttestedParallelGroup[];
+  getProvenance(): Readonly<ParallelSourceProvenance>;
+}

--- a/src/kernel/sourceAttestedReference.ts
+++ b/src/kernel/sourceAttestedReference.ts
@@ -1,0 +1,66 @@
+/** Reference parsing for source-owned versification without widening segments. */
+
+import { findBook, getBibleBookBounds } from './books.js';
+import { formatReference, parseReference } from './reference.js';
+import type { SourceParallelReferenceSegment } from './sourceAttestedParallels.js';
+
+export interface SourceAttestedLookupReference {
+  normalizedReference: string;
+  segments: SourceParallelReferenceSegment[];
+}
+
+export function parseSourceAttestedLookupReference(input: string): SourceAttestedLookupReference {
+  const raw = input.trim();
+  if (!raw.includes(',')) {
+    try {
+      const parsed = parseReference(raw);
+      return {
+        normalizedReference: formatReference(parsed),
+        segments: [{
+          bookNumber: parsed.book.number,
+          chapter: parsed.chapter,
+          startVerse: parsed.startVerse ?? 1,
+          endVerse: parsed.endVerse ?? parsed.startVerse ?? Number.POSITIVE_INFINITY,
+        }],
+      };
+    } catch {
+      // UBS source-language versification can exceed translation-oriented
+      // English verse maxima. Parse that narrow case below while retaining
+      // canonical book/chapter validation.
+    }
+  }
+
+  const match = /^(.+?)\s+(\d+):(\d+(?:-\d+)?(?:,(?:\d+:)?\d+(?:-\d+)?)*)$/.exec(raw);
+  if (!match) throw new Error(`Invalid source-attested reference: ${input}`);
+  const book = findBook(match[1]);
+  if (!book) throw new Error(`Invalid source-attested reference: ${input}`);
+  const firstChapter = safePositive(match[2], input);
+  const parts = match[3].split(',');
+  const segments = parts.map((part, index) => {
+    const full = /^(\d+):(\d+(?:-\d+)?)$/.exec(part);
+    const chapter = full ? safePositive(full[1], input) : firstChapter;
+    if (chapter > getBibleBookBounds(book).maxVerseByChapter.length) throw new Error(`Invalid source-attested reference: ${input}`);
+    const versePart = full ? full[2] : part;
+    const verse = /^(\d+)(?:-(\d+))?$/.exec(versePart);
+    if (!verse) throw new Error(`Invalid source-attested reference: ${input}`);
+    const startVerse = safePositive(verse[1], input);
+    const endVerse = verse[2] ? safePositive(verse[2], input) : startVerse;
+    if (endVerse < startVerse) throw new Error(`Invalid source-attested reference: ${input}`);
+    return { bookNumber: book.number, chapter, startVerse, endVerse, index };
+  });
+  const normalized = segments.map((segment, index) => {
+    const verses = segment.startVerse === segment.endVerse ? `${segment.startVerse}` : `${segment.startVerse}-${segment.endVerse}`;
+    if (index === 0) return `${book.name} ${segment.chapter}:${verses}`;
+    return segment.chapter === firstChapter ? verses : `${segment.chapter}:${verses}`;
+  }).join(',');
+  return {
+    normalizedReference: normalized,
+    segments: segments.map(({ index: _index, ...segment }) => segment),
+  };
+}
+
+function safePositive(raw: string, input: string): number {
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error(`Invalid source-attested reference: ${input}`);
+  return value;
+}

--- a/src/kernel/ubsParallelSource.ts
+++ b/src/kernel/ubsParallelSource.ts
@@ -1,0 +1,27 @@
+import type { ParallelSourceProvenance, SourceParallelMember } from './sourceAttestedParallels.js';
+import { sha256Hex } from './sha256.js';
+
+export const UBS_PARALLEL_PASSAGE_PROVENANCE: Readonly<ParallelSourceProvenance> = Object.freeze({
+  sourceId: 'ubs_paratext_parallel_passages',
+  title: 'UBS Parallel Passage Database',
+  publisher: 'United Bible Societies',
+  copyright: '© 2023 United Bible Societies',
+  license: 'CC BY-SA 4.0',
+  licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
+  sourceUrl: 'https://github.com/ubsicap/ubs-open-license/tree/fd7bcf88b20a1522d3916f437f012c561466fe7b/parallel%20passages',
+  sourcePath: 'parallel passages/ParallelPassages.xml',
+  sourceCommit: 'fd7bcf88b20a1522d3916f437f012c561466fe7b',
+  sourceCommitDate: '2023-07-10',
+  sourceBlob: 'b30af22e9ee4740f6c339eb267a59b8fdb9f83f7',
+  sourceBytes: 336250,
+  sourceSha256: 'd43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394',
+  transformVersion: 1,
+  modified: true,
+  modificationNote: 'References and alignment metadata normalized for local lookup; UBS group membership and member order preserved.',
+});
+
+/** Exact compiler identity: SHA-256 of ordered [marker, source locator, alignment] tuples. */
+export function deriveUbsParallelGroupId(members: readonly Pick<SourceParallelMember, 'languageMarker' | 'sourceReference' | 'alignmentRaw'>[]): string {
+  const canonical = JSON.stringify(members.map(member => [member.languageMarker, member.sourceReference, member.alignmentRaw]));
+  return `ubs-pp-${sha256Hex(canonical)}`;
+}

--- a/src/kernel/ubsParallelSource.ts
+++ b/src/kernel/ubsParallelSource.ts
@@ -15,13 +15,20 @@ export const UBS_PARALLEL_PASSAGE_PROVENANCE: Readonly<ParallelSourceProvenance>
   sourceBlob: 'b30af22e9ee4740f6c339eb267a59b8fdb9f83f7',
   sourceBytes: 336250,
   sourceSha256: 'd43e7554556c1a1c5e2464e6b5ad8a4ab9118ada11060bf6b200abf3d0d0a394',
-  transformVersion: 1,
+  transformVersion: 2,
   modified: true,
   modificationNote: 'References and alignment metadata normalized for local lookup; UBS group membership and member order preserved.',
 });
+
+/** Independently reviewed root emitted by compiler v2 and required at runtime. */
+export const UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY = 'a5fd0d4646cb69f426f592c6e334866191201fbe64691cd55c7f7ecd0ca9d4cc';
 
 /** Exact compiler identity: SHA-256 of ordered [marker, source locator, alignment] tuples. */
 export function deriveUbsParallelGroupId(members: readonly Pick<SourceParallelMember, 'languageMarker' | 'sourceReference' | 'alignmentRaw'>[]): string {
   const canonical = JSON.stringify(members.map(member => [member.languageMarker, member.sourceReference, member.alignmentRaw]));
   return `ubs-pp-${sha256Hex(canonical)}`;
+}
+
+export function computeUbsParallelArtifactIdentity(artifactWithoutIdentity: unknown): string {
+  return sha256Hex(JSON.stringify(artifactWithoutIdentity));
 }

--- a/src/services/bible/SourceAttestedParallelService.ts
+++ b/src/services/bible/SourceAttestedParallelService.ts
@@ -1,0 +1,25 @@
+/** Source-neutral application boundary for group-preserving parallel lookup. */
+
+import type {
+  ISourceAttestedParallelRepository,
+  SourceAttestedParallelLookup,
+} from '../../kernel/sourceAttestedParallels.js';
+import { parseSourceAttestedLookupReference } from '../../kernel/sourceAttestedReference.js';
+
+export interface SourceAttestedParallelLookupParams {
+  reference: string;
+  maxGroups?: number;
+}
+
+export class SourceAttestedParallelService {
+  constructor(private readonly repository: ISourceAttestedParallelRepository) {}
+
+  lookup(params: SourceAttestedParallelLookupParams): SourceAttestedParallelLookup {
+    const reference = parseSourceAttestedLookupReference(params.reference).normalizedReference;
+    const maxGroups = params.maxGroups ?? 5;
+    if (!Number.isSafeInteger(maxGroups) || maxGroups < 1 || maxGroups > 10) {
+      throw new Error('maxGroups must be an integer from 1 to 10');
+    }
+    return { reference, groups: this.repository.findGroups(reference, maxGroups) };
+  }
+}

--- a/src/services/bible/SourceAttestedParallelService.ts
+++ b/src/services/bible/SourceAttestedParallelService.ts
@@ -5,6 +5,7 @@ import type {
   SourceAttestedParallelLookup,
 } from '../../kernel/sourceAttestedParallels.js';
 import { parseSourceAttestedLookupReference } from '../../kernel/sourceAttestedReference.js';
+import { ValidationError } from '../../kernel/errors.js';
 
 export interface SourceAttestedParallelLookupParams {
   reference: string;
@@ -15,10 +16,15 @@ export class SourceAttestedParallelService {
   constructor(private readonly repository: ISourceAttestedParallelRepository) {}
 
   lookup(params: SourceAttestedParallelLookupParams): SourceAttestedParallelLookup {
-    const reference = parseSourceAttestedLookupReference(params.reference).normalizedReference;
+    let reference: string;
+    try {
+      reference = parseSourceAttestedLookupReference(params.reference).normalizedReference;
+    } catch {
+      throw new ValidationError('reference', 'reference must identify one canonical or source-versification Bible passage.');
+    }
     const maxGroups = params.maxGroups ?? 5;
     if (!Number.isSafeInteger(maxGroups) || maxGroups < 1 || maxGroups > 10) {
-      throw new Error('maxGroups must be an integer from 1 to 10');
+      throw new ValidationError('maxGroups', 'maxGroups must be an integer from 1 to 10.');
     }
     return { reference, groups: this.repository.findGroups(reference, maxGroups) };
   }

--- a/test/fixtures/ubsParallelCorpus.ts
+++ b/test/fixtures/ubsParallelCorpus.ts
@@ -1,31 +1,12 @@
 import type { SourceAttestedParallelGroup } from '../../src/kernel/sourceAttestedParallels.js';
+import { deriveUbsParallelGroupId, UBS_PARALLEL_PASSAGE_PROVENANCE } from '../../src/kernel/ubsParallelSource.js';
 
-export const fixtureProvenance = {
-  sourceId: 'ubs_paratext_parallel_passages',
-  title: 'UBS Parallel Passage Database',
-  publisher: 'United Bible Societies',
-  copyright: '© 2023 United Bible Societies',
-  license: 'CC BY-SA 4.0',
-  licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
-  sourceUrl: 'https://example.test/ubs',
-  sourcePath: 'parallel passages/ParallelPassages.xml',
-  sourceCommit: 'a'.repeat(40),
-  sourceCommitDate: '2023-07-10',
-  sourceBlob: 'b'.repeat(40),
-  sourceBytes: 100,
-  sourceSha256: 'c'.repeat(64),
-  transformVersion: 1,
-  modified: true,
-  modificationNote: 'References and alignment metadata normalized for local lookup.',
-} as const;
-
-const firstId = `ubs-pp-${'1'.repeat(64)}`;
-const secondId = `ubs-pp-${'2'.repeat(64)}`;
+export const fixtureProvenance = UBS_PARALLEL_PASSAGE_PROVENANCE;
 
 export function ubsFixture(): Record<string, unknown> {
   const groups: SourceAttestedParallelGroup[] = [
     {
-      groupId: firstId,
+      groupId: '',
       sourceOrdinal: 1,
       label: 'source_attested_parallel',
       directionality: 'unspecified',
@@ -55,7 +36,7 @@ export function ubsFixture(): Record<string, unknown> {
       provenance: { ...fixtureProvenance },
     },
     {
-      groupId: secondId,
+      groupId: '',
       sourceOrdinal: 2,
       label: 'source_attested_parallel',
       directionality: 'unspecified',
@@ -82,6 +63,8 @@ export function ubsFixture(): Record<string, unknown> {
       provenance: { ...fixtureProvenance },
     },
   ];
+  for (const group of groups) group.groupId = deriveUbsParallelGroupId(group.members);
+  const [firstId, secondId] = groups.map(group => group.groupId);
   return {
     schemaVersion: 'ubs-parallel-passages.v1',
     transformVersion: 1,

--- a/test/fixtures/ubsParallelCorpus.ts
+++ b/test/fixtures/ubsParallelCorpus.ts
@@ -1,0 +1,103 @@
+import type { SourceAttestedParallelGroup } from '../../src/kernel/sourceAttestedParallels.js';
+
+export const fixtureProvenance = {
+  sourceId: 'ubs_paratext_parallel_passages',
+  title: 'UBS Parallel Passage Database',
+  publisher: 'United Bible Societies',
+  copyright: '© 2023 United Bible Societies',
+  license: 'CC BY-SA 4.0',
+  licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
+  sourceUrl: 'https://example.test/ubs',
+  sourcePath: 'parallel passages/ParallelPassages.xml',
+  sourceCommit: 'a'.repeat(40),
+  sourceCommitDate: '2023-07-10',
+  sourceBlob: 'b'.repeat(40),
+  sourceBytes: 100,
+  sourceSha256: 'c'.repeat(64),
+  transformVersion: 1,
+  modified: true,
+  modificationNote: 'References and alignment metadata normalized for local lookup.',
+} as const;
+
+const firstId = `ubs-pp-${'1'.repeat(64)}`;
+const secondId = `ubs-pp-${'2'.repeat(64)}`;
+
+export function ubsFixture(): Record<string, unknown> {
+  const groups: SourceAttestedParallelGroup[] = [
+    {
+      groupId: firstId,
+      sourceOrdinal: 1,
+      label: 'source_attested_parallel',
+      directionality: 'unspecified',
+      members: [
+        {
+          sourceOrder: 1,
+          sourceReference: 'LUK 6:27-28,35',
+          normalizedReference: 'Luke 6:27-28,35',
+          segments: [
+            { bookNumber: 42, chapter: 6, startVerse: 27, endVerse: 28 },
+            { bookNumber: 42, chapter: 6, startVerse: 35, endVerse: 35 },
+          ],
+          languageMarker: 'GRK',
+          alignmentBasis: 'UBSGNT5',
+          alignmentRaw: '012345678',
+        },
+        {
+          sourceOrder: 2,
+          sourceReference: 'MAT 5:44',
+          normalizedReference: 'Matthew 5:44',
+          segments: [{ bookNumber: 40, chapter: 5, startVerse: 44, endVerse: 44 }],
+          languageMarker: 'GRK',
+          alignmentBasis: 'UBSGNT5',
+          alignmentRaw: '222',
+        },
+      ],
+      provenance: { ...fixtureProvenance },
+    },
+    {
+      groupId: secondId,
+      sourceOrdinal: 2,
+      label: 'source_attested_parallel',
+      directionality: 'unspecified',
+      members: [
+        {
+          sourceOrder: 1,
+          sourceReference: 'LUK 6:35-36',
+          normalizedReference: 'Luke 6:35-36',
+          segments: [{ bookNumber: 42, chapter: 6, startVerse: 35, endVerse: 36 }],
+          languageMarker: 'GRK',
+          alignmentBasis: 'UBSGNT5',
+          alignmentRaw: '111',
+        },
+        {
+          sourceOrder: 2,
+          sourceReference: 'LEV 19:18',
+          normalizedReference: 'Leviticus 19:18',
+          segments: [{ bookNumber: 3, chapter: 19, startVerse: 18, endVerse: 18 }],
+          languageMarker: 'HEB',
+          alignmentBasis: 'LXX',
+          alignmentRaw: '222',
+        },
+      ],
+      provenance: { ...fixtureProvenance },
+    },
+  ];
+  return {
+    schemaVersion: 'ubs-parallel-passages.v1',
+    transformVersion: 1,
+    label: 'source_attested_parallel',
+    directionality: 'unspecified',
+    license: { name: 'CC BY-SA 4.0', url: 'https://creativecommons.org/licenses/by-sa/4.0/' },
+    provenance: { ...fixtureProvenance },
+    groups,
+    referenceIndex: {
+      '3:19': [{ groupId: secondId, memberOrder: 2, segmentOrder: 1, startVerse: 18, endVerse: 18 }],
+      '40:5': [{ groupId: firstId, memberOrder: 2, segmentOrder: 1, startVerse: 44, endVerse: 44 }],
+      '42:6': [
+        { groupId: firstId, memberOrder: 1, segmentOrder: 1, startVerse: 27, endVerse: 28 },
+        { groupId: firstId, memberOrder: 1, segmentOrder: 2, startVerse: 35, endVerse: 35 },
+        { groupId: secondId, memberOrder: 1, segmentOrder: 1, startVerse: 35, endVerse: 36 },
+      ],
+    },
+  };
+}

--- a/test/fixtures/ubsParallelCorpus.ts
+++ b/test/fixtures/ubsParallelCorpus.ts
@@ -1,5 +1,9 @@
 import type { SourceAttestedParallelGroup } from '../../src/kernel/sourceAttestedParallels.js';
-import { deriveUbsParallelGroupId, UBS_PARALLEL_PASSAGE_PROVENANCE } from '../../src/kernel/ubsParallelSource.js';
+import {
+  computeUbsParallelArtifactIdentity,
+  deriveUbsParallelGroupId,
+  UBS_PARALLEL_PASSAGE_PROVENANCE,
+} from '../../src/kernel/ubsParallelSource.js';
 
 export const fixtureProvenance = UBS_PARALLEL_PASSAGE_PROVENANCE;
 
@@ -65,9 +69,9 @@ export function ubsFixture(): Record<string, unknown> {
   ];
   for (const group of groups) group.groupId = deriveUbsParallelGroupId(group.members);
   const [firstId, secondId] = groups.map(group => group.groupId);
-  return {
-    schemaVersion: 'ubs-parallel-passages.v1',
-    transformVersion: 1,
+  const projection = {
+    schemaVersion: 'ubs-parallel-passages.v2',
+    transformVersion: 2,
     label: 'source_attested_parallel',
     directionality: 'unspecified',
     license: { name: 'CC BY-SA 4.0', url: 'https://creativecommons.org/licenses/by-sa/4.0/' },
@@ -82,5 +86,16 @@ export function ubsFixture(): Record<string, unknown> {
         { groupId: secondId, memberOrder: 1, segmentOrder: 1, startVerse: 35, endVerse: 36 },
       ],
     },
+  };
+  return {
+    schemaVersion: projection.schemaVersion,
+    transformVersion: projection.transformVersion,
+    artifactIdentity: computeUbsParallelArtifactIdentity(projection),
+    label: projection.label,
+    directionality: projection.directionality,
+    license: projection.license,
+    provenance: projection.provenance,
+    groups: projection.groups,
+    referenceIndex: projection.referenceIndex,
   };
 }

--- a/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
+++ b/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import generatedCorpus from '../../../../src/data/ubs-parallel-passages.generated.json';
+import { UbsParallelPassageRepository } from '../../../../src/adapters/shared/UbsParallelPassageRepository.js';
+import { loadUbsParallelPassageRepository } from '../../../../src/adapters/data/loadUbsParallelPassages.js';
+import { ubsFixture } from '../../../fixtures/ubsParallelCorpus.js';
+
+describe('UbsParallelPassageRepository', () => {
+  it('validates and indexes the complete pinned artifact', () => {
+    const repository = new UbsParallelPassageRepository(generatedCorpus);
+    expect(repository.getProvenance()).toMatchObject({
+      sourceId: 'ubs_paratext_parallel_passages',
+      sourceCommit: 'fd7bcf88b20a1522d3916f437f012c561466fe7b',
+      license: 'CC BY-SA 4.0',
+    });
+    expect(repository.findGroups('Matthew 3:16-17', 1)[0].members.map(member => member.normalizedReference)).toEqual([
+      'Matthew 3:16-17', 'Mark 1:10-11', 'Luke 3:21-22', 'John 1:32',
+    ]);
+    expect(repository.findGroups('2 Kings 18:13', 1)[0].members.map(member => member.normalizedReference)).toEqual([
+      '2 Kings 18:13', '2 Chronicles 32:1', 'Isaiah 36:1',
+    ]);
+    expect(repository.findGroups('Psalm 18:51', 1)[0].members.map(member => member.normalizedReference)).toContain('Psalms 18:51');
+
+    const cases: Array<[string, string[]]> = [
+      ['Matthew 14:20', ['Matthew 14:20', 'Mark 6:42-43', 'Luke 9:17', 'John 6:12-13']],
+      ['Matthew 26:26', ['Matthew 26:26', 'Mark 14:22', 'Luke 22:19', '1 Corinthians 11:23-24']],
+      ['1 Kings 8:27', ['1 Kings 8:27', '2 Chronicles 2:5', '2 Chronicles 6:18']],
+      ['Isaiah 40:3', ['Isaiah 40:3', 'Matthew 3:3', 'Mark 1:3', 'Luke 3:4', 'John 1:23']],
+    ];
+    for (const [reference, members] of cases) {
+      const group = repository.findGroups(reference).find(candidate => members.every(member => candidate.members.some(item => item.normalizedReference === member)));
+      expect(group?.members.map(member => member.normalizedReference)).toEqual(members);
+      expect(group).toMatchObject({ label: 'source_attested_parallel', directionality: 'unspecified' });
+      expect(group).not.toHaveProperty('confidence');
+    }
+    expect(repository.findGroups('Matthew 3:3').length).toBeGreaterThanOrEqual(2);
+    expect(repository.findGroups('Luke 6:35').some(group => group.members.some(member => member.sourceReference.includes(',')))).toBe(true);
+  });
+
+  it('supports exact, overlap, reverse, discontinuous, deduplicated, source-ordered lookup', () => {
+    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const exact = repository.findGroups('Luke 6:35');
+    expect(exact.map(group => group.sourceOrdinal)).toEqual([1, 2]);
+    expect(exact[0].members).toHaveLength(2);
+    expect(repository.findGroups('Luke 6:29-34')).toEqual([]);
+    expect(repository.findGroups('Luke 6:27-28,35').map(group => group.sourceOrdinal)).toEqual([1, 2]);
+    expect(repository.findGroups('Luke 6:28-35').map(group => group.sourceOrdinal)).toEqual([1, 2]);
+    expect(repository.findGroups('Matthew 5:44')[0].groupId).toBe(exact[0].groupId);
+    expect(repository.findGroups('Luke 6', 1).map(group => group.sourceOrdinal)).toEqual([1]);
+    expect(() => repository.findGroups('Luke 6:35', 0)).toThrow('positive safe integer');
+  });
+
+  it('returns immutable complete groups and provenance', () => {
+    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const group = repository.findGroups('Luke 6:35')[0];
+    expect(Object.isFrozen(group)).toBe(true);
+    expect(Object.isFrozen(group.members)).toBe(true);
+    expect(Object.isFrozen(group.members[0].segments)).toBe(true);
+    expect(Object.isFrozen(repository.getProvenance())).toBe(true);
+  });
+
+  it('rejects structural, provenance, alignment, segment, and index drift', () => {
+    const mutate = (apply: (fixture: any) => void): unknown => {
+      const fixture = ubsFixture() as any;
+      apply(fixture);
+      return fixture;
+    };
+    const cases: unknown[] = [
+      mutate(value => { value.unknown = true; }),
+      mutate(value => { value.schemaVersion = 'v2'; }),
+      mutate(value => { value.provenance.sourceId = 'other'; }),
+      mutate(value => { value.groups[0].provenance.sourceSha256 = 'd'.repeat(64); }),
+      mutate(value => { value.groups[0].sourceOrdinal = 2; }),
+      mutate(value => { value.groups[0].members[0].sourceOrder = 2; }),
+      mutate(value => { value.groups[0].members[0].alignmentRaw = '9'; }),
+      mutate(value => { value.groups[0].members[0].alignmentBasis = 'BHS'; }),
+      mutate(value => { value.groups[0].members[0].normalizedReference = 'Luke 6:27-35'; }),
+      mutate(value => { value.groups[0].members[0].sourceReference = 'LUK 6:27-35'; }),
+      mutate(value => { value.groups[0].members[0].segments[0].bookNumber = 67; }),
+      mutate(value => { value.groups[0].members[0].segments[0].chapter = 99; }),
+      mutate(value => { value.referenceIndex['42:6'][0].startVerse = 26; }),
+      mutate(value => { delete value.referenceIndex['40:5']; }),
+      mutate(value => { value.groups.push(structuredClone(value.groups[0])); }),
+    ];
+    for (const artifact of cases) expect(() => new UbsParallelPassageRepository(artifact)).toThrow('[ubs-repository]');
+  });
+
+  it('loads identical bytes through Node and Worker-safe injected paths', () => {
+    const node = loadUbsParallelPassageRepository(new URL('../../../../src/data/ubs-parallel-passages.generated.json', import.meta.url).pathname);
+    const worker = new UbsParallelPassageRepository(generatedCorpus);
+    for (const reference of ['Matthew 3:3', 'Isaiah 40:3', 'Luke 6:35', '2 Kings 18:13']) {
+      expect(node.findGroups(reference).map(group => group.groupId)).toEqual(worker.findGroups(reference).map(group => group.groupId));
+      expect(node.findGroups(reference).map(group => group.provenance)).toEqual(worker.findGroups(reference).map(group => group.provenance));
+    }
+  });
+});

--- a/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
+++ b/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
@@ -75,6 +75,7 @@ describe('UbsParallelPassageRepository', () => {
       mutate(value => { value.groups[0].members[0].alignmentBasis = 'BHS'; }),
       mutate(value => { value.groups[0].members[0].normalizedReference = 'Luke 6:27-35'; }),
       mutate(value => { value.groups[0].members[0].sourceReference = 'LUK 6:27-35'; }),
+      mutate(value => { value.groups[0].members[0].sourceReference += ' '; }),
       mutate(value => { value.groups[0].members[0].segments[0].bookNumber = 67; }),
       mutate(value => { value.groups[0].members[0].segments[0].chapter = 99; }),
       mutate(value => { value.referenceIndex['42:6'][0].startVerse = 26; }),

--- a/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
+++ b/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
@@ -68,10 +68,19 @@ describe('UbsParallelPassageRepository', () => {
       mutate(value => { value.unknown = true; }),
       mutate(value => { value.schemaVersion = 'v2'; }),
       mutate(value => { value.provenance.sourceId = 'other'; }),
+      mutate(value => {
+        value.provenance.sourceCommit = 'd'.repeat(40);
+        value.provenance.sourceUrl = 'https://evil.example/fabricated';
+        for (const group of value.groups) {
+          group.provenance.sourceCommit = 'd'.repeat(40);
+          group.provenance.sourceUrl = 'https://evil.example/fabricated';
+        }
+      }),
       mutate(value => { value.groups[0].provenance.sourceSha256 = 'd'.repeat(64); }),
       mutate(value => { value.groups[0].sourceOrdinal = 2; }),
       mutate(value => { value.groups[0].members[0].sourceOrder = 2; }),
       mutate(value => { value.groups[0].members[0].alignmentRaw = '9'; }),
+      mutate(value => { value.groups[0].members[0].alignmentRaw = '112345678'; }),
       mutate(value => { value.groups[0].members[0].alignmentBasis = 'BHS'; }),
       mutate(value => { value.groups[0].members[0].normalizedReference = 'Luke 6:27-35'; }),
       mutate(value => { value.groups[0].members[0].sourceReference = 'LUK 6:27-35'; }),
@@ -79,6 +88,14 @@ describe('UbsParallelPassageRepository', () => {
       mutate(value => { value.groups[0].members[0].segments[0].bookNumber = 67; }),
       mutate(value => { value.groups[0].members[0].segments[0].chapter = 99; }),
       mutate(value => { value.referenceIndex['42:6'][0].startVerse = 26; }),
+      mutate(value => {
+        const replacement = `ubs-pp-${'d'.repeat(64)}`;
+        const original = value.groups[0].groupId;
+        value.groups[0].groupId = replacement;
+        for (const entries of Object.values(value.referenceIndex) as any[][]) {
+          for (const entry of entries) if (entry.groupId === original) entry.groupId = replacement;
+        }
+      }),
       mutate(value => { delete value.referenceIndex['40:5']; }),
       mutate(value => { value.groups.push(structuredClone(value.groups[0])); }),
     ];

--- a/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
+++ b/test/unit/adapters/shared/UbsParallelPassageRepository.test.ts
@@ -3,8 +3,17 @@ import generatedCorpus from '../../../../src/data/ubs-parallel-passages.generate
 import { UbsParallelPassageRepository } from '../../../../src/adapters/shared/UbsParallelPassageRepository.js';
 import { loadUbsParallelPassageRepository } from '../../../../src/adapters/data/loadUbsParallelPassages.js';
 import { ubsFixture } from '../../../fixtures/ubsParallelCorpus.js';
+import {
+  computeUbsParallelArtifactIdentity,
+  deriveUbsParallelGroupId,
+  UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY,
+} from '../../../../src/kernel/ubsParallelSource.js';
 
 describe('UbsParallelPassageRepository', () => {
+  const fixtureIdentity = (ubsFixture() as { artifactIdentity: string }).artifactIdentity;
+  const fixtureRepository = (artifact = ubsFixture()): UbsParallelPassageRepository =>
+    new UbsParallelPassageRepository(artifact, fixtureIdentity);
+
   it('validates and indexes the complete pinned artifact', () => {
     const repository = new UbsParallelPassageRepository(generatedCorpus);
     expect(repository.getProvenance()).toMatchObject({
@@ -12,6 +21,7 @@ describe('UbsParallelPassageRepository', () => {
       sourceCommit: 'fd7bcf88b20a1522d3916f437f012c561466fe7b',
       license: 'CC BY-SA 4.0',
     });
+    expect(generatedCorpus.artifactIdentity).toBe(UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY);
     expect(repository.findGroups('Matthew 3:16-17', 1)[0].members.map(member => member.normalizedReference)).toEqual([
       'Matthew 3:16-17', 'Mark 1:10-11', 'Luke 3:21-22', 'John 1:32',
     ]);
@@ -36,8 +46,37 @@ describe('UbsParallelPassageRepository', () => {
     expect(repository.findGroups('Luke 6:35').some(group => group.members.some(member => member.sourceReference.includes(',')))).toBe(true);
   });
 
+  it('rejects a fully coordinated but unreviewed artifact rewrite at the pinned root', () => {
+    const artifact = ubsFixture() as any;
+    const member = artifact.groups[0].members[0];
+    member.sourceReference = 'LUK 6:29';
+    member.normalizedReference = 'Luke 6:29';
+    member.segments = [{ bookNumber: 42, chapter: 6, startVerse: 29, endVerse: 29 }];
+    artifact.groups[0].groupId = deriveUbsParallelGroupId(artifact.groups[0].members);
+    artifact.referenceIndex = {};
+    for (const group of artifact.groups) {
+      for (const groupMember of group.members) {
+        groupMember.segments.forEach((segment: any, index: number) => {
+          const key = `${segment.bookNumber}:${segment.chapter}`;
+          (artifact.referenceIndex[key] ??= []).push({
+            groupId: group.groupId,
+            memberOrder: groupMember.sourceOrder,
+            segmentOrder: index + 1,
+            startVerse: segment.startVerse,
+            endVerse: segment.endVerse,
+          });
+        });
+      }
+    }
+    artifact.referenceIndex = Object.fromEntries(Object.entries(artifact.referenceIndex).sort(([a], [b]) => a.localeCompare(b)));
+    const { artifactIdentity: _old, ...projection } = artifact;
+    artifact.artifactIdentity = computeUbsParallelArtifactIdentity(projection);
+    expect(artifact.artifactIdentity).not.toBe(fixtureIdentity);
+    expect(() => fixtureRepository(artifact)).toThrow('artifactIdentity pin');
+  });
+
   it('supports exact, overlap, reverse, discontinuous, deduplicated, source-ordered lookup', () => {
-    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const repository = fixtureRepository();
     const exact = repository.findGroups('Luke 6:35');
     expect(exact.map(group => group.sourceOrdinal)).toEqual([1, 2]);
     expect(exact[0].members).toHaveLength(2);
@@ -50,7 +89,7 @@ describe('UbsParallelPassageRepository', () => {
   });
 
   it('returns immutable complete groups and provenance', () => {
-    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const repository = fixtureRepository();
     const group = repository.findGroups('Luke 6:35')[0];
     expect(Object.isFrozen(group)).toBe(true);
     expect(Object.isFrozen(group.members)).toBe(true);
@@ -99,7 +138,7 @@ describe('UbsParallelPassageRepository', () => {
       mutate(value => { delete value.referenceIndex['40:5']; }),
       mutate(value => { value.groups.push(structuredClone(value.groups[0])); }),
     ];
-    for (const artifact of cases) expect(() => new UbsParallelPassageRepository(artifact)).toThrow('[ubs-repository]');
+    for (const artifact of cases) expect(() => fixtureRepository(artifact as Record<string, unknown>)).toThrow('[ubs-repository]');
   });
 
   it('loads identical bytes through Node and Worker-safe injected paths', () => {

--- a/test/unit/kernel/sha256.test.ts
+++ b/test/unit/kernel/sha256.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { sha256Hex } from '../../../src/kernel/sha256.js';
+
+describe('Worker-safe SHA-256', () => {
+  it.each([
+    ['', 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'],
+    ['abc', 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'],
+    ['The quick brown fox jumps over the lazy dog', 'd7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592'],
+    ['Καὶ Ἑβραϊκά', 'e551529919c06d59e8cfd3b110119fce1d72639fb9429fe93bfdd3a9b4f85872'],
+  ])('matches the published digest for %j', (value, digest) => {
+    expect(sha256Hex(value)).toBe(digest);
+  });
+});

--- a/test/unit/scripts/buildUbsParallelPassages.test.ts
+++ b/test/unit/scripts/buildUbsParallelPassages.test.ts
@@ -7,6 +7,10 @@ import {
   type GeneratedUbsCorpus,
   type SourceMetadata,
 } from '../../../scripts/build-ubs-parallel-passages.js';
+import {
+  computeUbsParallelArtifactIdentity,
+  UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY,
+} from '../../../src/kernel/ubsParallelSource.js';
 
 const sourceDir = new URL('../../../data/parallel-passages/ubs-paratext/', import.meta.url);
 const sourcePath = new URL('ParallelPassages.xml', sourceDir);
@@ -89,6 +93,9 @@ describe('UBS/Paratext deterministic compiler', () => {
     expect(generated.provenance.license).toBe('CC BY-SA 4.0');
     expect(generated.provenance.modified).toBe(true);
     expect(generated.provenance.sourceSha256).toBe(metadata.sourceSha256);
+    expect(generated.artifactIdentity).toBe(UBS_PARALLEL_PASSAGE_ARTIFACT_IDENTITY);
+    const { artifactIdentity, ...identityProjection } = generated;
+    expect(computeUbsParallelArtifactIdentity(identityProjection)).toBe(artifactIdentity);
   });
 
   it('is byte-identical when compiled twice and matches the checked-in artifact', () => {

--- a/test/unit/services/bible/SourceAttestedParallelService.test.ts
+++ b/test/unit/services/bible/SourceAttestedParallelService.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ISourceAttestedParallelRepository } from '../../../../src/kernel/sourceAttestedParallels.js';
+import { UbsParallelPassageRepository } from '../../../../src/adapters/shared/UbsParallelPassageRepository.js';
+import { SourceAttestedParallelService } from '../../../../src/services/bible/SourceAttestedParallelService.js';
+import { ubsFixture } from '../../../fixtures/ubsParallelCorpus.js';
+
+describe('SourceAttestedParallelService', () => {
+  it('normalizes a reference and applies the bounded group default', () => {
+    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const findGroups = vi.spyOn(repository, 'findGroups');
+    const result = new SourceAttestedParallelService(repository).lookup({ reference: 'lk 6:35' });
+    expect(result.reference).toBe('Luke 6:35');
+    expect(result.groups.map(group => group.sourceOrdinal)).toEqual([1, 2]);
+    expect(findGroups).toHaveBeenCalledWith('Luke 6:35', 5);
+  });
+
+  it('passes an explicit limit without flattening or changing source evidence', () => {
+    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const result = new SourceAttestedParallelService(repository).lookup({ reference: 'Luke 6:35', maxGroups: 1 });
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({ label: 'source_attested_parallel', directionality: 'unspecified' });
+    expect(result.groups[0].members.map(member => member.normalizedReference)).toEqual(['Luke 6:27-28,35', 'Matthew 5:44']);
+    expect(result.groups[0]).not.toHaveProperty('confidence');
+    expect(result.groups[0]).not.toHaveProperty('relationship');
+  });
+
+  it.each([0, 11, 1.5, Number.NaN])('rejects invalid maxGroups %s before repository lookup', maxGroups => {
+    const repository: ISourceAttestedParallelRepository = {
+      findGroups: vi.fn(),
+      getProvenance: vi.fn(),
+    };
+    expect(() => new SourceAttestedParallelService(repository).lookup({ reference: 'John 1:1', maxGroups })).toThrow('1 to 10');
+    expect(repository.findGroups).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/services/bible/SourceAttestedParallelService.test.ts
+++ b/test/unit/services/bible/SourceAttestedParallelService.test.ts
@@ -32,4 +32,13 @@ describe('SourceAttestedParallelService', () => {
     expect(() => new SourceAttestedParallelService(repository).lookup({ reference: 'John 1:1', maxGroups })).toThrow('1 to 10');
     expect(repository.findGroups).not.toHaveBeenCalled();
   });
+
+  it('returns a typed validation error for an invalid reference', () => {
+    const repository: ISourceAttestedParallelRepository = {
+      findGroups: vi.fn(),
+      getProvenance: vi.fn(),
+    };
+    expect(() => new SourceAttestedParallelService(repository).lookup({ reference: 'not a passage' })).toThrow('reference must identify');
+    expect(repository.findGroups).not.toHaveBeenCalled();
+  });
 });

--- a/test/unit/services/bible/SourceAttestedParallelService.test.ts
+++ b/test/unit/services/bible/SourceAttestedParallelService.test.ts
@@ -5,8 +5,12 @@ import { SourceAttestedParallelService } from '../../../../src/services/bible/So
 import { ubsFixture } from '../../../fixtures/ubsParallelCorpus.js';
 
 describe('SourceAttestedParallelService', () => {
+  const fixtureRepository = (): UbsParallelPassageRepository => {
+    const artifact = ubsFixture();
+    return new UbsParallelPassageRepository(artifact, (artifact as { artifactIdentity: string }).artifactIdentity);
+  };
   it('normalizes a reference and applies the bounded group default', () => {
-    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const repository = fixtureRepository();
     const findGroups = vi.spyOn(repository, 'findGroups');
     const result = new SourceAttestedParallelService(repository).lookup({ reference: 'lk 6:35' });
     expect(result.reference).toBe('Luke 6:35');
@@ -15,7 +19,7 @@ describe('SourceAttestedParallelService', () => {
   });
 
   it('passes an explicit limit without flattening or changing source evidence', () => {
-    const repository = new UbsParallelPassageRepository(ubsFixture());
+    const repository = fixtureRepository();
     const result = new SourceAttestedParallelService(repository).lookup({ reference: 'Luke 6:35', maxGroups: 1 });
     expect(result.groups).toHaveLength(1);
     expect(result.groups[0]).toMatchObject({ label: 'source_attested_parallel', directionality: 'unspecified' });


### PR DESCRIPTION
## Summary

Adds the reviewed UBS/Paratext source-attested parallel-passage foundation: strict runtime-neutral domain contracts, canonical/source-versification reference parsing, independently pinned provenance and artifact identity, deterministic SHA-256 support, the generated artifact loader/repository, an internal lookup service, and corruption-focused tests.

This is the first PR in a two-PR stack. It targets `agent/d1-materialization-identity` (PR #15 head) and intentionally stops at commit `668b23d`, before normalized D1 runtime work.

## Rights and provenance

- Source: United Bible Societies Paratext parallel-passage dataset at the pinned upstream commit/blob recorded in `data/parallel-passages/ubs-paratext/SOURCE.json`.
- License: CC BY-SA 4.0, with source URL, commit, blob, byte count, and SHA-256 retained in the reviewed artifact provenance.
- The generated artifact identity is independently pinned and recomputed during validation; drifted source locators, provenance, bytes, or semantic content are rejected.

## Public behavior

This foundation is internal only. It does not register or alter an MCP tool, resource, prompt, schema, structured output, Markdown response, default, or guided workflow. The existing public `parallel_passages` behavior remains unchanged.

## Verification

- Strict whole-artifact validation and identity/provenance derivation tests.
- Source-reference, normalized-reference, versification, alignment, group-ID, and corruption tests.
- Typed validation behavior and Node file-loader coverage.
- Full repository test/type/build gates passed in the stacked implementation worktree.

## Stack and merge sequencing

1. Review and merge this PR after its base PR (`agent/d1-materialization-identity`) is merged/retargeted as appropriate.
2. PR B (`agent/ubs-d1-runtime`) targets this branch and contains only commits `2babb3b` and `b7ede39`.
3. After this PR merges, retarget PR B to the branch that contains this foundation (normally the updated main branch) and verify that PR B still shows exactly those two commits.

No preview-deployment label should be added from this PR. It performs no remote D1 operation or deployment.
