### PR TITLE
docs: record Phase 3 production release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Corrected
 
-- Reconciled the pending public contract at version 3.6.0: eleven tools, five
+- Reconciled the public contract at version 3.6.0: eleven tools, five
   prompts, 17 local historical documents, and transport-specific Logging.
 - Scoped D1 readiness to both schema and materialization identity. Remote D1
-  marker transitions, preview deployment, and production deployment remain
-  separate operational gates and are not performed by these code changes.
+  preparation and preview/production deployment remained separate operational
+  gates and were performed only through their authorized release workflows.
 - Removed public CCEL document-body retrieval and reconciled both historical
   tools with the currently local-only provider contract. Defensive external
   discovery architecture remains inactive for a separately reviewed future rollout.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,23 +17,28 @@ is local source context only and does not define the current product contract.
 - **UBS compiler / PR #13:** pinned UBS/Paratext source, license and provenance,
   deterministic compiler, generated-artifact verifier, and regression tests,
   merged as `4e02564531351f4a2de61d95dcebfd0dfd06d404`.
+- **Phase 3 research foundations / PR #21:** bounded inactive CCEL provider
+  architecture, D1 materialization identity, exact Strong's identities, local
+  primary-source research, normalized UBS runtime and public cutover, and
+  contextual original-language study, merged as
+  `639d0a02c1c666340f0e2ee3bcb4b4d5a336d9fb`.
 
 These entries describe merged repository state. Deployment state is established
 only by the relevant protected workflow and post-deployment smoke evidence; a
 merge or this roadmap is not evidence that preview or production was deployed.
 
-## Current Phase 3 release train
+## Shipped Phase 3 release train
 
-The following slices are implemented in the integration candidate and remain
-subject to their stacked PR reviews, CI, operational gates, and merge order:
+The following component slices were integrated, reviewed, and shipped through
+PR #21. Their stacked PRs #14–#20 are closed as superseded review vehicles:
 
 1. **PR #14 — bounded CCEL search adapter.** Defensive live-search transport,
    rights notices, budgets, caching, circuit behavior, and feature gates. The
    adapter is retained as inactive future-provider architecture and is not
    advertised or reachable through the current public MCP schemas.
 2. **PR #15 — D1 materialization identity.** Distinguishes schema compatibility
-   from the exact materialized corpus. A production marker transition is a
-   separately authorized data operation, not a side effect of merge or deploy.
+   from the exact materialized corpus. Production was cut over to a freshly
+   materialized replacement rather than mutating the predecessor database.
 3. **PR #16 — exact Strong's identities.** Preserves canonical and extended
    OpenScriptures/STEPBible identifiers without lossy four-digit coercion.
 4. **PR #17 — local primary-source research.** Adds the bounded
@@ -47,14 +52,18 @@ subject to their stacked PR reviews, CI, operational gates, and merge order:
    unconditional default, with bounded structured output. Legacy curated edges
    and OpenBible.info evidence remain available only through explicit separate
    selectors; raw UBS alignment is opt-in.
-8. **Integrated language-study slice.** Adds `original_language_study`, a
+8. **Integrated language-study slice.** Added `original_language_study`, a
    context-first workflow for one token in one verse, with morphology,
-   source-separated lexical evidence, provenance, and interpretive limits. It
-   must receive its own reviewable publication path before release.
+   source-separated lexical evidence, provenance, and interpretive limits.
 
-The integration candidate advertises eleven tools and structured output for
+The released server advertises eleven tools and structured output for
 `bible_lookup`, `parallel_passages`, `original_language_lookup`, and
 `original_language_study`. Markdown remains available for compatibility.
+
+Protected production workflow run `29257538930` deployed the PR #21 merge after
+the exact-corpus readiness gate passed. The post-deployment production audit
+passed all 84 checks. Live CCEL discovery remains intentionally disabled and is
+not part of the public MCP contract.
 
 ## Release gates
 
@@ -74,17 +83,16 @@ Code readiness and operational readiness are deliberately separate:
    structured-output contracts, UBS default and explicit-source behavior,
    Strong's extended identities, local primary-source search, language study,
    resources, prompts, and failure/privacy boundaries.
-6. Production D1 marker changes require explicit owner authorization, a
+6. Production D1 corpus changes require explicit owner authorization and a
+   compatible replacement or reviewed incremental migration. A metadata-only
+   transition is valid only when materialized rows are unchanged; it must use a
    conditional one-row update, immediate read-only readiness verification, and
    a prepared conditional rollback.
 7. Production merge/deployment occurs only after the integrated Sol review,
    green required checks, successful preview audit, and protected production
    approval. Production then receives the same bounded smoke audit.
 
