### PR TITLE
Add structured donation configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
+<!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,donation_config,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
 
 ### Added
 
 - Added stable MCP 2025-11-25 structured output and server-side schema
   validation for `bible_lookup`, `bible_cross_references`, `parallel_passages`,
-  `bible_verse_morphology`, `primary_source_search`, `original_language_lookup`, and
-  `original_language_study`, while keeping
+  `bible_verse_morphology`, `primary_source_search`, `original_language_lookup`,
+  `original_language_study`, and `donation_config`, while keeping
   their Markdown content available for legacy clients.
+- Added versioned `donation_config` results with explicit voluntary/no-feature-
+  unlock policy, the shared public donation URL, recipient address, and ordered
+  native/token asset metadata. The structure makes native addresses null,
+  rejects address/kind contradictions, retains exact token contract addresses,
+  and marks configured display order explicitly as non-ranking without implying price,
+  liquidity, bridge, or wallet capability.
 - Added versioned `bible_cross_references` results with requested and canonical
   references, effective query values, raw OpenBible.info ranking semantics,
   bounded positions, threshold-scoped result windows, and exact snapshot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Production MCP server for theological research. Eleven tools, six prompts, eight Bible translations, six commentaries, 17 historical documents, Greek/Hebrew language tools, and on-chain donation support. Tools, resources, and prompts are available on every transport; MCP Logging is stdio-only because HTTP is stateless.
 
-<!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
+<!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,donation_config,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
 
 ## Quick Start
 
@@ -96,7 +96,7 @@ test/
 | `original_language_lookup` | Strong's concordance plus opt-in exact corrected-corpus usage and bounded occurrence pages |
 | `bible_verse_morphology` | Word-by-word grammatical analysis for all 66 books |
 | `original_language_study` | Context-first study of one Greek or Hebrew token in one verse, with structured evidence and interpretive limits |
-| `donation_config` | Donation configuration: supported tokens, recipient address, chain details |
+| `donation_config` | Structured voluntary-donation configuration: public web URL, recipient address, and ordered native/token assets; no feature unlocks or asset rankings |
 | `verify_donation` | On-chain donation verification across Ethereum, Base, and Radius |
 
 All tools have annotations: `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The current registry contains eleven tools, six guided prompts, eight English
 Bible translations, six commentary sources, 17 locally indexed
 historical documents, Strong's dictionaries, and Greek/Hebrew morphology.
 
-<!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
+<!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,donation_config,original_language_lookup,original_language_study,parallel_passages,primary_source_search -->
 
 ## Remote endpoint
 
@@ -45,7 +45,7 @@ fresh server and transport.
 | `original_language_lookup` | Look up or search Strong's entries, with opt-in exact corrected-corpus usage and bounded occurrence pages for exact identities. |
 | `bible_verse_morphology` | Return bounded word-by-word morphology for one exact verse, with raw codes, nullable expansions, and separate pinned STEPBible morphology/lemma provenance. |
 | `original_language_study` | Resolve and study one Greek or Hebrew token in one verse with contextual morphology, source-separated lexical evidence, and explicit interpretive limits. |
-| `donation_config` | Return voluntary-donation recipient, asset, and chain configuration. |
+| `donation_config` | Return versioned structured voluntary-donation configuration with the public web URL, recipient, and ordered native/token assets; donations do not unlock features. |
 | `verify_donation` | Classify a transaction and confirm only supported transfers to the configured recipient. |
 
 `parallel_passages` defaults unconditionally to `corpora:
