### PR TITLE
Add local primary-source research bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with exact byte sizes. It does not advertise or invoke inactive CCEL adapters.
 - Added the local-only `primary-source-research` prompt for bounded topic surveys
   or exact-work searches followed by explicit MCP section reads.
+- Added v3 primary-source research bundles: relevance or deterministic
+  round-robin work selection, limit-plus-one result-window evidence, a
+  metadata-only `theologai://primary-sources/catalog` JSON resource, and guided
+  topic, exact-work, and separate-creator workflows. Markdown remains available.
 - Added `original_language_study`, a context-first study of one verse token that
   combines morphology and source-separated lexical evidence while stating its
   interpretive limits.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ fresh server and transport.
 | `parallel_passages` | Return complete UBS source-attested parallel groups by default; legacy curated edges and OpenBible.info cross references require explicit selectors and remain separate. |
 | `commentary_lookup` | Retrieve Matthew Henry, JFB, Adam Clarke, John Gill, Keil-Delitzsch (OT), or Tyndale notes. |
 | `classic_text_lookup` | Search and browse the 17 locally indexed historical documents. Remote CCEL document bodies are not retrieved or republished. |
-| `primary_source_search` | Execute a bounded local query plan with versioned structured results, exact work/creator and inclusive composition-year scope, explicit catalog coverage, and native links to exact section resources. Snippets remain discovery-only. |
+| `primary_source_search` | Execute a bounded local query plan with v3 structured results, relevance or deterministic work-diverse selection, honest result windows, exact work/creator and inclusive composition-year scope, explicit catalog coverage, and native links to exact section resources. Snippets remain discovery-only. |
 | `original_language_lookup` | Look up or search Strong's entries, with opt-in exact corrected-corpus usage and bounded occurrence pages for exact identities. |
 | `bible_verse_morphology` | Return word-by-word morphology for a specific verse. |
 | `original_language_study` | Resolve and study one Greek or Hebrew token in one verse with contextual morphology, source-separated lexical evidence, and explicit interpretive limits. |
@@ -74,7 +74,9 @@ content. Bible, parallel-passage, and original-language structured results
 include bounded, result-local provenance records. Primary-source results do not
 invent edition provenance records: their evidence policy explicitly marks
 edition provenance incomplete, and they link only canonical local sections with
-exact UTF-8 sizes. All other tools retain their current Markdown-only result
+exact UTF-8 sizes. Their result windows say only whether one additional match
+was directly observed through private lookahead; they do not imply exhaustive
+counts. All other tools retain their current Markdown-only result
 contract.
 
 ### Resources
@@ -83,6 +85,7 @@ contract.
 |---|---|
 | `theologai://translations` | Available Bible translations. |
 | `theologai://commentaries` | Available commentary sources. |
+| `theologai://primary-sources/catalog` | JSON metadata inventory for the hosted primary-source collection; no document bodies or provenance URLs. |
 | `theologai://documents/{slug}` | A locally indexed creed, confession, or catechism. |
 | `theologai://strongs/{number}` | A Strong's dictionary entry such as `G26` or `H430`. |
 
@@ -93,8 +96,8 @@ contract.
 | `word-study` | Strong's lookup/search, morphology, context, and synthesis. |
 | `passage-exegesis` | Text, language, cross references, commentary, and historical theology. |
 | `compare-translations` | Compare translation choices against morphology and lexical data. |
-| `confession-study` | Compare a doctrine across the locally indexed historical collection. |
-| `primary-source-research` | Survey a topic or scope separate creator, exact-work, and composition-year searches, then read selected exact sections as evidence. |
+| `confession-study` | Inspect the hosted catalog, build a work-diverse doctrinal survey, then read selected exact sections. |
+| `primary-source-research` | Inspect the catalog; use work diversity for topic/creator surveys or relevance within one work; then read at most five unique exact sections as evidence. |
 | `donate` | Explain voluntary donation options. |
 
 ## Content scope and provenance

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -54,11 +54,28 @@ modeled as a continuous 1677-1689 interval.
 
 ## Query behavior
 
+The listed, readable `theologai://primary-sources/catalog` resource exposes the
+hosted inventory as `application/json`. Its versioned payload includes only
+reviewed work metadata already materialized in `documents.metadata.catalog`:
+identity, title, document type, exact lookup aliases, composition interval,
+creator names and roles, metadata status, and stable provenance IDs. It embeds
+no work body and no provenance URL. Its policy object states that scope is the
+hosted collection only, aliases are routing-only, edition provenance is
+incomplete, and rights status is not established by this inventory.
+
 Each query may include one exact `work`, one exact reviewed creator name in
 `author`, and inclusive `startYear`/`endYear` bounds. Date matching uses interval
 overlap: a work is eligible when its reviewed composition interval overlaps the
 requested interval. Multi-creator research uses separate query-plan entries so
 coverage and misses cannot be blended.
+
+Each query accepts `selection: relevance | work_diversity`; omission defaults
+to `relevance`. Relevance selection preserves FTS rank followed by stable
+section identity and is the appropriate within-work locator. Work diversity is
+deterministic round-robin selection: the best matching section from each work
+precedes every second-best section, then every third-best section, with
+relevance and stable section identity breaking ties inside a round. SQLite and
+D1 use the same SQL generator and ordering contract.
 
 Lookup aliases are exact routing aids only. They are not creator/date metadata,
 historical evidence, or text shown as a research result. Generic labels such as
@@ -84,7 +101,23 @@ Local hits include at most four stable `metadataProvenanceIds`, allowing an
 auditor to resolve each runtime creator/date claim to the companion manifest
 without embedding source descriptions or URLs in every result.
 
+Structured output schema v3 adds the query's required
+`normalizedSelection` and a required provider `resultWindow`. Local searched
+queries privately request `limit + 1`, return at most `limit`, and report only
+`additional_match_observed` or `no_additional_match_observed`. Unsearched,
+unavailable, unsupported, catalog-miss, and dormant external-provider results
+use `not_evaluated`. This is deliberately not a total count or an exhaustiveness
+claim. If a plan-wide or presentation boundary removes returned matches, the
+public window changes to `additional_match_observed` and preserves a
+partial/fail-closed envelope where applicable.
+
 Search snippets remain discovery-only. Clients must call MCP `resources/read`
 on selected canonical section links before quotation, author/work comparison,
 or substantive conclusions. Edition and transcription provenance remains
 incomplete as stated by the existing evidence policy.
+
+The `primary-source-research` and `confession-study` prompts read the catalog
+before search. Topic and creator comparisons use work diversity; exact-work
+location uses relevance. Creator comparisons remain separate query items, use
+no proxy for an absent requested creator, deduplicate exact locators, and read
+no more than five exact section resources before synthesis.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -135,6 +135,21 @@ No other database deletion is authorized. The corrective preview gate is
 complete. Production remains untouched and requires a separate owner decision
 and protected release process.
 
+### Primary-source research-bundle follow-up (unreleased)
+
+The next local-only application slice upgrades `primary_source_search` to v3
+without adding a tool, migration, corpus body, live CCEL path, configuration,
+or deployment change. It adds relevance and deterministic round-robin
+work-diverse selection, limit-plus-one result-window evidence, and the listed
+metadata-only `theologai://primary-sources/catalog` JSON resource. Guided topic
+and creator surveys use work diversity; exact-work location uses relevance;
+creator scopes remain separate and exact-resource reads remain mandatory.
+
+This slice preserves creator roles, routing-only alias policy, incomplete
+edition provenance, unestablished catalog rights status, canonical fail-closed
+section locators, and backward-compatible Markdown. It must pass SQLite/D1
+parity, protocol tests, integrated review, CI, and preview audit before release.
+
 ## Release gates
 
 Code readiness and operational readiness are deliberately separate:
@@ -176,8 +191,8 @@ Code readiness and operational readiness are deliberately separate:
 - Expand primary-source discovery beyond the initial local collection through
   rights-reviewed, freely redistributable editions and provider adapters. Do
   not mirror or republish CCEL transcriptions without edition-specific rights.
-- Improve primary-source research bundles for topic surveys, within-work
-  location, and author comparison while leaving synthesis to the host model.
+- Review, integrate, and preview-audit the prepared primary-source research
+  bundle slice, leaving synthesis to the host model.
 - Evaluate section-span commentary only where provider coverage can be stated
   honestly; never relabel a section anchor as an exact verse range.
 - Continue modern MCP output improvements tool by tool when a stable structured

--- a/skills/confession-study/SKILL.md
+++ b/skills/confession-study/SKILL.md
@@ -22,6 +22,8 @@ prewritten grouping.
 
 ### Step 1: Identify Relevant Documents
 
+- Read `theologai://primary-sources/catalog` with MCP `resources/read` before
+  selecting works. Treat its aliases as exact routing aids, not evidence.
 - Treat any traditions named by the user as comparison interests, not as author
   filters or evidence that a document belongs to that tradition.
 - Do not infer tradition, authorship, or creator role from a title or topic.
@@ -29,7 +31,7 @@ prewritten grouping.
 ### Step 2: Search Across Traditions
 
 - Call `primary_source_search` with one bounded local query plan, for example
-  `{ "queries": [{ "id": "confession-topic", "text": "the doctrinal topic", "providers": ["local"], "match": "all_terms", "limit": 5 }] }`.
+  `{ "queries": [{ "id": "confession-topic", "text": "the doctrinal topic", "providers": ["local"], "match": "all_terms", "selection": "work_diversity", "limit": 5 }] }`.
 - Treat returned snippets as discovery-only. Preserve document metadata, creator
   names, and creator roles exactly as returned.
 - Do not claim the search covered sources outside the hosted collection, and do
@@ -37,7 +39,7 @@ prewritten grouping.
 
 ### Step 3: Read Specific Sections
 
-- Select only the most relevant returned sections.
+- Select at most five unique returned sections and deduplicate locators.
 - Follow each selected canonical `resource_link` with MCP `resources/read` and
   confirm the returned URI matches the selected locator.
 - Do not quote, characterize a position, or compare documents from snippets.

--- a/src/adapters/d1/D1HistoricalDocumentRepository.ts
+++ b/src/adapters/d1/D1HistoricalDocumentRepository.ts
@@ -14,8 +14,7 @@ import type {
 } from '../../kernel/repositories.js';
 import {
   composeLocalPrimarySourceFtsQuery,
-  LOCAL_PRIMARY_SOURCE_SEARCH_SQL,
-  localPrimarySourceScopedSearchSql,
+  localPrimarySourceSearchSql,
 } from '../shared/primarySourceSearchSql.js';
 import { mapDocumentDatabaseRow } from '../shared/historicalDocumentMetadata.js';
 
