### PR TITLE
docs: update Phase 3 release status

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -116,12 +116,21 @@ deployment gates before it can be called shipped.
   and the current production D1 intentionally cannot satisfy its transform-5
   readiness contract.
 - **Original-language usage output.** The public occurrence-count, attested-form,
-  book-distribution, and keyset-pagination slice exists only as a local commit.
-  It has not been pushed, opened as a PR, deployed, or released.
+  book-distribution, and keyset-pagination slice is Sol-approved and preserved
+  as local commits. Its public cursor now uses a reproducible morphology-scoped
+  identity, `c3600bb55da75aa600f8c97885efa7d58a3e8c29c3fcc6445a553091011beabd`,
+  rather than coupling language pagination to unrelated D1 data. It has not
+  been pushed, opened as a PR, deployed, or released.
 - **Primary-source catalog and scope.** Catalog-aware discovery work is local
-  and uncommitted while its authoritative metadata provenance is being
-  completed and reviewed. It has not been pushed, deployed, or released, and it
-  does not enable CCEL or publish external document bodies.
+  and Sol-approved with authoritative per-claim metadata provenance,
+  conservative date routing, and lookup-only aliases separated from historical
+  evidence. It does not enable CCEL or publish external document bodies.
+- **Combined public candidate.** Usage output and catalog scope are integrated
+  in local commit `341de01` with transform-6 whole-D1 identity
+  `c334b4b91c3a7c334a9425937c7f99473f27014ddae6cea377ee38bd578a6707`.
+  The combined suite, deterministic seed reconstruction, Workerd import,
+  runtime, E2E, and conformance checks pass. The branch remains unpushed,
+  undeployed, and unreleased until the dependency and preview gates below.
 
 ## Release gates
 
@@ -162,12 +171,12 @@ Code readiness and operational readiness are deliberately separate:
   then use a fresh transform-5 preview D1 replacement to verify occurrence
   counts, book distribution, attested forms, keyset pagination, legacy
   behavior, and stale cursor rejection.
-- Integrate the provenance-complete primary-source catalog and scope slice after
-  that usage rehearsal, preserving the reviewed metadata claims and advancing
-  the materialization identity deliberately. Rehearse the combined transform-6
-  candidate against another fresh preview database, then merge and promote the
-  integrated release only through its separately authorized production-data
-  and deployment gates.
+- After that usage rehearsal, replay the already assembled combined candidate
+  onto the reviewed stack and confirm its morphology-scoped identity remains
+  stable while the whole-D1 identity advances. Rehearse the combined
+  transform-6 candidate against another fresh preview database, then merge and
+  promote the integrated release only through its separately authorized
+  production-data and deployment gates.
 - Broaden advanced original-language study only after those foundations, using
   carefully sourced semantic-domain and discourse evidence useful to both
   beginners and readers of Greek or Hebrew.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -111,7 +111,10 @@ deployment gates before it can be called shipped.
   repository foundation is stacked on PR #27 and is published as a draft PR,
   but remains unmerged, undeployed, and unreleased. It does not yet change the
   public MCP behavior. It must be rebased or retargeted after PR #27 lands, then
-  receive fresh CI and review.
+  receive fresh CI and review. It should remain a reviewed foundation rather
+  than merge independently: every `main` push starts the production workflow,
+  and the current production D1 intentionally cannot satisfy its transform-5
+  readiness contract.
 - **Original-language usage output.** The public occurrence-count, attested-form,
   book-distribution, and keyset-pagination slice exists only as a local commit.
   It has not been pushed, opened as a PR, deployed, or released.
@@ -153,16 +156,18 @@ Code readiness and operational readiness are deliberately separate:
   accepted; prepare and promote production data only with explicit owner
   authorization.
 - After PR #27 lands, rebase or retarget draft PR #29 to `main`, rerun CI and
-  review, and land the invisible original-language usage foundation before its
-  public output slice.
-- Rebase the local original-language usage output onto the landed foundation,
-  then use a fresh preview D1 replacement to verify occurrence counts, book
-  distribution, attested forms, keyset pagination, legacy behavior, and stale
-  cursor rejection before release.
-- Integrate the local primary-source catalog and scope slice after the usage
-  output, preserving its authoritative per-claim provenance and advancing the
-  materialization identity deliberately; rehearse it against another fresh
-  preview database before release.
+  review, but keep the invisible foundation unmerged while its public slices
+  remain in flight.
+- Rebase the local original-language usage output onto the reviewed foundation,
+  then use a fresh transform-5 preview D1 replacement to verify occurrence
+  counts, book distribution, attested forms, keyset pagination, legacy
+  behavior, and stale cursor rejection.
+- Integrate the provenance-complete primary-source catalog and scope slice after
+  that usage rehearsal, preserving the reviewed metadata claims and advancing
+  the materialization identity deliberately. Rehearse the combined transform-6
+  candidate against another fresh preview database, then merge and promote the
+  integrated release only through its separately authorized production-data
+  and deployment gates.
 - Broaden advanced original-language study only after those foundations, using
   carefully sourced semantic-domain and discourse evidence useful to both
   beginners and readers of Greek or Hebrew.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -90,10 +90,35 @@ pinned OpenScriptures and STEPBible evidence, records the exact correction
 ledger, and advances the D1 materialization identity without changing corpus
 row counts or the public MCP tool inventory.
 
