### PR TITLE
feat: add primary-source evidence handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- theologai-public-contract tools=11 structured=bible_lookup,original_language_lookup,original_language_study,parallel_passages -->
+<!-- theologai-public-contract tools=11 structured=bible_lookup,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
 
 ### Added
 
 - Added stable MCP 2025-11-25 structured output and server-side schema
   validation for `bible_lookup`, `parallel_passages`,
-  `original_language_lookup`, and `original_language_study`, while keeping
+  `primary_source_search`, `original_language_lookup`, and
+  `original_language_study`, while keeping
   their Markdown content available for legacy clients.
 - Added bounded, result-local provenance records and structured-first guidance
   to the word-study, passage-exegesis, and compare-translations prompts.
@@ -21,8 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hard default to complete UBS source-attested groups. Legacy curated edges and
   OpenBible.info rows remain available only through explicit, separate selectors.
 - Added `primary_source_search`, an explicit, bounded local research-plan tool.
-  The public schema returns snippets and resolvable local section locators and
-  does not advertise or invoke inactive CCEL provider adapters.
+  Its versioned structured output keeps query/provider grouping and evidence
+  policy, while native resource links resolve selected canonical local sections
+  with exact byte sizes. It does not advertise or invoke inactive CCEL adapters.
+- Added the local-only `primary-source-research` prompt for bounded topic surveys
+  or exact-work searches followed by explicit MCP section reads.
 - Added `original_language_study`, a context-first study of one verse token that
   combines morphology and source-separated lexical evidence while stating its
   interpretive limits.
@@ -36,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Corrected
 
-- Reconciled the pending public contract at version 3.6.0: eleven tools, five
+- Reconciled the pending public contract at version 3.6.0: eleven tools, six
   prompts, 17 local historical documents, and transport-specific Logging.
 - Scoped D1 readiness to both schema and materialization identity. Remote D1
   marker transitions, preview deployment, and production deployment remain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
 # TheologAI — Development Guide
 
-Production MCP server for theological research. Eleven tools, five prompts, eight Bible translations, six commentaries, 17 historical documents, Greek/Hebrew language tools, and on-chain donation support. Tools, resources, and prompts are available on every transport; MCP Logging is stdio-only because HTTP is stateless.
+Production MCP server for theological research. Eleven tools, six prompts, eight Bible translations, six commentaries, 17 historical documents, Greek/Hebrew language tools, and on-chain donation support. Tools, resources, and prompts are available on every transport; MCP Logging is stdio-only because HTTP is stateless.
 
-<!-- theologai-public-contract tools=11 structured=bible_lookup,original_language_lookup,original_language_study,parallel_passages -->
+<!-- theologai-public-contract tools=11 structured=bible_lookup,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
 
 ## Quick Start
 
@@ -120,6 +120,7 @@ These prompts provide structured research methodologies. **Auto-trigger**: when 
 | `passage-exegesis` | `/mcp__theologai__passage-exegesis` | Exegete a passage, do deep analysis of verses, or study a text systematically |
 | `compare-translations` | `/mcp__theologai__compare-translations` | Compare how different translations render a passage, or explore translation differences |
 | `confession-study` | `/mcp__theologai__confession-study` | Compare doctrines across creeds, confessions, and catechisms from different traditions |
+| `primary-source-research` | `/mcp__theologai__primary-source-research` | Survey a topic or search one exact local work, then read selected exact sections as evidence |
 | `donate` | `/mcp__theologai__donate` | Donate, support the project, contribute financially, or ask about donations |
 
 When a user asks "what can you do?" or seems unsure how to proceed, mention these workflows as available research modes.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 TheologAI is an MCP server for Bible study and theological research. It runs
 locally over stdio or Streamable HTTP and on Cloudflare Workers with D1.
 
-The current registry contains eleven tools, five guided prompts, eight English
+The current registry contains eleven tools, six guided prompts, eight English
 Bible translations, six commentary sources, 17 locally indexed
 historical documents, Strong's dictionaries, and Greek/Hebrew morphology.
 
-<!-- theologai-public-contract tools=11 structured=bible_lookup,original_language_lookup,original_language_study,parallel_passages -->
+<!-- theologai-public-contract tools=11 structured=bible_lookup,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
 
 ## Remote endpoint
 
@@ -41,7 +41,7 @@ fresh server and transport.
 | `parallel_passages` | Return complete UBS source-attested parallel groups by default; legacy curated edges and OpenBible.info cross references require explicit selectors and remain separate. |
 | `commentary_lookup` | Retrieve Matthew Henry, JFB, Adam Clarke, John Gill, Keil-Delitzsch (OT), or Tyndale notes. |
 | `classic_text_lookup` | Search and browse the 17 locally indexed historical documents. Remote CCEL document bodies are not retrieved or republished. |
-| `primary_source_search` | Execute a bounded, explicit query plan against the local historical index. Returns snippets and exact local section locators, not document bodies. |
+| `primary_source_search` | Execute a bounded local query plan with versioned structured results and native links to exact section resources. Snippets remain discovery-only. |
 | `original_language_lookup` | Look up a Strong's entry or search for matching Greek/Hebrew entries. |
 | `bible_verse_morphology` | Return word-by-word morphology for a specific verse. |
 | `original_language_study` | Resolve and study one Greek or Hebrew token in one verse with contextual morphology, source-separated lexical evidence, and explicit interpretive limits. |
@@ -60,11 +60,15 @@ and conflicting old/new values are rejected.
 
 All tools are annotated as read-only, non-destructive, and idempotent. Tool
 inputs use closed, bounded JSON Schema 2020-12 contracts. `bible_lookup`,
-`parallel_passages`, `original_language_lookup`, and `original_language_study`
+`parallel_passages`, `primary_source_search`, `original_language_lookup`, and `original_language_study`
 also advertise versioned object-root `outputSchema`
 contracts and return matching `structuredContent` beside the existing Markdown
-content. Their structured results include bounded, result-local provenance
-records; all other tools retain their current Markdown-only result contract.
+content. Bible, parallel-passage, and original-language structured results
+include bounded, result-local provenance records. Primary-source results do not
+invent edition provenance records: their evidence policy explicitly marks
+edition provenance incomplete, and they link only canonical local sections with
+exact UTF-8 sizes. All other tools retain their current Markdown-only result
+contract.
 
 ### Resources
 
@@ -83,6 +87,7 @@ records; all other tools retain their current Markdown-only result contract.
 | `passage-exegesis` | Text, language, cross references, commentary, and historical theology. |
 | `compare-translations` | Compare translation choices against morphology and lexical data. |
 | `confession-study` | Compare a doctrine across the locally indexed historical collection. |
+| `primary-source-research` | Survey a topic or search one exact local work, then read selected exact sections as evidence. |
 | `donate` | Explain voluntary donation options. |
 
 ## Content scope and provenance
@@ -114,6 +119,12 @@ CCEL discovery adapters remain in the codebase as future provider architecture,
 but they are not advertised by the MCP schemas or reachable through the public
 tool registry. Any future external provider rollout must remain discovery-only
 until edition-specific rights and provider-policy gates are satisfied.
+
+Local search metadata identifies the cataloged work type and date when known;
+it does not establish an author, edition, transcription provenance, publication
+date, or rights status. Search snippets are discovery aids. Quote or analyze a
+selected passage only after reading its exact `theologai://documents/...#section-...`
+resource. The collection and every response are bounded and non-exhaustive.
 
 ### Language and reference data
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,8 +53,9 @@ subject to their stacked PR reviews, CI, operational gates, and merge order:
    must receive its own reviewable publication path before release.
 
 The integration candidate advertises eleven tools and structured output for
-`bible_lookup`, `parallel_passages`, `original_language_lookup`, and
-`original_language_study`. Markdown remains available for compatibility.
+`bible_lookup`, `parallel_passages`, `primary_source_search`,
+`original_language_lookup`, and `original_language_study`. Markdown remains
+available for compatibility.
 
 ## Release gates
 
@@ -70,10 +71,10 @@ Code readiness and operational readiness are deliberately separate:
 4. Preview deployment requires the repository's authorization label and
    protected environment approval. The live PR must still be open, non-draft,
    and authorized immediately before deployment.
-5. Preview smoke and a functional audit must cover all eleven tools, the four
+5. Preview smoke and a functional audit must cover all eleven tools, the five
    structured-output contracts, UBS default and explicit-source behavior,
    Strong's extended identities, local primary-source search, language study,
-   resources, prompts, and failure/privacy boundaries.
+   resources, all six prompts, and failure/privacy boundaries.
 6. Production D1 marker changes require explicit owner authorization, a
    conditional one-row update, immediate read-only readiness verification, and
    a prepared conditional rollback.

