### PR TITLE
Reconcile Phase 3 release records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.6.0] - 2026-07-15
-
 <!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,commentary_lookup,donation_config,original_language_lookup,original_language_study,parallel_passages,primary_source_search,verify_donation -->
+
+## [3.6.0] - 2026-07-15
 
 ### Added
 
@@ -284,8 +284,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/TJ-Frederick/TheologAI/compare/v3.6.0...HEAD
-[3.6.0]: https://github.com/TJ-Frederick/TheologAI/compare/v3.4.0...v3.6.0
+[Unreleased]: https://github.com/TJ-Frederick/TheologAI/compare/d395b3641eb00f6826eaba670c287f9a39dfa3da...HEAD
+[3.6.0]: https://github.com/TJ-Frederick/TheologAI/compare/v1.0.0-phase3.1...d395b3641eb00f6826eaba670c287f9a39dfa3da
 [3.4.0]: https://github.com/TJ-Frederick/TheologAI/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/yourusername/TheologAI/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/yourusername/TheologAI/compare/v3.1.0...v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Async/sync parity tests proving dual-target compatibility (8 tests)
   - Reusable `mockD1` test helper
 
-## [3.4.0] - 2025-10-09
+## 3.4.0 - 2025-10-09
 
 ### Added - Enhanced Discovery & Commentary Navigation
 
@@ -219,7 +219,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [3.3.0] - 2025-10-08 (Previous Release)
+## 3.3.0 - 2025-10-08 (Previous Release)
 
 ### Added
 - 6 additional Bible translations (KJV, WEB, BSB, ASV, YLT, DBY) via HelloAO API
@@ -229,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [3.2.0] - 2025-10-07
+## 3.2.0 - 2025-10-07
 
 ### Added
 - HelloAO Bible API integration
@@ -239,7 +239,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [3.1.0] - 2025-10-06
+## 3.1.0 - 2025-10-06
 
 ### Added
 - Matthew Henry's Complete Commentary (66 books) via CCEL
@@ -248,7 +248,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.5.0] - 2025-10-05
+## 2.5.0 - 2025-10-05
 
 ### Added
 - ESV HTML endpoint integration with footnote extraction
@@ -258,7 +258,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.0] - 2025-10-04
+## 2.0.0 - 2025-10-04
 
 ### Added
 - CCEL API adapter with Scripture, Work Section, and Fragment endpoints
@@ -271,7 +271,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.0.0] - 2025-10-03
+## 1.0.0 - 2025-10-03
 
 ### Added
 - Initial release
@@ -286,10 +286,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/TJ-Frederick/TheologAI/compare/d395b3641eb00f6826eaba670c287f9a39dfa3da...HEAD
 [3.6.0]: https://github.com/TJ-Frederick/TheologAI/compare/v1.0.0-phase3.1...d395b3641eb00f6826eaba670c287f9a39dfa3da
-[3.4.0]: https://github.com/TJ-Frederick/TheologAI/compare/v3.3.0...v3.4.0
-[3.3.0]: https://github.com/yourusername/TheologAI/compare/v3.2.0...v3.3.0
-[3.2.0]: https://github.com/yourusername/TheologAI/compare/v3.1.0...v3.2.0
-[3.1.0]: https://github.com/yourusername/TheologAI/compare/v2.5.0...v3.1.0
-[2.5.0]: https://github.com/yourusername/TheologAI/compare/v2.0.0...v2.5.0
-[2.0.0]: https://github.com/yourusername/TheologAI/compare/v1.0.0...v2.0.0
-[1.0.0]: https://github.com/yourusername/TheologAI/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-07-15
+
 <!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,commentary_lookup,donation_config,original_language_lookup,original_language_study,parallel_passages,primary_source_search,verify_donation -->
 
 ### Added