-PR #27 is not merged or deployed. Its next operational gate is a freshly
-migrated and fully seeded preview D1 replacement, followed by the protected
-preview deployment and complete preview audit. The currently bound preview and
-production databases must not be mutated in place to make the candidate pass.
+PR #27 remains open and unmerged, but its preview release gate is complete. A
+fresh replacement database, `theologai-preview-20260713-c`, was migrated and
+fully seeded without mutating its predecessor. Protected workflow run
+`29277315492` created GitHub deployment `5429947573` and deployed Worker version
+`734aec3b-d6c3-456b-a203-c7f940a2d081`. The combined preview audit passed all
+nine Strong's corrections, all 237 morphology corrections, all 11
+parallel-passage cases, and sampled the remaining MCP surface; positive donation
+verification remains manual. The preview authorization label was then removed
+and the revocation workflow completed successfully.
+
+This is preview evidence only. Production remains on the PR #26 release and was
+not changed, queried, or deployed as part of PR #27's preview preparation. PR
+#27 still requires its merge and separately authorized production-data and
+deployment gates before it can be called shipped.
+
+## Dependent work in flight
+
+- **Draft PR #29 — original-language usage foundation.** This migration and
+  repository foundation is stacked on PR #27 and is published as a draft PR,
+  but remains unmerged, undeployed, and unreleased. It does not yet change the
+  public MCP behavior. It must be rebased or retargeted after PR #27 lands, then
+  receive fresh CI and review.
+- **Original-language usage output.** The public occurrence-count, attested-form,
+  book-distribution, and keyset-pagination slice exists only as a local commit.
+  It has not been pushed, opened as a PR, deployed, or released.
+- **Primary-source catalog and scope.** Catalog-aware discovery work is local
+  and uncommitted while its authoritative metadata provenance is being
+  completed and reviewed. It has not been pushed, deployed, or released, and it
+  does not enable CCEL or publish external document bodies.
 
 ## Release gates
 
@@ -124,11 +149,20 @@ Code readiness and operational readiness are deliberately separate:
 
 ## Next work
 
-- Complete PR #27 through a fresh preview D1 replacement, protected preview
-  deployment, and functional audit before any merge or production cutover.
-- After the Unicode correction is merged and safely released, add the planned
-  advanced-usage schema for occurrence counts, book distribution, attested
-  forms, and keyset cursor pagination.
+- Merge PR #27 only after its completed preview evidence and release review are
+  accepted; prepare and promote production data only with explicit owner
+  authorization.
+- After PR #27 lands, rebase or retarget draft PR #29 to `main`, rerun CI and
+  review, and land the invisible original-language usage foundation before its
+  public output slice.
+- Rebase the local original-language usage output onto the landed foundation,
+  then use a fresh preview D1 replacement to verify occurrence counts, book
+  distribution, attested forms, keyset pagination, legacy behavior, and stale
+  cursor rejection before release.
+- Integrate the local primary-source catalog and scope slice after the usage
+  output, preserving its authoritative per-claim provenance and advancing the
+  materialization identity deliberately; rehearse it against another fresh
+  preview database before release.
 - Broaden advanced original-language study only after those foundations, using
   carefully sourced semantic-domain and discourse evidence useful to both
   beginners and readers of Greek or Hebrew.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,6 +22,9 @@ is local source context only and does not define the current product contract.
   primary-source research, normalized UBS runtime and public cutover, and
   contextual original-language study, merged as
   `639d0a02c1c666340f0e2ee3bcb4b4d5a336d9fb`.
+- **Phase 3 follow-up integration / PR #26:** pinned, reproducible
+  biblical-language source revisions plus the primary-source evidence handoff,
+  merged as `65db03e8cd02098064a748f96cca8da22c974381`.
 
 These entries describe merged repository state. Deployment state is established
 only by the relevant protected workflow and post-deployment smoke evidence; a
@@ -56,33 +59,41 @@ PR #21. Their stacked PRs #14–#20 are closed as superseded review vehicles:
    context-first workflow for one token in one verse, with morphology,
    source-separated lexical evidence, provenance, and interpretive limits.
 