@@ -66,19 +66,25 @@ adds the top 10 exact source variants and defaults to 8 raw occurrences (maximum
 responses.
 
 All tools are annotated as read-only, non-destructive, and idempotent. Tool
-inputs use closed, bounded JSON Schema 2020-12 contracts. Seven tools also
+inputs use closed, bounded JSON Schema 2020-12 contracts. Eight tools also
 advertise versioned object-root `outputSchema` contracts and return matching
 `structuredContent` beside the existing Markdown content: `bible_lookup`,
 `bible_cross_references`, `bible_verse_morphology`, `parallel_passages`,
 `primary_source_search`, `original_language_lookup`, and
-`original_language_study`. Bible, cross-reference, verse-morphology,
+`original_language_study`, plus `donation_config`. Bible, cross-reference, verse-morphology,
 parallel-passage, and original-language structured results
 include bounded, result-local provenance records. Primary-source results do not
 invent edition provenance records: their evidence policy explicitly marks
 edition provenance incomplete, and they link only canonical local sections with
 exact UTF-8 sizes. Their result windows say only whether one additional match
 was directly observed through private lookahead; they do not imply exhaustive
-counts. All other tools retain their current Markdown-only result
+counts. Donation configuration returns
+`assetOrderMeaning: configured_display_order_not_ranking`, preserving its
+configured display order while explicitly saying only that the order is not a
+ranking or recommendation. Clients must not infer preference, price, liquidity,
+bridge availability, or wallet support from the configuration;
+native assets have a null structured address and tokens retain their exact
+contract address. The remaining tools retain their current Markdown-only result
 contract.
 
 ### Resources

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -235,6 +235,18 @@ threshold, and every response—including an empty result—carries the exact
 checksum-pinned OpenBible.info snapshot provenance. It changes no corpus rows,
 SQL semantics, migration, configuration, or deployment behavior.
 
+### Structured donation-configuration follow-up (unreleased)
+
+The next bounded modern-output slice also adds a v1 object-root contract for
+`donation_config` while retaining the legacy Markdown. It exposes the existing
+public donation page, recipient, and configured asset values in their existing
+display order, includes a machine-readable marker that this order is not a
+ranking, and distinguishes native assets from tokens with a structurally
+enforced null-or-exact contract address. It states that donations are voluntary
+and do not affect feature access. The contract does not rank assets or claim price, liquidity, bridging,
+or wallet support. It changes no verification behavior, chain configuration,
+secret, migration, D1 state, or deployment setting.
+
 ## Release gates
 
 Code readiness and operational readiness are deliberately separate:
@@ -249,7 +261,7 @@ Code readiness and operational readiness are deliberately separate:
 4. Preview deployment requires the repository's authorization label and
    protected environment approval. The live PR must still be open, non-draft,
    and authorized immediately before deployment.
-5. Preview smoke and a functional audit must cover all eleven tools, the seven
+5. Preview smoke and a functional audit must cover all eleven tools, the eight
    structured-output contracts, UBS default and explicit-source behavior,
    Strong's extended identities, local primary-source search, language study,
    resources, all six prompts, and failure/privacy boundaries.

--- a/src/adapters/donation/OnChainVerifier.ts
+++ b/src/adapters/donation/OnChainVerifier.ts
@@ -3,9 +3,12 @@
 import { Cache } from '../../kernel/cache.js';
 import {
   DEFAULT_RPC_URLS,
+  SUPPORTED_DONATION_CHAINS,
   type ChainTransactionEvidence,
   type ChainTransferEvidence,
+  type DonationRpcKey,
   type ITransactionEvidenceProvider,
+  type SupportedDonationNetwork,
 } from '../../kernel/donation-types.js';
 import { readBoundedResponseText } from '../shared/HttpClient.js';
 
@@ -14,13 +17,25 @@ const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
 const WORD_PATTERN = /^0x[0-9a-fA-F]{64}$/;
 const MAX_RPC_RESPONSE_BYTES = 1024 * 1024;
 
-interface RpcConfig { chainId: number; url: string; name: string }
+interface RpcConfig {
+  chainId: number;
+  chainName: string;
+  network: SupportedDonationNetwork;
+  url: string;
+}
 export interface OnChainVerifierOptions {
   ethereum?: string;
   base?: string;
   radius?: string;
   rpcTimeoutMs?: number;
 }
+type RpcOverrideKey = Exclude<keyof OnChainVerifierOptions, 'rpcTimeoutMs'>;
+
+const RPC_KEY_BY_NETWORK = {
+  'eip155:1': 'ethereum',
+  'eip155:8453': 'base',
+  'eip155:723': 'radius',
+} as const satisfies Record<SupportedDonationNetwork, RpcOverrideKey & DonationRpcKey>;
 interface RpcReceiptLog { address: string; topics: string[]; data: string }
 interface RpcReceipt { status: string; blockNumber: string; logs: RpcReceiptLog[] }
 interface RpcTransaction { from: string; to: string | null; value: string }
@@ -33,11 +48,13 @@ export class OnChainVerifier implements ITransactionEvidenceProvider {
 
   constructor(options: OnChainVerifierOptions = {}) {
     this.rpcTimeoutMs = options.rpcTimeoutMs ?? 15000;
-    this.rpcs = [
-      { chainId: 1, url: options.ethereum ?? DEFAULT_RPC_URLS.ethereum, name: 'Ethereum' },
-      { chainId: 8453, url: options.base ?? DEFAULT_RPC_URLS.base, name: 'Base' },
-      { chainId: 723, url: options.radius ?? DEFAULT_RPC_URLS.radius, name: 'Radius' },
-    ];
+    this.rpcs = SUPPORTED_DONATION_CHAINS.map(chain => {
+      const rpcKey = RPC_KEY_BY_NETWORK[chain.network];
+      return {
+        ...chain,
+        url: options[rpcKey] ?? DEFAULT_RPC_URLS[rpcKey],
+      };
+    });
   }
 
   async getEvidence(txHash: string): Promise<ChainTransactionEvidence[]> {
@@ -50,7 +67,12 @@ export class OnChainVerifier implements ITransactionEvidenceProvider {
   }
 
   private async getChainEvidence(rpc: RpcConfig, txHash: string): Promise<ChainTransactionEvidence> {
-    const base = { txHash, chainId: rpc.chainId, chainName: rpc.name, transfers: [] as ChainTransferEvidence[] };
+    const base = {
+      txHash,
+      chainId: rpc.chainId,
+      chainName: rpc.chainName,
+      transfers: [] as ChainTransferEvidence[],
+    };
     const [receiptResult, transactionResult] = await Promise.all([
       this.rpcCall<RpcReceipt>(rpc.url, 'eth_getTransactionReceipt', [txHash]),
       this.rpcCall<RpcTransaction>(rpc.url, 'eth_getTransactionByHash', [txHash]),

--- a/src/formatters/donationFormatter.ts
+++ b/src/formatters/donationFormatter.ts
@@ -1,11 +1,12 @@
 /** Pure Markdown formatting for donation tool responses. */
 
 import type { DonationConfig, DonationVerifyResult } from '../kernel/donation-types.js';
+import { PUBLIC_DONATION_URL } from '../kernel/publicUrls.js';
 
 export function formatDonationConfig(config: DonationConfig): string {
   let s = '**TheologAI Donations**\n\n';
   s += 'Donations help support TheologAI\'s development and are entirely voluntary — all features are free regardless.\n\n';
-  s += '**Easiest option:** Donate via the web at [theologai.pages.dev](https://theologai.pages.dev/), which has a donation section with wallet connection support.\n\n';
+  s += `**Easiest option:** Donate via the web at [theologai.pages.dev](${PUBLIC_DONATION_URL}), which has a donation section with wallet connection support.\n\n`;
   s += `**Recipient address:** \`${config.recipientAddress}\`\n\n`;
   s += '| Token | Chain | Contract | Decimals |\n|-------|-------|----------|----------|\n';
   for (const token of config.tokens) {

--- a/src/kernel/donation-types.ts
+++ b/src/kernel/donation-types.ts
@@ -2,11 +2,22 @@
 
 export const RECIPIENT_ADDRESS = '0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04';
 
-export const DEFAULT_RPC_URLS: Record<string, string> = {
+export const DONATION_CONFIG_LIMITS = Object.freeze({
+  maxAssets: 20,
+  maxSymbolLength: 16,
+  maxNameLength: 100,
+  maxChainNameLength: 100,
+  maxNetworkLength: 41,
+  maxDecimals: 255,
+});
+
+export const DEFAULT_RPC_URLS = Object.freeze({
   ethereum: 'https://eth.llamarpc.com',
   base: 'https://mainnet.base.org',
   radius: 'https://rpc.radiustech.xyz',
-};
+});
+
+export type DonationRpcKey = keyof typeof DEFAULT_RPC_URLS;
 
 export const EXPLORER_URLS: Record<number, string> = {
   1: 'https://etherscan.io/tx/',
@@ -25,17 +36,43 @@ export interface TokenConfig {
   isNative: boolean;
 }
 
-export const SUPPORTED_TOKENS: TokenConfig[] = [
-  { symbol: 'USDC', name: 'USD Coin', chainId: 8453, chainName: 'Base', network: 'eip155:8453', asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', decimals: 6, isNative: false },
-  { symbol: 'USDC', name: 'USD Coin', chainId: 1, chainName: 'Ethereum', network: 'eip155:1', asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', decimals: 6, isNative: false },
-  { symbol: 'ETH', name: 'Ether', chainId: 1, chainName: 'Ethereum', network: 'eip155:1', asset: 'native', decimals: 18, isNative: true },
-  { symbol: 'ETH', name: 'Ether', chainId: 8453, chainName: 'Base', network: 'eip155:8453', asset: 'native', decimals: 18, isNative: true },
-  { symbol: 'SBC', name: 'Stablecoin', chainId: 723, chainName: 'Radius', network: 'eip155:723', asset: '0x33ad9e4bd16b69b5bfded37d8b5d9ff9aba014fb', decimals: 6, isNative: false },
-];
+export interface DonationChainConfig {
+  chainId: number;
+  chainName: string;
+  network: string;
+}
+
+/** Canonical chain identities used by both verification and public output. */
+export const SUPPORTED_DONATION_CHAINS = Object.freeze([
+  Object.freeze({ chainId: 1, chainName: 'Ethereum', network: 'eip155:1' }),
+  Object.freeze({ chainId: 8453, chainName: 'Base', network: 'eip155:8453' }),
+  Object.freeze({ chainId: 723, chainName: 'Radius', network: 'eip155:723' }),
+] as const satisfies readonly DonationChainConfig[]);
+
+export type SupportedDonationNetwork = typeof SUPPORTED_DONATION_CHAINS[number]['network'];
+
+const chain = (chainId: number): DonationChainConfig => {
+  const configured = SUPPORTED_DONATION_CHAINS.find(candidate => candidate.chainId === chainId);
+  if (!configured) throw new Error(`Missing donation chain configuration for chain ${chainId}`);
+  return configured;
+};
+
+const token = (
+  asset: Pick<TokenConfig, 'symbol' | 'name' | 'chainId' | 'asset' | 'decimals' | 'isNative'>,
+): Readonly<TokenConfig> => Object.freeze({ ...asset, ...chain(asset.chainId) });
+
+/** Ordered for stable display only; array position is never an asset ranking. */
+export const SUPPORTED_TOKENS: readonly Readonly<TokenConfig>[] = Object.freeze([
+  token({ symbol: 'USDC', name: 'USD Coin', chainId: 8453, asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', decimals: 6, isNative: false }),
+  token({ symbol: 'USDC', name: 'USD Coin', chainId: 1, asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', decimals: 6, isNative: false }),
+  token({ symbol: 'ETH', name: 'Ether', chainId: 1, asset: 'native', decimals: 18, isNative: true }),
+  token({ symbol: 'ETH', name: 'Ether', chainId: 8453, asset: 'native', decimals: 18, isNative: true }),
+  token({ symbol: 'SBC', name: 'Stablecoin', chainId: 723, asset: '0x33ad9e4bd16b69b5bfded37d8b5d9ff9aba014fb', decimals: 6, isNative: false }),
+]);
 
 export interface DonationConfig {
   recipientAddress: string;
-  tokens: TokenConfig[];
+  tokens: readonly Readonly<TokenConfig>[];
 }
 
 export interface ChainTransferEvidence {

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -95,6 +95,7 @@ export {
   OPENBIBLE_PROVENANCE_ID,
   OPENBIBLE_CROSS_REFERENCE_PROVENANCE,
 } from './openBibleCrossReferenceProvenance.js';
+export { PUBLIC_DONATION_URL } from './publicUrls.js';
 
 // Staged primary-source rollout flags
 export {

--- a/src/kernel/publicUrls.ts
+++ b/src/kernel/publicUrls.ts
@@ -1,0 +1,3 @@
+/** Stable public URLs shared by tool and prompt presentation layers. */
+
+export const PUBLIC_DONATION_URL = 'https://theologai.pages.dev/';

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -3,6 +3,7 @@ import { GetPromptRequestSchema, ListPromptsRequestSchema } from '@modelcontextp
 import { z } from 'zod/v4';
 import { parseReference } from '../kernel/reference.js';
 import { parseStrongsIdentity } from '../kernel/strongs.js';
+import { PUBLIC_DONATION_URL } from '../kernel/publicUrls.js';
 import { validatePromptArguments } from './validation.js';
 
 export interface RecommendedToolCall {
@@ -306,9 +307,9 @@ This workflow supports a topic survey, exact local-work search, inclusive overla
       case 'donate':
         text = `The user wants to donate to TheologAI. Donations are voluntary and all features remain free.
 
-**Easiest option:** Use [theologai.pages.dev](https://theologai.pages.dev/), which provides wallet connection support.
+The public donation page is [theologai.pages.dev](${PUBLIC_DONATION_URL}).
 
-For current recipient, token, contract, and chain details, call ${callText(calls[0])}. If a wallet MCP tool is available, use those returned details to help the user prepare the transfer.`;
+For current recipient, asset, contract, and chain details, call ${callText(calls[0])}. Prefer its structured \`webDonationUrl\`, \`recipientAddress\`, \`assetOrderMeaning\`, and \`assets[]\`; \`assetOrderMeaning\` explicitly says the stable display order is not a ranking or recommendation, and the Markdown remains the fallback. A native asset has a null \`assetAddress\`; a token has its exact contract address. Do not infer price, liquidity, bridge availability, or wallet support. Reiterate that donations are voluntary and do not unlock features. If a wallet MCP tool is available, use only capabilities that tool itself advertises to help the user prepare the transfer.`;
         break;
       default:
         // validatePromptArguments rejects unknown names before this branch.

--- a/src/mcp/schemas/donationConfig.ts
+++ b/src/mcp/schemas/donationConfig.ts
@@ -1,0 +1,116 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import {
+  DONATION_CONFIG_LIMITS,
+  RECIPIENT_ADDRESS,
+  SUPPORTED_TOKENS,
+  type TokenConfig,
+} from '../../kernel/donation-types.js';
+import { PUBLIC_DONATION_URL } from '../../kernel/publicUrls.js';
+
+interface DonationAssetOutputBase {
+  symbol: string;
+  name: string;
+  chainId: number;
+  chainName: string;
+  network: string;
+  decimals: number;
+}
+
+export type DonationAssetOutputV1 = DonationAssetOutputBase & (
+  | { assetKind: 'native'; assetAddress: null }
+  | { assetKind: 'token'; assetAddress: string }
+);
+
+export interface DonationConfigOutputV1 {
+  [key: string]: unknown;
+  schemaVersion: '1';
+  kind: 'donation_config';
+  voluntary: true;
+  featureAccessIndependentOfDonation: true;
+  assetOrderMeaning: 'configured_display_order_not_ranking';
+  webDonationUrl: string;
+  recipientAddress: string;
+  assets: DonationAssetOutputV1[];
+}
+
+const ADDRESS_PATTERN = '^0x[0-9a-fA-F]{40}$';
+const ASSET_REQUIRED = [
+  'symbol', 'name', 'chainId', 'chainName', 'network',
+  'assetKind', 'assetAddress', 'decimals',
+] as const;
+
+function assetSchema(token: Readonly<TokenConfig>) {
+  return {
+    type: 'object',
+    properties: {
+      symbol: {
+        type: 'string',
+        const: token.symbol,
+        minLength: 1,
+        maxLength: DONATION_CONFIG_LIMITS.maxSymbolLength,
+      },
+      name: {
+        type: 'string',
+        const: token.name,
+        minLength: 1,
+        maxLength: DONATION_CONFIG_LIMITS.maxNameLength,
+      },
+      chainId: { type: 'integer', const: token.chainId, minimum: 1 },
+      chainName: {
+        type: 'string',
+        const: token.chainName,
+        minLength: 1,
+        maxLength: DONATION_CONFIG_LIMITS.maxChainNameLength,
+      },
+      network: {
+        type: 'string',
+        const: token.network,
+        minLength: 3,
+        maxLength: DONATION_CONFIG_LIMITS.maxNetworkLength,
+        pattern: '^eip155:[1-9][0-9]*$',
+      },
+      assetKind: { type: 'string', const: token.isNative ? 'native' : 'token' },
+      assetAddress: token.isNative
+        ? { type: 'null' }
+        : { type: 'string', const: token.asset, pattern: ADDRESS_PATTERN },
+      decimals: {
+        type: 'integer',
+        const: token.decimals,
+        minimum: 0,
+        maximum: DONATION_CONFIG_LIMITS.maxDecimals,
+      },
+    },
+    required: [...ASSET_REQUIRED],
+    additionalProperties: false,
+  };
+}
+
+export const donationConfigOutputSchema = {
+  type: 'object',
+  properties: {
+    schemaVersion: { type: 'string', const: '1' },
+    kind: { type: 'string', const: 'donation_config' },
+    voluntary: { type: 'boolean', const: true },
+    featureAccessIndependentOfDonation: { type: 'boolean', const: true },
+    assetOrderMeaning: {
+      type: 'string',
+      const: 'configured_display_order_not_ranking',
+      description: 'Array order is stable display configuration, not a preference or recommendation.',
+    },
+    webDonationUrl: { type: 'string', const: PUBLIC_DONATION_URL, minLength: 1, maxLength: 2048 },
+    recipientAddress: { type: 'string', const: RECIPIENT_ADDRESS, pattern: ADDRESS_PATTERN },
+    assets: {
+      type: 'array',
+      minItems: 1,
+      maxItems: DONATION_CONFIG_LIMITS.maxAssets,
+      uniqueItems: true,
+      description: 'Configured display order only; array position is not an asset ranking.',
+      items: { oneOf: SUPPORTED_TOKENS.map(assetSchema) },
+    },
+  },
+  required: [
+    'schemaVersion', 'kind', 'voluntary', 'featureAccessIndependentOfDonation',
+    'assetOrderMeaning', 'webDonationUrl', 'recipientAddress', 'assets',
+  ],
+  additionalProperties: false,
+} as NonNullable<Tool['outputSchema']>;

--- a/src/presenters/donationConfigStructured.ts
+++ b/src/presenters/donationConfigStructured.ts
@@ -1,0 +1,131 @@
+import {
+  DONATION_CONFIG_LIMITS,
+  RECIPIENT_ADDRESS,
+  SUPPORTED_DONATION_CHAINS,
+  SUPPORTED_TOKENS,
+  type DonationChainConfig,
+  type DonationConfig,
+  type TokenConfig,
+} from '../kernel/donation-types.js';
+import { PUBLIC_DONATION_URL } from '../kernel/publicUrls.js';
+import type {
+  DonationAssetOutputV1,
+  DonationConfigOutputV1,
+} from '../mcp/schemas/donationConfig.js';
+
+const ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/;
+const SYMBOL_PATTERN = /^[A-Z0-9][A-Z0-9._-]*$/;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001F\u007F]/;
+
+const assetIdentity = (token: Readonly<TokenConfig>): string => (
+  `${token.chainId}:${token.isNative ? 'native' : token.asset.toLowerCase()}`
+);
+
+const configuredAssets = new Map(SUPPORTED_TOKENS.map(token => [assetIdentity(token), token]));
+const configuredChains = new Map<number, DonationChainConfig>(
+  SUPPORTED_DONATION_CHAINS.map(chain => [chain.chainId, chain]),
+);
+
+/** Present donation configuration without adding preferences or wallet claims. */
+export function presentDonationConfigStructured(config: DonationConfig): DonationConfigOutputV1 {
+  validateConfig(config);
+  return {
+    schemaVersion: '1',
+    kind: 'donation_config',
+    voluntary: true,
+    featureAccessIndependentOfDonation: true,
+    assetOrderMeaning: 'configured_display_order_not_ranking',
+    webDonationUrl: PUBLIC_DONATION_URL,
+    recipientAddress: config.recipientAddress,
+    assets: config.tokens.map((token): DonationAssetOutputV1 => (
+      token.isNative ? {
+        symbol: token.symbol,
+        name: token.name,
+        chainId: token.chainId,
+        chainName: token.chainName,
+        network: token.network,
+        assetKind: 'native',
+        assetAddress: null,
+        decimals: token.decimals,
+      } : {
+        symbol: token.symbol,
+        name: token.name,
+        chainId: token.chainId,
+        chainName: token.chainName,
+        network: token.network,
+        assetKind: 'token',
+        assetAddress: token.asset,
+        decimals: token.decimals,
+      }
+    )),
+  };
+}
+
+function validateConfig(config: DonationConfig): void {
+  if (config.recipientAddress !== RECIPIENT_ADDRESS || !ADDRESS_PATTERN.test(config.recipientAddress)) {
+    throw new Error('Donation recipient does not match the configured recipient');
+  }
+  if (config.tokens.length < 1 || config.tokens.length > DONATION_CONFIG_LIMITS.maxAssets) {
+    throw new Error(`Donation configuration must contain 1-${DONATION_CONFIG_LIMITS.maxAssets} assets`);
+  }
+
+  const seen = new Set<string>();
+  for (const token of config.tokens) {
+    validateAssetFields(token);
+    const identity = assetIdentity(token);
+    if (seen.has(identity)) {
+      throw new Error(`Duplicate donation asset identity on chain ${token.chainId}`);
+    }
+    seen.add(identity);
+
+    const configured = configuredAssets.get(identity);
+    if (!configured || !sameAssetConfiguration(token, configured)) {
+      throw new Error(`Donation asset ${token.symbol} on chain ${token.chainId} does not match the supported catalog`);
+    }
+  }
+}
+
+function validateAssetFields(token: Readonly<TokenConfig>): void {
+  if (!Number.isSafeInteger(token.chainId) || token.chainId < 1) {
+    throw new Error(`Donation asset ${token.symbol} has an invalid chain ID`);
+  }
+  const chain = configuredChains.get(token.chainId);
+  if (!chain || token.chainName !== chain.chainName || token.network !== chain.network) {
+    throw new Error(`Donation asset ${token.symbol} has inconsistent chain identity`);
+  }
+  if (
+    token.symbol.length < 1
+    || token.symbol.length > DONATION_CONFIG_LIMITS.maxSymbolLength
+    || !SYMBOL_PATTERN.test(token.symbol)
+  ) {
+    throw new Error('Donation asset has an invalid symbol');
+  }
+  if (
+    token.name.length < 1
+    || token.name.length > DONATION_CONFIG_LIMITS.maxNameLength
+    || token.name !== token.name.trim()
+    || CONTROL_CHARACTER_PATTERN.test(token.name)
+  ) {
+    throw new Error(`Donation asset ${token.symbol} has an invalid name`);
+  }
+  if (!Number.isInteger(token.decimals) || token.decimals < 0 || token.decimals > DONATION_CONFIG_LIMITS.maxDecimals) {
+    throw new Error(`Donation asset ${token.symbol} has invalid decimals`);
+  }
+  if (token.isNative && token.asset !== 'native') {
+    throw new Error(`Native asset ${token.symbol} on ${token.chainName} has a contract address`);
+  }
+  if (!token.isNative && !ADDRESS_PATTERN.test(token.asset)) {
+    throw new Error(`Token asset ${token.symbol} on ${token.chainName} has no contract address`);
+  }
+}
+
+function sameAssetConfiguration(actual: Readonly<TokenConfig>, expected: Readonly<TokenConfig>): boolean {
+  return actual.symbol === expected.symbol
+    && actual.name === expected.name
+    && actual.chainId === expected.chainId
+    && actual.chainName === expected.chainName
+    && actual.network === expected.network
+    && actual.asset === expected.asset
+    && actual.decimals === expected.decimals
+    && actual.isNative === expected.isNative;
+}

--- a/src/tools/v2/donationConfig.ts
+++ b/src/tools/v2/donationConfig.ts
@@ -9,6 +9,8 @@ import type { ToolHandler } from '../../kernel/types.js';
 import type { DonationService } from '../../services/donation/DonationService.js';
 import { formatDonationConfig } from '../../formatters/donationFormatter.js';
 import { handleToolError } from '../../kernel/errors.js';
+import { donationConfigOutputSchema } from '../../mcp/schemas/donationConfig.js';
+import { presentDonationConfigStructured } from '../../presenters/donationConfigStructured.js';
 
 export function createDonationConfigHandler(donationService: DonationService): ToolHandler {
   return {
@@ -21,6 +23,7 @@ export function createDonationConfigHandler(donationService: DonationService): T
       required: [],
       additionalProperties: false,
     },
+    outputSchema: donationConfigOutputSchema,
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -33,6 +36,7 @@ export function createDonationConfigHandler(donationService: DonationService): T
         const text = formatDonationConfig(config);
         return {
           content: [{ type: 'text' as const, text }],
+          structuredContent: presentDonationConfigStructured(config),
         };
       } catch (error) {
         return handleToolError(error as Error);

--- a/test/integration/current/mcp-protocol.test.ts
+++ b/test/integration/current/mcp-protocol.test.ts
@@ -103,6 +103,7 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
         'original_language_lookup',
         'bible_verse_morphology',
         'original_language_study',
+        'donation_config',
       ]);
       expect(listed.tools.find(tool => tool.name === 'bible_lookup')?.outputSchema).toMatchObject({
         type: 'object',
@@ -144,6 +145,11 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
       });
       expect(JSON.stringify(primarySource).toLowerCase()).not.toContain('ccel');
       expect((primarySource.structuredContent as any).coverage).not.toHaveProperty('ccelAttempted');
+      expect(listed.tools.find(tool => tool.name === 'donation_config')?.outputSchema).toMatchObject({
+        type: 'object',
+        additionalProperties: false,
+        properties: { schemaVersion: { const: '1' }, kind: { const: 'donation_config' } },
+      });
       const resources = await client.listResources();
       expect(resources.resources).toContainEqual(expect.objectContaining({
         uri: 'theologai://primary-sources/catalog', mimeType: 'application/json',

--- a/test/unit/adapters/donation/OnChainVerifier.test.ts
+++ b/test/unit/adapters/donation/OnChainVerifier.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { OnChainVerifier } from '../../../../src/adapters/donation/OnChainVerifier.js';
+import { SUPPORTED_DONATION_CHAINS } from '../../../../src/kernel/donation-types.js';
 
 const TX_HASH = `0x${'ab'.repeat(32)}`;
 const TOKEN = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
@@ -48,6 +49,21 @@ afterEach(() => {
 });
 
 describe('OnChainVerifier evidence', () => {
+  it('verifies exactly every chain advertised by the shared donation catalog', async () => {
+    mockByChain(() => response(null));
+    const provider = new OnChainVerifier({ ethereum: 'eth', base: 'base', radius: 'radius' });
+
+    const evidence = await provider.getEvidence(TX_HASH);
+
+    expect(evidence.map(({ chainId, chainName }) => ({ chainId, chainName }))).toEqual(
+      SUPPORTED_DONATION_CHAINS.map(({ chainId, chainName }) => ({ chainId, chainName })),
+    );
+    expect(evidence).toHaveLength(SUPPORTED_DONATION_CHAINS.length);
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => String(url)).sort()).toEqual(
+      ['eth', 'eth', 'base', 'base', 'radius', 'radius'].sort(),
+    );
+  });
+
   it('decodes every valid transfer log plus a native transfer', async () => {
     mockChains(
       receipt({ logs: [transfer(), transfer(TO, `0x${'33'.repeat(20)}`, 2n)] }),

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -126,6 +126,7 @@ describe('published project contract', () => {
         'bible_cross_references',
         'bible_lookup',
         'bible_verse_morphology',
+        'donation_config',
         'original_language_lookup',
         'original_language_study',
         'parallel_passages',

--- a/test/unit/formatters/donationFormatter.test.ts
+++ b/test/unit/formatters/donationFormatter.test.ts
@@ -68,6 +68,21 @@ describe('formatDonationConfig', () => {
     const out = formatDonationConfig(makeDonationConfig());
     expect(out).toBe(out.trim());
   });
+
+  it('retains the legacy Markdown byte for byte after sharing the public URL', () => {
+    expect(formatDonationConfig(makeDonationConfig())).toBe(
+      '**TheologAI Donations**\n\n'
+      + 'Donations help support TheologAI\'s development and are entirely voluntary — all features are free regardless.\n\n'
+      + '**Easiest option:** Donate via the web at [theologai.pages.dev](https://theologai.pages.dev/), which has a donation section with wallet connection support.\n\n'
+      + '**Recipient address:** `0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04`\n\n'
+      + '| Token | Chain | Contract | Decimals |\n'
+      + '|-------|-------|----------|----------|\n'
+      + '| USDC | Base | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | 6 |\n'
+      + '| ETH | Ethereum | native | 18 |\n\n'
+      + '---\n'
+      + '*Always include the recipient address and token options when presenting donation info to the user.*',
+    );
+  });
 });
 
 describe('formatDonationVerifyResult', () => {

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -63,6 +63,7 @@ describe('MCP structured output validation', () => {
       'original_language_lookup',
       'bible_verse_morphology',
       'original_language_study',
+      'donation_config',
     ]);
     for (const toolName of withOutput) {
       const schema = listed.tools.find(tool => tool.name === toolName)?.outputSchema;

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -752,6 +752,13 @@ describe('shared MCP registration', () => {
       type: 'text',
       text: expect.stringContaining('theologai.pages.dev'),
     }));
+    const donateText = donate.messages[0].content.type === 'text'
+      ? donate.messages[0].content.text
+      : '';
+    expect(donateText).toContain('Prefer its structured `webDonationUrl`, `recipientAddress`, `assetOrderMeaning`, and `assets[]`');
+    expect(donateText).toContain('stable display order is not a ranking or recommendation');
+    expect(donateText).toContain('donations are voluntary and do not unlock features');
+    expect(donateText).toContain('Do not infer price, liquidity, bridge availability, or wallet support');
   });
 
   it('uses InvalidParams for unknown prompts and missing prompt arguments', async () => {

--- a/test/unit/presenters/donationConfigStructured.test.ts
+++ b/test/unit/presenters/donationConfigStructured.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SUPPORTED_TOKENS,
+  type DonationConfig,
+  type TokenConfig,
+} from '../../../src/kernel/donation-types.js';
+import { PUBLIC_DONATION_URL } from '../../../src/kernel/publicUrls.js';
+import { donationConfigOutputSchema } from '../../../src/mcp/schemas/donationConfig.js';
+import { validatorFor } from '../../../src/mcp/validation.js';
+import { presentDonationConfigStructured } from '../../../src/presenters/donationConfigStructured.js';
+
+const TOKEN_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const RECIPIENT = '0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04';
+
+function config(tokens: DonationConfig['tokens']): DonationConfig {
+  return { recipientAddress: RECIPIENT, tokens };
+}
+
+describe('presentDonationConfigStructured', () => {
+  it('preserves configured order and values while distinguishing native and token assets', () => {
+    const output = presentDonationConfigStructured(config([
+      {
+        symbol: 'USDC', name: 'USD Coin', chainId: 8453, chainName: 'Base',
+        network: 'eip155:8453', asset: TOKEN_ADDRESS, decimals: 6, isNative: false,
+      },
+      {
+        symbol: 'ETH', name: 'Ether', chainId: 1, chainName: 'Ethereum',
+        network: 'eip155:1', asset: 'native', decimals: 18, isNative: true,
+      },
+    ]));
+
+    expect(output).toEqual({
+      schemaVersion: '1',
+      kind: 'donation_config',
+      voluntary: true,
+      featureAccessIndependentOfDonation: true,
+      assetOrderMeaning: 'configured_display_order_not_ranking',
+      webDonationUrl: PUBLIC_DONATION_URL,
+      recipientAddress: RECIPIENT,
+      assets: [
+        {
+          symbol: 'USDC', name: 'USD Coin', chainId: 8453, chainName: 'Base',
+          network: 'eip155:8453', assetKind: 'token', assetAddress: TOKEN_ADDRESS, decimals: 6,
+        },
+        {
+          symbol: 'ETH', name: 'Ether', chainId: 1, chainName: 'Ethereum',
+          network: 'eip155:1', assetKind: 'native', assetAddress: null, decimals: 18,
+        },
+      ],
+    });
+    expect(validatorFor(donationConfigOutputSchema)(output).valid).toBe(true);
+  });
+
+  it('advertises a structural native/token union that rejects contradictory addresses', () => {
+    const output = presentDonationConfigStructured(config(SUPPORTED_TOKENS));
+    const validate = validatorFor(donationConfigOutputSchema);
+
+    const nativeWithContract = structuredClone(output);
+    const native = nativeWithContract.assets.find(asset => asset.assetKind === 'native')!;
+    native.assetAddress = TOKEN_ADDRESS as never;
+    expect(validate(nativeWithContract).valid).toBe(false);
+
+    const tokenWithNull = structuredClone(output);
+    const tokenAsset = tokenWithNull.assets.find(asset => asset.assetKind === 'token')!;
+    tokenAsset.assetAddress = null as never;
+    expect(validate(tokenWithNull).valid).toBe(false);
+
+    const tokenWithoutAddress = structuredClone(output) as any;
+    delete tokenWithoutAddress.assets.find((asset: any) => asset.assetKind === 'token').assetAddress;
+    expect(validate(tokenWithoutAddress).valid).toBe(false);
+
+    const duplicateAsset = structuredClone(output);
+    duplicateAsset.assets.push({ ...duplicateAsset.assets[0] });
+    expect(validate(duplicateAsset).valid).toBe(false);
+
+    const inconsistentNetwork = structuredClone(output);
+    inconsistentNetwork.assets[0].network = 'eip155:1';
+    expect(validate(inconsistentNetwork).valid).toBe(false);
+
+    const inconsistentChainId = structuredClone(output);
+    inconsistentChainId.assets[0].chainId = 1;
+    expect(validate(inconsistentChainId).valid).toBe(false);
+
+    const oversizedName = structuredClone(output);
+    oversizedName.assets[0].name = 'x'.repeat(101);
+    expect(validate(oversizedName).valid).toBe(false);
+
+    const wrongRecipient = structuredClone(output);
+    wrongRecipient.recipientAddress = '0x1111111111111111111111111111111111111111';
+    expect(validate(wrongRecipient).valid).toBe(false);
+  });
+
+  it('fails closed when native/token metadata contradicts its asset value', () => {
+    expect(() => presentDonationConfigStructured(config([{
+      symbol: 'ETH', name: 'Ether', chainId: 1, chainName: 'Ethereum',
+      network: 'eip155:1', asset: TOKEN_ADDRESS, decimals: 18, isNative: true,
+    }]))).toThrow('has a contract address');
+
+    expect(() => presentDonationConfigStructured(config([{
+      symbol: 'USDC', name: 'USD Coin', chainId: 8453, chainName: 'Base',
+      network: 'eip155:8453', asset: 'native', decimals: 6, isNative: false,
+    }]))).toThrow('has no contract address');
+  });
+
+  it('fails closed on inconsistent chain identities and unsupported catalog values', () => {
+    const usdc = { ...SUPPORTED_TOKENS[0] };
+    expect(() => presentDonationConfigStructured(config([
+      { ...usdc, network: 'eip155:1' },
+    ]))).toThrow('inconsistent chain identity');
+    expect(() => presentDonationConfigStructured(config([
+      { ...usdc, chainName: 'Ethereum' },
+    ]))).toThrow('inconsistent chain identity');
+    expect(() => presentDonationConfigStructured(config([
+      { ...usdc, decimals: 18 },
+    ]))).toThrow('does not match the supported catalog');
+  });
+
+  it('fails closed on duplicate asset identities and invalid bounded fields', () => {
+    const usdc = { ...SUPPORTED_TOKENS[0] };
+    expect(() => presentDonationConfigStructured(config([usdc, { ...usdc }]))).toThrow(
+      'Duplicate donation asset identity',
+    );
+
+    const invalidCases: Array<[Partial<TokenConfig>, string]> = [
+      [{ symbol: 'x'.repeat(17) }, 'invalid symbol'],
+      [{ name: ` ${usdc.name}` }, 'invalid name'],
+      [{ chainId: 0 }, 'invalid chain ID'],
+      [{ decimals: 256 }, 'invalid decimals'],
+    ];
+    for (const [changes, message] of invalidCases) {
+      expect(() => presentDonationConfigStructured(config([{ ...usdc, ...changes }]))).toThrow(message);
+    }
+  });
+
+  it('fails closed on recipient drift, empty catalogs, and oversized catalogs', () => {
+    expect(() => presentDonationConfigStructured({
+      recipientAddress: '0x1111111111111111111111111111111111111111',
+      tokens: SUPPORTED_TOKENS,
+    })).toThrow('recipient');
+    expect(() => presentDonationConfigStructured(config([]))).toThrow('must contain 1-20 assets');
+    expect(() => presentDonationConfigStructured(config(Array.from({ length: 21 }, (_, index) => ({
+      ...SUPPORTED_TOKENS[0],
+      asset: `0x${index.toString(16).padStart(40, '0')}`,
+    }))))).toThrow('must contain 1-20 assets');
+  });
+});

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -952,17 +952,13 @@ describe('bible_verse_morphology handler', () => {
 
 describe('donation handlers', () => {
   it('formats donation configuration without accepting input fields', async () => {
+    const tokenAddress = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+    const recipientAddress = '0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04';
     const getConfig = vi.fn<DonationService['getConfig']>().mockReturnValue({
-      recipientAddress: '0xrecipient',
+      recipientAddress,
       tokens: [{
-        symbol: 'ETH',
-        name: 'Ether',
-        chainId: 1,
-        chainName: 'Ethereum',
-        network: 'eip155:1',
-        asset: 'native',
-        decimals: 18,
-        isNative: true,
+        symbol: 'USDC', name: 'USD Coin', chainId: 8453, chainName: 'Base',
+        network: 'eip155:8453', asset: tokenAddress, decimals: 6, isNative: false,
       }],
     });
     const handler = createDonationConfigHandler(serviceDouble({ getConfig }));
@@ -970,8 +966,20 @@ describe('donation handlers', () => {
     const result = await handler.handler({});
 
     expect(getConfig).toHaveBeenCalledOnce();
-    expect(textOf(result)).toContain('`0xrecipient`');
-    expect(textOf(result)).toContain('| ETH | Ethereum | native | 18 |');
+    expect(textOf(result)).toContain(`\`${recipientAddress}\``);
+    expect(textOf(result)).toContain(`| USDC | Base | \`${tokenAddress}\` | 6 |`);
+    expect(result.structuredContent).toEqual({
+      schemaVersion: '1', kind: 'donation_config', voluntary: true,
+      featureAccessIndependentOfDonation: true,
+      assetOrderMeaning: 'configured_display_order_not_ranking',
+      webDonationUrl: 'https://theologai.pages.dev/',
+      recipientAddress,
+      assets: [{
+        symbol: 'USDC', name: 'USD Coin', chainId: 8453, chainName: 'Base',
+        network: 'eip155:8453', assetKind: 'token', assetAddress: tokenAddress, decimals: 6,
+      }],
+    });
+    expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
   });
 
   it('returns configuration failures as tool errors', async () => {

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -146,6 +146,15 @@ describe('Worker MCP endpoint in workerd', () => {
           name: 'primary_source_search',
           outputSchema: expect.objectContaining({ type: 'object', additionalProperties: false }),
         }),
+        expect.objectContaining({
+          name: 'donation_config',
+          outputSchema: expect.objectContaining({
+            type: 'object', additionalProperties: false,
+            properties: expect.objectContaining({
+              kind: expect.objectContaining({ const: 'donation_config' }),
+            }),
+          }),
+        }),
       ]),
     });
     const primarySourceTool = (listed.message.result?.tools as Array<Record<string, unknown>>)
@@ -187,6 +196,47 @@ describe('Worker MCP endpoint in workerd', () => {
           sourceSurfaceVariants: [expect.objectContaining({ sourceForm: 'ἀγάπη·' })],
           occurrences: [expect.objectContaining({ sourceForm: 'ἀγάπη·', exactMorphologyKey: 'G0026' })],
         },
+      },
+    });
+  });
+
+  it('returns structured donation configuration without changing its Markdown fallback', async () => {
+    const donation = await rpc('tools/call', {
+      name: 'donation_config',
+      arguments: {},
+    }, 32);
+
+    expect(donation.response.status).toBe(200);
+    expect(donation.message.error).toBeUndefined();
+    expect(donation.message.result).toMatchObject({
+      content: [expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('[theologai.pages.dev](https://theologai.pages.dev/)'),
+      })],
+      structuredContent: {
+        schemaVersion: '1',
+        kind: 'donation_config',
+        voluntary: true,
+        featureAccessIndependentOfDonation: true,
+        assetOrderMeaning: 'configured_display_order_not_ranking',
+        webDonationUrl: 'https://theologai.pages.dev/',
+        recipientAddress: '0xf2BE3382cF48ef5CAf21Ca3B01C4e6fC3Ea04B04',
+        assets: [
+          expect.objectContaining({
+            symbol: 'USDC', chainId: 8453, assetKind: 'token',
+            assetAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          }),
+          expect.objectContaining({
+            symbol: 'USDC', chainId: 1, assetKind: 'token',
+            assetAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          }),
+          expect.objectContaining({ symbol: 'ETH', chainId: 1, assetKind: 'native', assetAddress: null }),
+          expect.objectContaining({ symbol: 'ETH', chainId: 8453, assetKind: 'native', assetAddress: null }),
+          expect.objectContaining({
+            symbol: 'SBC', chainId: 723, assetKind: 'token',
+            assetAddress: '0x33ad9e4bd16b69b5bfded37d8b5d9ff9aba014fb',
+          }),
+        ],
       },
     });
   });


### PR DESCRIPTION
## What changed

- adds a strict v1 `structuredContent` contract for `donation_config`
- distinguishes native assets from token contracts and rejects contradictory or missing addresses
- validates recipient, bounded asset fields, chain/network identity, duplicate identities, and shared-catalog consistency
- derives output schema, presenter checks, and verifier chain identities from shared donation configuration
- centralizes the public donation URL while preserving legacy Markdown bytes and current donation policy

## Safety and semantics

The contract states that donations are voluntary and never unlock features. Configured display order is explicitly not a ranking or recommendation; clients must not infer price, liquidity, bridge availability, or wallet support. No supported asset, recipient, RPC endpoint, explorer, verification policy, D1 binding, migration, Wrangler setting, secret, or deployment state changes.

## Stack and review

- exact parent: production `main` at `d9b24eb2b7045b8d156b90be185c399a661c6f40`
- reviewed head: `d33cc596e7e5bb1399dc6d698b1abf8608c0c7b2`
- mechanical rebase from the pre-merge stack had no conflicts; stable patch ID and range-diff are exactly unchanged
- independent Sol implementation and rebase reviews: P0 0 / P1 0 / P2 0 / P3 0
- remains draft, unlabeled, and undeployed

## Verification (Node 22)

- full unit: 1,305 passed, one expected skip
- targeted unit/docs: 132 passed
- MCP integration: 3/3
- Worker runtime: 21/21
- Node, Worker, and Worker-runtime typechecks
- build and documentation contract
- `git diff --check`