@@ -282,7 +284,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/TJ-Frederick/TheologAI/compare/v3.4.0...HEAD
+[Unreleased]: https://github.com/TJ-Frederick/TheologAI/compare/v3.6.0...HEAD
+[3.6.0]: https://github.com/TJ-Frederick/TheologAI/compare/v3.4.0...v3.6.0
 [3.4.0]: https://github.com/TJ-Frederick/TheologAI/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/yourusername/TheologAI/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/yourusername/TheologAI/compare/v3.1.0...v3.2.0

--- a/docs/ADDING-CONFESSIONS.md
+++ b/docs/ADDING-CONFESSIONS.md
@@ -7,6 +7,9 @@
 > [ROADMAP.md](ROADMAP.md) and the edition-specific provenance and licensing
 > requirements in [NOTICE.md](../NOTICE.md). The age of the underlying work does
 > not establish rights to a particular transcription, edition, or translation.
+> Do not acquire source text, create a parser, or add JSON until a review has
+> recorded the exact edition, source, license or public-domain basis,
+> transcription provenance, required attribution, and approval to redistribute.
 
 This guide documents the systematic approach for adding lengthy confessional documents (creeds, confessions, catechisms) to the TheologAI MCP server.
 
@@ -24,7 +27,11 @@ Each document is a JSON file with metadata fields:
 - `topics`: Array of searchable keywords
 - `sections`: Array of document sections (chapters, articles, or Q&A)
 
-## Adding a New Document
+## Adding a New Document After Rights Approval
+
+Every method below begins only after the hard approval prerequisite above is
+met. The examples describe data shaping after an approved source is already in
+hand; they do not authorize acquiring or copying a source.
 
 ### Method 1: Short Documents (Creeds)
 For brief documents like the Apostles' Creed, manually create the JSON file.
@@ -49,12 +56,14 @@ For brief documents like the Apostles' Creed, manually create the JSON file.
 ### Method 2: Lengthy Documents (Confessions, Catechisms)
 For large documents like Westminster Confession, use the parsing approach.
 
-#### Step-by-Step Process (Used for Westminster Confession):
+#### Historical parsing process (used for Westminster Confession)
 