@@ -110,9 +109,7 @@ export class D1HistoricalDocumentRepository implements IHistoricalDocumentReposi
   async searchPrimarySources(options: PrimarySourceLocalSearchOptions): Promise<PrimarySourceLocalSearchRow[]> {
     validatePrimarySourceOptions(options);
     const ftsQuery = composeLocalPrimarySourceFtsQuery(options.text, options.match);
-    const statement = this.db.prepare(options.documentIds
-      ? localPrimarySourceScopedSearchSql(options.documentIds.length)
-      : LOCAL_PRIMARY_SOURCE_SEARCH_SQL);
+    const statement = this.db.prepare(localPrimarySourceSearchSql(options.selection ?? 'relevance', options.documentIds?.length));
     const bound = options.documentIds
       ? statement.bind(ftsQuery, ...options.documentIds, options.limit)
       : statement.bind(ftsQuery, options.limit);
@@ -167,7 +164,8 @@ function mapPrimarySourceRow(row: PrimarySourceSearchDatabaseRow): PrimarySource
 function validatePrimarySourceOptions(options: PrimarySourceLocalSearchOptions): void {
   if (!options || typeof options.text !== 'string' || options.text.length < 1) throw new Error('Primary-source search text is required');
   if (options.match !== 'all_terms' && options.match !== 'phrase') throw new Error('Primary-source match mode is invalid');
-  if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 8) throw new Error('Primary-source limit must be 1..8');
+  if (options.selection !== undefined && options.selection !== 'relevance' && options.selection !== 'work_diversity') throw new Error('Primary-source selection is invalid');
+  if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 9) throw new Error('Primary-source internal limit must be 1..9');
   if (options.documentIds !== undefined && (!Array.isArray(options.documentIds)
     || options.documentIds.length < 1 || options.documentIds.length > 17
     || options.documentIds.some(id => typeof id !== 'string' || id.length < 1)

--- a/src/adapters/data/HistoricalDocumentRepository.ts
+++ b/src/adapters/data/HistoricalDocumentRepository.ts
@@ -16,7 +16,7 @@ import type {
 import {
   composeLocalPrimarySourceFtsQuery,
   LOCAL_PRIMARY_SOURCE_SEARCH_SQL,
-  localPrimarySourceScopedSearchSql,
+  localPrimarySourceSearchSql,
 } from '../shared/primarySourceSearchSql.js';
 import { mapDocumentDatabaseRow } from '../shared/historicalDocumentMetadata.js';
 
@@ -134,10 +134,14 @@ export class HistoricalDocumentRepository implements IHistoricalDocumentReposito
   searchPrimarySources(options: PrimarySourceLocalSearchOptions): PrimarySourceLocalSearchRow[] {
     validatePrimarySourceOptions(options);
     const ftsQuery = composeLocalPrimarySourceFtsQuery(options.text, options.match);
+    const selection = options.selection ?? 'relevance';
+    const sql = localPrimarySourceSearchSql(selection, options.documentIds?.length);
+    const statement = selection === 'relevance' && options.documentIds === undefined
+      ? this.stmtPrimarySourceSearch
+      : this.db.prepare(sql);
     const rows = options.documentIds
-      ? this.db.prepare(localPrimarySourceScopedSearchSql(options.documentIds.length))
-        .all(ftsQuery, ...options.documentIds, options.limit)
-      : this.stmtPrimarySourceSearch.all(ftsQuery, options.limit);
+      ? statement.all(ftsQuery, ...options.documentIds, options.limit)
+      : statement.all(ftsQuery, options.limit);
     return (rows as PrimarySourceSearchDatabaseRow[]).map(mapPrimarySourceRow);
   }
 
@@ -192,7 +196,8 @@ function mapPrimarySourceRow(row: PrimarySourceSearchDatabaseRow): PrimarySource
 function validatePrimarySourceOptions(options: PrimarySourceLocalSearchOptions): void {
   if (!options || typeof options.text !== 'string' || options.text.length < 1) throw new Error('Primary-source search text is required');
   if (options.match !== 'all_terms' && options.match !== 'phrase') throw new Error('Primary-source match mode is invalid');
-  if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 8) throw new Error('Primary-source limit must be 1..8');
+  if (options.selection !== undefined && options.selection !== 'relevance' && options.selection !== 'work_diversity') throw new Error('Primary-source selection is invalid');
+  if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 9) throw new Error('Primary-source internal limit must be 1..9');
   if (options.documentIds !== undefined && (!Array.isArray(options.documentIds)
     || options.documentIds.length < 1 || options.documentIds.length > 17
     || options.documentIds.some(id => typeof id !== 'string' || id.length < 1)

--- a/src/adapters/shared/primarySourceSearchSql.ts
+++ b/src/adapters/shared/primarySourceSearchSql.ts
@@ -1,4 +1,4 @@
-import type { PrimarySourceSearchMatch } from '../../services/historical/primarySourceTypes.js';
+import type { PrimarySourceSearchMatch, PrimarySourceSelection } from '../../services/historical/primarySourceTypes.js';
 
 export const LOCAL_PRIMARY_SOURCE_SEARCH_SQL = `SELECT ds.id, ds.document_id, ds.section_number, ds.title, ds.content, ds.topics,
        d.title AS document_title, d.type AS document_type, d.date AS document_date, d.metadata AS document_metadata
@@ -8,6 +8,8 @@ export const LOCAL_PRIMARY_SOURCE_SEARCH_SQL = `SELECT ds.id, ds.document_id, ds
  WHERE sections_fts MATCH ?
  ORDER BY rank, ds.id
  LIMIT ?`;
+
+export const LOCAL_PRIMARY_SOURCE_WORK_DIVERSE_SEARCH_SQL = workDiverseSql();
 
 export function localPrimarySourceScopedSearchSql(documentCount: number): string {
   if (!Number.isSafeInteger(documentCount) || documentCount < 1 || documentCount > 17) {
@@ -21,6 +23,50 @@ export function localPrimarySourceScopedSearchSql(documentCount: number): string
  WHERE sections_fts MATCH ? AND ds.document_id IN (${Array(documentCount).fill('?').join(', ')})
  ORDER BY rank, ds.id
  LIMIT ?`;
+}
+
+export function localPrimarySourceWorkDiverseScopedSearchSql(documentCount: number): string {
+  if (!Number.isSafeInteger(documentCount) || documentCount < 1 || documentCount > 17) {
+    throw new Error('Local primary-source document scope must contain 1..17 documents');
+  }
+  return workDiverseSql(` AND ds.document_id IN (${Array(documentCount).fill('?').join(', ')})`);
+}
+
+export function localPrimarySourceSearchSql(selection: PrimarySourceSelection, documentCount?: number): string {
+  if (selection === 'relevance') {
+    return documentCount === undefined ? LOCAL_PRIMARY_SOURCE_SEARCH_SQL : localPrimarySourceScopedSearchSql(documentCount);
+  }
+  if (selection === 'work_diversity') {
+    return documentCount === undefined ? LOCAL_PRIMARY_SOURCE_WORK_DIVERSE_SEARCH_SQL : localPrimarySourceWorkDiverseScopedSearchSql(documentCount);
+  }
+  throw new Error('Local primary-source selection is invalid');
+}
+
+/**
+ * Deterministic round-robin selection: the best section from every matching
+ * work precedes every second-best section, then every third-best section.
+ * Relevance and the stable section row id break ties within each round.
+ */
+function workDiverseSql(scope = ''): string {
+  return `WITH matching_sections AS (
+    SELECT ds.id, ds.document_id, ds.section_number, ds.title, ds.content, ds.topics,
+           d.title AS document_title, d.type AS document_type, d.date AS document_date,
+           d.metadata AS document_metadata, bm25(sections_fts) AS relevance_rank
+      FROM sections_fts
+      JOIN document_sections ds ON ds.id = sections_fts.rowid
+      JOIN documents d ON d.id = ds.document_id
+     WHERE sections_fts MATCH ?${scope}
+  ), ranked_sections AS (
+    SELECT *, ROW_NUMBER() OVER (
+      PARTITION BY document_id ORDER BY relevance_rank, id
+    ) AS work_rank
+      FROM matching_sections
+  )
+  SELECT id, document_id, section_number, title, content, topics,
+         document_title, document_type, document_date, document_metadata
+    FROM ranked_sections
+   ORDER BY work_rank, relevance_rank, id
+   LIMIT ?`;
 }
 
 /** Compose only quoted FTS5 literals; caller text can never become FTS syntax. */

--- a/src/formatters/primarySourceFormatter.ts
+++ b/src/formatters/primarySourceFormatter.ts
@@ -8,10 +8,14 @@ export function formatPrimarySourceSearch(result: PresentedPrimarySourceSearch):
     '',
   ];
   for (const query of result.queries) {
-    lines.push(`## Query \`${safe(query.id)}\``, '', `Match mode: ${query.normalizedMode}`, '');
+    lines.push(
+      `## Query \`${safe(query.id)}\``, '',
+      `Match mode: ${query.normalizedMode} · Selection: ${query.normalizedSelection}`, '',
+    );
     for (const provider of query.providers) {
       const name = provider.provider === 'local' ? 'Local historical index' : 'CCEL live search';
       lines.push(`### ${name}`, '', `Status: **${provider.status}** · Returned hits: ${provider.hitCount}`, '');
+      lines.push(`Result window: ${provider.resultWindow.additionalMatchStatus}`, '');
       if (provider.scope) {
         const requested = [
           provider.scope.requested.work ? `work=${safe(provider.scope.requested.work)}` : '',

--- a/src/kernel/repositories.ts
+++ b/src/kernel/repositories.ts
@@ -187,6 +187,7 @@ export interface DocumentSection {
 export interface PrimarySourceLocalSearchOptions {
   text: string;
   match: 'all_terms' | 'phrase';
+  selection?: 'relevance' | 'work_diversity';
   documentIds?: string[];
   limit: number;
 }

--- a/src/mcp/primarySourceCatalog.ts
+++ b/src/mcp/primarySourceCatalog.ts
@@ -1,0 +1,33 @@
+import type { DocumentInfo } from '../kernel/repositories.js';
+
+export const PRIMARY_SOURCE_CATALOG_URI = 'theologai://primary-sources/catalog';
+
+/** Public metadata-only inventory. It deliberately contains no work bodies or provenance URLs. */
+export function buildPrimarySourceCatalog(documents: DocumentInfo[]) {
+  const works = documents
+    .filter((document): document is DocumentInfo & { catalog: NonNullable<DocumentInfo['catalog']> } => document.catalog !== undefined)
+    .map(document => ({
+      id: document.id,
+      title: document.title,
+      documentType: document.type,
+      lookupAliases: [...document.catalog.lookupAliases],
+      composition: { ...document.catalog.composition },
+      creators: document.catalog.creators.map(creator => ({ ...creator })),
+      metadataStatus: document.catalog.metadataStatus,
+      metadataProvenanceIds: [...document.catalog.metadataProvenanceIds],
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id, 'en-US'));
+
+  return {
+    schemaVersion: '1' as const,
+    kind: 'local_primary_source_catalog' as const,
+    workCount: works.length,
+    works,
+    policies: {
+      scope: 'hosted_collection_only' as const,
+      lookupAliasUse: 'exact_routing_only_not_metadata_evidence' as const,
+      editionProvenance: 'incomplete' as const,
+      rightsStatus: 'not_established' as const,
+    },
+  };
+}

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -103,6 +103,7 @@ export function recommendedToolCallsForPrompt(
             text: topic,
             providers: ['local'],
             match: 'all_terms',
+            selection: 'work_diversity',
             limit: 5,
           }],
         },
@@ -131,6 +132,7 @@ export function recommendedToolCallsForPrompt(
             text: topic,
             providers: ['local'],
             match: 'all_terms',
+            selection: work ? 'relevance' : 'work_diversity',
             ...scoped,
             ...(author ? { author } : {}),
             limit,
@@ -267,11 +269,12 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
         const hint = traditions ? ` Focus on: ${traditions.split(',').map(item => item.trim()).join(', ')}.` : '';
         text = `Cross-tradition doctrinal comparison on "${topic}".${hint}
 
-1. **Run bounded local discovery** — ${callText(calls[0])}. Treat snippets as discovery-only and do not claim the search covered sources outside the hosted collection. The requested tradition names are comparison interests, not author filters or evidence that a work belongs to that tradition.
-2. **Preserve source metadata** — Keep each hit's creator names and creator roles exactly as returned. Never relabel an issuing, drafting, revising, or compiling body as an author, and never infer a work's tradition or author attribution from its title, topic, or the user's requested traditions.
-3. **Read exact evidence** — Before quotation, doctrinal claims, or comparison, follow the selected canonical \`resource_link\` blocks with MCP \`resources/read\` and confirm each returned URI matches the selected locator. Do not rely on snippets alone.
-4. **Biblical foundations** — Use \`bible_lookup\` and \`bible_cross_references\` for passages actually identified in the sections you read.
-5. **Compare cautiously** — Explain agreement, divergence, Scripture use, and historical context only from exact sections read. Distinguish document statements from interpretation, and do not treat missing search hits as historical silence.`;
+1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Use only its reviewed work and creator metadata to plan the comparison; aliases route exact work lookups but are not metadata evidence. Do not substitute another creator or work for one absent from this catalog.
+2. **Run bounded local discovery** — ${callText(calls[0])}. The work-diverse selection builds a deterministic topic survey across hosted works. Treat snippets as discovery-only and do not claim the search covered sources outside the hosted collection. The requested tradition names are comparison interests, not author filters or evidence that a work belongs to that tradition.
+3. **Preserve source metadata** — Keep each hit's creator names and creator roles exactly as returned. Never relabel an issuing, drafting, revising, or compiling body as an author, and never infer a work's tradition or author attribution from its title, topic, or the user's requested traditions.
+4. **Read exact evidence** — Before quotation, doctrinal claims, or comparison, follow at most five unique canonical \`resource_link\` blocks with MCP \`resources/read\` and confirm each returned URI matches the selected locator. Deduplicate repeated locators and do not rely on snippets alone.
+5. **Biblical foundations** — Use \`bible_lookup\` and \`bible_cross_references\` for passages actually identified in the sections you read.
+6. **Compare cautiously** — Explain agreement, divergence, Scripture use, and historical context only from exact sections read. Distinguish document statements from interpretation, and do not treat missing search hits as historical silence.`;
         break;
       }
       case 'primary-source-research': {
@@ -280,13 +283,14 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
         const authors = args?.authors?.split(',').map(value => value.trim()).filter(Boolean) ?? [];
         text = `Research primary-source evidence about "${topic}"${work ? ` within the exact local work "${work}"` : ' across the locally indexed collection'}${authors.length ? ` for the separately scoped creators ${authors.map(value => `"${value}"`).join(', ')}` : ''}.
 
-1. **Run bounded discovery** — ${callText(calls[0])}. This workflow is local-only: do not claim it searched CCEL, the web, an exhaustive catalog, or works outside the server's collection.
-2. **Use the structured result** — Preserve each separate creator query, provider status, catalog \`scope\` status/count/work list/truncation, rank, notices, creator roles, document type/date, locator, and \`evidencePolicy\`. A \`catalog_miss\` means the hosted catalog did not match the restriction; \`no_results\` means eligible hosted works were searched but no text hit matched. Treat every snippet as \`discovery_only\`.
-3. **Read selected evidence before quotation or comparison** — Follow at most ${args?.maxSections?.trim() || '3'} canonical \`resource_link\` blocks using MCP \`resources/read\`. Confirm that the returned URI matches the selected locator. Do not quote, compare creators/works, or draw substantive conclusions from snippets alone.
-4. **Report provenance honestly** — Edition provenance is incomplete. Do not invent an author, edition, transcription source, publication date, or rights status. Work-level type/date metadata is not edition metadata.
-5. **Synthesize with limits** — Distinguish what the selected sections say from your interpretation. Name searches that returned no results or unsupported filters; do not treat missing hits as historical silence.
+1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Confirm requested exact works and creator names there before searching. If Calvin, Erasmus, Luther, or any other requested creator is absent, report that catalog gap; never use a confession or similarly themed work as a proxy.
+2. **Run bounded discovery** — ${callText(calls[0])}. This workflow is local-only: do not claim it searched CCEL, the web, an exhaustive catalog, or works outside the server's collection. Topic and creator surveys use deterministic work diversity; exact within-work location uses relevance.
+3. **Use the v3 structured result** — Preserve each separate creator query, \`normalizedSelection\`, provider status, \`resultWindow\`, catalog \`scope\` status/count/work list/truncation, rank, notices, creator roles, document type/date, locator, and \`evidencePolicy\`. \`additional_match_observed\` means only that at least one more match was seen beyond the returned window, not that the corpus was exhaustively counted. A \`catalog_miss\` means the hosted catalog did not match the restriction; \`no_results\` means eligible hosted works were searched but no text hit matched. Treat every snippet as \`discovery_only\`.
+4. **Read selected evidence before quotation or comparison** — Follow at most ${args?.maxSections?.trim() || '3'} unique canonical \`resource_link\` blocks using MCP \`resources/read\`. Deduplicate locators and confirm that every returned URI matches the selected locator. Do not quote, compare creators/works, or draw substantive conclusions from snippets alone.
+5. **Report provenance honestly** — Edition provenance is incomplete and rights status is not established by the catalog resource. Do not invent an author, edition, transcription source, publication date, or rights status. Work-level type/date metadata is not edition metadata.
+6. **Synthesize with limits** — Distinguish what the selected sections say from your interpretation. Name searches that returned no results or unsupported filters; do not treat missing hits as historical silence.
 
-This workflow supports a topic survey, exact local-work search, inclusive overlapping composition-year scope, and up to four creator scopes. Creator comparisons always use separate query-plan items and only sections actually read; a drafting or issuing body is never relabeled as an author.`;
+This workflow supports a topic survey, exact local-work search, inclusive overlapping composition-year scope, and up to four creator scopes. Creator comparisons always use separate query-plan items and only sections actually read; a drafting or issuing body is never relabeled as an author. Never issue more than four query groups or read more than five exact section resources in one workflow.`;
         break;
       }
       case 'donate':

--- a/src/mcp/schemas/primarySourceSearch.ts
+++ b/src/mcp/schemas/primarySourceSearch.ts
@@ -116,6 +116,18 @@ const providerProperties = {
   searched: { type: 'boolean' },
   page: { type: 'integer', minimum: 1, maximum: 3 },
   hitCount: { type: 'integer', minimum: 0, maximum: 8 },
+  resultWindow: {
+    type: 'object',
+    properties: {
+      returnedHitCount: { type: 'integer', minimum: 0, maximum: 8 },
+      additionalMatchStatus: {
+        type: 'string',
+        enum: ['additional_match_observed', 'no_additional_match_observed', 'not_evaluated'],
+      },
+    },
+    required: ['returnedHitCount', 'additionalMatchStatus'],
+    additionalProperties: false,
+  },
   notices: { type: 'array', maxItems: 16, items: { type: 'string', maxLength: 500 } },
 } as const;
 
@@ -128,7 +140,7 @@ const provider = {
       scope: catalogScope,
       hits: { type: 'array', maxItems: 8, items: localHit },
     },
-    required: ['provider', 'status', 'searched', 'page', 'hitCount', 'hits', 'notices'],
+    required: ['provider', 'status', 'searched', 'page', 'hitCount', 'resultWindow', 'hits', 'notices'],
     additionalProperties: false,
   }, {
     type: 'object',
@@ -137,7 +149,7 @@ const provider = {
       provider: { const: 'ccel_live' },
       hits: { type: 'array', maxItems: 8, items: ccelHit },
     },
-    required: ['provider', 'status', 'searched', 'page', 'hitCount', 'hits', 'notices'],
+    required: ['provider', 'status', 'searched', 'page', 'hitCount', 'resultWindow', 'hits', 'notices'],
     additionalProperties: false,
   }],
 } as const;
@@ -145,7 +157,7 @@ const provider = {
 export const primarySourceSearchOutputSchema = {
   type: 'object',
   properties: {
-    schemaVersion: { const: '2' },
+    schemaVersion: { const: '3' },
     kind: { const: 'primary_source_search' },
     planStatus: { type: 'string', enum: ['complete', 'partial', 'unavailable'] },
     queries: {
@@ -155,9 +167,10 @@ export const primarySourceSearchOutputSchema = {
         properties: {
           id: { type: 'string', minLength: 1, maxLength: 40 },
           normalizedMode: { type: 'string', enum: ['all_terms', 'phrase'] },
+          normalizedSelection: { type: 'string', enum: ['relevance', 'work_diversity'] },
           providers: { type: 'array', minItems: 1, maxItems: 2, items: provider },
         },
-        required: ['id', 'normalizedMode', 'providers'],
+        required: ['id', 'normalizedMode', 'normalizedSelection', 'providers'],
         additionalProperties: false,
       },
     },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -25,6 +25,7 @@ import { internalError, resourceNotFound } from './errors.js';
 import { registerPromptHandlers } from './prompts.js';
 import { registerToolHandlers } from './tools.js';
 import { jsonSchemaValidator } from './validation.js';
+import { buildPrimarySourceCatalog, PRIMARY_SOURCE_CATALOG_URI } from './primarySourceCatalog.js';
 
 export interface McpServerServices {
   bibleService: Pick<BibleService, 'getSupportedTranslations'>;
@@ -97,6 +98,12 @@ export function createTheologAiMcpServer(
     // Individual historical documents
     try {
       const docs = await services.historicalService.listDocuments();
+      resources.push({
+        uri: PRIMARY_SOURCE_CATALOG_URI,
+        name: 'Local Primary-source Catalog',
+        description: 'Reviewed metadata for works hosted in the local primary-source collection',
+        mimeType: 'application/json',
+      });
       for (const doc of docs) {
         resources.push({
           uri: `theologai://documents/${doc.id}`,
@@ -168,6 +175,17 @@ export function createTheologAiMcpServer(
       return {
         contents: [{ uri, mimeType: 'text/markdown', text: lines.join('\n') }],
       };
+    }
+
+    if (uri === PRIMARY_SOURCE_CATALOG_URI) {
+      try {
+        const catalog = buildPrimarySourceCatalog(await services.historicalService.listDocuments());
+        return {
+          contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(catalog, null, 2) }],
+        };
+      } catch {
+        throw internalError('Unable to read resource');
+      }
     }
 
     // theologai://documents/{slug}[#section-{sectionNumber}]

--- a/src/presenters/primarySourceSearchStructured.ts
+++ b/src/presenters/primarySourceSearchStructured.ts
@@ -5,6 +5,7 @@ import type {
   PrimarySourceProvider,
   PrimarySourceProviderStatus,
   PrimarySourceSearchMatch,
+  PrimarySourceSelection,
   PrimarySourceSearchPlanResult,
 } from '../services/historical/primarySourceTypes.js';
 
@@ -52,6 +53,10 @@ export interface PresentedPrimarySourceProvider {
   searched: boolean;
   page: number;
   hitCount: number;
+  resultWindow: {
+    returnedHitCount: number;
+    additionalMatchStatus: 'additional_match_observed' | 'no_additional_match_observed' | 'not_evaluated';
+  };
   hits: PresentedPrimarySourceHit[];
   notices: string[];
   scope?: {
@@ -66,11 +71,12 @@ export interface PresentedPrimarySourceProvider {
 export interface PresentedPrimarySourceQuery {
   id: string;
   normalizedMode: PrimarySourceSearchMatch;
+  normalizedSelection: PrimarySourceSelection;
   providers: PresentedPrimarySourceProvider[];
 }
 
 export interface PresentedPrimarySourceSearch extends Record<string, unknown> {
-  schemaVersion: '2';
+  schemaVersion: '3';
   kind: 'primary_source_search';
   planStatus: 'complete' | 'partial' | 'unavailable';
   queries: PresentedPrimarySourceQuery[];
@@ -104,6 +110,9 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
         ? [`${omitted} provider group${omitted === 1 ? ' was' : 's were'} omitted from query ${boundedText(query.id, 40)} because the result exceeded the public limit of 2 providers per query.`]
         : [];
     }),
+    ...boundedQueries.flatMap(query => isSelection(query.normalizedSelection)
+      ? []
+      : [`Query ${boundedText(query.id, 40)} supplied invalid normalized selection metadata; relevance was used as a safe display fallback.`]),
   ];
   const envelopeChanged = envelopeNotices.length > 0;
   const queries = boundedQueries.map(query => {
@@ -111,6 +120,7 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
     return {
       id: boundedText(query.id, 40),
       normalizedMode: query.normalizedMode,
+      normalizedSelection: isSelection(query.normalizedSelection) ? query.normalizedSelection : 'relevance' as const,
       providers: query.providers.slice(0, 2).map(provider => {
         const hits = provider.hits.slice(0, 8).flatMap(hit => {
           const presented = presentHit(hit, query.id, provider.provider);
@@ -118,16 +128,18 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
         });
         const omitted = provider.hits.length - hits.length;
         const countMismatch = provider.hitCount !== provider.hits.length;
+        const resultWindowValid = validResultWindow(provider.resultWindow, provider.hits.length);
         const scope = provider.provider === 'local' ? presentScope(provider.scope) : undefined;
         const scopeIsMeaningful = provider.searched || provider.status === 'catalog_miss';
         const scopeInvalid = provider.provider === 'local'
           && ((provider.scope !== undefined && !scope) || (scopeIsMeaningful && !scope));
-        const downgraded = omitted > 0 || countMismatch || providerGroupsOmitted || scopeInvalid;
+        const downgraded = omitted > 0 || countMismatch || !resultWindowValid || providerGroupsOmitted || scopeInvalid;
         const notices = [...provider.notices];
         if (omitted > 0) {
           notices.push(`${omitted} ${provider.provider} hit${omitted === 1 ? '' : 's'} omitted because the locator, group attribution, or bounded metadata was invalid.`);
         }
         if (countMismatch) notices.push('Provider-reported hit count did not match its returned hit array.');
+        if (!resultWindowValid) notices.push('Provider result-window metadata was absent or invalid.');
         if (providerGroupsOmitted) notices.push('One or more provider groups were omitted because the query exceeded the public provider-group limit.');
         if (scopeInvalid) notices.push('Local catalog scope metadata was absent or invalid.');
         return {
@@ -136,6 +148,14 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
           searched: provider.searched,
           page: provider.page,
           hitCount: hits.length,
+          resultWindow: {
+            returnedHitCount: hits.length,
+            additionalMatchStatus: omitted > 0
+              ? 'additional_match_observed' as const
+              : resultWindowValid
+                ? provider.resultWindow.additionalMatchStatus
+                : 'not_evaluated' as const,
+          },
           hits,
           notices: uniqueBounded(notices, 16, 500),
           ...(provider.provider === 'local' && scope
@@ -154,15 +174,21 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
   const omittedCcel = omittedProviderGroups.filter(provider => provider.provider === 'ccel_live');
   const statuses = providers.map(provider => provider.status);
   const hasUsableResult = providers.some(provider => provider.hits.length > 0 || COMPLETE_STATUSES.has(provider.status));
-  const planStatus = envelopeChanged
+  const recomputedPlanStatus = envelopeChanged
     ? 'partial'
     : statuses.every(status => COMPLETE_STATUSES.has(status))
       ? 'complete'
       : !hasUsableResult && statuses.every(status => UNAVAILABLE_STATUSES.has(status))
         ? 'unavailable'
         : 'partial';
+  // A service-enforced aggregate response boundary is intentionally partial
+  // even when every individual provider status remains successful. Preserve
+  // that conservative downgrade; presentation can only degrade it further.
+  const planStatus = recomputedPlanStatus === 'complete' && result.planStatus === 'partial'
+    ? 'partial'
+    : recomputedPlanStatus;
   return {
-    schemaVersion: '2',
+    schemaVersion: '3',
     kind: 'primary_source_search',
     planStatus,
     queries,
@@ -185,6 +211,29 @@ export function presentPrimarySourceSearch(result: PrimarySourceSearchPlanResult
     },
     evidencePolicy: PRIMARY_SOURCE_EVIDENCE_POLICY,
   };
+}
+
+function validResultWindow(
+  value: PrimarySourcePlanResultWindow | undefined,
+  returnedHits: number,
+): value is PrimarySourcePlanResultWindow {
+  return value !== undefined
+    && Number.isSafeInteger(value.returnedHitCount)
+    && value.returnedHitCount === returnedHits
+    && RESULT_WINDOW_STATUSES.has(value.additionalMatchStatus);
+}
+
+type PrimarySourcePlanResultWindow = {
+  returnedHitCount: number;
+  additionalMatchStatus: 'additional_match_observed' | 'no_additional_match_observed' | 'not_evaluated';
+};
+
+const RESULT_WINDOW_STATUSES = new Set<PrimarySourcePlanResultWindow['additionalMatchStatus']>([
+  'additional_match_observed', 'no_additional_match_observed', 'not_evaluated',
+]);
+
+function isSelection(value: unknown): value is PrimarySourceSelection {
+  return value === 'relevance' || value === 'work_diversity';
 }
 
 const COMPLETE_STATUSES = new Set<PrimarySourceProviderStatus>(['ok', 'no_results', 'catalog_miss']);

--- a/src/services/historical/LocalPrimarySourceSearchProvider.ts
+++ b/src/services/historical/LocalPrimarySourceSearchProvider.ts
@@ -3,6 +3,7 @@ import { buildLocalDocumentResourceUri } from '../../kernel/documentResource.js'
 import {
   LOCAL_PRIMARY_SOURCE_ATTRIBUTION,
   type PrimarySourceProviderResult,
+  type PrimarySourceResultWindow,
   type PrimarySourceSearchQuery,
 } from './primarySourceTypes.js';
 import { formatLocalDocumentSectionResource } from '../../formatters/historicalFormatter.js';
@@ -13,6 +14,7 @@ export class LocalPrimarySourceSearchProvider {
   async search(input: PrimarySourceSearchQuery): Promise<PrimarySourceProviderResult> {
     const page = input.page ?? 1;
     const limit = input.limit ?? 5;
+    const selection = input.selection ?? 'relevance';
     if (page !== 1) {
       return result('unsupported_filter', page, false, [], ['The local historical index does not support pagination; page was not silently ignored.']);
     }
@@ -25,10 +27,12 @@ export class LocalPrimarySourceSearchProvider {
     const rows = await this.repository.searchPrimarySources({
       text: input.text,
       match: input.match ?? 'all_terms',
+      selection,
       ...(selected.restricted ? { documentIds: selected.documents.map(document => document.id) } : {}),
-      limit,
+      limit: limit + 1,
     });
-    const hits = rows.map((row, index) => ({
+    const additionalMatchObserved = rows.length > limit;
+    const hits = rows.slice(0, limit).map((row, index) => ({
       provider: 'local' as const,
       title: row.document.title,
       ...(row.section.title ? { sectionLabel: row.section.title } : {}),
@@ -52,7 +56,10 @@ export class LocalPrimarySourceSearchProvider {
         formatLocalDocumentSectionResource(row.document, row.section),
       ).byteLength,
     }));
-    return result(hits.length > 0 ? 'ok' : 'no_results', page, true, hits, selected.notices, selected.scope);
+    return result(
+      hits.length > 0 ? 'ok' : 'no_results', page, true, hits, selected.notices, selected.scope,
+      additionalMatchObserved ? 'additional_match_observed' : 'no_additional_match_observed',
+    );
   }
 }
 
@@ -63,8 +70,13 @@ function result(
   hits: PrimarySourceProviderResult['hits'] = [],
   notices: string[] = [],
   scope?: PrimarySourceProviderResult['scope'],
+  additionalMatchStatus: PrimarySourceResultWindow['additionalMatchStatus'] = 'not_evaluated',
 ): PrimarySourceProviderResult {
-  return { provider: 'local', status, searched, page, hitCount: hits.length, hits, notices, ...(scope ? { scope } : {}) };
+  return {
+    provider: 'local', status, searched, page, hitCount: hits.length, hits, notices,
+    resultWindow: { returnedHitCount: hits.length, additionalMatchStatus },
+    ...(scope ? { scope } : {}),
+  };
 }
 
 function normalizeForExactComparison(value: string): string {

--- a/src/services/historical/PrimarySourceSearchService.ts
+++ b/src/services/historical/PrimarySourceSearchService.ts
@@ -16,7 +16,7 @@ const MAX_QUERIES = 4;
 const MAX_CCEL_QUERIES = 3;
 const MAX_TOTAL_HITS = 32;
 const QUERY_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,39}$/;
-const QUERY_KEYS = new Set(['id', 'text', 'providers', 'match', 'author', 'work', 'startYear', 'endYear', 'page', 'limit']);
+const QUERY_KEYS = new Set(['id', 'text', 'providers', 'match', 'selection', 'author', 'work', 'startYear', 'endYear', 'page', 'limit']);
 const COMPLETE_STATUSES = new Set<PrimarySourceProviderStatus>(['ok', 'no_results', 'catalog_miss']);
 const UNAVAILABLE_STATUSES = new Set<PrimarySourceProviderStatus>(['unavailable', 'disabled', 'rate_limited', 'interface_changed']);
 
@@ -34,10 +34,12 @@ export class PrimarySourceSearchService {
   async search(input: unknown): Promise<PrimarySourceSearchPlanResult> {
     const queries = validatePlan(input);
     const queryResults = await Promise.all(queries.map(query => this.executeQuery(query)));
-    enforceAggregateHitBudget(queryResults);
+    const aggregateTruncated = enforceAggregateHitBudget(queryResults);
     const providerResults = queryResults.flatMap(query => query.providers);
     const statuses = providerResults.map(provider => provider.status);
-    const planStatus = statuses.every(status => COMPLETE_STATUSES.has(status))
+    const planStatus = aggregateTruncated
+      ? 'partial'
+      : statuses.every(status => COMPLETE_STATUSES.has(status))
       ? 'complete'
       : statuses.every(status => UNAVAILABLE_STATUSES.has(status))
       ? 'unavailable'
@@ -62,7 +64,7 @@ export class PrimarySourceSearchService {
 
   private async executeQuery(query: NormalizedPlanQuery): Promise<PrimarySourcePlanQueryResult> {
     const providers = await Promise.all(query.providers.map(provider => this.executeProvider(query, provider)));
-    return { id: query.id, normalizedMode: query.match, providers };
+    return { id: query.id, normalizedMode: query.match, normalizedSelection: query.selection, providers };
   }
 
   private async executeProvider(query: NormalizedPlanQuery, provider: PrimarySourceRequestedProvider): Promise<PrimarySourcePlanProviderResult> {
@@ -81,33 +83,40 @@ export class PrimarySourceSearchService {
       result = {
         provider: 'ccel_live', status: 'unsupported_filter', searched: false, page: query.page,
         hitCount: 0, hits: [], notices: ['Live CCEL discovery does not expose reviewed composition-date bounds; the date restriction was not ignored.'],
+        resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' },
       };
     } else if (provider === 'ccel' && !this.options.ccelLiveSearch) {
       result = {
         provider: 'ccel_live', status: 'disabled', searched: false, page: query.page,
         hitCount: 0, hits: [], notices: ['Live CCEL search is disabled. No remote request was made.'],
+        resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' },
       };
     } else {
       try {
         result = provider === 'local'
-          ? await this.local.search(providerQuery)
+          ? await this.local.search({ ...providerQuery, selection: query.selection })
           : await this.ccel.search(providerQuery);
       } catch {
         result = {
           provider: provider === 'local' ? 'local' : 'ccel_live',
           status: 'unavailable', searched: false, page: query.page,
           hitCount: 0, hits: [], notices: [`${provider === 'local' ? 'Local primary-source search' : 'Live CCEL search'} is temporarily unavailable.`],
+          resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' },
         };
       }
     }
     return {
       ...result,
+      resultWindow: result.resultWindow ?? {
+        returnedHitCount: result.hits.length,
+        additionalMatchStatus: 'not_evaluated',
+      },
       hits: result.hits.map(hit => ({ ...hit, queryId: query.id })),
     };
   }
 }
 
-interface NormalizedPlanQuery extends Required<Pick<PrimarySourceSearchPlanQuery, 'id' | 'text' | 'providers' | 'match' | 'page' | 'limit'>> {
+interface NormalizedPlanQuery extends Required<Pick<PrimarySourceSearchPlanQuery, 'id' | 'text' | 'providers' | 'match' | 'selection' | 'page' | 'limit'>> {
   author?: string;
   work?: string;
   startYear?: number;
@@ -144,6 +153,8 @@ function validateQuery(input: unknown, index: number): NormalizedPlanQuery {
   const match = query.match ?? 'all_terms';
   if (match !== 'all_terms' && match !== 'phrase') throw new ValidationError(`${path}.match`, 'match must be all_terms or phrase.');
   if (match === 'all_terms' && text.split(' ').length > 12) throw new ValidationError(`${path}.text`, 'all_terms text may contain at most 12 terms.');
+  const selection = query.selection ?? 'relevance';
+  if (selection !== 'relevance' && selection !== 'work_diversity') throw new ValidationError(`${path}.selection`, 'selection must be relevance or work_diversity.');
   if (!Array.isArray(query.providers) || query.providers.length < 1 || query.providers.length > 2) throw new ValidationError(`${path}.providers`, 'providers must contain local, ccel, or both.');
   const providers = query.providers as unknown[];
   if (providers.some(provider => provider !== 'local' && provider !== 'ccel') || new Set(providers).size !== providers.length) {
@@ -165,6 +176,7 @@ function validateQuery(input: unknown, index: number): NormalizedPlanQuery {
     text,
     providers: providers as PrimarySourceRequestedProvider[],
     match: match as PrimarySourceSearchMatch,
+    selection,
     page: page as number,
     limit: limit as number,
     ...(author ? { author } : {}),
@@ -190,18 +202,25 @@ function normalizeLiteral(value: unknown, field: string, maximum: number): strin
   return normalized;
 }
 
-function enforceAggregateHitBudget(queries: PrimarySourcePlanQueryResult[]): void {
+function enforceAggregateHitBudget(queries: PrimarySourcePlanQueryResult[]): boolean {
   let remaining = MAX_TOTAL_HITS;
+  let truncated = false;
   for (const query of queries) {
     for (const provider of query.providers) {
       if (provider.hits.length > remaining) {
+        truncated = true;
         provider.hits = provider.hits.slice(0, remaining);
         provider.hitCount = provider.hits.length;
+        provider.resultWindow = {
+          returnedHitCount: provider.hits.length,
+          additionalMatchStatus: 'additional_match_observed',
+        };
         provider.notices = [...provider.notices, 'The plan-wide 32-hit response budget truncated later provider results.'];
       }
       remaining -= provider.hits.length;
     }
   }
+  return truncated;
 }
 
 function aggregateStatus(results: PrimarySourcePlanProviderResult[]): PrimarySourceProviderStatus {

--- a/src/services/historical/primarySourceTypes.ts
+++ b/src/services/historical/primarySourceTypes.ts
@@ -6,6 +6,7 @@
  */
 
 export type PrimarySourceSearchMatch = 'all_terms' | 'phrase';
+export type PrimarySourceSelection = 'relevance' | 'work_diversity';
 
 export type PrimarySourceRequestedProvider = 'local' | 'ccel';
 
@@ -30,6 +31,7 @@ export interface PrimarySourceSearchQuery {
   endYear?: number;
   page?: number;
   limit?: number;
+  selection?: PrimarySourceSelection;
 }
 
 export interface CcelSectionLocator {
@@ -102,14 +104,21 @@ export type PrimarySourcePlanHit = PrimarySourceSearchHit & {
   queryId: string;
 };
 
-export interface PrimarySourcePlanProviderResult extends Omit<PrimarySourceProviderResult, 'hits'> {
+export interface PrimarySourcePlanProviderResult extends Omit<PrimarySourceProviderResult, 'hits' | 'resultWindow'> {
   hits: PrimarySourcePlanHit[];
+  resultWindow: PrimarySourceResultWindow;
 }
 
 export interface PrimarySourcePlanQueryResult {
   id: string;
   normalizedMode: PrimarySourceSearchMatch;
+  normalizedSelection: PrimarySourceSelection;
   providers: PrimarySourcePlanProviderResult[];
+}
+
+export interface PrimarySourceResultWindow {
+  returnedHitCount: number;
+  additionalMatchStatus: 'additional_match_observed' | 'no_additional_match_observed' | 'not_evaluated';
 }
 
 export interface PrimarySourceSearchCoverage {
@@ -136,6 +145,8 @@ export interface PrimarySourceProviderResult {
   searched: boolean;
   page: number;
   hitCount: number;
+  /** Added by local lookahead; the plan service normalizes dormant providers to not_evaluated. */
+  resultWindow?: PrimarySourceResultWindow;
   hits: PrimarySourceSearchHit[];
   notices: string[];
   scope?: PrimarySourceCatalogScope;

--- a/src/tools/v2/primarySourceSearch.ts
+++ b/src/tools/v2/primarySourceSearch.ts
@@ -30,6 +30,10 @@ export function createPrimarySourceSearchHandler(service: Pick<PrimarySourceSear
                 description: 'Current public provider contract. Only the locally indexed collection is available.',
               },
               match: { type: 'string', enum: ['all_terms', 'phrase'], default: 'all_terms' },
+              selection: {
+                type: 'string', enum: ['relevance', 'work_diversity'], default: 'relevance',
+                description: 'Use relevance for within-work location; use work_diversity for deterministic research bundles that round-robin across matching hosted works.',
+              },
               author: { type: 'string', minLength: 1, maxLength: 100, description: 'One exact reviewed creator name. Use separate query-plan items for different creators; creator roles are not relabeled as authorship.' },
               work: { type: 'string', minLength: 1, maxLength: 160, description: 'Exact hosted work slug, title, or lookup-only alias.' },
               startYear: { type: 'integer', minimum: -5000, maximum: 3000, description: 'Inclusive lower bound. A work is eligible when its reviewed composition interval overlaps the requested interval.' },

--- a/test/fixtures/mcpCompositionRoot.ts
+++ b/test/fixtures/mcpCompositionRoot.ts
@@ -138,7 +138,10 @@ export function createDeterministicMcpFixture(): DeterministicMcpFixture {
   const historicalService = new HistoricalDocumentService(historicalRepository);
   const primarySourceSearchService = new PrimarySourceSearchService(
     new LocalPrimarySourceSearchProvider(historicalRepository),
-    { search: async () => ({ provider: 'ccel_live', status: 'disabled', searched: false, page: 1, hitCount: 0, hits: [], notices: [] }) },
+    { search: async () => ({
+      provider: 'ccel_live', status: 'disabled', searched: false, page: 1, hitCount: 0, hits: [], notices: [],
+      resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' },
+    }) },
     { ccelLiveSearch: false },
   );
   const strongsService = new StrongsService(strongsRepository, morphologyRepository);

--- a/test/integration/current/mcp-protocol.test.ts
+++ b/test/integration/current/mcp-protocol.test.ts
@@ -112,6 +112,18 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
         additionalProperties: false,
         properties: { schemaVersion: { const: '1' }, kind: { const: 'original_language_lookup' } },
       });
+      expect(listed.tools.find(tool => tool.name === 'primary_source_search')?.outputSchema).toMatchObject({
+        properties: { schemaVersion: { const: '3' } },
+      });
+      const resources = await client.listResources();
+      expect(resources.resources).toContainEqual(expect.objectContaining({
+        uri: 'theologai://primary-sources/catalog', mimeType: 'application/json',
+      }));
+      const catalog = await client.readResource({ uri: 'theologai://primary-sources/catalog' });
+      expect(JSON.parse(String(catalog.contents[0].text))).toMatchObject({
+        schemaVersion: '1', kind: 'local_primary_source_catalog', workCount: 0,
+        policies: { scope: 'hosted_collection_only', rightsStatus: 'not_established' },
+      });
       expect(listed.tools).toEqual(expect.arrayContaining([
         expect.objectContaining({
           name: 'bible_lookup',
@@ -184,10 +196,15 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
           text: expect.stringContaining('Plan status: **complete**'),
         })],
         structuredContent: {
-          schemaVersion: '2',
+          schemaVersion: '3',
           kind: 'primary_source_search',
           planStatus: 'complete',
-          queries: [expect.anything()],
+          queries: [expect.objectContaining({
+            normalizedSelection: 'relevance',
+            providers: [expect.objectContaining({
+              resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' },
+            })],
+          })],
           coverage: expect.any(Object),
           evidencePolicy: {
             snippetUse: 'discovery_only',

--- a/test/unit/adapters/d1/D1HistoricalDocumentRepository.test.ts
+++ b/test/unit/adapters/d1/D1HistoricalDocumentRepository.test.ts
@@ -240,5 +240,16 @@ describe('D1HistoricalDocumentRepository', () => {
         section: { section_number: '1', content: 'We believe in one God...' },
       });
     });
+
+    it('uses the same deterministic work-diverse SQL and bindings as SQLite', async () => {
+      const db = createSimpleD1([]);
+      await new D1HistoricalDocumentRepository(db as any).searchPrimarySources({
+        text: 'grace', match: 'all_terms', selection: 'work_diversity', documentIds: ['nicene-creed'], limit: 9,
+      });
+      const sql = db.prepare.mock.calls[0][0] as string;
+      expect(sql).toMatch(/ROW_NUMBER\(\) OVER \([\s\S]*PARTITION BY document_id/);
+      expect(sql).toMatch(/ds\.document_id IN \(\?\)[\s\S]*ORDER BY work_rank, relevance_rank, id/);
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('"grace"', 'nicene-creed', 9);
+    });
   });
 });

--- a/test/unit/adapters/data/HistoricalDocumentRepository.test.ts
+++ b/test/unit/adapters/data/HistoricalDocumentRepository.test.ts
@@ -108,6 +108,18 @@ describe('HistoricalDocumentRepository', () => {
     expect(db.statement(/JOIN documents d[\s\S]*ORDER BY rank/).all).toHaveBeenCalledWith('"union with Christ"', 3);
   });
 
+  it('uses deterministic round-robin SQL for work-diverse selection', () => {
+    const db = new FakeSqliteDatabase([{ match: 'ranked_sections', all: [] }]);
+    const repo = new HistoricalDocumentRepository(db.asDatabase());
+
+    repo.searchPrimarySources({ text: 'grace', match: 'all_terms', selection: 'work_diversity', limit: 9 });
+
+    const statement = db.statement('ranked_sections');
+    expect(statement.sql).toMatch(/ROW_NUMBER\(\) OVER \([\s\S]*PARTITION BY document_id[\s\S]*ORDER BY relevance_rank, id/);
+    expect(statement.sql).toMatch(/ORDER BY work_rank, relevance_rank, id/);
+    expect(statement.all).toHaveBeenCalledWith('"grace"', 9);
+  });
+
   it('finds documents by exact id, title fragment, then id fragment', () => {
     const docs = [
       documentRow,

--- a/test/unit/adapters/repositoryParity.test.ts
+++ b/test/unit/adapters/repositoryParity.test.ts
@@ -140,11 +140,14 @@ describe('SQLite and D1 repository parity with identical real data', () => {
       INSERT INTO morph_codes VALUES ('V-AAI-3S', 'Verb Aorist Active Indicative 3rd Singular');
 
       INSERT INTO documents VALUES
-        ('nicene-creed', 'Nicene Creed', 'creed', '381', '{"topics":["trinity"]}');
+        ('nicene-creed', 'Nicene Creed', 'creed', '381', '{"topics":["trinity"]}'),
+        ('augsburg-confession', 'Augsburg Confession', 'confession', '1530', '{"topics":["doctrine"]}');
       INSERT INTO document_sections
         (id, document_id, section_number, title, content, topics) VALUES
         (1, 'nicene-creed', '1', 'The Creed', 'We believe in one almighty God.', '["trinity","God"]'),
-        (2, 'nicene-creed', '2', NULL, 'And in one Lord Jesus Christ.', NULL);
+        (2, 'nicene-creed', '2', NULL, 'And in one Lord Jesus Christ.', NULL),
+        (3, 'augsburg-confession', '1', 'God', 'Our churches teach with common consent one divine essence.', NULL),
+        (4, 'augsburg-confession', '2', 'The Son', 'One Christ is true God and true man.', NULL);
       INSERT INTO sections_fts(rowid, title, content, topics)
         SELECT id, title, content, topics FROM document_sections ORDER BY id;
     `);
@@ -212,13 +215,21 @@ describe('SQLite and D1 repository parity with identical real data', () => {
     });
     await expect(d1Historical.findDocumentByName('Nicene'))
       .resolves.toEqual(sqliteHistorical.findDocumentByName('Nicene'));
-    const primaryOptions = { text: 'one almighty', match: 'all_terms' as const, documentId: 'nicene-creed', limit: 8 };
+    const primaryOptions = { text: 'one almighty', match: 'all_terms' as const, documentIds: ['nicene-creed'], limit: 8 };
     await expect(d1Historical.searchPrimarySources(primaryOptions))
       .resolves.toEqual(sqliteHistorical.searchPrimarySources(primaryOptions));
     expect(sqliteHistorical.searchPrimarySources(primaryOptions)[0]).toMatchObject({
       document: { id: 'nicene-creed', title: 'Nicene Creed' },
       section: { section_number: '1' },
     });
+    const workDiverseOptions = {
+      text: 'one', match: 'all_terms' as const, selection: 'work_diversity' as const, limit: 3,
+    };
+    const sqliteDiverse = sqliteHistorical.searchPrimarySources(workDiverseOptions);
+    await expect(d1Historical.searchPrimarySources(workDiverseOptions)).resolves.toEqual(sqliteDiverse);
+    expect(new Set(sqliteDiverse.slice(0, 2).map(row => row.document.id))).toEqual(
+      new Set(['nicene-creed', 'augsburg-confession']),
+    );
   });
 
   it('returns identical morphology with shared fallback and canonical book ordering', async () => {

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -64,7 +64,7 @@ describe('MCP structured output validation', () => {
       const schema = listed.tools.find(tool => tool.name === toolName)?.outputSchema;
       expect(schema).toMatchObject({ type: 'object', additionalProperties: false });
       expect(schema).not.toHaveProperty('$ref');
-      expect(schema?.properties?.schemaVersion).toMatchObject({ const: toolName === 'primary_source_search' ? '2' : '1' });
+      expect(schema?.properties?.schemaVersion).toMatchObject({ const: toolName === 'primary_source_search' ? '3' : '1' });
     }
   });
 

--- a/test/unit/mcp/promptContracts.test.ts
+++ b/test/unit/mcp/promptContracts.test.ts
@@ -139,22 +139,22 @@ describe('prompt-recommended tool-call contracts', () => {
   it('keeps primary-source research local, bounded, and exact-work aware', () => {
     expect(recommendedToolCallsForPrompt('primary-source-research', { topic: 'eucharist' })).toEqual([{
       tool: 'primary_source_search',
-      arguments: { queries: [{ id: 'topic-survey', text: 'eucharist', providers: ['local'], match: 'all_terms', limit: 3 }] },
+      arguments: { queries: [{ id: 'topic-survey', text: 'eucharist', providers: ['local'], match: 'all_terms', selection: 'work_diversity', limit: 3 }] },
     }]);
     expect(recommendedToolCallsForPrompt('primary-source-research', {
       topic: 'eucharist', work: 'council-of-trent', maxSections: '5',
     })[0].arguments).toMatchObject({
-      queries: [{ id: 'exact-local-work', work: 'council-of-trent', providers: ['local'], limit: 5 }],
+      queries: [{ id: 'exact-local-work', work: 'council-of-trent', providers: ['local'], selection: 'relevance', limit: 5 }],
     });
     expect(recommendedToolCallsForPrompt('primary-source-research', {
       topic: 'eucharist', authors: 'Erasmus of Rotterdam, Martin Luther', startYear: '1500', endYear: '1600',
     })[0].arguments).toEqual({
       queries: [{
         id: 'creator-1', text: 'eucharist', providers: ['local'], match: 'all_terms',
-        author: 'Erasmus of Rotterdam', startYear: 1500, endYear: 1600, limit: 3,
+        selection: 'work_diversity', author: 'Erasmus of Rotterdam', startYear: 1500, endYear: 1600, limit: 3,
       }, {
         id: 'creator-2', text: 'eucharist', providers: ['local'], match: 'all_terms',
-        author: 'Martin Luther', startYear: 1500, endYear: 1600, limit: 3,
+        selection: 'work_diversity', author: 'Martin Luther', startYear: 1500, endYear: 1600, limit: 3,
       }],
     });
   });
@@ -167,7 +167,7 @@ describe('prompt-recommended tool-call contracts', () => {
       arguments: {
         queries: [{
           id: 'confession-topic', text: 'justification', providers: ['local'],
-          match: 'all_terms', limit: 5,
+          match: 'all_terms', selection: 'work_diversity', limit: 5,
         }],
       },
     }]);

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -62,6 +62,13 @@ function makeMockRoot(): McpCompositionRoot {
           type: 'creed',
           date: '325',
           topics: ['trinity'],
+          catalog: {
+            lookupAliases: ['The Nicene Creed'],
+            composition: { startYear: 381, endYear: 381, label: '381 AD' },
+            creators: [{ name: 'First Council of Constantinople', role: 'revising_body' as const }],
+            metadataStatus: 'collective' as const,
+            metadataProvenanceIds: ['hist-meta-test-nicene'],
+          },
         }],
         getDocument: async () => ({
           id: 'nicene-creed',
@@ -306,6 +313,7 @@ describe('shared MCP registration', () => {
     expect(resources.resources.map(resource => resource.uri)).toEqual([
       'theologai://translations',
       'theologai://commentaries',
+      'theologai://primary-sources/catalog',
       'theologai://documents/nicene-creed',
     ]);
     expect(templates.resourceTemplates.map(template => template.uriTemplate)).toEqual([
@@ -326,6 +334,22 @@ describe('shared MCP registration', () => {
     expect(commentaries.contents[0]).toEqual(expect.objectContaining({
       text: expect.stringContaining('verseNumber metadata'),
     }));
+
+    const catalog = await client.readResource({ uri: 'theologai://primary-sources/catalog' });
+    expect(catalog.contents[0]).toMatchObject({ mimeType: 'application/json' });
+    expect(JSON.parse(String(catalog.contents[0].text))).toEqual({
+      schemaVersion: '1', kind: 'local_primary_source_catalog', workCount: 1,
+      works: [{
+        id: 'nicene-creed', title: 'Nicene Creed', documentType: 'creed',
+        lookupAliases: ['The Nicene Creed'], composition: { startYear: 381, endYear: 381, label: '381 AD' },
+        creators: [{ name: 'First Council of Constantinople', role: 'revising_body' }],
+        metadataStatus: 'collective', metadataProvenanceIds: ['hist-meta-test-nicene'],
+      }],
+      policies: {
+        scope: 'hosted_collection_only', lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+        editionProvenance: 'incomplete', rightsStatus: 'not_established',
+      },
+    });
   });
 
   it.each(LOGGING_SERVER_VARIANTS)('$name warns when historical resources are unavailable and returns static resources', async ({ create }) => {
@@ -445,8 +469,9 @@ describe('shared MCP registration', () => {
     root.tools = root.tools.map(tool => tool.name === 'primary_source_search'
       ? createPrimarySourceSearchHandler({ search: async () => ({
         planStatus: 'complete',
-        queries: [{ id: 'topic', normalizedMode: 'all_terms', providers: [{
+        queries: [{ id: 'topic', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [{
           provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 1, notices: [],
+          resultWindow: { returnedHitCount: 1, additionalMatchStatus: 'no_additional_match_observed' },
           hits: [{
             queryId: 'topic', provider: 'local', title: doc!.title,
             sectionLabel: section.title, snippet: 'We believe',
@@ -658,7 +683,8 @@ describe('shared MCP registration', () => {
       ? confessionStudy.messages[0].content.text
       : '';
     expect(confessionText).toContain('`primary_source_search`');
-    expect(confessionText).toContain('follow the selected canonical `resource_link` blocks');
+    expect(confessionText).toContain('follow at most five unique canonical `resource_link` blocks');
+    expect(confessionText).toContain('theologai://primary-sources/catalog');
     expect(confessionText).toContain('Never relabel an issuing, drafting, revising, or compiling body as an author');
     expect(confessionText).toContain('never infer a work\'s tradition or author attribution');
 

--- a/test/unit/services/historical/LocalPrimarySourceSearchProvider.test.ts
+++ b/test/unit/services/historical/LocalPrimarySourceSearchProvider.test.ts
@@ -26,7 +26,10 @@ describe('LocalPrimarySourceSearchProvider', () => {
   it('returns bounded snippet-only factual metadata and an exact locator', async () => {
     const repo = repository();
     const result = await new LocalPrimarySourceSearchProvider(repo).search({ text: 'grace', work: 'INSTITUTES', limit: 3 });
-    expect(result).toMatchObject({ provider: 'local', status: 'ok', searched: true, hitCount: 1 });
+    expect(result).toMatchObject({
+      provider: 'local', status: 'ok', searched: true, hitCount: 1,
+      resultWindow: { returnedHitCount: 1, additionalMatchStatus: 'no_additional_match_observed' },
+    });
     expect(result.hits[0]).toMatchObject({
       title: 'Institutes', sectionLabel: 'Union', snippetOnly: true,
       snippet: 'Grace with [forged](https://evil.test) # heading',
@@ -37,7 +40,24 @@ describe('LocalPrimarySourceSearchProvider', () => {
     expect(result.hits[0].resourceSizeBytes).toBe(new TextEncoder().encode(
       formatLocalDocumentSectionResource(row[0].document, row[0].section),
     ).byteLength);
-    expect(repo.searchPrimarySources).toHaveBeenCalledWith({ text: 'grace', match: 'all_terms', documentIds: ['institutes'], limit: 3 });
+    expect(repo.searchPrimarySources).toHaveBeenCalledWith({
+      text: 'grace', match: 'all_terms', selection: 'relevance', documentIds: ['institutes'], limit: 4,
+    });
+  });
+
+  it('uses one private lookahead row to report an observed additional match without returning it', async () => {
+    const base = repository();
+    const first = await base.searchPrimarySources({ text: 'grace', match: 'all_terms', limit: 1 });
+    const searchPrimarySources = vi.fn().mockReturnValue([first[0], {
+      ...first[0], section: { ...first[0].section, id: 2, section_number: '3.2' },
+    }]);
+    const result = await new LocalPrimarySourceSearchProvider(repository({ searchPrimarySources })).search({
+      text: 'grace', selection: 'work_diversity', limit: 1,
+    });
+
+    expect(searchPrimarySources).toHaveBeenCalledWith(expect.objectContaining({ selection: 'work_diversity', limit: 2 }));
+    expect(result.hits).toHaveLength(1);
+    expect(result.resultWindow).toEqual({ returnedHitCount: 1, additionalMatchStatus: 'additional_match_observed' });
   });
 
   it('applies exact reviewed creator scope and never ignores unsupported pagination', async () => {

--- a/test/unit/services/historical/PrimarySourceSearchService.test.ts
+++ b/test/unit/services/historical/PrimarySourceSearchService.test.ts
@@ -6,6 +6,7 @@ function providerResult(provider: 'local' | 'ccel_live', status: PrimarySourcePr
   return {
     provider, status, searched: status !== 'disabled', page: 1,
     hitCount: count,
+    resultWindow: { returnedHitCount: count, additionalMatchStatus: 'not_evaluated' },
     hits: Array.from({ length: count }, (_, index) => ({
       provider, title: `${provider} ${index}`, snippet: 'evidence',
       locator: provider === 'local'
@@ -38,8 +39,11 @@ describe('PrimarySourceSearchService', () => {
     const service = new PrimarySourceSearchService(local as any, ccel as any, { ccelLiveSearch: false });
     const result = await service.search(plan([query({ text: '  union\n with   Christ  ', providers: ['local'] })]));
     expect(result.planStatus).toBe('complete');
+    expect(result.queries[0]).toMatchObject({ normalizedMode: 'all_terms', normalizedSelection: 'relevance' });
     expect(result.queries[0].providers[0].hits[0].queryId).toBe('q1');
-    expect(local.search).toHaveBeenCalledWith(expect.objectContaining({ text: 'union with Christ', match: 'all_terms', page: 1, limit: 5 }));
+    expect(local.search).toHaveBeenCalledWith(expect.objectContaining({
+      text: 'union with Christ', match: 'all_terms', selection: 'relevance', page: 1, limit: 5,
+    }));
     expect(ccel.search).not.toHaveBeenCalled();
   });
 
@@ -83,8 +87,11 @@ describe('PrimarySourceSearchService', () => {
     const ccel = { search: vi.fn().mockResolvedValue(providerResult('ccel_live', 'ok', 8)) };
     const queries = [0, 1, 2, 3].map(index => query({ id: `q${index}`, providers: ['local', ...(index < 3 ? ['ccel'] : [])], limit: 8 }));
     const result = await new PrimarySourceSearchService(local as any, ccel as any, { ccelLiveSearch: true }).search(plan(queries));
+    expect(result.planStatus).toBe('partial');
     expect(result.queries.flatMap(item => item.providers).flatMap(item => item.hits)).toHaveLength(32);
     expect(result.queries[0].providers[0].hits[0].rankWithinProvider).toBe(1);
+    const truncated = result.queries.flatMap(item => item.providers).find(item => item.hits.length < 8);
+    expect(truncated?.resultWindow.additionalMatchStatus).toBe('additional_match_observed');
   });
 
   it.each([
@@ -95,6 +102,7 @@ describe('PrimarySourceSearchService', () => {
     plan([query({ match: 'all_terms', text: 'one two three four five six seven eight nine ten eleven twelve thirteen' })]),
     plan([query({ startYear: 1600, endYear: 1500 })]),
     plan([query({ startYear: 1500.5 })]),
+    plan([query({ selection: 'random' })]),
     { queries: [query()], extra: true },
   ])('rejects invalid bounded plans %#', async invalid => {
     const service = new PrimarySourceSearchService({ search: vi.fn() } as any, { search: vi.fn() } as any, { ccelLiveSearch: false });

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -8,13 +8,16 @@ describe('primary_source_search handler', () => {
     eligibleDocuments: [{ id: 'institutes', title: 'Institutes', metadataStatus: 'reviewed' as const }],
     eligibleDocumentsTruncated: false,
   };
+  const resultWindow = (returnedHitCount: number, additionalMatchStatus = 'not_evaluated') => ({
+    returnedHitCount, additionalMatchStatus,
+  });
   it('advertises the exact closed bounded plan schema and read-only annotations', () => {
     const handler = createPrimarySourceSearchHandler({ search: vi.fn() } as any);
     expect(handler.name).toBe('primary_source_search');
     expect(handler.outputSchema).toMatchObject({
       type: 'object', additionalProperties: false,
       properties: {
-        schemaVersion: { const: '2' },
+        schemaVersion: { const: '3' },
         kind: { const: 'primary_source_search' },
       },
     });
@@ -25,6 +28,7 @@ describe('primary_source_search handler', () => {
     const item = (handler.inputSchema.properties?.queries as any).items;
     expect(item.required).toEqual(['id', 'text', 'providers']);
     expect(item.properties.providers).toMatchObject({ maxItems: 1, items: { enum: ['local'] } });
+    expect(item.properties.selection).toMatchObject({ enum: ['relevance', 'work_diversity'], default: 'relevance' });
     expect(item.properties.author.description).toContain('separate query-plan items');
     expect(item.properties.page.description).toContain('only page 1');
     expect(handler.description).toContain('composition-year ranges');
@@ -48,9 +52,10 @@ describe('primary_source_search handler', () => {
   });
 
   it('formats partial results and marks all-provider unavailability as a tool error', async () => {
-    const query = (providers: any[]) => [{ id: 'q', normalizedMode: 'all_terms', providers }];
+    const query = (providers: any[]) => [{ id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers }];
     const provider = (name: 'local' | 'ccel_live', status: string, searched: boolean) => ({
       provider: name, status, searched, page: 1, hitCount: 0, hits: [], notices: [],
+      resultWindow: resultWindow(0),
       ...(name === 'local' ? { scope } : {}),
     });
     const coverage = { localAttempted: false, localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] };
@@ -62,13 +67,31 @@ describe('primary_source_search handler', () => {
     expect(await handler.handler({ queries: [] })).toMatchObject({ isError: true });
   });
 
+  it('preserves a service-declared partial aggregate window even when provider statuses are complete', async () => {
+    const service = { search: vi.fn().mockResolvedValue({
+      planStatus: 'partial',
+      queries: [{
+        id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance',
+        providers: [{
+          provider: 'local', status: 'no_results', searched: true, page: 1,
+          hitCount: 0, hits: [], notices: ['The plan-wide response budget truncated later provider results.'], scope,
+          resultWindow: resultWindow(0, 'additional_match_observed'),
+        }],
+      }],
+      coverage: { localAttempted: true, localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    }) };
+    const result = await createPrimarySourceSearchHandler(service as any).handler({ queries: [] });
+    expect(result.structuredContent).toMatchObject({ planStatus: 'partial' });
+  });
+
   it.each(['unsupported_filter', 'unavailable', 'disabled', 'rate_limited', 'interface_changed'] as const)(
     'preserves the unsearched local %s status when catalog scope is not meaningful',
     async status => {
       const service = { search: vi.fn().mockResolvedValue({
         planStatus: status === 'unsupported_filter' ? 'partial' : 'unavailable',
-        queries: [{ id: 'q', normalizedMode: 'all_terms', providers: [{
+        queries: [{ id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [{
           provider: 'local', status, searched: false, page: 2, hitCount: 0, hits: [], notices: [],
+          resultWindow: resultWindow(0),
         }] }],
         coverage: { localAttempted: false, localStatus: status, localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] },
       }) };
@@ -88,8 +111,9 @@ describe('primary_source_search handler', () => {
   it('still fails closed when a searched local result omits meaningful catalog scope', async () => {
     const service = { search: vi.fn().mockResolvedValue({
       planStatus: 'complete',
-      queries: [{ id: 'q', normalizedMode: 'all_terms', providers: [{
+      queries: [{ id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [{
         provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0, hits: [], notices: [],
+        resultWindow: resultWindow(0, 'no_additional_match_observed'),
       }] }],
       coverage: { localAttempted: true, localStatus: 'no_results', localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] },
     }) };
@@ -118,8 +142,8 @@ describe('primary_source_search handler', () => {
     const service = { search: vi.fn().mockResolvedValue({
       planStatus: 'complete',
       queries: [{
-        id: 'q1', normalizedMode: 'all_terms',
-        providers: [{ provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 2, hits: [hit, { ...hit }], notices: [], scope }],
+        id: 'q1', normalizedMode: 'all_terms', normalizedSelection: 'relevance',
+        providers: [{ provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 2, resultWindow: resultWindow(2), hits: [hit, { ...hit }], notices: [], scope }],
       }],
       coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 2, ccelAttempted: false, ccelHitCount: 0, notices: [] },
     }) };
@@ -139,7 +163,7 @@ describe('primary_source_search handler', () => {
       annotations: { audience: ['assistant'] },
     }]);
     expect(result.structuredContent).toMatchObject({
-      schemaVersion: '2', kind: 'primary_source_search',
+      schemaVersion: '3', kind: 'primary_source_search',
       evidencePolicy: {
         snippetUse: 'discovery_only', selectedSectionAccess: 'mcp_resource_read',
         coverageScope: 'bounded_non_exhaustive', editionProvenance: 'incomplete',
@@ -152,8 +176,9 @@ describe('primary_source_search handler', () => {
   it('omits malicious or noncanonical locators from both structured hits and links', async () => {
     const service = { search: vi.fn().mockResolvedValue({
       planStatus: 'complete',
-      queries: [{ id: 'q1', normalizedMode: 'phrase', providers: [{
+      queries: [{ id: 'q1', normalizedMode: 'phrase', normalizedSelection: 'relevance', providers: [{
         provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 2, notices: [], scope,
+        resultWindow: resultWindow(2),
         hits: [{
           queryId: 'q1', provider: 'local', title: 'Forged', snippet: 'snippet',
           locator: { kind: 'local_section', documentId: '../secret', sectionId: '1', url: 'https://evil.test' },
@@ -202,8 +227,9 @@ describe('primary_source_search handler', () => {
     } as const;
     const service = { search: vi.fn().mockResolvedValue({
       planStatus: 'complete',
-      queries: [{ id: 'q1', normalizedMode: 'phrase', providers: [{
+      queries: [{ id: 'q1', normalizedMode: 'phrase', normalizedSelection: 'relevance', providers: [{
         provider: 'local', status: 'ok', searched: true, page: 1, hitCount: 4, notices: [], scope,
+        resultWindow: resultWindow(4),
         hits: [
           validLocalHit,
           { ...validLocalHit, queryId: 'q2', title: 'Foreign query evidence', rankWithinProvider: 2 },
@@ -244,6 +270,7 @@ describe('primary_source_search handler', () => {
   it('fails closed when a service returns excess query groups', async () => {
     const emptyLocalProvider = {
       provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0, hits: [], notices: [], scope,
+      resultWindow: resultWindow(0, 'no_additional_match_observed'),
     } as const;
     const omittedHit = {
       queryId: 'q5', provider: 'local', title: 'Omitted fifth-query evidence', snippet: 'Must not leak.',
@@ -254,11 +281,11 @@ describe('primary_source_search handler', () => {
       rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'Local', resourceSizeBytes: 25,
     } as const;
     const queries = [1, 2, 3, 4].map(number => ({
-      id: `q${number}`, normalizedMode: 'all_terms', providers: [emptyLocalProvider],
+      id: `q${number}`, normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [emptyLocalProvider],
     }));
     queries.push({
-      id: 'q5', normalizedMode: 'all_terms',
-      providers: [{ ...emptyLocalProvider, status: 'ok', hitCount: 1, hits: [omittedHit] }],
+      id: 'q5', normalizedMode: 'all_terms', normalizedSelection: 'relevance',
+      providers: [{ ...emptyLocalProvider, status: 'ok', hitCount: 1, resultWindow: resultWindow(1), hits: [omittedHit] }],
     } as any);
     const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue({
       planStatus: 'complete', queries,
@@ -284,6 +311,7 @@ describe('primary_source_search handler', () => {
   it('fails closed when a query returns excess provider groups', async () => {
     const emptyLocalProvider = {
       provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0, hits: [], notices: [], scope,
+      resultWindow: resultWindow(0, 'no_additional_match_observed'),
     } as const;
     const omittedHit = {
       queryId: 'q1', provider: 'local', title: 'Omitted third-provider evidence', snippet: 'Must not leak.',
@@ -295,10 +323,10 @@ describe('primary_source_search handler', () => {
     } as const;
     const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue({
       planStatus: 'complete',
-      queries: [{ id: 'q1', normalizedMode: 'all_terms', providers: [
+      queries: [{ id: 'q1', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [
         emptyLocalProvider,
         emptyLocalProvider,
-        { ...emptyLocalProvider, status: 'ok', hitCount: 1, hits: [omittedHit] },
+        { ...emptyLocalProvider, status: 'ok', hitCount: 1, resultWindow: resultWindow(1), hits: [omittedHit] },
       ] }],
       coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 1, ccelAttempted: false, ccelHitCount: 0, notices: [] },
     }) } as any);

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -221,11 +221,22 @@ describe('Worker MCP endpoint in workerd', () => {
     expect(listed.message.error).toBeUndefined();
     expect(listed.message.result?.resources).toEqual(expect.arrayContaining([
       expect.objectContaining({
+        uri: 'theologai://primary-sources/catalog',
+        mimeType: 'application/json',
+      }),
+      expect.objectContaining({
         uri: 'theologai://documents/apostles-creed',
         name: "Apostles' Creed",
         description: 'Creed (c. 390)',
       }),
     ]));
+
+    const catalog = await rpc('resources/read', { uri: 'theologai://primary-sources/catalog' }, 40);
+    expect(catalog.response.status).toBe(200);
+    expect(JSON.parse(String((catalog.message.result?.contents as Array<{ text: string }>)[0].text))).toMatchObject({
+      schemaVersion: '1', kind: 'local_primary_source_catalog', workCount: 1,
+      policies: { scope: 'hosted_collection_only', rightsStatus: 'not_established' },
+    });
 
     const read = await rpc('resources/read', {
       uri: 'theologai://documents/apostles-creed',
@@ -489,10 +500,12 @@ describe('Worker MCP endpoint in workerd', () => {
         }),
       ],
       structuredContent: {
-        schemaVersion: '2', kind: 'primary_source_search', planStatus: 'complete',
+        schemaVersion: '3', kind: 'primary_source_search', planStatus: 'complete',
         queries: [expect.objectContaining({
+          normalizedSelection: 'relevance',
           providers: [expect.objectContaining({
             provider: 'local', hitCount: 1,
+            resultWindow: { returnedHitCount: 1, additionalMatchStatus: 'no_additional_match_observed' },
             hits: [expect.objectContaining({ documentType: 'Creed', documentDate: 'c. 390' })],
           })],
         })],


### PR DESCRIPTION
## Summary

Upgrades the existing local `primary_source_search` query-plan boundary into a more useful research bundle for topic surveys, within-work location, and separate creator comparison. It adds no overlapping tool and leaves synthesis to the host model.

This is a stacked follow-up to #30. It should be retargeted to `main` after #30 merges.

## What changes

- adds optional `selection: relevance | work_diversity`, defaulting to existing relevance behavior
- implements deterministic round-robin work diversity through shared SQLite/D1 SQL
- upgrades structured output to v3 with explicit `normalizedSelection`
- reports honest provider result windows using bounded `limit + 1` lookahead, without claiming exhaustiveness
- adds the metadata-only `theologai://primary-sources/catalog` JSON resource for exact hosted work aliases and reviewed creator roles
- updates primary-source and confession workflows to inspect the catalog, keep creator searches separate, deduplicate locators, and read at most five exact section resources before synthesis
- preserves Markdown compatibility, canonical fail-closed locators, local-only scope, and existing rights/provenance disclosures

## Verification

- independent Sol deep review: approved with no P0-P2 findings
- full unit suite: 1,208 passed, 1 expected generated-database skip
- targeted slice tests: 142 passed
- integration: 3/3; Worker runtime: 20/20
- real SQLite/D1 repository parity passed
- Node, Worker, and Worker-runtime typechecks passed
- build, documentation contract, and diff validation passed

No migrations, corpus data, document bodies, live CCEL access, Worker configuration, or deployment changes.