-The released server advertises eleven tools and structured output for
-`bible_lookup`, `parallel_passages`, `original_language_lookup`, and
-`original_language_study`. Markdown remains available for compatibility.
+The released server advertises eleven tools, six guided prompts, and structured
+output for `bible_lookup`, `parallel_passages`, `primary_source_search`,
+`original_language_lookup`, and `original_language_study`. Markdown remains
+available for compatibility.
 
-Protected production workflow run `29257538930` deployed the PR #21 merge after
-the exact-corpus readiness gate passed. The post-deployment production audit
-passed all 84 checks. Live CCEL discovery remains intentionally disabled and is
-not part of the public MCP contract.
+PR #26 made the two formerly staged follow-up slices part of the shipped
+baseline:
 
-## Current follow-up integration candidate
+1. **Pinned biblical-language source revisions.** Immutable upstream source
+   identities, source and generated-artifact verification, and a reproducible,
+   atomic regeneration workflow with semantic-drift reporting.
+2. **Primary-source evidence handoff.** A stable, bounded structured-output
+   contract for `primary_source_search`, the local-only
+   `primary-source-research` prompt, and exact native resource links for
+   selected canonical sections. It does not enable or advertise live CCEL
+   discovery.
 
-Two independently reviewed follow-up slices are staged after the shipped PR #21
-baseline and are not yet merged or deployed:
+Protected production workflow run `29267651916` deployed the PR #26 merge after
+the release gates passed. The post-deployment production audit passed 54/54
+checks, and the focused parallel-passage audit passed 11/11 checks. Live CCEL
+discovery remains intentionally disabled and is not part of the public MCP
+contract.
 
-1. **Pinned biblical-language source revisions.** Records immutable upstream
-   source identities, verifies source and generated-artifact integrity, and adds
-   a reproducible, atomic regeneration workflow with semantic-drift reporting.
-2. **Primary-source evidence handoff.** Gives `primary_source_search` a stable,
-   bounded structured-output contract plus the local-only
-   `primary-source-research` prompt and exact native resource links for selected
-   canonical sections. It does not enable or advertise live CCEL discovery.
+## Current release candidate
 
-The follow-up integration candidate still advertises eleven tools, but expands
-structured output to `bible_lookup`, `parallel_passages`,
-`primary_source_search`, `original_language_lookup`, and
-`original_language_study`, and expands the guided prompt set from five to six.
-These candidate counts do not describe the currently deployed PR #21 server.
+**PR #27 — biblical-language Unicode correction** is the current release
+candidate. It repairs the bounded historical UTF-8 corruption against the
+pinned OpenScriptures and STEPBible evidence, records the exact correction
+ledger, and advances the D1 materialization identity without changing corpus
+row counts or the public MCP tool inventory.
+
+PR #27 is not merged or deployed. Its next operational gate is a freshly
+migrated and fully seeded preview D1 replacement, followed by the protected
+preview deployment and complete preview audit. The currently bound preview and
+production databases must not be mutated in place to make the candidate pass.
 
 ## Release gates
 
@@ -113,11 +124,11 @@ Code readiness and operational readiness are deliberately separate:
 
 ## Next work
 
-- Correct known Greek/Hebrew Unicode normalization and display defects against
-  pinned-source evidence before expanding language-study interpretation.
-- After Unicode correctness is established, add the planned advanced-usage
-  schema for occurrence counts, book distribution, attested forms, and keyset
-  cursor pagination.
+- Complete PR #27 through a fresh preview D1 replacement, protected preview
+  deployment, and functional audit before any merge or production cutover.
+- After the Unicode correction is merged and safely released, add the planned
+  advanced-usage schema for occurrence counts, book distribution, attested
+  forms, and keyset cursor pagination.
 - Broaden advanced original-language study only after those foundations, using
   carefully sourced semantic-domain and discourse evidence useful to both
   beginners and readers of Greek or Hebrew.


### PR DESCRIPTION
## What changed

- records PR #26 as merged and deployed to production
- records PR #27 as open and unmerged while documenting its completed fresh-preview-D1, protected-deployment, and functional-audit evidence
- distinguishes draft PR #29 from the unpushed original-language usage output and uncommitted primary-source catalog/scope work
- updates dependency order and preserves separate production authorization gates

## Why

The roadmap still described PR #27 preview preparation and audit as future work after those gates had passed. That stale framing could lead later implementation and release work to use the wrong baseline or mistake downstream local work for shipped behavior.

## Impact

Documentation only. No runtime, database, workflow, preview, or production behavior changes.

## Verification

- `git diff --check`
- `npm run docs:check`: 5/5 on Node 22
- live PR state checked for PR #27 and draft PR #29