-**1. Download Source Text**
-   - Find reliable plain text source (CCEL, denominational websites, Project Gutenberg)
-   - Prefer sources with clear structure and minimal formatting
-   - Example: `curl -o /tmp/westminster-confession.txt https://www.ccel.org/creeds/westminster-confession.txt`
+**1. Record the approved source**
+   - Record the exact edition, transcription provenance, source URL, rights
+     basis, license, attribution, and approval evidence.
+   - CCEL hosting is not rights evidence and CCEL text must not be downloaded or
+     republished through this process.
+   - Continue only with the exact source approved by the rights review.
 
 **2. Analyze Document Structure**
    ```bash
@@ -176,51 +185,56 @@ The `parse-westminster.py` script serves as a reusable template. To adapt for ot
    - Each source has unique artifacts
    - Add regex patterns specific to source formatting
 
-## Documents Ready to Add
+## Candidate Inventory — Not Approved to Add
+
+Every candidate below requires rights, edition, license, and transcription-
+provenance review and explicit approval before source acquisition or ingestion.
+The modern *Catechism of the Catholic Church* is not presumed public domain.
 
 ### Reformed/Presbyterian:
-- **Westminster Shorter Catechism** (Q&A format, ~107 questions)
-- **Westminster Larger Catechism** (Q&A format, ~196 questions)
-- **Belgic Confession** (37 articles)
-- **Canons of Dort** (5 heads of doctrine)
-- **Second Helvetic Confession** (30 chapters)
-- **Scots Confession** (25 chapters)
+- **Westminster Shorter Catechism** (Q&A format, ~107 questions) — rights/edition/license/provenance review required
+- **Westminster Larger Catechism** (Q&A format, ~196 questions) — rights/edition/license/provenance review required
+- **Belgic Confession** (37 articles) — rights/edition/license/provenance review required
+- **Canons of Dort** (5 heads of doctrine) — rights/edition/license/provenance review required
+- **Second Helvetic Confession** (30 chapters) — rights/edition/license/provenance review required
+- **Scots Confession** (25 chapters) — rights/edition/license/provenance review required
 
 ### Lutheran:
-- **Augsburg Confession** (28 articles + 21 articles)
-- **Small Catechism** (Luther, Q&A format)
-- **Large Catechism** (Luther, chapters)
-- **Formula of Concord** (12 articles)
+- **Augsburg Confession** (28 articles + 21 articles) — rights/edition/license/provenance review required
+- **Small Catechism** (Luther, Q&A format) — rights/edition/license/provenance review required
+- **Large Catechism** (Luther, chapters) — rights/edition/license/provenance review required
+- **Formula of Concord** (12 articles) — rights/edition/license/provenance review required
 
 ### Anglican:
-- **Thirty-Nine Articles** (39 articles)
+- **Thirty-Nine Articles** (39 articles) — rights/edition/license/provenance review required
 
 ### Baptist:
-- **London Baptist Confession** (1689, 32 chapters)
-- **New Hampshire Confession** (18 articles)
+- **London Baptist Confession** (1689, 32 chapters) — rights/edition/license/provenance review required
+- **New Hampshire Confession** (18 articles) — rights/edition/license/provenance review required
 
 ### Roman Catholic:
-- **Catechism of the Catholic Church** (~700 pages, 2865 articles)
-- **Council of Trent** (decrees and canons)
-- **First Vatican Council** (4 constitutions)
+- **Catechism of the Catholic Church** (~700 pages, 2865 articles) — modern
+  edition/translation; rights/edition/license/provenance review required
+- **Council of Trent** (decrees and canons) — rights/edition/license/provenance review required
+- **First Vatican Council** (4 constitutions) — rights/edition/license/provenance review required
 
 ### Eastern Orthodox:
-- **Confession of Dositheus** (18 decrees)
-- **Longer Catechism** (Philaret of Moscow, Q&A)
-- **Confession of Peter Mogila** (articles)
+- **Confession of Dositheus** (18 decrees) — rights/edition/license/provenance review required
+- **Longer Catechism** (Philaret of Moscow, Q&A) — rights/edition/license/provenance review required
+- **Confession of Peter Mogila** (articles) — rights/edition/license/provenance review required
 
 ## Estimated Sizes
 
 Based on Westminster Confession (34 chapters = 80KB = 12,770 words):
 
-| Document | Sections | Est. Size | Format |
-|----------|----------|-----------|--------|
-| Westminster Shorter Cat. | 107 Q | ~40 KB | Q&A |
-| Westminster Larger Cat. | 196 Q | ~150 KB | Q&A |
-| Belgic Confession | 37 art. | ~80 KB | Articles |
-| Augsburg Confession | 28 art. | ~60 KB | Articles |
-| Canons of Dort | 5 heads | ~70 KB | Heads/Articles |
-| Catechism of Catholic Church | 2865 art. | ~3 MB | Articles |
+| Document | Sections | Est. Size | Format | Status |
+|----------|----------|-----------|--------|--------|
+| Westminster Shorter Cat. | 107 Q | ~40 KB | Q&A | Rights/edition/license/provenance review required |
+| Westminster Larger Cat. | 196 Q | ~150 KB | Q&A | Rights/edition/license/provenance review required |
+| Belgic Confession | 37 art. | ~80 KB | Articles | Rights/edition/license/provenance review required |
+| Augsburg Confession | 28 art. | ~60 KB | Articles | Rights/edition/license/provenance review required |
+| Canons of Dort | 5 heads | ~70 KB | Heads/Articles | Rights/edition/license/provenance review required |
+| Catechism of Catholic Church | 2865 art. | ~3 MB | Articles | Modern edition; rights/edition/license/provenance review required |
 
 **Total estimated (all documents): ~4-6 MB**
 

--- a/docs/ADDING-CONFESSIONS.md
+++ b/docs/ADDING-CONFESSIONS.md
@@ -1,5 +1,13 @@
 # Adding Historical Documents to TheologAI
 
+> **Legacy guide warning:** The download-and-parse workflow below records a
+> historical implementation technique; it is not approved for new ingestion.
+> In particular, do not download, copy, or republish CCEL-hosted text through
+> this workflow. New documents must follow the current rights-aware process in
+> [ROADMAP.md](ROADMAP.md) and the edition-specific provenance and licensing
+> requirements in [NOTICE.md](../NOTICE.md). The age of the underlying work does
+> not establish rights to a particular transcription, edition, or translation.
+
 This guide documents the systematic approach for adding lengthy confessional documents (creeds, confessions, catechisms) to the TheologAI MCP server.
 
 ## Directory Structure

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -99,8 +99,8 @@ The structured-output release ledger is:
   `b10427f0-9692-45ec-9089-e3027be58805`; coordinator 7/7 and independent
   23/23 audits, with no findings.
 - PR #38: production run `29448002771`, deployment `5463551874`, Worker
-  `e0371eb4-05c6-4415-b479-b01ac2630be0`; production audit 94/94, with no
-  findings.
+  `e0371eb4-05c6-4415-b479-b01ac2630be0`; coordinator 11/11 and independent
+  94/94 audits, with no findings.
 - PR #37: production run `29451333738`, deployment `5464194228`, Worker
   `9d2b757b-8b9b-4318-b09d-14f62815bf82`; coordinator 73/73 and independent
   91/91 audits, with no P0-P3 findings.
@@ -109,6 +109,16 @@ Each release retained production D1 `theologai-production-20260715-a`
 (`c6535a4a-1953-4279-b277-7368445fc61a`), passed strict readiness as `ready`,
 and performed zero readiness writes. Live CCEL discovery remains intentionally
 disabled and outside the public MCP contract.
+
+The current production Worker is PR #37 version
+`9d2b757b-8b9b-4318-b09d-14f62815bf82`; its immediate compatible same-D1
+predecessor is PR #38 version `e0371eb4-05c6-4415-b479-b01ac2630be0`. The
+current preview Worker is PR #37 version
+`fb2b8e41-4310-43f3-a8f0-571a64a733ac`; its immediate compatible same-D1
+predecessor is PR #38 version `404b7eb3-7244-436d-bfa5-8359ac3a4aab`. Both
+preview versions use `theologai-preview-20260714-a`
+(`0dab804f-8df0-4727-93bd-299612b6e179`). These are retained rollback options;
+no rollback is recorded as executed.
 
 ## Shipped Unicode correction release
 
@@ -158,8 +168,8 @@ deployed it on
 same D1 database. Targeted and independent full-surface black-box re-audits
 found no P0-P2 issues and confirmed all previously identified P0-P2 release
 findings were fixed. This is the audited corrective application evidence and
-does not predict the Worker UUID produced by any later deployment. The current
-immediate preview rollback pair is PR #34 Worker version
+does not predict the Worker UUID produced by any later deployment. At that
+point, the immediate preview rollback pair was PR #34 Worker version
 `ab270f0b-2627-4057-a182-a66cd750b118` with unchanged D1
 `theologai-preview-20260714-a`. Retain the verified PR #27 Worker version
 `734aec3b-d6c3-456b-a203-c7f940a2d081` with

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,6 +40,18 @@ is local source context only and does not define the current product contract.
   fail-closed section coverage, official content-shape parsing, and aligned
   public guidance, reviewed at `32441d99de673eccce0a57fd74801fb94db04944`
   and merged as `9f6aa128eeab663ef04a315ab0c14b8ae9a3376d`.
+- **Structured cross references / PR #35:** bounded, provenance-bearing v1
+  output for `bible_cross_references`, merged as
+  `d9b24eb2b7045b8d156b90be185c399a661c6f40`.
+- **Structured donation configuration / PR #36:** conservative v1 public
+  configuration output, merged as
+  `551b599a12f4844915504ba5529066a1bbff7797`.
+- **Structured donation verification / PR #38:** fail-closed v1 transaction
+  evidence and coverage output, merged as
+  `1d7369b1c232e9469abe5475d8e5f77cd22c9f13`.
+- **Structured commentary / PR #37:** provider-evidenced coverage identity,
+  rights and delivery provenance, and bounded v1 output, merged as
+  `d395b3641eb00f6826eaba670c287f9a39dfa3da`.
 
 These entries describe merged repository state. Deployment state is established
 only by the relevant protected workflow and post-deployment smoke evidence; a
@@ -74,34 +86,29 @@ PR #21. Their stacked PRs #14–#20 are closed as superseded review vehicles:
    context-first workflow for one token in one verse, with morphology,
    source-separated lexical evidence, provenance, and interpretive limits.
 
-The released server advertises eleven tools, six guided prompts, and structured
-output for `bible_lookup`, `parallel_passages`, `primary_source_search`,
-`original_language_lookup`, and `original_language_study`. Markdown remains
-available for compatibility.
+The released server advertises eleven tools and six guided prompts. Ten tools
+have versioned structured contracts while retaining Markdown compatibility;
+`classic_text_lookup` is the sole Markdown-only tool.
 
-Protected production workflow run `29418476587` deployed the PR #39 merge after
-the exact-corpus readiness gate passed. GitHub deployment `5457655742` deployed
-Worker version `a74f0848-5b68-4d7a-834e-aa3221ebda3b` at 100% with production D1
-`theologai-production-20260715-a`
-(`c6535a4a-1953-4279-b277-7368445fc61a`). The post-deployment strict readiness
-check returned `ready` with zero writes. The independent production audit
-scored 87/90 with no P0 or P1 findings and one P2 commentary-coverage finding.
+The structured-output release ledger is:
 
-PR #40 corrected that finding without changing either D1 binding. Protected
-preview run `29425323205` deployed reviewed head
-`32441d99de673eccce0a57fd74801fb94db04944` as GitHub deployment `5459322775`
-and Worker version `34a0a557-9ddb-4940-9862-6b25e1dd98e6` at 100%, bound to
-preview D1 `theologai-preview-20260714-a`
-(`0dab804f-8df0-4727-93bd-299612b6e179`). The coordinator audit passed 15/15
-and the independent audit passed 27/27 with no P0-P3 findings. Protected
-production run `29427137668` then deployed merge
-`9f6aa128eeab663ef04a315ab0c14b8ae9a3376d` as GitHub deployment `5459432945`
-and Worker version `656e9e3a-7044-45ca-9144-4ec7eae94d8d` at 100%. That PR #40
-Worker is the current production version and remains bound to production D1
-`theologai-production-20260715-a`. Readiness returned `ready` with zero writes;
-the coordinator audit passed 15/15 and the independent audit passed 27/27 with
-no P0-P3 findings. Live CCEL discovery remains intentionally disabled and is
-not part of the public MCP contract.
+- PR #35: production run `29436689148`, deployment `5461346778`, Worker
+  `24da1fd6-7a99-447e-86d4-17571d901b09`; coordinator 9/9 and independent
+  10/10 audits, with no findings.
+- PR #36: production run `29441298979`, deployment `5462262765`, Worker
+  `b10427f0-9692-45ec-9089-e3027be58805`; coordinator 7/7 and independent
+  23/23 audits, with no findings.
+- PR #38: production run `29448002771`, deployment `5463551874`, Worker
+  `e0371eb4-05c6-4415-b479-b01ac2630be0`; production audit 94/94, with no
+  findings.
+- PR #37: production run `29451333738`, deployment `5464194228`, Worker
+  `9d2b757b-8b9b-4318-b09d-14f62815bf82`; coordinator 73/73 and independent
+  91/91 audits, with no P0-P3 findings.
+
+Each release retained production D1 `theologai-production-20260715-a`
+(`c6535a4a-1953-4279-b277-7368445fc61a`), passed strict readiness as `ready`,
+and performed zero readiness writes. Live CCEL discovery remains intentionally
+disabled and outside the public MCP contract.
 
 ## Shipped Unicode correction release
 
@@ -222,9 +229,9 @@ prefix/suffix gloss segments such as `heavens` within `the/ heavens`, while
 remaining fail-closed for ambiguous candidates. No corpus rows or source data
 were changed by that application-layer correction.
 
-### Structured cross-reference follow-up (unreleased)
+### Structured cross-reference follow-up (shipped)
 
-The next modern-output slice adds a v1 object-root contract for
+This modern-output slice adds a v1 object-root contract for
 `bible_cross_references` without changing its Markdown. It distinguishes the
 caller's requested reference from the canonical verse actually queried,
 materializes effective query defaults, preserves raw OpenBible.info vote order
@@ -235,9 +242,9 @@ threshold, and every response—including an empty result—carries the exact
 checksum-pinned OpenBible.info snapshot provenance. It changes no corpus rows,
 SQL semantics, migration, configuration, or deployment behavior.
 
-### Structured donation-configuration follow-up (unreleased)
+### Structured donation-configuration follow-up (shipped)
 
-The next bounded modern-output slice also adds a v1 object-root contract for
+This bounded modern-output slice adds a v1 object-root contract for
 `donation_config` while retaining the legacy Markdown. It exposes the existing
 public donation page, recipient, and configured asset values in their existing
 display order, includes a machine-readable marker that this order is not a
@@ -247,7 +254,7 @@ and do not affect feature access. The contract does not rank assets or claim pri
 or wallet support. It changes no verification behavior, chain configuration,
 secret, migration, D1 state, or deployment setting.
 
-### Structured donation-verification follow-up (unreleased)
+### Structured donation-verification follow-up (shipped)
 
 `verify_donation` now pairs its legacy Markdown with a conservative v1 object
 contract. It reports exactly Ethereum, Base, and Radius checks; distinguishes
@@ -261,7 +268,7 @@ allowlists. Unknown, duplicate, missing, or mismatched chain evidence fails
 closed. A successful receipt means only
 `receipt_observed_no_confirmation_depth`, not confirmation depth or finality.
 
-### Structured commentary follow-up (unreleased)
+### Structured commentary follow-up (shipped)
 
 `commentary_lookup` now pairs its byte-compatible legacy Markdown with a v1
 object-root result. Coverage is carried from provider parsing into the service
@@ -310,12 +317,15 @@ Code readiness and operational readiness are deliberately separate:
 
 ## Next work
 
-- Broaden advanced original-language study only after those foundations, using
-  carefully sourced semantic-domain and discourse evidence useful to both
-  beginners and readers of Greek or Hebrew.
-- Expand primary-source discovery beyond the initial local collection through
-  rights-reviewed, freely redistributable editions and provider adapters. Do
-  not mirror or republish CCEL transcriptions without edition-specific rights.
+- Decide and review a bounded, discovery-only public rollout of the retained
+  CCEL search adapter. It must remain request-scoped and must not crawl, mirror,
+  store, or republish CCEL document bodies.
+- Expand the local primary-source corpus with rights-reviewed, freely
+  redistributable editions and explicit edition provenance. Do not mirror or
+  republish CCEL transcriptions without edition-specific rights.
+- Broaden original-language study with a separately sourced semantic-domain
+  layer useful to both beginners and readers of Greek or Hebrew; evaluate
+  MACULA discourse/context evidence only after that foundation is reviewed.
 - Evaluate section-span commentary only where provider coverage can be stated
   honestly; never relabel a section anchor as an exact verse range.
 - Continue modern MCP output improvements tool by tool when a stable structured

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -2,14 +2,12 @@
 
 ## Deployment baseline and rollback posture (2026-07-15)
 
-PR #40 merge `9f6aa128eeab663ef04a315ab0c14b8ae9a3376d` is the verified
-production application baseline. It corrects the sole P2 commentary-coverage
-finding from the historical PR #39 production audit without changing the
-transform-version-6 corpus or either D1 binding. Protected production run
-`29427137668` returned a read-only D1 readiness result of `ready` with zero
-writes, then GitHub deployment `5459432945` deployed Worker version
-`656e9e3a-7044-45ca-9144-4ec7eae94d8d` at 100%. The coordinator audit passed
-15/15 and the independent audit passed 27/27 with no P0-P3 findings.
+PR #37 merge `d395b3641eb00f6826eaba670c287f9a39dfa3da` is the verified
+production application baseline. Protected production run `29451333738`
+returned a read-only D1 readiness result of `ready` with zero writes, then
+GitHub deployment `5464194228` deployed Worker version
+`9d2b757b-8b9b-4318-b09d-14f62815bf82` at 100%. The coordinator audit passed
+73/73 and the independent audit passed 91/91 with no P0-P3 findings.
 
 The deployed logical D1 bindings and retained rollback posture are recorded
 below as point-in-time evidence. Cloudflare deployment history and the approved
@@ -20,8 +18,8 @@ binding.
 
 | Environment | Deployed logical database | Current posture | Rollback posture |
 |---|---|---|---|
-| Production | `theologai-production-20260715-a` (`c6535a4a-1953-4279-b277-7368445fc61a`) | PR #40 merge `9f6aa128eeab663ef04a315ab0c14b8ae9a3376d` deployed successfully by protected GitHub Actions run `29427137668`; GitHub deployment `5459432945` serves Worker version `656e9e3a-7044-45ca-9144-4ec7eae94d8d` at 100%. Post-deployment readiness was `ready` with zero writes; coordinator and independent audits passed 15/15 and 27/27 with no P0-P3 findings. | Retain PR #39 Worker version `a74f0848-5b68-4d7a-834e-aa3221ebda3b` with the same `theologai-production-20260715-a` D1 as the immediate matched rollback pair. Also retain Worker version `49746830-16ce-40dc-b8a5-3cdc9ab79217` with `theologai-production-20260713-b`, Worker version `17869daf-f5e4-4d80-9240-6bc4fbb8d395` with `theologai-production-20260713-a`, and Worker version `c291ca9f-bb1b-4e6e-abd5-d6a3ea4f0704` with `theologai-production-20260711-a` as older rollback history. Do not mix a database with incompatible code or delete another database without separate owner approval. |
-| Preview | `theologai-preview-20260714-a` (`0dab804f-8df0-4727-93bd-299612b6e179`) | Protected run `29425323205` deployed reviewed PR #40 head `32441d99de673eccce0a57fd74801fb94db04944` as GitHub deployment `5459322775` and Worker version `34a0a557-9ddb-4940-9862-6b25e1dd98e6` at 100%. Coordinator and independent audits passed 15/15 and 27/27 with no P0-P3 findings. | Retain PR #34 Worker version `ab270f0b-2627-4057-a182-a66cd750b118` with the same `theologai-preview-20260714-a` D1 as the immediate matched rollback pair. Also retain Worker version `734aec3b-d6c3-456b-a203-c7f940a2d081` with `theologai-preview-20260713-c` and Worker version `3c8ad7ef-50ed-42a7-9c71-2ac8c2dd6d7f` with `theologai-preview-20260712-b` as older matched rollback history. Do not delete another database without separate owner approval. |
+| Production | `theologai-production-20260715-a` (`c6535a4a-1953-4279-b277-7368445fc61a`) | PR #37 merge `d395b3641eb00f6826eaba670c287f9a39dfa3da` deployed by protected run `29451333738`; deployment `5464194228` serves Worker `9d2b757b-8b9b-4318-b09d-14f62815bf82` at 100%. Readiness was `ready` with zero writes; coordinator and independent audits passed 73/73 and 91/91 with no P0-P3 findings. | Retain PR #38 Worker `e0371eb4-05c6-4415-b479-b01ac2630be0` with the same production D1 as the immediate compatible predecessor. Older matched pairs remain historical options below. No rollback is recorded as executed; do not mix incompatible code and data or delete another database without separate owner approval. |
+| Preview | `theologai-preview-20260714-a` (`0dab804f-8df0-4727-93bd-299612b6e179`) | Protected run `29450048707` deployed reviewed PR #37 head `5c6df7f1a340a9a0b43c3260d104cbd6d8d1ebfb` as deployment `5464127644` and Worker `fb2b8e41-4310-43f3-a8f0-571a64a733ac` at 100%. Coordinator and independent audits completed with no P0-P3 findings. | Retain PR #38 Worker `404b7eb3-7244-436d-bfa5-8359ac3a4aab` with the same preview D1 as the immediate compatible predecessor. Older matched pairs remain historical options below. No rollback is recorded as executed; do not delete another database without separate owner approval. |
 
 ### Deployed PR #39 transform-version-6 production replacement
 
@@ -50,9 +48,9 @@ zero writes.
 
 The independent bounded production audit scored 87/90 with no P0 or P1
 findings. Its only P2 concerned exact-verse commentary coverage. PR #40 later
-corrected and released that finding as recorded below. Preserve this PR #39
-Worker with `theologai-production-20260715-a` as the immediate matched rollback
-pair for the corrective release. Preserve the older matched rollback records
+corrected and released that finding as recorded below. This PR #39 Worker with
+`theologai-production-20260715-a` was the immediate matched rollback pair for
+the corrective release. Preserve the older matched rollback records
 below as well; no additional database deletion is authorized without separate
 owner approval.
 
@@ -208,8 +206,8 @@ P0-P2 issues and confirmed all previously identified P0-P2 release findings
 were fixed. PR #34 subsequently merged as `ce335266d989b40afebe398aeb39dbd2082d926a`.
 Its final protected preview run `29379359308` deployed Worker version
 `ab270f0b-2627-4057-a182-a66cd750b118` at 100% with the same prepared preview
-database, and the final audits remained clear of P0-P2 findings. Retain the
-current immediate preview rollback pair: PR #34 Worker version
+database, and the final audits remained clear of P0-P2 findings. At that point,
+the immediate preview rollback pair was PR #34 Worker version
 `ab270f0b-2627-4057-a182-a66cd750b118` with unchanged D1
 `theologai-preview-20260714-a`. The verified PR #27 Worker version
 `734aec3b-d6c3-456b-a203-c7f940a2d081` with `theologai-preview-20260713-c` is


### PR DESCRIPTION
## What changed

- reconciles `ROADMAP.md` with the shipped PR #35, #36, #38, and #37 structured-output releases
- records the current production/preview Workers and immediate compatible same-D1 predecessors
- corrects the public contract to eleven tools, ten structured contracts, six prompts, and one Markdown-only tool
- moves shipped 3.6.0 work out of the changelog's Unreleased section without inventing historical release links
- marks the old confession-ingestion workflow as legacy and removes actionable CCEL acquisition/republication instructions
- orders the next work around bounded CCEL discovery, rights-reviewed local editions, and advanced original-language semantics

## Verification and review

- Node 22 `npm run docs:check`: 5/5
- remaining changelog links resolve successfully
- current Worker, D1, workflow, deployment, and audit evidence cross-checked against GitHub and Cloudflare
- independent final review: P0 0 / P1 0 / P2 0 / P3 0
- `git diff --check`

## Deployment note

This is documentation-only. Merging currently starts the production workflow even when Worker bytes are unchanged. Do not approve that deployment solely for this PR; cancel or leave the redundant production environment gate unapproved.