-No current roadmap statement claims that the pending D1 transition, preview
-deployment, production deployment, or any live CCEL enablement has happened.
-
-## Next work after this train
+## Next work
 
 - Expand primary-source discovery beyond the initial local collection through
   rights-reviewed, freely redistributable editions and provider adapters. Do

--- a/docs/UBS-D1-INTERNAL-RUNTIME.md
+++ b/docs/UBS-D1-INTERNAL-RUNTIME.md
@@ -1,10 +1,13 @@
 # UBS normalized D1 internal runtime
 
-This slice materializes the reviewed UBS/Paratext v2 generated artifact into D1
-for Worker runtime use. It is internal plumbing only: it does not change the
-`parallel_passages` tool, MCP resources, prompts, schemas, structured output,
-Markdown, defaults, or guided workflows. A later public hard-cutover requires a
-separate product contract and release review.
+> **Historical slice record.** This document describes the internal PR #19
+> foundation and its point-in-time rollout evidence. The later public hard
+> cutover shipped through PR #21 and is now the production default.
+
+This slice materialized the reviewed UBS/Paratext v2 generated artifact into D1
+for Worker runtime use. In isolation it did not change the `parallel_passages`
+public contract; PR #21 subsequently supplied and released that separately
+reviewed contract.
 
 ## Storage and identity
 
@@ -72,10 +75,13 @@ The preview dry bundle contained 404 inputs, measured 2,307,852 raw
 bytes / 427,709 gzip bytes, and its esbuild metadata contained no UBS generated
 JSON input.
 
-## Preview replacement runbook and prepared candidate
+## Historical preview replacement runbook and preparation evidence
 
-The currently deployed preview database lacks migration 0002 and the normalized
-rows, so a metadata-only marker update is invalid. When separately authorized:
+At the start of this slice, the deployed preview database lacked migration 0002
+and the normalized rows, so a metadata-only marker update was invalid. The
+authorized candidate preparation followed steps 1–5. Steps 6–7 recorded the
+intended deployment and rollback sequence but were not performed for candidate
+`theologai-preview-20260712-a`:
 
 1. Inventory the currently bound preview database and retain it for rollback.
 2. Create a uniquely named empty preview replacement in the same jurisdiction;
@@ -92,15 +98,13 @@ rows, so a metadata-only marker update is invalid. When separately authorized:
    revision. Do not weaken the readiness gate or delete either database during
    the verification window.
 
-No command in this document authorizes remote creation, migration, import,
-binding change, deployment, or deletion. Production requires its own later
-authorization and replacement plan.
+No command in this historical record independently authorizes a future remote
+creation, migration, import, binding change, deployment, or deletion.
 
 The separately authorized preparation was completed on 2026-07-12 for
 `theologai-preview-20260712-a` in the same `ENAM` location and unrestricted
 jurisdiction as the retained rollback database
 `theologai-preview-20260710-c`. Both migrations and all 29 ordered seed files
-completed, and the strict remote readiness gate returned `ready`. The local
-preview binding now names the prepared candidate for review, but no Worker was
-deployed by this preparation step. The old database remains the deployed
-preview binding and rollback target until an approved preview deployment.
+completed, and the strict remote readiness gate returned `ready`. That candidate
+was later superseded by the transform-version-3 preview database documented in
+`docs/worker-operations.md`; this paragraph is not current binding evidence.

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -1,11 +1,11 @@
 # Worker operations
 
-## Deployment baseline and rollback posture (2026-07-12)
+## Deployment baseline and rollback posture (2026-07-13)
 
-PR #10 (`71a3f0d`) is the current production application baseline. Production
-deployed successfully after a read-only D1 readiness result of `ready`.
-Preview runs the Phase 3 PR #21 application from `446a9eb` against the prepared
-schema-0002, transform-version-3 database described below.
+PR #21 (`639d0a0`) is the current production application baseline. Protected
+workflow run `29257538930` deployed it after a read-only D1 readiness result of
+`ready`. Preview runs the final PR #21 head `247b280` against the schema-0002,
+transform-version-3 database described below.
 
 The deployed logical D1 bindings and retained rollback posture are recorded
 below as point-in-time evidence. Cloudflare deployment history and the approved
@@ -16,10 +16,10 @@ binding.
 
 | Environment | Active logical database | Current posture | Rollback posture |
 |---|---|---|---|