--- a/src/adapters/commentary/CcelSearchAdapter.ts
+++ b/src/adapters/commentary/CcelSearchAdapter.ts
@@ -305,7 +305,16 @@ function countCharacters(value: string): number {
 }
 
 function cloneResult(result: PrimarySourceProviderResult): PrimarySourceProviderResult {
-  return { ...result, hits: result.hits.map(hit => ({ ...hit, locator: { ...hit.locator } })), notices: [...result.notices] };
+  return {
+    ...result,
+    hits: result.hits.map(cloneHit),
+    notices: [...result.notices],
+  };
+}
+
+function cloneHit(hit: PrimarySourceSearchHit): PrimarySourceSearchHit {
+  if (hit.provider === 'local') return { ...hit, locator: { ...hit.locator } };
+  return { ...hit, locator: { ...hit.locator } };
 }
 
 function resultFor(

--- a/src/formatters/historicalFormatter.ts
+++ b/src/formatters/historicalFormatter.ts
@@ -10,6 +10,24 @@ export const LOCAL_HISTORICAL_SOURCE = LOCAL_PRIMARY_SOURCE_ATTRIBUTION;
 
 const localSource = `*Source: ${LOCAL_HISTORICAL_SOURCE}*`;
 
+/** Canonical exact-section representation shared by resources/read and link sizing. */
+export function formatLocalDocumentSectionResource(doc: DocumentInfo, section: DocumentSection): string {
+  const heading = section.title
+    ? `## ${section.section_number ? `${section.section_number}. ` : ''}${section.title}`
+    : section.section_number ? `## Section ${section.section_number}` : '## Selected section';
+  return [
+    `# ${doc.title}\n`,
+    `**Type:** ${doc.type}`,
+    doc.date ? `**Date:** ${doc.date}` : '',
+    '',
+    heading,
+    '',
+    section.content,
+    '',
+    localSource,
+  ].filter(Boolean).join('\n');
+}
+
 /** Format a document listing */
 export function formatDocumentList(docs: DocumentInfo[]): string {
   let s = `**Available Historical Documents** (${docs.length})\n\n`;

--- a/src/formatters/primarySourceFormatter.ts
+++ b/src/formatters/primarySourceFormatter.ts
@@ -1,8 +1,6 @@
-import type { PrimarySourceSearchPlanResult } from '../services/historical/primarySourceTypes.js';
-import { buildLocalDocumentResourceUri } from '../kernel/documentResource.js';
-import { normalizeCcelSectionLocator } from '../adapters/commentary/CcelSearchAdapter.js';
+import type { PresentedPrimarySourceSearch } from '../presenters/primarySourceSearchStructured.js';
 
-export function formatPrimarySourceSearch(result: PrimarySourceSearchPlanResult): string {
+export function formatPrimarySourceSearch(result: PresentedPrimarySourceSearch): string {
   const lines = [
     '# Primary-source discovery',
     '',
@@ -32,7 +30,12 @@ export function formatPrimarySourceSearch(result: PrimarySourceSearchPlanResult)
   lines.push(`- Local: ${result.coverage.localStatus ?? 'not requested'}; ${result.coverage.localHitCount} returned hits`);
   lines.push(`- CCEL: ${result.coverage.ccelStatus ?? 'not requested'}; ${result.coverage.ccelHitCount} returned hits`);
   for (const notice of result.coverage.notices) lines.push(`- ${safe(notice)}`);
-  lines.push('', '_Results are bounded discovery evidence, not an exhaustive catalog. Missing hits do not establish historical silence._');
+  lines.push(
+    '',
+    '_Evidence policy: snippets are discovery aids only. Read a selected exact MCP section resource before quotation or substantive conclusions._',
+    '_Results are bounded discovery evidence, not an exhaustive catalog; missing hits do not establish historical silence._',
+    '_Edition provenance is incomplete. Catalog type/date describe the work; this server does not claim a reviewed author, edition, transcription provenance, or rights status where none is supplied._',
+  );
   return lines.join('\n').trim();
 }
 
@@ -45,15 +48,6 @@ function safe(value: string): string {
     .replace(/[\\`*_{}\[\]()<>#+.!|>-]/g, character => `\\${character}`);
 }
 
-function formatLocator(locator: PrimarySourceSearchPlanResult['queries'][number]['providers'][number]['hits'][number]['locator']): string {
-  if (locator.kind === 'local_section') {
-    const canonical = buildLocalDocumentResourceUri(locator.documentId, locator.sectionId);
-    if (canonical && locator.url === canonical) return `[exact section](${canonical})`;
-  } else {
-    const normalized = normalizeCcelSectionLocator(locator.url);
-    if (normalized && normalized.work === locator.work && normalized.section === locator.section) {
-      return `[exact section](${normalized.url})`;
-    }
-  }
-  return safe(locator.url);
+function formatLocator(locator: PresentedPrimarySourceSearch['queries'][number]['providers'][number]['hits'][number]['locator']): string {
+  return `[exact section](${locator.url})`;
 }

--- a/src/kernel/errors.ts
+++ b/src/kernel/errors.ts
@@ -140,7 +140,7 @@ function containsImplementationDetail(message: string): boolean {
 }
 
 /** Format an error as an MCP tool error response */
-export function handleToolError(error: Error) {
+export function handleToolError(error: Error): import('./types.js').ToolResult {
   return {
     content: [{ type: 'text' as const, text: getUserMessage(error) }],
     isError: true,

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -6,7 +6,7 @@
  *   - Removed unimplemented params (includeCrossRefs, include_cross_references)
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ContentBlock, TextContent, Tool } from '@modelcontextprotocol/sdk/types.js';
 
 // ── Tool infrastructure ──
 
@@ -19,11 +19,10 @@ export interface ToolHandler {
   handler: (params: Record<string, unknown>) => Promise<ToolResult>;
 }
 
-export interface ToolResult {
-  content: Array<{ type: 'text'; text: string }>;
-  structuredContent?: Record<string, unknown>;
-  isError?: boolean;
-}
+export type ToolResult = Omit<CallToolResult, 'content'> & {
+  /** Legacy Markdown is always first; later blocks may use the native MCP union. */
+  content: [TextContent, ...ContentBlock[]];
+};
 
 // ── Bible types ──
 

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -95,6 +95,27 @@ export function recommendedToolCallsForPrompt(
         { tool: 'classic_text_lookup', arguments: { query: topic } },
       ];
     }
+    case 'primary-source-research': {
+      const topic = args?.topic?.trim() ?? '';
+      const work = args?.work?.trim();
+      const requestedLimit = Number(args?.maxSections?.trim() || '3');
+      const limit = Number.isSafeInteger(requestedLimit) && requestedLimit >= 1 && requestedLimit <= 5
+        ? requestedLimit
+        : 3;
+      return [{
+        tool: 'primary_source_search',
+        arguments: {
+          queries: [{
+            id: work ? 'exact-local-work' : 'topic-survey',
+            text: topic,
+            providers: ['local'],
+            match: 'all_terms',
+            ...(work ? { work } : {}),
+            limit,
+          }],
+        },
+      }];
+    }
     case 'donate':
       return [{ tool: 'donation_config', arguments: {} }];
     default:
@@ -140,6 +161,15 @@ export function registerPromptHandlers(server: Server): void {
         arguments: [
           { name: 'topic', description: 'The doctrine or topic to compare', required: true },
           { name: 'traditions', description: 'Comma-separated traditions to focus on', required: false },
+        ],
+      },
+      {
+        name: 'primary-source-research',
+        description: 'Find and read bounded evidence from the locally indexed historical collection',
+        arguments: [
+          { name: 'topic', description: 'Topic or terms to find in the local historical collection', required: true },
+          { name: 'work', description: 'Optional exact local work title or slug; not an author name', required: false },
+          { name: 'maxSections', description: 'Maximum selected sections as a string integer from 1 to 5. Default: 3.', required: false },
         ],
       },
       { name: 'donate', description: 'Guide for donating to support TheologAI development', arguments: [] },
@@ -215,6 +245,20 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
 3. **Read sections** — Browse the relevant documents.
 4. **Biblical foundations** — Use \`bible_lookup\` and \`bible_cross_references\` for passages identified in the documents.
 5. **Compare** — Explain agreement, divergence, Scripture use, and historical context.`;
+        break;
+      }
+      case 'primary-source-research': {
+        const topic = args?.topic ?? '';
+        const work = args?.work?.trim();
+        text = `Research primary-source evidence about "${topic}"${work ? ` within the exact local work "${work}"` : ' across the locally indexed collection'}.
+
+1. **Run bounded discovery** — ${callText(calls[0])}. This workflow is local-only: do not claim it searched CCEL, the web, an exhaustive catalog, or works outside the server's collection.
+2. **Use the structured result** — Preserve query/provider grouping, rank, status, notices, document type/date, locator, and \`evidencePolicy\`. Treat every snippet as \`discovery_only\`, not as quotation evidence.
+3. **Read selected evidence** — Follow at most ${args?.maxSections?.trim() || '3'} canonical \`resource_link\` blocks using MCP \`resources/read\`. Confirm that the returned URI matches the selected locator before quoting the exact section.
+4. **Report provenance honestly** — Edition provenance is incomplete. Do not invent an author, edition, transcription source, publication date, or rights status. Work-level type/date metadata is not edition metadata.
+5. **Synthesize with limits** — Distinguish what the selected sections say from your interpretation. Name searches that returned no results or unsupported filters; do not treat missing hits as historical silence.
+
+This workflow supports a topic survey or one exact local-work search. It does not perform author comparisons; for comparisons, run separate bounded local searches and compare only sections you actually read.`;
         break;
       }
       case 'donate':

--- a/src/mcp/schemas/primarySourceSearch.ts
+++ b/src/mcp/schemas/primarySourceSearch.ts
@@ -1,0 +1,138 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+const status = {
+  type: 'string',
+  enum: ['ok', 'no_results', 'unavailable', 'disabled', 'rate_limited', 'interface_changed', 'unsupported_filter'],
+} as const;
+
+const localLocator = {
+  type: 'object',
+  properties: {
+    kind: { const: 'local_section' },
+    url: { type: 'string', maxLength: 384 },
+    documentId: { type: 'string', minLength: 1, maxLength: 160 },
+    sectionId: { type: 'string', minLength: 1, maxLength: 160 },
+  },
+  required: ['kind', 'url', 'documentId', 'sectionId'],
+  additionalProperties: false,
+} as const;
+
+const ccelLocator = {
+  type: 'object',
+  properties: {
+    kind: { const: 'ccel_section' },
+    url: { type: 'string', maxLength: 2_048 },
+    work: { type: 'string', minLength: 1, maxLength: 160 },
+    section: { type: 'string', minLength: 1, maxLength: 160 },
+  },
+  required: ['kind', 'url', 'work', 'section'],
+  additionalProperties: false,
+} as const;
+
+const commonHitProperties = {
+  queryId: { type: 'string', minLength: 1, maxLength: 40 },
+  title: { type: 'string', minLength: 1, maxLength: 300 },
+  author: { type: 'string', minLength: 1, maxLength: 200 },
+  sectionLabel: { type: 'string', minLength: 1, maxLength: 300 },
+  snippet: { type: 'string', maxLength: 500 },
+  rankWithinProvider: { type: 'integer', minimum: 1, maximum: 32 },
+  page: { type: 'integer', minimum: 1, maximum: 3 },
+  snippetOnly: { const: true },
+  attribution: { type: 'string', minLength: 1, maxLength: 300 },
+  documentType: { type: 'string', minLength: 1, maxLength: 100 },
+  documentDate: { type: 'string', minLength: 1, maxLength: 100 },
+} as const;
+
+const commonHitRequired = [
+  'queryId', 'title', 'snippet', 'rankWithinProvider', 'page', 'snippetOnly', 'attribution',
+] as const;
+
+const hit = {
+  oneOf: [
+    {
+      type: 'object',
+      properties: {
+        ...commonHitProperties,
+        provider: { const: 'local' },
+        locator: localLocator,
+        resourceSizeBytes: { type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+      },
+      required: [...commonHitRequired, 'provider', 'locator', 'resourceSizeBytes'],
+      additionalProperties: false,
+    },
+    {
+      type: 'object',
+      properties: {
+        ...commonHitProperties,
+        provider: { const: 'ccel_live' },
+        locator: ccelLocator,
+      },
+      required: [...commonHitRequired, 'provider', 'locator'],
+      additionalProperties: false,
+    },
+  ],
+} as const;
+
+const provider = {
+  type: 'object',
+  properties: {
+    provider: { type: 'string', enum: ['local', 'ccel_live'] },
+    status,
+    searched: { type: 'boolean' },
+    page: { type: 'integer', minimum: 1, maximum: 3 },
+    hitCount: { type: 'integer', minimum: 0, maximum: 8 },
+    hits: { type: 'array', maxItems: 8, items: hit },
+    notices: { type: 'array', maxItems: 16, items: { type: 'string', maxLength: 500 } },
+  },
+  required: ['provider', 'status', 'searched', 'page', 'hitCount', 'hits', 'notices'],
+  additionalProperties: false,
+} as const;
+
+export const primarySourceSearchOutputSchema = {
+  type: 'object',
+  properties: {
+    schemaVersion: { const: '1' },
+    kind: { const: 'primary_source_search' },
+    planStatus: { type: 'string', enum: ['complete', 'partial', 'unavailable'] },
+    queries: {
+      type: 'array', minItems: 1, maxItems: 4,
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', minLength: 1, maxLength: 40 },
+          normalizedMode: { type: 'string', enum: ['all_terms', 'phrase'] },
+          providers: { type: 'array', minItems: 1, maxItems: 2, items: provider },
+        },
+        required: ['id', 'normalizedMode', 'providers'],
+        additionalProperties: false,
+      },
+    },
+    coverage: {
+      type: 'object',
+      properties: {
+        localAttempted: { type: 'boolean' },
+        localStatus: status,
+        localHitCount: { type: 'integer', minimum: 0, maximum: 32 },
+        ccelAttempted: { type: 'boolean' },
+        ccelStatus: status,
+        ccelHitCount: { type: 'integer', minimum: 0, maximum: 32 },
+        notices: { type: 'array', maxItems: 32, items: { type: 'string', maxLength: 500 } },
+      },
+      required: ['localAttempted', 'localHitCount', 'ccelAttempted', 'ccelHitCount', 'notices'],
+      additionalProperties: false,
+    },
+    evidencePolicy: {
+      type: 'object',
+      properties: {
+        snippetUse: { const: 'discovery_only' },
+        selectedSectionAccess: { const: 'mcp_resource_read' },
+        coverageScope: { const: 'bounded_non_exhaustive' },
+        editionProvenance: { const: 'incomplete' },
+      },
+      required: ['snippetUse', 'selectedSectionAccess', 'coverageScope', 'editionProvenance'],
+      additionalProperties: false,
+    },
+  },
+  required: ['schemaVersion', 'kind', 'planStatus', 'queries', 'coverage', 'evidencePolicy'],
+  additionalProperties: false,
+} as NonNullable<Tool['outputSchema']>;

--- a/src/mcp/schemas/primarySourceSearch.ts
+++ b/src/mcp/schemas/primarySourceSearch.ts
@@ -47,45 +47,57 @@ const commonHitRequired = [
   'queryId', 'title', 'snippet', 'rankWithinProvider', 'page', 'snippetOnly', 'attribution',
 ] as const;
 
-const hit = {
-  oneOf: [
-    {
-      type: 'object',
-      properties: {
-        ...commonHitProperties,
-        provider: { const: 'local' },
-        locator: localLocator,
-        resourceSizeBytes: { type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
-      },
-      required: [...commonHitRequired, 'provider', 'locator', 'resourceSizeBytes'],
-      additionalProperties: false,
-    },
-    {
-      type: 'object',
-      properties: {
-        ...commonHitProperties,
-        provider: { const: 'ccel_live' },
-        locator: ccelLocator,
-      },
-      required: [...commonHitRequired, 'provider', 'locator'],
-      additionalProperties: false,
-    },
-  ],
+const localHit = {
+  type: 'object',
+  properties: {
+    ...commonHitProperties,
+    provider: { const: 'local' },
+    locator: localLocator,
+    resourceSizeBytes: { type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+  },
+  required: [...commonHitRequired, 'provider', 'locator', 'resourceSizeBytes'],
+  additionalProperties: false,
+} as const;
+
+const ccelHit = {
+  type: 'object',
+  properties: {
+    ...commonHitProperties,
+    provider: { const: 'ccel_live' },
+    locator: ccelLocator,
+  },
+  required: [...commonHitRequired, 'provider', 'locator'],
+  additionalProperties: false,
+} as const;
+
+const providerProperties = {
+  status,
+  searched: { type: 'boolean' },
+  page: { type: 'integer', minimum: 1, maximum: 3 },
+  hitCount: { type: 'integer', minimum: 0, maximum: 8 },
+  notices: { type: 'array', maxItems: 16, items: { type: 'string', maxLength: 500 } },
 } as const;
 
 const provider = {
-  type: 'object',
-  properties: {
-    provider: { type: 'string', enum: ['local', 'ccel_live'] },
-    status,
-    searched: { type: 'boolean' },
-    page: { type: 'integer', minimum: 1, maximum: 3 },
-    hitCount: { type: 'integer', minimum: 0, maximum: 8 },
-    hits: { type: 'array', maxItems: 8, items: hit },
-    notices: { type: 'array', maxItems: 16, items: { type: 'string', maxLength: 500 } },
-  },
-  required: ['provider', 'status', 'searched', 'page', 'hitCount', 'hits', 'notices'],
-  additionalProperties: false,
+  oneOf: [{
+    type: 'object',
+    properties: {
+      ...providerProperties,
+      provider: { const: 'local' },
+      hits: { type: 'array', maxItems: 8, items: localHit },
+    },
+    required: ['provider', 'status', 'searched', 'page', 'hitCount', 'hits', 'notices'],
+    additionalProperties: false,
+  }, {
+    type: 'object',
+    properties: {
+      ...providerProperties,
+      provider: { const: 'ccel_live' },
+      hits: { type: 'array', maxItems: 8, items: ccelHit },
+    },
+    required: ['provider', 'status', 'searched', 'page', 'hitCount', 'hits', 'notices'],
+    additionalProperties: false,
+  }],
 } as const;
 
 export const primarySourceSearchOutputSchema = {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -15,7 +15,7 @@ import {
 import { NotFoundError } from '../kernel/errors.js';
 import { parseStrongsIdentity } from '../kernel/strongs.js';
 import { parseLocalDocumentResourceUri } from '../kernel/documentResource.js';
-import { LOCAL_HISTORICAL_SOURCE } from '../formatters/historicalFormatter.js';
+import { formatLocalDocumentSectionResource, LOCAL_HISTORICAL_SOURCE } from '../formatters/historicalFormatter.js';
 import type { ToolHandler } from '../kernel/types.js';
 import type { BibleService } from '../services/bible/BibleService.js';
 import type { CommentaryService } from '../services/commentary/CommentaryService.js';
@@ -179,22 +179,12 @@ export function createTheologAiMcpServer(
         if (documentResource.sectionId !== undefined) {
           if (doc.id !== documentResource.documentId) throw new NotFoundError('document', 'Exact document resource identity did not match.');
           const section = await services.historicalService.getSection(doc.id, documentResource.sectionId);
-          const heading = section.title
-            ? `## ${section.section_number ? `${section.section_number}. ` : ''}${section.title}`
-            : section.section_number ? `## Section ${section.section_number}` : '## Selected section';
-          const lines = [
-            `# ${doc.title}\n`,
-            `**Type:** ${doc.type}`,
-            doc.date ? `**Date:** ${doc.date}` : '',
-            '',
-            heading,
-            '',
-            section.content,
-            '',
-            `*Source: ${LOCAL_HISTORICAL_SOURCE}*`,
-          ];
           return {
-            contents: [{ uri, mimeType: 'text/markdown', text: lines.filter(Boolean).join('\n') }],
+            contents: [{
+              uri,
+              mimeType: 'text/markdown',
+              text: formatLocalDocumentSectionResource(doc, section),
+            }],
           };
         }
 

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -109,6 +109,7 @@ const PROMPT_ARGUMENTS = {
   'passage-exegesis': { required: ['reference'], allowed: ['reference', 'translation'] },
   'compare-translations': { required: ['reference'], allowed: ['reference', 'translations'] },
   'confession-study': { required: ['topic'], allowed: ['topic', 'traditions'] },
+  'primary-source-research': { required: ['topic'], allowed: ['topic', 'work', 'maxSections'] },
   donate: { required: [], allowed: [] },
 } as const;
 
@@ -168,5 +169,21 @@ export function validatePromptArguments(
 
   if (['passage-exegesis', 'compare-translations'].includes(name) && (stringValues.reference?.length ?? 0) > 100) {
     throw new McpError(ErrorCode.InvalidParams, `Argument "reference" for prompt "${name}" exceeds 100 characters`);
+  }
+
+  if (name === 'primary-source-research') {
+    const topicLength = Array.from(stringValues.topic.trim()).length;
+    if (topicLength < 1 || topicLength > 200) {
+      throw new McpError(ErrorCode.InvalidParams, 'Argument "topic" for prompt "primary-source-research" must be between 1 and 200 characters');
+    }
+    if (stringValues.work !== undefined) {
+      const workLength = Array.from(stringValues.work.trim()).length;
+      if (workLength < 1 || workLength > 160) {
+        throw new McpError(ErrorCode.InvalidParams, 'Argument "work" for prompt "primary-source-research" must be between 1 and 160 characters');
+      }
+    }
+    if (stringValues.maxSections !== undefined && !/^[1-5]$/.test(stringValues.maxSections.trim())) {
+      throw new McpError(ErrorCode.InvalidParams, 'Argument "maxSections" for prompt "primary-source-research" must be a string integer from 1 to 5');
+    }
   }
 }

--- a/src/presenters/primarySourceSearchStructured.ts
+++ b/src/presenters/primarySourceSearchStructured.ts
@@ -82,7 +82,7 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
     normalizedMode: query.normalizedMode,
     providers: query.providers.slice(0, 2).map(provider => {
       const hits = provider.hits.slice(0, 8).flatMap(hit => {
-        const presented = presentHit(hit);
+        const presented = presentHit(hit, query.id, provider.provider);
         return presented ? [presented] : [];
       });
       const omitted = provider.hits.length - hits.length;
@@ -90,7 +90,7 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
       const downgraded = omitted > 0 || countMismatch;
       const notices = [...provider.notices];
       if (omitted > 0) {
-        notices.push(`${omitted} ${provider.provider} hit${omitted === 1 ? '' : 's'} omitted because the locator or bounded metadata was invalid.`);
+        notices.push(`${omitted} ${provider.provider} hit${omitted === 1 ? '' : 's'} omitted because the locator, group attribution, or bounded metadata was invalid.`);
       }
       if (countMismatch) notices.push('Provider-reported hit count did not match its returned hit array.');
       return {
@@ -138,7 +138,16 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
 const COMPLETE_STATUSES = new Set<PrimarySourceProviderStatus>(['ok', 'no_results']);
 const UNAVAILABLE_STATUSES = new Set<PrimarySourceProviderStatus>(['unavailable', 'disabled', 'rate_limited', 'interface_changed']);
 
-function presentHit(hit: PrimarySourcePlanHit): PresentedPrimarySourceHit | undefined {
+function presentHit(
+  hit: PrimarySourcePlanHit,
+  expectedQueryId: string,
+  expectedProvider: PrimarySourceProvider,
+): PresentedPrimarySourceHit | undefined {
+  // A hit is evidence for exactly the query/provider group that contains it.
+  // Never repair or relabel a mismatched upstream result: omitting it causes
+  // the enclosing provider to be downgraded to interface_changed.
+  if (hit.queryId !== expectedQueryId || hit.provider !== expectedProvider) return undefined;
+
   const common = {
     queryId: boundedText(hit.queryId, 40),
     title: boundedText(hit.title, 300),
@@ -174,10 +183,16 @@ function presentHit(hit: PrimarySourcePlanHit): PresentedPrimarySourceHit | unde
     };
   }
 
-  const normalized = normalizeCcelSectionLocator(hit.locator.url);
-  if (!normalized || normalized.url !== hit.locator.url
-    || normalized.work !== hit.locator.work || normalized.section !== hit.locator.section) return undefined;
-  return { ...common, provider: 'ccel_live', locator: normalized };
+  if (hit.provider === 'ccel_live') {
+    const normalized = normalizeCcelSectionLocator(hit.locator.url);
+    if (!normalized || normalized.url !== hit.locator.url
+      || normalized.work !== hit.locator.work || normalized.section !== hit.locator.section) return undefined;
+    return { ...common, provider: 'ccel_live', locator: normalized };
+  }
+
+  // Runtime data can drift ahead of this closed public contract even though
+  // TypeScript currently knows only the two providers above.
+  return undefined;
 }
 
 function boundedText(value: string, maximum: number): string {

--- a/src/presenters/primarySourceSearchStructured.ts
+++ b/src/presenters/primarySourceSearchStructured.ts
@@ -77,56 +77,87 @@ export interface PresentedPrimarySourceSearch extends Record<string, unknown> {
 
 /** Canonical public result used by Markdown, structured output, and native links. */
 export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult): PresentedPrimarySourceSearch {
-  const queries = result.queries.slice(0, 4).map(query => ({
-    id: boundedText(query.id, 40),
-    normalizedMode: query.normalizedMode,
-    providers: query.providers.slice(0, 2).map(provider => {
-      const hits = provider.hits.slice(0, 8).flatMap(hit => {
-        const presented = presentHit(hit, query.id, provider.provider);
-        return presented ? [presented] : [];
-      });
-      const omitted = provider.hits.length - hits.length;
-      const countMismatch = provider.hitCount !== provider.hits.length;
-      const downgraded = omitted > 0 || countMismatch;
-      const notices = [...provider.notices];
-      if (omitted > 0) {
-        notices.push(`${omitted} ${provider.provider} hit${omitted === 1 ? '' : 's'} omitted because the locator, group attribution, or bounded metadata was invalid.`);
-      }
-      if (countMismatch) notices.push('Provider-reported hit count did not match its returned hit array.');
-      return {
-        provider: provider.provider,
-        status: downgraded ? 'interface_changed' as const : provider.status,
-        searched: provider.searched,
-        page: provider.page,
-        hitCount: hits.length,
-        hits,
-        notices: uniqueBounded(notices, 16, 500),
-      };
+  const boundedQueries = result.queries.slice(0, 4);
+  const omittedQueries = result.queries.slice(4);
+  const omittedProviderGroups = [
+    ...omittedQueries.flatMap(query => query.providers),
+    ...boundedQueries.flatMap(query => query.providers.slice(2)),
+  ];
+  const envelopeNotices = [
+    ...(omittedQueries.length > 0
+      ? [`${omittedQueries.length} query group${omittedQueries.length === 1 ? ' was' : 's were'} omitted because the result exceeded the public limit of 4.`]
+      : []),
+    ...boundedQueries.flatMap(query => {
+      const omitted = query.providers.length - 2;
+      return omitted > 0
+        ? [`${omitted} provider group${omitted === 1 ? ' was' : 's were'} omitted from query ${boundedText(query.id, 40)} because the result exceeded the public limit of 2 providers per query.`]
+        : [];
     }),
-  }));
+  ];
+  const envelopeChanged = envelopeNotices.length > 0;
+  const queries = boundedQueries.map(query => {
+    const providerGroupsOmitted = query.providers.length > 2;
+    return {
+      id: boundedText(query.id, 40),
+      normalizedMode: query.normalizedMode,
+      providers: query.providers.slice(0, 2).map(provider => {
+        const hits = provider.hits.slice(0, 8).flatMap(hit => {
+          const presented = presentHit(hit, query.id, provider.provider);
+          return presented ? [presented] : [];
+        });
+        const omitted = provider.hits.length - hits.length;
+        const countMismatch = provider.hitCount !== provider.hits.length;
+        const downgraded = omitted > 0 || countMismatch || providerGroupsOmitted;
+        const notices = [...provider.notices];
+        if (omitted > 0) {
+          notices.push(`${omitted} ${provider.provider} hit${omitted === 1 ? '' : 's'} omitted because the locator, group attribution, or bounded metadata was invalid.`);
+        }
+        if (countMismatch) notices.push('Provider-reported hit count did not match its returned hit array.');
+        if (providerGroupsOmitted) notices.push('One or more provider groups were omitted because the query exceeded the public provider-group limit.');
+        return {
+          provider: provider.provider,
+          status: downgraded ? 'interface_changed' as const : provider.status,
+          searched: provider.searched,
+          page: provider.page,
+          hitCount: hits.length,
+          hits,
+          notices: uniqueBounded(notices, 16, 500),
+        };
+      }),
+    };
+  });
   const providers = queries.flatMap(query => query.providers);
   const local = providers.filter(provider => provider.provider === 'local');
   const ccel = providers.filter(provider => provider.provider === 'ccel_live');
+  const omittedLocal = omittedProviderGroups.filter(provider => provider.provider === 'local');
+  const omittedCcel = omittedProviderGroups.filter(provider => provider.provider === 'ccel_live');
   const statuses = providers.map(provider => provider.status);
   const hasUsableResult = providers.some(provider => provider.hits.length > 0 || COMPLETE_STATUSES.has(provider.status));
-  const planStatus = statuses.every(status => COMPLETE_STATUSES.has(status))
-    ? 'complete'
-    : !hasUsableResult && statuses.every(status => UNAVAILABLE_STATUSES.has(status))
-      ? 'unavailable'
-      : 'partial';
+  const planStatus = envelopeChanged
+    ? 'partial'
+    : statuses.every(status => COMPLETE_STATUSES.has(status))
+      ? 'complete'
+      : !hasUsableResult && statuses.every(status => UNAVAILABLE_STATUSES.has(status))
+        ? 'unavailable'
+        : 'partial';
   return {
     schemaVersion: '1',
     kind: 'primary_source_search',
     planStatus,
     queries,
     coverage: {
-      localAttempted: local.some(provider => provider.searched),
-      ...(local.length ? { localStatus: aggregateStatus(local) } : {}),
+      localAttempted: [...local, ...omittedLocal].some(provider => provider.searched),
+      ...(omittedLocal.length
+        ? { localStatus: 'interface_changed' as const }
+        : local.length ? { localStatus: aggregateStatus(local) } : {}),
       localHitCount: countHits(local),
-      ccelAttempted: ccel.some(provider => provider.searched),
-      ...(ccel.length ? { ccelStatus: aggregateStatus(ccel) } : {}),
+      ccelAttempted: [...ccel, ...omittedCcel].some(provider => provider.searched),
+      ...(omittedCcel.length
+        ? { ccelStatus: 'interface_changed' as const }
+        : ccel.length ? { ccelStatus: aggregateStatus(ccel) } : {}),
       ccelHitCount: countHits(ccel),
       notices: uniqueBounded([
+        ...envelopeNotices,
         ...result.coverage.notices,
         ...providers.flatMap(provider => provider.notices),
       ], 32, 500),

--- a/src/presenters/primarySourceSearchStructured.ts
+++ b/src/presenters/primarySourceSearchStructured.ts
@@ -1,0 +1,203 @@
+import { normalizeCcelSectionLocator } from '../adapters/commentary/CcelSearchAdapter.js';
+import { buildLocalDocumentResourceUri } from '../kernel/documentResource.js';
+import type {
+  PrimarySourcePlanHit,
+  PrimarySourceProvider,
+  PrimarySourceProviderStatus,
+  PrimarySourceSearchMatch,
+  PrimarySourceSearchPlanResult,
+} from '../services/historical/primarySourceTypes.js';
+
+export const PRIMARY_SOURCE_EVIDENCE_POLICY = {
+  snippetUse: 'discovery_only',
+  selectedSectionAccess: 'mcp_resource_read',
+  coverageScope: 'bounded_non_exhaustive',
+  editionProvenance: 'incomplete',
+} as const;
+
+export interface PresentedLocalPrimarySourceHit extends PresentedPrimarySourceHitBase {
+  provider: 'local';
+  locator: { kind: 'local_section'; url: string; documentId: string; sectionId: string };
+  resourceSizeBytes: number;
+}
+
+export interface PresentedCcelPrimarySourceHit extends PresentedPrimarySourceHitBase {
+  provider: 'ccel_live';
+  locator: { kind: 'ccel_section'; url: string; work: string; section: string };
+}
+
+export type PresentedPrimarySourceHit = PresentedLocalPrimarySourceHit | PresentedCcelPrimarySourceHit;
+
+interface PresentedPrimarySourceHitBase {
+  queryId: string;
+  title: string;
+  author?: string;
+  sectionLabel?: string;
+  snippet: string;
+  rankWithinProvider: number;
+  page: number;
+  snippetOnly: true;
+  attribution: string;
+  documentType?: string;
+  documentDate?: string;
+}
+
+export interface PresentedPrimarySourceProvider {
+  provider: PrimarySourceProvider;
+  status: PrimarySourceProviderStatus;
+  searched: boolean;
+  page: number;
+  hitCount: number;
+  hits: PresentedPrimarySourceHit[];
+  notices: string[];
+}
+
+export interface PresentedPrimarySourceQuery {
+  id: string;
+  normalizedMode: PrimarySourceSearchMatch;
+  providers: PresentedPrimarySourceProvider[];
+}
+
+export interface PresentedPrimarySourceSearch extends Record<string, unknown> {
+  schemaVersion: '1';
+  kind: 'primary_source_search';
+  planStatus: 'complete' | 'partial' | 'unavailable';
+  queries: PresentedPrimarySourceQuery[];
+  coverage: {
+    localAttempted: boolean;
+    localStatus?: PrimarySourceProviderStatus;
+    localHitCount: number;
+    ccelAttempted: boolean;
+    ccelStatus?: PrimarySourceProviderStatus;
+    ccelHitCount: number;
+    notices: string[];
+  };
+  evidencePolicy: typeof PRIMARY_SOURCE_EVIDENCE_POLICY;
+}
+
+/** Canonical public result used by Markdown, structured output, and native links. */
+export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult): PresentedPrimarySourceSearch {
+  const queries = result.queries.slice(0, 4).map(query => ({
+    id: boundedText(query.id, 40),
+    normalizedMode: query.normalizedMode,
+    providers: query.providers.slice(0, 2).map(provider => {
+      const hits = provider.hits.slice(0, 8).flatMap(hit => {
+        const presented = presentHit(hit);
+        return presented ? [presented] : [];
+      });
+      const omitted = provider.hits.length - hits.length;
+      const countMismatch = provider.hitCount !== provider.hits.length;
+      const downgraded = omitted > 0 || countMismatch;
+      const notices = [...provider.notices];
+      if (omitted > 0) {
+        notices.push(`${omitted} ${provider.provider} hit${omitted === 1 ? '' : 's'} omitted because the locator or bounded metadata was invalid.`);
+      }
+      if (countMismatch) notices.push('Provider-reported hit count did not match its returned hit array.');
+      return {
+        provider: provider.provider,
+        status: downgraded ? 'interface_changed' as const : provider.status,
+        searched: provider.searched,
+        page: provider.page,
+        hitCount: hits.length,
+        hits,
+        notices: uniqueBounded(notices, 16, 500),
+      };
+    }),
+  }));
+  const providers = queries.flatMap(query => query.providers);
+  const local = providers.filter(provider => provider.provider === 'local');
+  const ccel = providers.filter(provider => provider.provider === 'ccel_live');
+  const statuses = providers.map(provider => provider.status);
+  const hasUsableResult = providers.some(provider => provider.hits.length > 0 || COMPLETE_STATUSES.has(provider.status));
+  const planStatus = statuses.every(status => COMPLETE_STATUSES.has(status))
+    ? 'complete'
+    : !hasUsableResult && statuses.every(status => UNAVAILABLE_STATUSES.has(status))
+      ? 'unavailable'
+      : 'partial';
+  return {
+    schemaVersion: '1',
+    kind: 'primary_source_search',
+    planStatus,
+    queries,
+    coverage: {
+      localAttempted: local.some(provider => provider.searched),
+      ...(local.length ? { localStatus: aggregateStatus(local) } : {}),
+      localHitCount: countHits(local),
+      ccelAttempted: ccel.some(provider => provider.searched),
+      ...(ccel.length ? { ccelStatus: aggregateStatus(ccel) } : {}),
+      ccelHitCount: countHits(ccel),
+      notices: uniqueBounded([
+        ...result.coverage.notices,
+        ...providers.flatMap(provider => provider.notices),
+      ], 32, 500),
+    },
+    evidencePolicy: PRIMARY_SOURCE_EVIDENCE_POLICY,
+  };
+}
+
+const COMPLETE_STATUSES = new Set<PrimarySourceProviderStatus>(['ok', 'no_results']);
+const UNAVAILABLE_STATUSES = new Set<PrimarySourceProviderStatus>(['unavailable', 'disabled', 'rate_limited', 'interface_changed']);
+
+function presentHit(hit: PrimarySourcePlanHit): PresentedPrimarySourceHit | undefined {
+  const common = {
+    queryId: boundedText(hit.queryId, 40),
+    title: boundedText(hit.title, 300),
+    ...(hit.author ? { author: boundedText(hit.author, 200) } : {}),
+    ...(hit.sectionLabel ? { sectionLabel: boundedText(hit.sectionLabel, 300) } : {}),
+    snippet: boundedText(hit.snippet, 500),
+    rankWithinProvider: hit.rankWithinProvider,
+    page: hit.page,
+    snippetOnly: true as const,
+    attribution: boundedText(hit.attribution, 300),
+    ...(hit.documentType ? { documentType: boundedText(hit.documentType, 100) } : {}),
+    ...(hit.documentDate ? { documentDate: boundedText(hit.documentDate, 100) } : {}),
+  };
+  if (!common.queryId || !common.title || !common.attribution
+    || !Number.isSafeInteger(common.rankWithinProvider) || common.rankWithinProvider < 1 || common.rankWithinProvider > 32
+    || !Number.isSafeInteger(common.page) || common.page < 1 || common.page > 3) return undefined;
+
+  if (hit.provider === 'local') {
+    const canonical = buildLocalDocumentResourceUri(hit.locator.documentId, hit.locator.sectionId);
+    const size = hit.resourceSizeBytes;
+    if (!canonical || canonical !== hit.locator.url
+      || !Number.isSafeInteger(size) || size < 0 || size > Number.MAX_SAFE_INTEGER) return undefined;
+    return {
+      ...common,
+      provider: 'local',
+      locator: {
+        kind: 'local_section',
+        url: canonical,
+        documentId: hit.locator.documentId,
+        sectionId: hit.locator.sectionId,
+      },
+      resourceSizeBytes: size,
+    };
+  }
+
+  const normalized = normalizeCcelSectionLocator(hit.locator.url);
+  if (!normalized || normalized.url !== hit.locator.url
+    || normalized.work !== hit.locator.work || normalized.section !== hit.locator.section) return undefined;
+  return { ...common, provider: 'ccel_live', locator: normalized };
+}
+
+function boundedText(value: string, maximum: number): string {
+  return Array.from(value.normalize('NFC')
+    .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200F\u202A-\u202E\u2066-\u2069]/g, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim()).slice(0, maximum).join('');
+}
+
+function uniqueBounded(values: string[], maximumItems: number, maximumLength: number): string[] {
+  return [...new Set(values.map(value => boundedText(value, maximumLength)).filter(Boolean))].slice(0, maximumItems);
+}
+
+function countHits(providers: PresentedPrimarySourceProvider[]): number {
+  return providers.reduce((total, provider) => total + provider.hits.length, 0);
+}
+
+function aggregateStatus(providers: PresentedPrimarySourceProvider[]): PrimarySourceProviderStatus {
+  const priority: PrimarySourceProviderStatus[] = [
+    'unavailable', 'rate_limited', 'interface_changed', 'disabled', 'unsupported_filter', 'ok', 'no_results',
+  ];
+  return priority.find(status => providers.some(provider => provider.status === status)) ?? 'unavailable';
+}

--- a/src/services/historical/LocalPrimarySourceSearchProvider.ts
+++ b/src/services/historical/LocalPrimarySourceSearchProvider.ts
@@ -5,6 +5,7 @@ import {
   type PrimarySourceProviderResult,
   type PrimarySourceSearchQuery,
 } from './primarySourceTypes.js';
+import { formatLocalDocumentSectionResource } from '../../formatters/historicalFormatter.js';
 
 export class LocalPrimarySourceSearchProvider {
   constructor(private readonly repository: IHistoricalDocumentRepository) {}
@@ -54,6 +55,11 @@ export class LocalPrimarySourceSearchProvider {
       page,
       snippetOnly: true as const,
       attribution: LOCAL_PRIMARY_SOURCE_ATTRIBUTION,
+      documentType: row.document.type,
+      ...(row.document.date ? { documentDate: row.document.date } : {}),
+      resourceSizeBytes: new TextEncoder().encode(
+        formatLocalDocumentSectionResource(row.document, row.section),
+      ).byteLength,
     }));
     return result(hits.length > 0 ? 'ok' : 'no_results', page, true, hits);
   }

--- a/src/services/historical/primarySourceTypes.ts
+++ b/src/services/historical/primarySourceTypes.ts
@@ -45,28 +45,43 @@ export interface LocalSectionLocator {
 
 export type PrimarySourceLocator = CcelSectionLocator | LocalSectionLocator;
 
-export interface PrimarySourceSearchHit {
-  provider: PrimarySourceProvider;
+interface PrimarySourceSearchHitBase {
   title: string;
   author?: string;
   sectionLabel?: string;
   snippet: string;
-  locator: PrimarySourceLocator;
   rankWithinProvider: number;
   page: number;
   /** Search snippets are discovery metadata, never fetched evidence. */
   snippetOnly: true;
   attribution: string;
+  /** Reviewed catalog metadata. Absence means unknown, not that the work has no type/date. */
+  documentType?: string;
+  documentDate?: string;
 }
+
+export interface LocalPrimarySourceSearchHit extends PrimarySourceSearchHitBase {
+  provider: 'local';
+  locator: LocalSectionLocator;
+  /** Exact UTF-8 byte size of the corresponding MCP resource representation. */
+  resourceSizeBytes: number;
+}
+
+export interface CcelPrimarySourceSearchHit extends PrimarySourceSearchHitBase {
+  provider: 'ccel_live';
+  locator: CcelSectionLocator;
+}
+
+export type PrimarySourceSearchHit = LocalPrimarySourceSearchHit | CcelPrimarySourceSearchHit;
 
 export interface PrimarySourceSearchPlanQuery extends PrimarySourceSearchQuery {
   id: string;
   providers: PrimarySourceRequestedProvider[];
 }
 
-export interface PrimarySourcePlanHit extends PrimarySourceSearchHit {
+export type PrimarySourcePlanHit = PrimarySourceSearchHit & {
   queryId: string;
-}
+};
 
 export interface PrimarySourcePlanProviderResult extends Omit<PrimarySourceProviderResult, 'hits'> {
   hits: PrimarySourcePlanHit[];

--- a/src/tools/v2/primarySourceSearch.ts
+++ b/src/tools/v2/primarySourceSearch.ts
@@ -2,6 +2,13 @@ import type { ToolHandler } from '../../kernel/types.js';
 import { handleToolError } from '../../kernel/errors.js';
 import type { PrimarySourceSearchService } from '../../services/historical/PrimarySourceSearchService.js';
 import { formatPrimarySourceSearch } from '../../formatters/primarySourceFormatter.js';
+import { primarySourceSearchOutputSchema } from '../../mcp/schemas/primarySourceSearch.js';
+import {
+  presentPrimarySourceSearch,
+  type PresentedPrimarySourceSearch,
+} from '../../presenters/primarySourceSearchStructured.js';
+import { buildLocalDocumentResourceUri } from '../../kernel/documentResource.js';
+import type { ResourceLink } from '@modelcontextprotocol/sdk/types.js';
 
 export function createPrimarySourceSearchHandler(service: Pick<PrimarySourceSearchService, 'search'>): ToolHandler {
   return {
@@ -36,6 +43,7 @@ export function createPrimarySourceSearchHandler(service: Pick<PrimarySourceSear
       required: ['queries'],
       additionalProperties: false,
     },
+    outputSchema: primarySourceSearchOutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     handler: async params => {
       try {
@@ -46,13 +54,49 @@ export function createPrimarySourceSearchHandler(service: Pick<PrimarySourceSear
             }))
           : params.queries;
         const result = await service.search({ ...params, queries });
+        const presented = presentPrimarySourceSearch(result);
         return {
-          content: [{ type: 'text', text: formatPrimarySourceSearch(result) }],
-          ...(result.planStatus === 'unavailable' ? { isError: true } : {}),
+          content: [
+            { type: 'text', text: formatPrimarySourceSearch(presented) },
+            ...localSectionResourceLinks(presented),
+          ],
+          structuredContent: presented,
+          ...(presented.planStatus === 'unavailable' ? { isError: true } : {}),
         };
       } catch (error) {
         return handleToolError(error as Error);
       }
     },
   };
+}
+
+/** Build links only from validated presentation data, never directly from provider locators. */
+function localSectionResourceLinks(presented: PresentedPrimarySourceSearch): ResourceLink[] {
+  const links: ResourceLink[] = [];
+  const seen = new Set<string>();
+  for (const query of presented.queries) {
+    for (const provider of query.providers) {
+      for (const candidate of provider.hits) {
+        if (candidate.provider !== 'local') continue;
+        const { locator } = candidate;
+        const canonical = buildLocalDocumentResourceUri(locator.documentId, locator.sectionId);
+        if (!canonical || canonical !== locator.url || seen.has(canonical)) continue;
+        seen.add(canonical);
+        const section = candidate.sectionLabel ? ` — ${candidate.sectionLabel}` : '';
+        const metadata = [candidate.documentType, candidate.documentDate].filter(Boolean).join(', ');
+        links.push({
+          type: 'resource_link',
+          uri: canonical,
+          name: `local-primary-source/${locator.documentId}/${locator.sectionId}`,
+          title: `${candidate.title}${section}`,
+          description: `${metadata ? `${metadata}. ` : ''}Exact local section selected by primary-source discovery.`,
+          mimeType: 'text/markdown',
+          size: candidate.resourceSizeBytes,
+          annotations: { audience: ['assistant'] },
+        });
+        if (links.length === 32) return links;
+      }
+    }
+  }
+  return links;
 }

--- a/test/integration/current/mcp-protocol.test.ts
+++ b/test/integration/current/mcp-protocol.test.ts
@@ -98,6 +98,7 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
       expect(listed.tools.filter(tool => tool.outputSchema).map(tool => tool.name)).toEqual([
         'bible_lookup',
         'parallel_passages',
+        'primary_source_search',
         'original_language_lookup',
         'original_language_study',
       ]);
@@ -176,6 +177,19 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
         content: [expect.objectContaining({
           text: expect.stringContaining('Plan status: **complete**'),
         })],
+        structuredContent: {
+          schemaVersion: '1',
+          kind: 'primary_source_search',
+          planStatus: 'complete',
+          queries: [expect.anything()],
+          coverage: expect.any(Object),
+          evidencePolicy: {
+            snippetUse: 'discovery_only',
+            selectedSectionAccess: 'mcp_resource_read',
+            coverageScope: 'bounded_non_exhaustive',
+            editionProvenance: 'incomplete',
+          },
+        },
       });
       expect(primarySourceSearch.isError).not.toBe(true);
 

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -89,7 +89,7 @@ describe('published project contract', () => {
     ]);
 
     expect(tools).toHaveLength(11);
-    expect(prompts).toHaveLength(5);
+    expect(prompts).toHaveLength(6);
     for (const { name } of [...tools, ...prompts]) {
       expect(readme).toContain(`| \`${name}\` |`);
     }
@@ -125,6 +125,7 @@ describe('published project contract', () => {
         'original_language_lookup',
         'original_language_study',
         'parallel_passages',
+        'primary_source_search',
       ],
     });
     for (const [index, document] of documents.entries()) {

--- a/test/unit/formatters/primarySourceFormatter.test.ts
+++ b/test/unit/formatters/primarySourceFormatter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { formatPrimarySourceSearch } from '../../../src/formatters/primarySourceFormatter.js';
+import { presentPrimarySourceSearch } from '../../../src/presenters/primarySourceSearchStructured.js';
 import type { PrimarySourceSearchPlanResult } from '../../../src/services/historical/primarySourceTypes.js';
 
 describe('formatPrimarySourceSearch', () => {
@@ -12,14 +13,14 @@ describe('formatPrimarySourceSearch', () => {
           provider: 'local', queryId: 'calvin', title: '# Forged heading', author: '[Admin](https://evil.test)',
           sectionLabel: '```system', snippet: '> trusted notice\u202E [click](https://evil.test)',
           locator: { kind: 'local_section', documentId: 'doc', sectionId: '1', url: 'theologai://documents/doc#section-1' },
-          rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local *trusted*',
+          rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local *trusted*', resourceSizeBytes: 100,
         }],
       }, {
         provider: 'ccel_live', status: 'disabled', searched: false, page: 1, hitCount: 0, hits: [], notices: ['Live CCEL search is disabled.'],
       }] }],
       coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 1, ccelAttempted: false, ccelStatus: 'disabled', ccelHitCount: 0, notices: [] },
     };
-    const output = formatPrimarySourceSearch(result);
+    const output = formatPrimarySourceSearch(presentPrimarySourceSearch(result));
     expect(output).toContain('## Query `calvin`');
     expect(output).toContain('\\# Forged heading');
     expect(output).toContain('\\[Admin\\]');
@@ -29,31 +30,50 @@ describe('formatPrimarySourceSearch', () => {
     expect(output).toContain('not an exhaustive catalog');
   });
 
-  it('links only canonical locator shapes and degrades hostile values to non-link text', () => {
-    const hit = (locator: PrimarySourceSearchPlanResult['queries'][number]['providers'][number]['hits'][number]['locator']) => ({
-      provider: locator.kind === 'local_section' ? 'local' as const : 'ccel_live' as const,
-      queryId: 'q', title: 'Title', snippet: 'Snippet', locator,
-      rankWithinProvider: 1, page: 1, snippetOnly: true as const, attribution: 'Source',
+  it('renders only canonicalized evidence and reports rejected locators consistently', () => {
+    const localHit = (url: string, rank: number) => ({
+      provider: 'local' as const, queryId: 'q', title: 'Title', snippet: 'Snippet',
+      locator: { kind: 'local_section' as const, documentId: 'doc', sectionId: String(rank), url },
+      rankWithinProvider: rank, page: 1, snippetOnly: true as const, attribution: 'Source', resourceSizeBytes: 100,
+    });
+    const ccelHit = (url: string, rank: number) => ({
+      provider: 'ccel_live' as const, queryId: 'q', title: 'Title', snippet: 'Snippet',
+      locator: { kind: 'ccel_section' as const, work: 'calvin/institutes', section: 'iv.xvii', url },
+      rankWithinProvider: rank, page: 1, snippetOnly: true as const, attribution: 'Source',
     });
     const result: PrimarySourceSearchPlanResult = {
       planStatus: 'complete',
       queries: [{ id: 'q', normalizedMode: 'all_terms', providers: [{
-        provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 4, notices: [],
+        provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 2, notices: [],
         hits: [
-          hit({ kind: 'local_section', documentId: 'doc', sectionId: '1', url: 'theologai://documents/doc#section-1' }),
-          hit({ kind: 'local_section', documentId: 'doc', sectionId: '1', url: 'javascript:alert(1)' }),
-          hit({ kind: 'ccel_section', work: 'calvin/institutes', section: 'iv.xvii', url: 'https://www.ccel.org/ccel/calvin/institutes/iv.xvii.html' }),
-          hit({ kind: 'ccel_section', work: 'calvin/institutes', section: 'iv.xvii', url: 'https://evil.test/ccel/calvin/institutes/iv.xvii.html' }),
+          localHit('theologai://documents/doc#section-1', 1),
+          localHit('javascript:alert(1)', 2),
+        ],
+      }, {
+        provider: 'ccel_live', status: 'ok', searched: true, page: 1, hitCount: 2, notices: [],
+        hits: [
+          ccelHit('https://ccel.org/ccel/calvin/institutes/iv.xvii.html', 1),
+          ccelHit('https://evil.test/ccel/calvin/institutes/iv.xvii.html', 2),
         ],
       }] }],
-      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 4, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 2, ccelAttempted: true, ccelStatus: 'ok', ccelHitCount: 2, notices: [] },
     };
-    const output = formatPrimarySourceSearch(result);
+    const presented = presentPrimarySourceSearch(result);
+    const output = formatPrimarySourceSearch(presented);
     expect(output).toContain('[exact section](theologai://documents/doc#section-1)');
     expect(output).toContain('[exact section](https://ccel.org/ccel/calvin/institutes/iv.xvii.html)');
-    expect(output).toContain('javascript:alert\\(1\\)');
-    expect(output).toContain('https://evil\\.test/ccel/calvin/institutes/iv\\.xvii\\.html');
-    expect(output).not.toContain('](javascript:');
-    expect(output).not.toContain('](https://evil.test');
+    expect(output).not.toContain('javascript:');
+    expect(output).not.toContain('evil.test');
+    expect(output).toContain('Status: **interface_changed**');
+    expect(output).toContain('1 local hit omitted');
+    expect(output).toContain('1 ccel\\_live hit omitted');
+    expect(presented).toMatchObject({
+      planStatus: 'partial',
+      queries: [{ providers: [
+        { status: 'interface_changed', hitCount: 1 },
+        { status: 'interface_changed', hitCount: 1 },
+      ] }],
+      coverage: { localStatus: 'interface_changed', localHitCount: 1, ccelStatus: 'interface_changed', ccelHitCount: 1 },
+    });
   });
 });

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -56,6 +56,7 @@ describe('MCP structured output validation', () => {
     expect(withOutput).toEqual([
       'bible_lookup',
       'parallel_passages',
+      'primary_source_search',
       'original_language_lookup',
       'original_language_study',
     ]);

--- a/test/unit/mcp/promptContracts.test.ts
+++ b/test/unit/mcp/promptContracts.test.ts
@@ -11,6 +11,7 @@ import { createParallelPassagesHandler } from '../../../src/tools/v2/parallelPas
 import { createStrongsLookupHandler } from '../../../src/tools/v2/strongsLookup.js';
 import { createVerseMorphologyHandler } from '../../../src/tools/v2/verseMorphology.js';
 import { createOriginalLanguageStudyHandler } from '../../../src/tools/v2/originalLanguageStudy.js';
+import { createPrimarySourceSearchHandler } from '../../../src/tools/v2/primarySourceSearch.js';
 
 const unused = {} as never;
 const tools: ToolHandler[] = [
@@ -22,6 +23,7 @@ const tools: ToolHandler[] = [
   createStrongsLookupHandler(unused),
   createVerseMorphologyHandler(unused),
   createOriginalLanguageStudyHandler(unused),
+  createPrimarySourceSearchHandler(unused),
   createDonationConfigHandler(unused),
 ];
 
@@ -38,6 +40,7 @@ describe('prompt-recommended tool-call contracts', () => {
     ['compare-translations', { reference: 'Philippians 2:6-8', translations: 'ESV,KJV,NET,BSB' }],
     ['compare-translations', { reference: 'John 1:1', translations: 'unknown' }],
     ['confession-study', { topic: 'justification', traditions: 'Reformed, Lutheran' }],
+    ['primary-source-research', { topic: "Lord's Supper", work: 'westminster-confession', maxSections: '2' }],
     ['donate', undefined],
   ] as const)('%s emits only calls accepted by advertised tool schemas', (name, args) => {
     const calls = recommendedToolCallsForPrompt(name, args);
@@ -82,5 +85,17 @@ describe('prompt-recommended tool-call contracts', () => {
     const calls = recommendedToolCallsForPrompt('word-study', { word: 'love', reference: 'John 3:16' });
     expect(calls.map(call => call.tool)).toContain('bible_verse_morphology');
     expect(calls.map(call => call.tool)).not.toContain('original_language_study');
+  });
+
+  it('keeps primary-source research local, bounded, and exact-work aware', () => {
+    expect(recommendedToolCallsForPrompt('primary-source-research', { topic: 'eucharist' })).toEqual([{
+      tool: 'primary_source_search',
+      arguments: { queries: [{ id: 'topic-survey', text: 'eucharist', providers: ['local'], match: 'all_terms', limit: 3 }] },
+    }]);
+    expect(recommendedToolCallsForPrompt('primary-source-research', {
+      topic: 'eucharist', work: 'council-of-trent', maxSections: '5',
+    })[0].arguments).toMatchObject({
+      queries: [{ id: 'exact-local-work', work: 'council-of-trent', providers: ['local'], limit: 5 }],
+    });
   });
 });

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -11,6 +11,8 @@ import { createWorkerMcpServer } from '../../../src/worker-server.js';
 import type { WorkerCompositionRoot } from '../../../src/tools/worker/index.js';
 import { StrongsService } from '../../../src/services/languages/StrongsService.js';
 import { readFileSync } from 'node:fs';
+import { createPrimarySourceSearchHandler } from '../../../src/tools/v2/primarySourceSearch.js';
+import { formatLocalDocumentSectionResource } from '../../../src/formatters/historicalFormatter.js';
 
 const TOOL_NAMES = [
   'bible_lookup',
@@ -434,6 +436,51 @@ describe('shared MCP registration', () => {
     expect(root.services.historicalService.getSection).toHaveBeenCalledWith('nicene-creed', '1');
   });
 
+  it('returns a native primary-source link whose exact byte size matches resources/read', async () => {
+    const root = makeMockRoot();
+    const doc = await root.services.historicalService.getDocument('nicene-creed');
+    const section = await root.services.historicalService.getSection('nicene-creed', '1');
+    const resourceText = formatLocalDocumentSectionResource(doc!, section);
+    const resourceSizeBytes = new TextEncoder().encode(resourceText).byteLength;
+    root.tools = root.tools.map(tool => tool.name === 'primary_source_search'
+      ? createPrimarySourceSearchHandler({ search: async () => ({
+        planStatus: 'complete',
+        queries: [{ id: 'topic', normalizedMode: 'all_terms', providers: [{
+          provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 1, notices: [],
+          hits: [{
+            queryId: 'topic', provider: 'local', title: doc!.title,
+            sectionLabel: section.title, snippet: 'We believe',
+            locator: {
+              kind: 'local_section', documentId: doc!.id, sectionId: section.section_number,
+              url: 'theologai://documents/nicene-creed#section-1',
+            },
+            rankWithinProvider: 1, page: 1, snippetOnly: true,
+            attribution: 'TheologAI local historical-document collection',
+            documentType: doc!.type, documentDate: doc!.date!, resourceSizeBytes,
+          }],
+        }] }],
+        coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 1, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+      }) } as any)
+      : tool);
+    const client = await connect(createTheologAiMcpServer(root, '1.0.0-test').server);
+
+    const result = await client.callTool({
+      name: 'primary_source_search',
+      arguments: { queries: [{ id: 'topic', text: 'belief', providers: ['local'] }] },
+    });
+    const link = result.content.find(block => block.type === 'resource_link');
+    expect(link).toMatchObject({
+      type: 'resource_link', uri: 'theologai://documents/nicene-creed#section-1',
+      mimeType: 'text/markdown', size: resourceSizeBytes,
+      annotations: { audience: ['assistant'] },
+    });
+    if (!link || link.type !== 'resource_link') throw new Error('Expected resource link');
+    const read = await client.readResource({ uri: link.uri });
+    const readText = String(read.contents[0].text);
+    expect(new TextEncoder().encode(readText).byteLength).toBe(link.size);
+    expect(readText).toBe(resourceText);
+  });
+
   it('canonicalizes classical and extended Strong\'s resources and rejects invalid domain numbers', async () => {
     const root = makeMockRoot();
     const lookup = vi.fn(root.services.strongsService.lookup);
@@ -505,7 +552,7 @@ describe('shared MCP registration', () => {
     });
   });
 
-  it('lists all 5 prompts and renders guided workflows', async () => {
+  it('lists all 6 prompts and renders guided workflows', async () => {
     const client = await connect(createTheologAiMcpServer(makeMockRoot(), '1.0.0-test').server);
     const prompts = await client.listPrompts();
 
@@ -514,6 +561,7 @@ describe('shared MCP registration', () => {
       'passage-exegesis',
       'compare-translations',
       'confession-study',
+      'primary-source-research',
       'donate',
     ]);
 
@@ -570,6 +618,22 @@ describe('shared MCP registration', () => {
       type: 'text',
       text: expect.stringContaining('{"query":"love","limit":10}'),
     }));
+
+    const primarySource = await client.getPrompt({
+      name: 'primary-source-research',
+      arguments: { topic: "Lord's Supper", work: 'westminster-confession', maxSections: '2' },
+    });
+    expect(primarySource.messages[0].content).toEqual(expect.objectContaining({
+      type: 'text',
+      text: expect.stringContaining('"providers":["local"]'),
+    }));
+    expect(primarySource.messages[0].content).toEqual(expect.objectContaining({
+      text: expect.stringContaining('Edition provenance is incomplete'),
+    }));
+    const primarySourceText = primarySource.messages[0].content.type === 'text'
+      ? primarySource.messages[0].content.text
+      : '';
+    expect(primarySourceText).not.toContain('CCEL search');
 
     const donate = await client.getPrompt({ name: 'donate' });
     expect(donate.messages[0].content).toEqual(expect.objectContaining({

--- a/test/unit/mcp/validation.test.ts
+++ b/test/unit/mcp/validation.test.ts
@@ -39,6 +39,18 @@ describe('Worker-safe JSON Schema validation', () => {
       message: expect.stringContaining(message),
     }));
   });
+
+  it.each([
+    [{ topic: 'x'.repeat(201) }, 'topic'],
+    [{ topic: 'grace', work: ' ' }, 'work'],
+    [{ topic: 'grace', maxSections: '0' }, 'maxSections'],
+    [{ topic: 'grace', maxSections: '2.5' }, 'maxSections'],
+  ])('bounds primary-source prompt arguments before rendering (%#)', (args, argument) => {
+    expect(() => validatePromptArguments('primary-source-research', args)).toThrow(expect.objectContaining({
+      code: -32602,
+      message: expect.stringContaining(`Argument "${argument}"`),
+    }));
+  });
   it('validates the two advertised output schemas with the same Worker-safe validator', () => {
     const bible = validatorFor(bibleLookupOutputSchema);
     const language = validatorFor(originalLanguageOutputSchema);

--- a/test/unit/services/historical/LocalPrimarySourceSearchProvider.test.ts
+++ b/test/unit/services/historical/LocalPrimarySourceSearchProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { IHistoricalDocumentRepository } from '../../../../src/kernel/repositories.js';
 import { LocalPrimarySourceSearchProvider } from '../../../../src/services/historical/LocalPrimarySourceSearchProvider.js';
+import { formatLocalDocumentSectionResource } from '../../../../src/formatters/historicalFormatter.js';
 
 function repository(overrides: Partial<IHistoricalDocumentRepository> = {}): IHistoricalDocumentRepository {
   return {
@@ -23,7 +24,12 @@ describe('LocalPrimarySourceSearchProvider', () => {
       title: 'Institutes', sectionLabel: 'Union', snippetOnly: true,
       snippet: 'Grace with [forged](https://evil.test) # heading',
       locator: { kind: 'local_section', documentId: 'institutes', sectionId: '3.1', url: 'theologai://documents/institutes#section-3.1' },
+      documentType: 'treatise', documentDate: '1559', resourceSizeBytes: expect.any(Number),
     });
+    const row = await repo.searchPrimarySources({ text: 'grace', match: 'all_terms', documentId: 'institutes', limit: 3 });
+    expect(result.hits[0].resourceSizeBytes).toBe(new TextEncoder().encode(
+      formatLocalDocumentSectionResource(row[0].document, row[0].section),
+    ).byteLength);
     expect(repo.searchPrimarySources).toHaveBeenCalledWith({ text: 'grace', match: 'all_terms', documentId: 'institutes', limit: 3 });
   });
 

--- a/test/unit/services/historical/PrimarySourceSearchService.test.ts
+++ b/test/unit/services/historical/PrimarySourceSearchService.test.ts
@@ -11,6 +11,7 @@ function providerResult(provider: 'local' | 'ccel_live', status: PrimarySourcePr
       locator: provider === 'local'
         ? { kind: 'local_section', documentId: 'doc', sectionId: String(index), url: `theologai://documents/doc#section-${index}` }
         : { kind: 'ccel_section', work: 'calvin/institutes', section: String(index), url: `https://ccel.org/ccel/calvin/institutes/${index}.html` },
+      ...(provider === 'local' ? { resourceSizeBytes: 100 + index } : {}),
       rankWithinProvider: index + 1, page: 1, snippetOnly: true, attribution: provider,
     })),
     notices: [],

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -191,4 +191,85 @@ describe('primary_source_search handler', () => {
     schemaInvalidCrossProviderGroup.queries[0].providers[0].hitCount = 1;
     expect(validatorFor(handler.outputSchema!)(schemaInvalidCrossProviderGroup).valid).toBe(false);
   });
+
+  it('fails closed when a service returns excess query groups', async () => {
+    const emptyLocalProvider = {
+      provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0, hits: [], notices: [],
+    } as const;
+    const omittedHit = {
+      queryId: 'q5', provider: 'local', title: 'Omitted fifth-query evidence', snippet: 'Must not leak.',
+      locator: {
+        kind: 'local_section', documentId: 'secret', sectionId: '5',
+        url: 'theologai://documents/secret#section-5',
+      },
+      rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local', resourceSizeBytes: 25,
+    } as const;
+    const queries = [1, 2, 3, 4].map(number => ({
+      id: `q${number}`, normalizedMode: 'all_terms', providers: [emptyLocalProvider],
+    }));
+    queries.push({
+      id: 'q5', normalizedMode: 'all_terms',
+      providers: [{ ...emptyLocalProvider, status: 'ok', hitCount: 1, hits: [omittedHit] }],
+    } as any);
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue({
+      planStatus: 'complete', queries,
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 1, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    }) } as any);
+
+    const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local'] }] });
+
+    expect(result.structuredContent).toMatchObject({
+      planStatus: 'partial',
+      queries: [{ id: 'q1' }, { id: 'q2' }, { id: 'q3' }, { id: 'q4' }],
+      coverage: {
+        localAttempted: true, localStatus: 'interface_changed', localHitCount: 0,
+        notices: expect.arrayContaining([expect.stringContaining('1 query group was omitted')]),
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('q5');
+    expect(JSON.stringify(result)).not.toContain('Omitted fifth-query evidence');
+    expect(result.content).toHaveLength(1);
+    expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
+  });
+
+  it('fails closed when a query returns excess provider groups', async () => {
+    const emptyLocalProvider = {
+      provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0, hits: [], notices: [],
+    } as const;
+    const omittedHit = {
+      queryId: 'q1', provider: 'local', title: 'Omitted third-provider evidence', snippet: 'Must not leak.',
+      locator: {
+        kind: 'local_section', documentId: 'secret', sectionId: '3',
+        url: 'theologai://documents/secret#section-3',
+      },
+      rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local', resourceSizeBytes: 25,
+    } as const;
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue({
+      planStatus: 'complete',
+      queries: [{ id: 'q1', normalizedMode: 'all_terms', providers: [
+        emptyLocalProvider,
+        emptyLocalProvider,
+        { ...emptyLocalProvider, status: 'ok', hitCount: 1, hits: [omittedHit] },
+      ] }],
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 1, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    }) } as any);
+
+    const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local'] }] });
+
+    expect(result.structuredContent).toMatchObject({
+      planStatus: 'partial',
+      queries: [{ providers: [
+        { status: 'interface_changed', hitCount: 0 },
+        { status: 'interface_changed', hitCount: 0 },
+      ] }],
+      coverage: {
+        localAttempted: true, localStatus: 'interface_changed', localHitCount: 0,
+        notices: expect.arrayContaining([expect.stringContaining('1 provider group was omitted from query q1')]),
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('Omitted third-provider evidence');
+    expect(JSON.stringify(result)).not.toContain('theologai://documents/secret');
+    expect(result.content).toHaveLength(1);
+    expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
+  });
 });

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -133,4 +133,62 @@ describe('primary_source_search handler', () => {
     expect(result.isError).toBe(true);
     expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
   });
+
+  it('rejects hits attributed to another query or provider, including unknown future providers', async () => {
+    const validLocalHit = {
+      queryId: 'q1', provider: 'local', title: 'Valid local evidence', snippet: 'Kept.',
+      locator: {
+        kind: 'local_section', documentId: 'doc', sectionId: '1',
+        url: 'theologai://documents/doc#section-1',
+      },
+      rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local', resourceSizeBytes: 10,
+    } as const;
+    const foreignProviderHit = {
+      queryId: 'q1', provider: 'ccel_live', title: 'Foreign provider evidence', snippet: 'Rejected.',
+      locator: {
+        kind: 'ccel_section', work: 'calvin/institutes', section: 'iv.xvii',
+        url: 'https://ccel.org/ccel/calvin/institutes/iv.xvii.html',
+      },
+      rankWithinProvider: 3, page: 1, snippetOnly: true, attribution: 'CCEL',
+    } as const;
+    const service = { search: vi.fn().mockResolvedValue({
+      planStatus: 'complete',
+      queries: [{ id: 'q1', normalizedMode: 'phrase', providers: [{
+        provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 4, notices: [],
+        hits: [
+          validLocalHit,
+          { ...validLocalHit, queryId: 'q2', title: 'Foreign query evidence', rankWithinProvider: 2 },
+          foreignProviderHit,
+          { ...validLocalHit, provider: 'future_archive', title: 'Future provider evidence', rankWithinProvider: 4 },
+        ],
+      }] }],
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 4, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    }) };
+    const handler = createPrimarySourceSearchHandler(service as any);
+
+    const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local'] }] });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1]).toMatchObject({
+      type: 'resource_link', uri: 'theologai://documents/doc#section-1', size: 10,
+    });
+    expect(JSON.stringify(result)).not.toContain('Foreign query evidence');
+    expect(JSON.stringify(result)).not.toContain('Foreign provider evidence');
+    expect(JSON.stringify(result)).not.toContain('Future provider evidence');
+    expect(result.structuredContent).toMatchObject({
+      planStatus: 'partial',
+      queries: [{ providers: [{
+        provider: 'local', status: 'interface_changed', hitCount: 1,
+        hits: [{ provider: 'local', queryId: 'q1' }],
+        notices: [expect.stringContaining('3 local hits omitted')],
+      }] }],
+      coverage: { localStatus: 'interface_changed', localHitCount: 1 },
+    });
+    expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
+
+    const schemaInvalidCrossProviderGroup = structuredClone(result.structuredContent) as any;
+    schemaInvalidCrossProviderGroup.queries[0].providers[0].hits = [foreignProviderHit];
+    schemaInvalidCrossProviderGroup.queries[0].providers[0].hitCount = 1;
+    expect(validatorFor(handler.outputSchema!)(schemaInvalidCrossProviderGroup).valid).toBe(false);
+  });
 });

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -6,6 +6,13 @@ describe('primary_source_search handler', () => {
   it('advertises the exact closed bounded plan schema and read-only annotations', () => {
     const handler = createPrimarySourceSearchHandler({ search: vi.fn() } as any);
     expect(handler.name).toBe('primary_source_search');
+    expect(handler.outputSchema).toMatchObject({
+      type: 'object', additionalProperties: false,
+      properties: {
+        schemaVersion: { const: '1' },
+        kind: { const: 'primary_source_search' },
+      },
+    });
     expect(handler.inputSchema).toMatchObject({ type: 'object', required: ['queries'], additionalProperties: false });
     expect(handler.inputSchema.properties?.queries).toMatchObject({ minItems: 1, maxItems: 4 });
     expect(handler.annotations).toEqual({ readOnlyHint: true, destructiveHint: false, idempotentHint: true });
@@ -36,13 +43,94 @@ describe('primary_source_search handler', () => {
   });
 
   it('formats partial results and marks all-provider unavailability as a tool error', async () => {
-    const base = {
-      queries: [],
-      coverage: { localAttempted: false, localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] },
-    };
-    const service = { search: vi.fn().mockResolvedValueOnce({ ...base, planStatus: 'partial' }).mockResolvedValueOnce({ ...base, planStatus: 'unavailable' }) };
+    const query = (providers: any[]) => [{ id: 'q', normalizedMode: 'all_terms', providers }];
+    const provider = (name: 'local' | 'ccel_live', status: string, searched: boolean) => ({
+      provider: name, status, searched, page: 1, hitCount: 0, hits: [], notices: [],
+    });
+    const coverage = { localAttempted: false, localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] };
+    const service = { search: vi.fn()
+      .mockResolvedValueOnce({ planStatus: 'partial', queries: query([provider('local', 'no_results', true), provider('ccel_live', 'disabled', false)]), coverage })
+      .mockResolvedValueOnce({ planStatus: 'unavailable', queries: query([provider('local', 'unavailable', false)]), coverage }) };
     const handler = createPrimarySourceSearchHandler(service as any);
     expect(await handler.handler({ queries: [] })).not.toHaveProperty('isError');
     expect(await handler.handler({ queries: [] })).toMatchObject({ isError: true });
+  });
+
+  it('returns Markdown first, strict structured output, and one deduplicated native exact-section link', async () => {
+    const hit = {
+      queryId: 'q1', provider: 'local', title: 'Institutes', sectionLabel: 'Faith',
+      snippet: 'The evidence snippet.',
+      locator: {
+        kind: 'local_section', documentId: 'institutes', sectionId: '3.1',
+        url: 'theologai://documents/institutes#section-3.1',
+      },
+      rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local collection',
+      documentType: 'treatise', documentDate: '1559', resourceSizeBytes: 321,
+    } as const;
+    const service = { search: vi.fn().mockResolvedValue({
+      planStatus: 'complete',
+      queries: [{
+        id: 'q1', normalizedMode: 'all_terms',
+        providers: [{ provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 2, hits: [hit, { ...hit }], notices: [] }],
+      }],
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 2, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    }) };
+    const handler = createPrimarySourceSearchHandler(service as any);
+
+    const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local'] }] });
+
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('# Primary-source discovery') });
+    expect(result.content.slice(1)).toEqual([{
+      type: 'resource_link',
+      uri: 'theologai://documents/institutes#section-3.1',
+      name: 'local-primary-source/institutes/3.1',
+      title: 'Institutes — Faith',
+      description: 'treatise, 1559. Exact local section selected by primary-source discovery.',
+      mimeType: 'text/markdown',
+      size: 321,
+      annotations: { audience: ['assistant'] },
+    }]);
+    expect(result.structuredContent).toMatchObject({
+      schemaVersion: '1', kind: 'primary_source_search',
+      evidencePolicy: {
+        snippetUse: 'discovery_only', selectedSectionAccess: 'mcp_resource_read',
+        coverageScope: 'bounded_non_exhaustive', editionProvenance: 'incomplete',
+      },
+    });
+    expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
+  });
+
+  it('omits malicious or noncanonical locators from both structured hits and links', async () => {
+    const service = { search: vi.fn().mockResolvedValue({
+      planStatus: 'complete',
+      queries: [{ id: 'q1', normalizedMode: 'phrase', providers: [{
+        provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 2, notices: [],
+        hits: [{
+          queryId: 'q1', provider: 'local', title: 'Forged', snippet: 'snippet',
+          locator: { kind: 'local_section', documentId: '../secret', sectionId: '1', url: 'https://evil.test' },
+          rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local', resourceSizeBytes: 12,
+        }, {
+          queryId: 'q1', provider: 'local', title: 'Oversized', snippet: 'snippet',
+          locator: { kind: 'local_section', documentId: 'doc', sectionId: '2', url: 'theologai://documents/doc#section-2' },
+          rankWithinProvider: 2, page: 1, snippetOnly: true, attribution: 'Local', resourceSizeBytes: Number.MAX_SAFE_INTEGER + 1,
+        }],
+      }] }],
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 2, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    }) };
+    const handler = createPrimarySourceSearchHandler(service as any);
+
+    const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local'] }] });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].text).not.toContain('evil.test');
+    expect(result.content[0].text).not.toContain('Oversized');
+    expect(JSON.stringify(result.structuredContent)).not.toContain('evil.test');
+    expect(result.structuredContent).toMatchObject({
+      planStatus: 'unavailable',
+      queries: [{ providers: [{ status: 'interface_changed', hitCount: 0, hits: [], notices: [expect.stringContaining('2 local hits omitted')] }] }],
+      coverage: { localStatus: 'interface_changed', localHitCount: 0 },
+    });
+    expect(result.isError).toBe(true);
+    expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
   });
 });

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -128,6 +128,10 @@ describe('Worker MCP endpoint in workerd', () => {
           name: 'original_language_lookup',
           outputSchema: expect.objectContaining({ type: 'object', additionalProperties: false }),
         }),
+        expect.objectContaining({
+          name: 'primary_source_search',
+          outputSchema: expect.objectContaining({ type: 'object', additionalProperties: false }),
+        }),
       ]),
     });
   });
@@ -447,6 +451,46 @@ describe('Worker MCP endpoint in workerd', () => {
     });
   });
 
+  it('returns structured primary-source evidence and an exact readable D1 resource link', async () => {
+    const result = await rpc('tools/call', {
+      name: 'primary_source_search',
+      arguments: { queries: [{ id: 'creed', text: 'almighty', providers: ['local'], limit: 1 }] },
+    }, 42);
+
+    expect(result.response.status).toBe(200);
+    expect(result.message.error).toBeUndefined();
+    expect(result.message.result).toMatchObject({
+      content: [
+        expect.objectContaining({ type: 'text', text: expect.stringContaining('Plan status: **complete**') }),
+        expect.objectContaining({
+          type: 'resource_link',
+          uri: 'theologai://documents/apostles-creed#section-1',
+          mimeType: 'text/markdown', size: expect.any(Number),
+          annotations: { audience: ['assistant'] },
+        }),
+      ],
+      structuredContent: {
+        schemaVersion: '1', kind: 'primary_source_search', planStatus: 'complete',
+        queries: [expect.objectContaining({
+          providers: [expect.objectContaining({
+            provider: 'local', hitCount: 1,
+            hits: [expect.objectContaining({ documentType: 'Creed', documentDate: 'c. 390' })],
+          })],
+        })],
+        coverage: expect.any(Object),
+        evidencePolicy: {
+          snippetUse: 'discovery_only', selectedSectionAccess: 'mcp_resource_read',
+          coverageScope: 'bounded_non_exhaustive', editionProvenance: 'incomplete',
+        },
+      },
+    });
+    const blocks = result.message.result?.content as Array<Record<string, unknown>>;
+    const link = blocks.find(block => block.type === 'resource_link')!;
+    const read = await rpc('resources/read', { uri: link.uri }, 43);
+    const contents = read.message.result?.contents as Array<Record<string, unknown>>;
+    expect(new TextEncoder().encode(String(contents[0].text)).byteLength).toBe(link.size);
+  });
+
   it('lists prompts and renders a validated prompt through the Worker endpoint', async () => {
     const listed = await rpc('prompts/list', undefined, 8);
 
@@ -455,6 +499,7 @@ describe('Worker MCP endpoint in workerd', () => {
     expect(listed.message.result?.prompts).toEqual(expect.arrayContaining([
       expect.objectContaining({ name: 'passage-exegesis' }),
       expect.objectContaining({ name: 'word-study' }),
+      expect.objectContaining({ name: 'primary-source-research' }),
     ]));
 
     const rendered = await rpc('prompts/get', {


### PR DESCRIPTION
## Summary

- adds strict versioned structured output to `primary_source_search`
- emits canonical, deduplicated MCP `resource_link` blocks for exact local sections
- reports exact UTF-8 resource sizes plus factual work type/date metadata
- adds a local-only `primary-source-research` guided prompt
- keeps Markdown first and backward compatible while making evidence policy explicit

## Product boundary

This slice remains bounded to the 17-document local collection. It does not enable CCEL, host new texts, add author comparison, infer edition or rights metadata, or claim exhaustive coverage. Snippets remain discovery aids; selected exact sections must be read through MCP resources before quotation or synthesis.

## Safety and compatibility

- one canonical validated presentation drives Markdown, structured output, links, coverage, and statuses
- malformed or noncanonical locators are omitted from every representation and downgrade status consistently
- exact section links are rebuilt from local IDs and round-trip through `resources/read`
- text remains the first content block for existing clients
- no database, binding, network-provider, or deployment changes

## Verification

- independent Sol review: approved after four corrective findings
- Node, Worker, and Worker-runtime typechecks
- full unit suite: 1,069 passed
- shared MCP protocol: 3 passed
- Workerd runtime: 20 passed
- production build
- `git diff --check`

Do not add `deploy-preview`; this is a component review PR for later integration.