-| Production | `theologai-production-20260711-a` | PR #10 merge remains deployed while the Phase 3 production candidate below is reviewed. | The deployed Worker and this database are the retained matched rollback pair. Do not mix this database with Phase 3 code or delete it during the release window. |
-| Preview | `theologai-preview-20260712-b` | Phase 3 PR #21 head `173a6a4` deployed successfully by GitHub Actions run `29221227777` after the read-only readiness gate passed. | `theologai-preview-20260712-a` and `theologai-preview-20260710-c` are retained candidates only. Candidate `-a` predates transform version 3; candidate `-c` belongs to the earlier PR #10 deployment. Verify the retained Worker/config pair and run its exact readiness contract before either is used. |
+| Production | `theologai-production-20260713-a` | PR #21 merge `639d0a0` deployed successfully by GitHub Actions run `29257538930`; deployment `2a9dbaf4-3fa9-431a-b8ba-265f0809e2c2` serves Worker version `2e55ef40-d450-4978-adf6-9fc28c349e61`. | Retain Worker version `c291ca9f-bb1b-4e6e-abd5-d6a3ea4f0704` with `theologai-production-20260711-a` as the predecessor matched pair. Do not mix that database with Phase 3 code or delete it during the observation window. |
+| Preview | `theologai-preview-20260712-b` | Final PR #21 head `247b280` deployed successfully by GitHub Actions run `29256660848`; deployment `d28d1d73` serves Worker version `3c8ad7ef-50ed-42a7-9c71-2ac8c2dd6d7f`. | `theologai-preview-20260712-a` and `theologai-preview-20260710-c` are retained candidates only. Candidate `-a` predates transform version 3; candidate `-c` belongs to the earlier PR #10 deployment. Verify the retained Worker/config pair and run its exact readiness contract before either is used. |
 
-### Prepared Phase 3 production candidate (not deployed)
+### Active Phase 3 production database
 
 On 2026-07-13, `theologai-production-20260713-a` was created in Eastern North
 America (`ENAM`) with no jurisdiction restriction, migrated through
@@ -30,11 +30,11 @@ scoped materialization identity
 Its database ID is recorded only in the reviewable top-level binding in
 `wrangler.toml`.
 
-The strict remote readiness gate returned `ready` against the candidate before
-this binding change was committed. Updating `wrangler.toml` prepares the matched
-Phase 3 code/config release; it does not change the deployed production Worker. The
-existing PR #10 Worker and `theologai-production-20260711-a` remain active and
-must be retained together until the protected main-branch deployment succeeds.
+The strict remote readiness gate returned `ready` before the binding change was
+committed and again in protected production workflow run `29257538930`. That
+workflow deployed the matched PR #21 code and configuration. The independent
+post-deployment audit passed all 84 checks. Retain the predecessor PR #10 Worker
+and `theologai-production-20260711-a` together during the observation window.
 
 ### Active Phase 3 preview database
 
@@ -53,15 +53,15 @@ materialization identity
 Hebrew morphology transform version 3, the Genesis 1:1 Hebrew lemma sentinel,
 `quick_check = ok`, and zero foreign-key violations.
 
-GitHub Actions run `29220658995` subsequently rechecked live authorization and
-the remote readiness contract, then deployed PR #21 head `446a9eb` with this
-database bound to preview. Retain both earlier candidates during the verification
-window, but do not describe either as ready for this head without its own matched
+GitHub Actions run `29256660848` rechecked live authorization and the remote
+readiness contract, then deployed final PR #21 head `247b280` with this database
+bound to preview. Retain both earlier candidates during the verification window,
+but do not describe either as ready for this head without its own matched
 compatibility proof. Do not delete any retained database as part of deployment.
 
 ### Hebrew-lemma materialization follow-up
 
-The prepared `theologai-preview-20260712-b` candidate includes deterministic
+The active `theologai-preview-20260712-b` database includes deterministic
 Hebrew lemma population and passed the transform-version-3 readiness gate. The
 earlier `theologai-preview-20260712-a` candidate predates those materialized row
 changes and must not be marker-updated or rebound to an application revision


### PR DESCRIPTION
## Summary

- records PR #21 as the shipped Phase 3 production baseline
- replaces stale production and preview candidate language with verified deployment evidence
- preserves the UBS D1 document as an explicitly historical slice record
- corrects the changelog to describe the released 3.6.0 contract

## Why

PR #21 merged and deployed successfully, but the tracked roadmap and operations documents still described it as a pending candidate. That could mislead future release or rollback decisions. The update also clarifies that row-changing D1 corpus revisions require a replacement or reviewed migration; metadata-only transitions are safe only when the materialized rows are unchanged.

## Impact

Documentation only. There are no Worker, D1, binding, schema, data, or runtime changes, and this PR does not authorize a deployment or database cleanup.

## Verification

- independent release-documentation review: approved after two accuracy repairs
- `npm run docs:check` under Node 22.23.1: 5/5 passed
- `git diff --check`
