### PR TITLE
Harden dormant CCEL search parsing policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ upstream GET per admitted cache miss, at most five metadata hits, and at most
 240 Unicode characters per discovery snippet. It accepts only structurally
 reviewed Bootstrap result cards and reduces a tracking-bearing “Read online”
 link to a canonical allowlisted CCEL exact-section path; tracking query and hash
-values are discarded. These safeguards do not authorize or enable live use.
+values are discarded. Balanced-card parsing uses explicit title/author roles,
+and a no-results marker is accepted only when no competing result structure is
+present. These safeguards do not authorize or enable live use.
 Any future external provider rollout must remain discovery-only until
 edition-specific rights and provider-policy gates are satisfied.
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ CCEL discovery adapters remain in the codebase as future provider architecture,
 but CCEL is not requestable in the public input schema and is unreachable from
 the public tool handler. The v3 output schema and structured result are also
 strictly local-only; dormant external-provider result shapes remain internal.
+The dormant adapter is restricted to page 1, one non-following/non-retried
+upstream GET per admitted cache miss, at most five metadata hits, and at most
+240 Unicode characters per discovery snippet. It accepts only structurally
+reviewed Bootstrap result cards and reduces a tracking-bearing “Read online”
+link to a canonical allowlisted CCEL exact-section path; tracking query and hash
+values are discarded. These safeguards do not authorize or enable live use.
 Any future external provider rollout must remain discovery-only until
 edition-specific rights and provider-policy gates are satisfied.
 

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -29,9 +29,17 @@ live-search flag remains off by default.
   Metadata outside a closed card, nested cards, unreviewed wrappers, implied
   closing tags, and ambiguous card boundaries are rejected. `template`,
   `noscript`, `textarea`, `script`, `style`, SVG/MathML, other inert elements,
-  and hidden subtrees do not contribute metadata or visible text. Title and
+  and subtrees marked with `hidden`, boolean `inert`, or ASCII-normalized
+  `aria-hidden="true"` do not contribute metadata or visible text. Title and
   author are selected by their exact `title` and `author` span class roles
   rather than DOM order, and the author role retains the reviewed `by` marker.
+  Accepted direct ancestry must also agree with parse5 source locations.
+  Table-context elements or source tags anywhere after the results heading are
+  rejected because the reviewed interface does not use tables and HTML5 foster
+  parenting can otherwise move card markup outside its source wrapper. Narrow
+  source-gap checks around accepted structural nodes likewise reject formatting
+  wrappers repaired by the adoption-agency algorithm; they do not implement a
+  second HTML tokenizer.
 - Empty-state policy: `no_results` requires exactly one reviewed
   `h2#CCEL_Search_results` immediately followed by exactly one
   `<p>No results found.</p>`. A competing results heading, duplicate empty
@@ -59,13 +67,13 @@ live-search flag remains off by default.
   (BSD-2-Clause). Worker dry-run bundling and Node/Worker typechecks are release
   gates for this dormant adapter.
 - 2026-07-15 local verification on Node 22.23.1 measured 1,000 valid parses at
-  0.031 ms median / 2.846 ms maximum, 50 pre-parse rejections of a 100,000-
-  attribute input at 0.729 ms median / 0.819 ms maximum, and 50 bounded
-  rejections of 10,000 nested headings at 4.305 ms median / 10.153 ms maximum.
+  0.035 ms median / 3.419 ms maximum, 50 pre-parse rejections of a 100,000-
+  attribute input at 0.795 ms median / 0.885 ms maximum, and 50 bounded
+  rejections of 10,000 nested headings at 5.636 ms median / 11.760 ms maximum.
   These figures are diagnostic observations, not portable performance SLAs.
-  Against the immediately preceding commit, the preview Worker dry bundle grew
-  from 2,603,119 to 2,893,515 raw bytes (+290,396) and from 492,279 to 554,011
-  gzip bytes (+61,732); Wrangler 4.107.0 completed both dry runs successfully.
+  Against the pre-parse5 `a47573f` baseline, the preview Worker dry bundle grew
+  from 2,603,119 to 2,899,157 raw bytes (+296,038) and from 492,279 to 555,191
+  gzip bytes (+62,912); Wrangler 4.107.0 completed both dry runs successfully.
 
 No live CCEL request, body persistence, production flag change, or remote
 mutation is authorized by this record.

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -21,7 +21,18 @@ live-search flag remains off by default.
   one `h5.card-title` with separate title and author spans, exactly one snippet
   paragraph, and exactly one “Read online” anchor. An earlier cover/image link
   is never treated as the section locator. Selector or anatomy ambiguity fails
-  closed as `interface_changed`.
+  closed as `interface_changed`. A bounded Node/Worker-compatible structural
+  tokenizer requires balanced cards and tracked child elements; metadata
+  outside a closed card, nested cards, and ambiguous div/card boundaries are
+  rejected. Title and author are selected by their explicit `title` and
+  `author` span class roles rather than DOM order, and the author role retains
+  the reviewed `by` marker.
+- Empty-state policy: `no_results` requires exactly one reviewed
+  `h2#CCEL_Search_results` immediately followed by exactly one
+  `<p>No results found.</p>`. A competing results heading, duplicate empty
+  marker, `.card` opening, `h5.card-title`, `p.card-text`, or “Read online”
+  anchor makes the response an interface contradiction. Contradictions are
+  never inserted into the negative cache.
 - Locator policy: a result locator must reduce to the exact allowlisted HTTPS
   path `https://ccel.org/ccel/{author}/{work}/{section}.html`. The complete
   provider query and hash are discarded before construction of the returned

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -5,8 +5,9 @@
 > retrieve or republish CCEL document bodies. A future discovery-only rollout
 > requires a new preflight and explicit release review.
 
-Recorded 2026-07-11 for PR 1. This is an operational review record, not an
-enablement approval. The live-search flag remains off by default.
+Originally recorded 2026-07-11 and updated 2026-07-15 for dormant parser-policy
+hardening. This is an architecture record, not an enablement approval. The
+live-search flag remains off by default.
 
 - Search surface reviewed: `https://ccel.org/?page=1&text=...`
 - Search contract reviewed: [CCEL Search Help](https://www.ccel.org/help/search), including the documented `author`, `authorID`, `title`, and `bookID` fields.
@@ -14,7 +15,23 @@ enablement approval. The live-search flag remains off by default.
 - Copyright status: no rights determination is made by this adapter. Search snippets are discovery-only metadata; edition-specific copyright and permission checks remain a later rollout gate. The [CCEL Copyright Policy](https://www.ccel.org/about/copyright.html) is reference material, not an approval.
 - Terms status: not reviewed or approved for this feature. Terms approval remains an explicit operator gate; copyright policy is not treated as a substitute for terms-of-use approval.
 - Robots status: not fetched by this slice. `https://www.ccel.org/robots.txt` must be checked manually by the operator immediately before any preview enablement and again for adapter releases. No automated test fetches robots or the live search surface.
-- Interface status: `search-results.html` is a dated, sanitized capture of the visible `h2` search heading, `h5` result headings, section links, and text metadata; `no-results.html` and `policy-page.html` preserve only their reviewed structural `h2`/`p` and `h1`/`p` states. Adversarial markup is isolated in `malicious.html` and is not provenance. Selector/state drift fails closed as `interface_changed`; upstream selector approval remains pending before enablement.
+- Interface status: tests use synthetic markup that models the reviewed
+  `h2#CCEL_Search_results` plus Bootstrap `.card` anatomy without copying real
+  titles, authors, snippets, or tracking values. Each card must contain exactly
+  one `h5.card-title` with separate title and author spans, exactly one snippet
+  paragraph, and exactly one “Read online” anchor. An earlier cover/image link
+  is never treated as the section locator. Selector or anatomy ambiguity fails
+  closed as `interface_changed`.
+- Locator policy: a result locator must reduce to the exact allowlisted HTTPS
+  path `https://ccel.org/ccel/{author}/{work}/{section}.html`. The complete
+  provider query and hash are discarded before construction of the returned
+  locator; `token`, `queryID`, `resultID`, and analogous opaque values are not
+  returned, cached, persisted, or logged by this adapter.
+- Request/output policy: page 1 only; at most five hits; at most 240 Unicode
+  characters per snippet; one upstream GET for an admitted cache miss; manual
+  redirect mode with zero redirects followed; zero retries. Existing response
+  byte limits, wall/stream timeouts, queue bounds, cache bounds, circuit state,
+  and policy/security latches remain fail closed.
 
 No live CCEL request, body persistence, production flag change, or remote
 mutation is authorized by this record.

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -21,12 +21,17 @@ live-search flag remains off by default.
   one `h5.card-title` with separate title and author spans, exactly one snippet
   paragraph, and exactly one “Read online” anchor. An earlier cover/image link
   is never treated as the section locator. Selector or anatomy ambiguity fails
-  closed as `interface_changed`. A bounded Node/Worker-compatible structural
-  tokenizer requires balanced cards and tracked child elements; metadata
-  outside a closed card, nested cards, and ambiguous div/card boundaries are
-  rejected. Title and author are selected by their explicit `title` and
-  `author` span class roles rather than DOM order, and the author role retains
-  the reviewed `by` marker.
+  closed as `interface_changed`. HTML is parsed once with the standards-based
+  `parse5` HTML5 tree builder; the same pure-ESM implementation bundles for
+  Node and Workers. Result cards must be direct siblings after the reviewed
+  heading, and `.card-body`, title heading, title/author roles, snippet, and
+  “Read online” anchor must retain their reviewed direct-containment paths.
+  Metadata outside a closed card, nested cards, unreviewed wrappers, implied
+  closing tags, and ambiguous card boundaries are rejected. `template`,
+  `noscript`, `textarea`, `script`, `style`, SVG/MathML, other inert elements,
+  and hidden subtrees do not contribute metadata or visible text. Title and
+  author are selected by their exact `title` and `author` span class roles
+  rather than DOM order, and the author role retains the reviewed `by` marker.
 - Empty-state policy: `no_results` requires exactly one reviewed
   `h2#CCEL_Search_results` immediately followed by exactly one
   `<p>No results found.</p>`. A competing results heading, duplicate empty
@@ -41,8 +46,26 @@ live-search flag remains off by default.
 - Request/output policy: page 1 only; at most five hits; at most 240 Unicode
   characters per snippet; one upstream GET for an admitted cache miss; manual
   redirect mode with zero redirects followed; zero retries. Existing response
-  byte limits, wall/stream timeouts, queue bounds, cache bounds, circuit state,
-  and policy/security latches remain fail closed.
+  wall/stream timeouts, queue bounds, cache bounds, circuit state, and
+  policy/security latches remain fail closed. Because the HTML5 parse itself is
+  synchronous, input is capped at 256 KiB before parsing. The projected tree is
+  additionally capped at 10,000 nodes, 10,000 total attributes, 64 attributes
+  per element, depth 64, 100,000 text code units, and a 100 ms parse/traversal
+  deadline.
+- Parser dependency: `parse5` is exact-pinned at `8.0.1`, the current version
+  returned by the authoritative npm registry during this 2026-07-15 review.
+  Its package metadata declares MIT, pure ESM, and an ESM export at
+  `./dist/index.js`; its sole installed dependency edge is `entities@8.0.0`
+  (BSD-2-Clause). Worker dry-run bundling and Node/Worker typechecks are release
+  gates for this dormant adapter.
+- 2026-07-15 local verification on Node 22.23.1 measured 1,000 valid parses at
+  0.031 ms median / 2.846 ms maximum, 50 pre-parse rejections of a 100,000-
+  attribute input at 0.729 ms median / 0.819 ms maximum, and 50 bounded
+  rejections of 10,000 nested headings at 4.305 ms median / 10.153 ms maximum.
+  These figures are diagnostic observations, not portable performance SLAs.
+  Against the immediately preceding commit, the preview Worker dry bundle grew
+  from 2,603,119 to 2,893,515 raw bytes (+290,396) and from 492,279 to 554,011
+  gzip bytes (+61,732); Wrangler 4.107.0 completed both dry runs successfully.
 
 No live CCEL request, body persistence, production flag change, or remote
 mutation is authorized by this record.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "agents": "0.17.3",
         "better-sqlite3": "^12.6.2",
         "dotenv": "^17.2.3",
+        "parse5": "8.0.1",
         "typescript": "^5.9.2",
         "zod": "4.3.6"
       },
@@ -5207,6 +5208,30 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "agents": "0.17.3",
     "better-sqlite3": "^12.6.2",
     "dotenv": "^17.2.3",
+    "parse5": "8.0.1",
     "typescript": "^5.9.2",
     "zod": "4.3.6"
   },

--- a/src/adapters/commentary/CcelSearchAdapter.ts
+++ b/src/adapters/commentary/CcelSearchAdapter.ts
@@ -6,6 +6,7 @@
  * enabled by a caller that has passed the rollout gate.
  */
 
+import { parse, type DefaultTreeAdapterTypes } from 'parse5';
 import { ValidationError } from '../../kernel/errors.js';
 import {
   type PrimarySourceProviderResult,
@@ -13,7 +14,6 @@ import {
   type PrimarySourceSearchMatch,
   type PrimarySourceSearchQuery,
 } from '../../services/historical/primarySourceTypes.js';
-import { decodeHtmlEntities, stripHtml } from '../shared/HtmlParser.js';
 import type { PrimarySourceFeatureFlags } from '../../kernel/featureFlags.js';
 
 export const CCEL_SEARCH_ATTRIBUTION = 'CCEL (Christian Classics Ethereal Library)' as const;
@@ -28,9 +28,15 @@ export const CCEL_SEARCH_LIMITS = Object.freeze({
   maxPage: 1,
   maxHitsPerResponse: 5,
   maxCandidateResults: 50,
-  maxStructuralTokens: 20_000,
-  maxStructuralDepth: 128,
-  maxResponseBytes: 1024 * 1024,
+  maxTreeNodes: 10_000,
+  maxTreeAttributes: 10_000,
+  maxAttributesPerElement: 64,
+  maxTreeDepth: 64,
+  maxTreeTextCharacters: 100_000,
+  maxParseTraversalMs: 100,
+  // parse5 is standards-compliant but parses synchronously, so an input cap
+  // must bound work before tree traversal can enforce its finer budgets.
+  maxResponseBytes: 256 * 1024,
   maxTitleCharacters: 300,
   maxAuthorResultCharacters: 200,
   maxSectionCharacters: 300,
@@ -706,20 +712,19 @@ function tokenizeWords(value: string): string[] {
 /** Parse only known result metadata; selector drift is an error, not no-results. */
 export function parseCcelSearchHtml(html: string, page: number): ParsedSearch {
   if (html.length === 0) throw new CcelSearchFailure('parser');
-  const sanitizedHtml = removeUnsafeMarkup(html);
-  if (/<!--|-->|<\/?(?:script|style|form|nav|header|footer)\b/iu.test(sanitizedHtml)) {
-    throw new CcelSearchFailure('parser');
+  if (new TextEncoder().encode(html).byteLength > CCEL_SEARCH_LIMITS.maxResponseBytes) {
+    throw new CcelSearchFailure('too_large');
   }
-  if (hasReviewedPolicyMarker(sanitizedHtml)) throw new CcelSearchFailure('policy');
-  const document = tokenizeReviewedStructure(sanitizedHtml);
-  const searchState = identifySearchState(sanitizedHtml, document);
+  const document = parseReviewedDocument(html);
+  if (hasReviewedPolicyMarker(document)) throw new CcelSearchFailure('policy');
+  const searchState = identifySearchState(document);
   if (searchState.kind === 'empty') return { hits: [], notices: [] };
 
   const hits: PrimarySourceSearchHit[] = [];
   const seen = new Set<string>();
   let aggregateCharacters = 0;
   for (const element of searchState.cards) {
-    const card = parseResultCard(sanitizedHtml, element);
+    const card = parseResultCard(element);
     if (seen.has(card.locator.url)) continue;
     const { locator, title, author, snippet } = card;
     const hitCharacters = title.length + author.length + snippet.length
@@ -746,21 +751,18 @@ export function parseCcelSearchHtml(html: string, page: number): ParsedSearch {
   return { hits, notices: [] };
 }
 
-function hasReviewedPolicyMarker(html: string): boolean {
-  return /<h1\b[^>]*>\s*Access denied\s*<\/h1>\s*<p\b[^>]*>\s*Please complete the CAPTCHA to continue\.\s*<\/p>/i.test(html);
-}
-
-type ReviewedTagName = 'div' | 'h2' | 'h5' | 'p' | 'a' | 'span';
+type TreeNode = DefaultTreeAdapterTypes.Node;
+type TreeElement = DefaultTreeAdapterTypes.Element;
 
 interface ReviewedElement {
-  name: ReviewedTagName;
+  name: string;
   attributes: ReadonlyMap<string, string>;
-  start: number;
-  contentStart: number;
-  contentEnd: number;
-  end: number;
+  order: number;
+  explicitlyClosed: boolean;
   parent?: ReviewedElement;
   children: ReviewedElement[];
+  content: Array<string | ReviewedElement>;
+  text: string;
 }
 
 interface ReviewedDocument {
@@ -771,147 +773,169 @@ type ReviewedSearchState =
   | { kind: 'empty' }
   | { kind: 'results'; cards: ReviewedElement[] };
 
-const REVIEWED_TAGS = new Set<ReviewedTagName>(['div', 'h2', 'h5', 'p', 'a', 'span']);
+const INERT_OR_NON_TEXT_ELEMENTS = new Set([
+  'canvas', 'embed', 'iframe', 'math', 'noscript', 'object', 'script', 'style',
+  'svg', 'template', 'textarea',
+]);
+const STRICTLY_CLOSED_RESULT_ELEMENTS = new Set(['a', 'div', 'h2', 'h5', 'p', 'span']);
+const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+const REJECTED_PARSE_ERRORS = new Set([
+  'duplicate-attribute',
+  'eof-in-element-that-can-contain-only-text',
+  'unexpected-null-character',
+]);
 
 /**
- * Tokenize only the reviewed search-structure tags. This deliberately avoids
- * DOMParser/HTMLRewriter so the same fail-closed parser runs in Node and a
- * Worker. Quoted `>` characters are respected and every tracked element must
- * be balanced within bounded token/depth budgets.
+ * Build one standards-compliant HTML5 tree in both Node and Workers. The
+ * synchronous parse is protected by the byte cap; this traversal adds node,
+ * attribute, depth, text, and elapsed-time budgets and creates a much smaller
+ * view containing only visible HTML elements.
  */
-function tokenizeReviewedStructure(html: string): ReviewedDocument {
-  const elements: ReviewedElement[] = [];
-  const stack: ReviewedElement[] = [];
-  let cursor = 0;
-  let tokenCount = 0;
-  while (cursor < html.length) {
-    const start = html.indexOf('<', cursor);
-    if (start < 0) break;
-    const end = scanTagEnd(html, start);
-    if (end < 0) throw new CcelSearchFailure('parser');
-    tokenCount++;
-    if (tokenCount > CCEL_SEARCH_LIMITS.maxStructuralTokens) throw new CcelSearchFailure('too_large');
-    const raw = html.slice(start + 1, end);
-    cursor = end + 1;
-    if (/^\s*[!?]/u.test(raw)) continue;
+function parseReviewedDocument(html: string): ReviewedDocument {
+  const startedAt = monotonicNow();
+  const deadline = startedAt + CCEL_SEARCH_LIMITS.maxParseTraversalMs;
+  let rejectedParseError = false;
+  let tree: DefaultTreeAdapterTypes.Document;
+  try {
+    tree = parse(html, {
+      sourceCodeLocationInfo: true,
+      onParseError: error => {
+        if (REJECTED_PARSE_ERRORS.has(error.code)) rejectedParseError = true;
+      },
+    });
+  } catch {
+    throw new CcelSearchFailure('parser');
+  }
+  if (monotonicNow() > deadline) throw new CcelSearchFailure('too_large');
+  if (rejectedParseError) throw new CcelSearchFailure('parser');
 
-    const closing = /^\s*\/\s*([A-Za-z][A-Za-z0-9:-]*)\s*$/u.exec(raw);
-    if (closing) {
-      const name = closing[1].toLocaleLowerCase('en-US');
-      if (!isReviewedTag(name)) continue;
-      const open = stack.at(-1);
-      if (!open || open.name !== name) throw new CcelSearchFailure('parser');
-      open.contentEnd = start;
-      open.end = end + 1;
-      stack.pop();
+  const elements: ReviewedElement[] = [];
+  const pending: Array<{
+    node: TreeNode;
+    depth: number;
+    excluded: boolean;
+    parent?: ReviewedElement;
+  }> = [...tree.childNodes].reverse().map(node => ({ node, depth: 1, excluded: false }));
+  let nodeCount = 0;
+  let attributeCount = 0;
+  let textCharacters = 0;
+
+  while (pending.length > 0) {
+    const frame = pending.pop();
+    if (!frame) break;
+    nodeCount++;
+    if (nodeCount > CCEL_SEARCH_LIMITS.maxTreeNodes) throw new CcelSearchFailure('too_large');
+    if (frame.depth > CCEL_SEARCH_LIMITS.maxTreeDepth) throw new CcelSearchFailure('too_large');
+    if ((nodeCount & 127) === 0 && monotonicNow() > deadline) throw new CcelSearchFailure('too_large');
+
+    if (isTextNode(frame.node)) {
+      textCharacters += frame.node.value.length;
+      if (textCharacters > CCEL_SEARCH_LIMITS.maxTreeTextCharacters) throw new CcelSearchFailure('too_large');
+      if (!frame.excluded && frame.parent) frame.parent.content.push(frame.node.value);
       continue;
     }
+    if (!isTreeElement(frame.node)) continue;
 
-    const opening = /^\s*([A-Za-z][A-Za-z0-9:-]*)([\s\S]*?)\s*(\/)?\s*$/u.exec(raw);
-    if (!opening) throw new CcelSearchFailure('parser');
-    const name = opening[1].toLocaleLowerCase('en-US');
-    if (!isReviewedTag(name)) continue;
-    const attributes = parseReviewedAttributes(opening[2]);
-    const parent = stack.at(-1);
-    const element: ReviewedElement = {
-      name,
-      attributes,
-      start,
-      contentStart: end + 1,
-      contentEnd: end + 1,
-      end: end + 1,
-      ...(parent ? { parent } : {}),
-      children: [],
-    };
-    parent?.children.push(element);
-    elements.push(element);
-    if (opening[3]) continue;
-    stack.push(element);
-    if (stack.length > CCEL_SEARCH_LIMITS.maxStructuralDepth) throw new CcelSearchFailure('too_large');
+    const node = frame.node;
+    attributeCount += node.attrs.length;
+    if (node.attrs.length > CCEL_SEARCH_LIMITS.maxAttributesPerElement
+      || attributeCount > CCEL_SEARCH_LIMITS.maxTreeAttributes) {
+      throw new CcelSearchFailure('too_large');
+    }
+    const attributes = new Map(node.attrs.map(attribute => [attribute.name, attribute.value]));
+    const excluded = frame.excluded
+      || node.namespaceURI !== HTML_NAMESPACE
+      || INERT_OR_NON_TEXT_ELEMENTS.has(node.tagName)
+      || attributes.has('hidden')
+      || attributes.get('aria-hidden')?.toLocaleLowerCase('en-US') === 'true';
+    let reviewedParent = frame.parent;
+    if (!excluded) {
+      const location = node.sourceCodeLocation;
+      const reviewed: ReviewedElement = {
+        name: node.tagName,
+        attributes,
+        order: elements.length,
+        explicitlyClosed: location?.startTag !== undefined && location.endTag !== undefined,
+        ...(frame.parent ? { parent: frame.parent } : {}),
+        children: [],
+        content: [],
+        text: '',
+      };
+      frame.parent?.children.push(reviewed);
+      frame.parent?.content.push(reviewed);
+      elements.push(reviewed);
+      reviewedParent = reviewed;
+    }
+
+    const childNodes = node.tagName === 'template' && 'content' in node
+      ? node.content.childNodes
+      : node.childNodes;
+    for (let index = childNodes.length - 1; index >= 0; index--) {
+      pending.push({
+        node: childNodes[index],
+        depth: frame.depth + 1,
+        excluded,
+        ...(reviewedParent ? { parent: reviewedParent } : {}),
+      });
+    }
   }
-  if (stack.length !== 0) throw new CcelSearchFailure('parser');
+  if (monotonicNow() > deadline) throw new CcelSearchFailure('too_large');
+  for (let index = elements.length - 1; index >= 0; index--) {
+    elements[index].text = elements[index].content
+      .map(part => typeof part === 'string' ? part : part.text)
+      .join('');
+  }
   return { elements };
 }
 
-function scanTagEnd(html: string, start: number): number {
-  let quote: '"' | "'" | undefined;
-  for (let index = start + 1; index < html.length; index++) {
-    const character = html[index];
-    if (quote) {
-      if (character === quote) quote = undefined;
-    } else if (character === '"' || character === "'") {
-      quote = character;
-    } else if (character === '>') {
-      return index;
-    }
-  }
-  return -1;
+function monotonicNow(): number {
+  return globalThis.performance?.now() ?? Date.now();
 }
 
-function parseReviewedAttributes(source: string): ReadonlyMap<string, string> {
-  const attributes = new Map<string, string>();
-  let cursor = 0;
-  while (cursor < source.length) {
-    while (/\s/u.test(source[cursor] ?? '')) cursor++;
-    if (cursor >= source.length) break;
-    const nameMatch = /^[^\s=/>]+/u.exec(source.slice(cursor));
-    if (!nameMatch) throw new CcelSearchFailure('parser');
-    const name = nameMatch[0].toLocaleLowerCase('en-US');
-    cursor += nameMatch[0].length;
-    while (/\s/u.test(source[cursor] ?? '')) cursor++;
-    let value = '';
-    if (source[cursor] === '=') {
-      cursor++;
-      while (/\s/u.test(source[cursor] ?? '')) cursor++;
-      const quote = source[cursor];
-      if (quote === '"' || quote === "'") {
-        cursor++;
-        const valueEnd = source.indexOf(quote, cursor);
-        if (valueEnd < 0) throw new CcelSearchFailure('parser');
-        value = source.slice(cursor, valueEnd);
-        cursor = valueEnd + 1;
-      } else {
-        const valueMatch = /^[^\s>]+/u.exec(source.slice(cursor));
-        if (!valueMatch) throw new CcelSearchFailure('parser');
-        value = valueMatch[0];
-        cursor += value.length;
-      }
-    }
-    if (attributes.has(name)) throw new CcelSearchFailure('parser');
-    attributes.set(name, decodeHtmlEntities(value));
-  }
-  return attributes;
+function isTextNode(node: TreeNode): node is DefaultTreeAdapterTypes.TextNode {
+  return node.nodeName === '#text';
 }
 
-function isReviewedTag(value: string): value is ReviewedTagName {
-  return REVIEWED_TAGS.has(value as ReviewedTagName);
+function isTreeElement(node: TreeNode): node is TreeElement {
+  return 'tagName' in node && Array.isArray(node.attrs);
 }
 
-function identifySearchState(html: string, document: ReviewedDocument): ReviewedSearchState {
+function hasReviewedPolicyMarker(document: ReviewedDocument): boolean {
+  return document.elements.some(element => element.name === 'h1'
+    && elementText(element, 64).toLocaleLowerCase('en-US') === 'access denied'
+    && element.parent?.children.some(sibling => sibling.order > element.order
+      && sibling.name === 'p'
+      && elementText(sibling, 128) === 'Please complete the CAPTCHA to continue.'
+      && areAdjacentInContent(element, sibling)) === true);
+}
+
+function identifySearchState(document: ReviewedDocument): ReviewedSearchState {
   const resultHeadings = document.elements.filter(element => element.name === 'h2' && (
     element.attributes.get('id') === 'CCEL_Search_results'
-    || elementText(html, element, CCEL_SEARCH_LIMITS.maxTitleCharacters) === 'CCEL Search results'
+    || elementText(element, CCEL_SEARCH_LIMITS.maxTitleCharacters) === 'CCEL Search results'
   ));
   if (resultHeadings.length !== 1) throw new CcelSearchFailure('parser');
   const heading = resultHeadings[0];
   if (heading.attributes.get('id') !== 'CCEL_Search_results'
-    || elementText(html, heading, CCEL_SEARCH_LIMITS.maxTitleCharacters) !== 'CCEL Search results') {
+    || elementText(heading, CCEL_SEARCH_LIMITS.maxTitleCharacters) !== 'CCEL Search results'
+    || !isExplicitlyClosed(heading)) {
     throw new CcelSearchFailure('parser');
   }
 
   const emptyMarkers = document.elements.filter(element => element.name === 'p'
-    && elementText(html, element, 64) === 'No results found.');
-  const cards = document.elements.filter(element => element.name === 'div'
-    && element.start >= heading.end
-    && hasElementClass(element, 'card'));
+    && elementText(element, 64) === 'No results found.');
+  const allCards = document.elements.filter(element => element.name === 'div' && hasElementClass(element, 'card'));
+  const cards = allCards.filter(element => element.order > heading.order);
   if (cards.length > CCEL_SEARCH_LIMITS.maxCandidateResults) throw new CcelSearchFailure('too_large');
   for (const card of cards) {
-    if (card.end - card.start > CCEL_SEARCH_LIMITS.maxAggregateResultCharacters) throw new CcelSearchFailure('too_large');
-    if (ancestorWithClass(card.parent, 'card')) throw new CcelSearchFailure('parser');
+    if (card.parent !== heading.parent || ancestorWithClass(card.parent, 'card') || !isExplicitlyClosed(card)) {
+      throw new CcelSearchFailure('parser');
+    }
   }
+  if (allCards.length !== cards.length) throw new CcelSearchFailure('parser');
 
-  const resultLikeOutsideCard = document.elements.some(element => element.start > heading.end
-    && isResultMetadataElement(html, element)
+  const resultLikeOutsideCard = document.elements.some(element => element.order > heading.order
+    && isResultMetadataElement(element)
     && !ancestorWithClass(element.parent, 'card'));
   if (resultLikeOutsideCard) throw new CcelSearchFailure('parser');
 
@@ -919,8 +943,9 @@ function identifySearchState(html: string, document: ReviewedDocument): Reviewed
     const marker = emptyMarkers.length === 1 ? emptyMarkers[0] : undefined;
     const immediate = marker !== undefined
       && marker.parent === heading.parent
-      && /^\s*$/u.test(html.slice(heading.end, marker.start));
-    if (!immediate || cards.length > 0 || hasAnyResultMetadata(html, document, heading.end)) {
+      && isExplicitlyClosed(marker)
+      && areAdjacentInContent(heading, marker);
+    if (!immediate || cards.length > 0 || hasAnyResultMetadata(document, heading.order)) {
       throw new CcelSearchFailure('parser');
     }
     return { kind: 'empty' };
@@ -929,17 +954,26 @@ function identifySearchState(html: string, document: ReviewedDocument): Reviewed
   return { kind: 'results', cards };
 }
 
-function hasAnyResultMetadata(html: string, document: ReviewedDocument, after: number): boolean {
-  return document.elements.some(element => element.start > after && isResultMetadataElement(html, element));
+function areAdjacentInContent(first: ReviewedElement, second: ReviewedElement): boolean {
+  if (!first.parent || first.parent !== second.parent) return false;
+  const firstIndex = first.parent.content.indexOf(first);
+  const secondIndex = first.parent.content.indexOf(second);
+  if (firstIndex < 0 || secondIndex <= firstIndex) return false;
+  return first.parent.content.slice(firstIndex + 1, secondIndex)
+    .every(part => typeof part === 'string' && /^[\t\n\f\r ]*$/u.test(part));
 }
 
-function isResultMetadataElement(html: string, element: ReviewedElement): boolean {
+function hasAnyResultMetadata(document: ReviewedDocument, after: number): boolean {
+  return document.elements.some(element => element.order > after && isResultMetadataElement(element));
+}
+
+function isResultMetadataElement(element: ReviewedElement): boolean {
   return (element.name === 'h5' && hasElementClass(element, 'card-title'))
     || (element.name === 'p' && hasElementClass(element, 'card-text'))
-    || (element.name === 'a' && elementText(html, element, 32).toLocaleLowerCase('en-US') === 'read online');
+    || (element.name === 'a' && elementText(element, 32).toLocaleLowerCase('en-US') === 'read online');
 }
 
-function parseResultCard(html: string, card: ReviewedElement): {
+function parseResultCard(card: ReviewedElement): {
   title: string;
   author: string;
   snippet: string;
@@ -948,34 +982,46 @@ function parseResultCard(html: string, card: ReviewedElement): {
   const descendants = descendantElements(card);
   const nestedCards = descendants.filter(element => element.name === 'div' && hasElementClass(element, 'card'));
   if (nestedCards.length > 0) throw new CcelSearchFailure('parser');
-  const bodies = card.children.filter(element => element.name === 'div' && hasElementClass(element, 'card-body'));
-  if (bodies.length !== 1) throw new CcelSearchFailure('parser');
+  const bodies = descendants.filter(element => element.name === 'div' && hasElementClass(element, 'card-body'));
+  if (bodies.length !== 1 || bodies[0].parent !== card || !isExplicitlyClosed(bodies[0])) {
+    throw new CcelSearchFailure('parser');
+  }
   const body = bodies[0];
   const bodyDescendants = descendantElements(body);
 
-  const headings = bodyDescendants.filter(element => element.name === 'h5' && hasElementClass(element, 'card-title'));
-  if (headings.length !== 1) throw new CcelSearchFailure('parser');
+  const headings = body.children.filter(element => element.name === 'h5' && hasElementClass(element, 'card-title'));
+  if (headings.length !== 1 || !isExplicitlyClosed(headings[0])) throw new CcelSearchFailure('parser');
   const spans = descendantElements(headings[0]).filter(element => element.name === 'span');
-  if (spans.length !== 2) throw new CcelSearchFailure('parser');
+  if (spans.length !== 2 || spans.some(element => element.parent !== headings[0] || !isExplicitlyClosed(element))) {
+    throw new CcelSearchFailure('parser');
+  }
   const titleSpans = spans.filter(element => hasElementClass(element, 'title'));
   const authorSpans = spans.filter(element => hasElementClass(element, 'author'));
   if (titleSpans.length !== 1 || authorSpans.length !== 1
     || spans.some(element => Number(hasElementClass(element, 'title')) + Number(hasElementClass(element, 'author')) !== 1)) {
     throw new CcelSearchFailure('parser');
   }
-  const title = elementText(html, titleSpans[0], CCEL_SEARCH_LIMITS.maxTitleCharacters);
-  const authorMarker = elementText(html, authorSpans[0], CCEL_SEARCH_LIMITS.maxAuthorResultCharacters + 3);
+  const title = elementText(titleSpans[0], CCEL_SEARCH_LIMITS.maxTitleCharacters);
+  const authorMarker = elementText(authorSpans[0], CCEL_SEARCH_LIMITS.maxAuthorResultCharacters + 3);
   if (!title || /^by\s+/iu.test(title) || !/^by\s+\S/iu.test(authorMarker)) throw new CcelSearchFailure('parser');
   const author = sanitizePlainText(authorMarker.replace(/^by\s+/iu, ''), CCEL_SEARCH_LIMITS.maxAuthorResultCharacters);
   if (!author) throw new CcelSearchFailure('parser');
 
-  const paragraphs = bodyDescendants.filter(element => element.name === 'p');
-  if (paragraphs.length !== 1 || !hasElementClass(paragraphs[0], 'card-text')) throw new CcelSearchFailure('parser');
-  const snippet = elementText(html, paragraphs[0], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
+  const paragraphs = body.children.filter(element => element.name === 'p');
+  if (paragraphs.length !== 1 || !hasElementClass(paragraphs[0], 'card-text') || !isExplicitlyClosed(paragraphs[0])) {
+    throw new CcelSearchFailure('parser');
+  }
+  const snippet = elementText(paragraphs[0], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
 
-  const readLinks = bodyDescendants.filter(element => element.name === 'a'
-    && elementText(html, element, 32).toLocaleLowerCase('en-US') === 'read online');
-  if (readLinks.length !== 1) throw new CcelSearchFailure('parser');
+  const readLinks = body.children.filter(element => element.name === 'a'
+    && elementText(element, 32).toLocaleLowerCase('en-US') === 'read online');
+  if (readLinks.length !== 1 || !isExplicitlyClosed(readLinks[0])) throw new CcelSearchFailure('parser');
+  if (bodyDescendants.some(element => isResultMetadataElement(element)
+    && element !== headings[0]
+    && element !== paragraphs[0]
+    && element !== readLinks[0])) {
+    throw new CcelSearchFailure('parser');
+  }
   const href = readLinks[0].attributes.get('href');
   const locator = href === undefined ? undefined : normalizeCcelSectionLocator(href);
   if (!locator) throw new CcelSearchFailure('parser');
@@ -994,8 +1040,8 @@ function descendantElements(element: ReviewedElement): ReviewedElement[] {
   return descendants;
 }
 
-function elementText(html: string, element: ReviewedElement, maxCharacters: number): string {
-  return sanitizePlainText(html.slice(element.contentStart, element.contentEnd), maxCharacters);
+function elementText(element: ReviewedElement, maxCharacters: number): string {
+  return sanitizePlainText(element.text, maxCharacters);
 }
 
 function hasElementClass(element: ReviewedElement, token: string): boolean {
@@ -1012,19 +1058,15 @@ function ancestorWithClass(element: ReviewedElement | undefined, token: string):
 }
 
 function hasClassToken(classValue: string, token: string): boolean {
-  return classValue.split(/\s+/u).includes(token);
+  return classValue.split(/[\t\n\f\r ]+/u).includes(token);
 }
 
-function removeUnsafeMarkup(html: string): string {
-  return html
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/<(script|style|form|nav|header|footer)\b[^>]*>[\s\S]*?<\/\1>/gi, '')
-    .replace(/<[^>]*\b(?:hidden|aria-hidden\s*=\s*["']true["'])[^>]*>[\s\S]*?<\/[^>]+>/gi, '');
+function isExplicitlyClosed(element: ReviewedElement): boolean {
+  return !STRICTLY_CLOSED_RESULT_ELEMENTS.has(element.name) || element.explicitlyClosed;
 }
 
-function sanitizePlainText(html: string, maxCharacters: number): string {
-  const stripped = stripHtml(html);
-  const decoded = decodeHtmlEntities(stripped)
+function sanitizePlainText(text: string, maxCharacters: number): string {
+  const decoded = text
     .replace(/[\u0000-\u001F\u007F-\u009F]/g, ' ')
     .replace(/\s+/gu, ' ')
     .trim();

--- a/src/adapters/commentary/CcelSearchAdapter.ts
+++ b/src/adapters/commentary/CcelSearchAdapter.ts
@@ -717,14 +717,17 @@ export function parseCcelSearchHtml(html: string, page: number): ParsedSearch {
   }
   const document = parseReviewedDocument(html);
   if (hasReviewedPolicyMarker(document)) throw new CcelSearchFailure('policy');
-  const searchState = identifySearchState(document);
+  const searchState = identifySearchState(html, document);
+  ensureParseDeadline(document);
   if (searchState.kind === 'empty') return { hits: [], notices: [] };
 
   const hits: PrimarySourceSearchHit[] = [];
   const seen = new Set<string>();
   let aggregateCharacters = 0;
   for (const element of searchState.cards) {
-    const card = parseResultCard(element);
+    ensureParseDeadline(document);
+    const card = parseResultCard(html, document, element);
+    ensureParseDeadline(document);
     if (seen.has(card.locator.url)) continue;
     const { locator, title, author, snippet } = card;
     const hitCharacters = title.length + author.length + snippet.length
@@ -759,6 +762,10 @@ interface ReviewedElement {
   attributes: ReadonlyMap<string, string>;
   order: number;
   explicitlyClosed: boolean;
+  sourceStart: number;
+  sourceEnd: number;
+  sourceContentStart: number;
+  sourceContentEnd: number;
   parent?: ReviewedElement;
   children: ReviewedElement[];
   content: Array<string | ReviewedElement>;
@@ -767,6 +774,7 @@ interface ReviewedElement {
 
 interface ReviewedDocument {
   elements: ReviewedElement[];
+  deadline: number;
 }
 
 type ReviewedSearchState =
@@ -778,7 +786,10 @@ const INERT_OR_NON_TEXT_ELEMENTS = new Set([
   'svg', 'template', 'textarea',
 ]);
 const STRICTLY_CLOSED_RESULT_ELEMENTS = new Set(['a', 'div', 'h2', 'h5', 'p', 'span']);
+const TABLE_CONTEXT_ELEMENTS = new Set(['caption', 'col', 'colgroup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr']);
 const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+const TABLE_SOURCE_PATTERN = /<\/?[\t\n\f\r ]*(?:caption|col|colgroup|table|tbody|td|tfoot|th|thead|tr)\b/iu;
+const ADOPTION_FORMATTING_SOURCE_PATTERN = /<\/?[\t\n\f\r ]*(?:b|big|code|em|font|i|nobr|s|small|strike|strong|tt|u)\b/iu;
 const REJECTED_PARSE_ERRORS = new Set([
   'duplicate-attribute',
   'eof-in-element-that-can-contain-only-text',
@@ -847,7 +858,8 @@ function parseReviewedDocument(html: string): ReviewedDocument {
       || node.namespaceURI !== HTML_NAMESPACE
       || INERT_OR_NON_TEXT_ELEMENTS.has(node.tagName)
       || attributes.has('hidden')
-      || attributes.get('aria-hidden')?.toLocaleLowerCase('en-US') === 'true';
+      || attributes.has('inert')
+      || trimAsciiWhitespace(attributes.get('aria-hidden') ?? '').toLocaleLowerCase('en-US') === 'true';
     let reviewedParent = frame.parent;
     if (!excluded) {
       const location = node.sourceCodeLocation;
@@ -856,6 +868,10 @@ function parseReviewedDocument(html: string): ReviewedDocument {
         attributes,
         order: elements.length,
         explicitlyClosed: location?.startTag !== undefined && location.endTag !== undefined,
+        sourceStart: location?.startOffset ?? -1,
+        sourceEnd: location?.endOffset ?? -1,
+        sourceContentStart: location?.startTag?.endOffset ?? -1,
+        sourceContentEnd: location?.endTag?.startOffset ?? -1,
         ...(frame.parent ? { parent: frame.parent } : {}),
         children: [],
         content: [],
@@ -885,11 +901,19 @@ function parseReviewedDocument(html: string): ReviewedDocument {
       .map(part => typeof part === 'string' ? part : part.text)
       .join('');
   }
-  return { elements };
+  return { elements, deadline };
 }
 
 function monotonicNow(): number {
   return globalThis.performance?.now() ?? Date.now();
+}
+
+function trimAsciiWhitespace(value: string): string {
+  return value.replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/gu, '');
+}
+
+function ensureParseDeadline(document: ReviewedDocument): void {
+  if (monotonicNow() > document.deadline) throw new CcelSearchFailure('too_large');
 }
 
 function isTextNode(node: TreeNode): node is DefaultTreeAdapterTypes.TextNode {
@@ -909,7 +933,7 @@ function hasReviewedPolicyMarker(document: ReviewedDocument): boolean {
       && areAdjacentInContent(element, sibling)) === true);
 }
 
-function identifySearchState(document: ReviewedDocument): ReviewedSearchState {
+function identifySearchState(html: string, document: ReviewedDocument): ReviewedSearchState {
   const resultHeadings = document.elements.filter(element => element.name === 'h2' && (
     element.attributes.get('id') === 'CCEL_Search_results'
     || elementText(element, CCEL_SEARCH_LIMITS.maxTitleCharacters) === 'CCEL Search results'
@@ -918,9 +942,20 @@ function identifySearchState(document: ReviewedDocument): ReviewedSearchState {
   const heading = resultHeadings[0];
   if (heading.attributes.get('id') !== 'CCEL_Search_results'
     || elementText(heading, CCEL_SEARCH_LIMITS.maxTitleCharacters) !== 'CCEL Search results'
-    || !isExplicitlyClosed(heading)) {
+    || !isExplicitlyClosed(heading)
+    || !hasValidSourceBounds(heading)
+    || !hasDirectSourceContainment(heading.parent, heading)) {
     throw new CcelSearchFailure('parser');
   }
+  const resultsRegionEnd = heading.parent!.sourceContentEnd;
+  const resultsSource = html.slice(heading.sourceEnd, resultsRegionEnd);
+  if (TABLE_SOURCE_PATTERN.test(resultsSource)
+    || document.elements.some(element => TABLE_CONTEXT_ELEMENTS.has(element.name)
+      && element.sourceStart >= heading.sourceEnd
+      && element.sourceStart < resultsRegionEnd)) {
+    throw new CcelSearchFailure('parser');
+  }
+  assertNoNonAncestorSourceWrapper(document, heading);
 
   const emptyMarkers = document.elements.filter(element => element.name === 'p'
     && elementText(element, 64) === 'No results found.');
@@ -928,9 +963,14 @@ function identifySearchState(document: ReviewedDocument): ReviewedSearchState {
   const cards = allCards.filter(element => element.order > heading.order);
   if (cards.length > CCEL_SEARCH_LIMITS.maxCandidateResults) throw new CcelSearchFailure('too_large');
   for (const card of cards) {
-    if (card.parent !== heading.parent || ancestorWithClass(card.parent, 'card') || !isExplicitlyClosed(card)) {
+    if (card.parent !== heading.parent
+      || card.sourceStart < heading.sourceEnd
+      || ancestorWithClass(card.parent, 'card')
+      || !isExplicitlyClosed(card)
+      || !hasDirectSourceContainment(card.parent, card)) {
       throw new CcelSearchFailure('parser');
     }
+    assertNoNonAncestorSourceWrapper(document, card);
   }
   if (allCards.length !== cards.length) throw new CcelSearchFailure('parser');
 
@@ -944,6 +984,8 @@ function identifySearchState(document: ReviewedDocument): ReviewedSearchState {
     const immediate = marker !== undefined
       && marker.parent === heading.parent
       && isExplicitlyClosed(marker)
+      && hasDirectSourceContainment(marker.parent, marker)
+      && !sourceGapMatches(html, heading.sourceEnd, marker.sourceStart, ADOPTION_FORMATTING_SOURCE_PATTERN)
       && areAdjacentInContent(heading, marker);
     if (!immediate || cards.length > 0 || hasAnyResultMetadata(document, heading.order)) {
       throw new CcelSearchFailure('parser');
@@ -951,6 +993,19 @@ function identifySearchState(document: ReviewedDocument): ReviewedSearchState {
     return { kind: 'empty' };
   }
   if (cards.length === 0) throw new CcelSearchFailure('parser');
+  const sourceOrderedCards = [...cards].sort((left, right) => left.sourceStart - right.sourceStart);
+  if (sourceOrderedCards.some((card, index) => card !== cards[index])) throw new CcelSearchFailure('parser');
+  const resultGaps: Array<[number, number]> = [
+    [heading.sourceEnd, sourceOrderedCards[0].sourceStart],
+    ...sourceOrderedCards.slice(1).map((card, index): [number, number] => [sourceOrderedCards[index].sourceEnd, card.sourceStart]),
+  ];
+  const parentContentEnd = heading.parent?.sourceContentEnd ?? -1;
+  if (parentContentEnd >= sourceOrderedCards.at(-1)!.sourceEnd) {
+    resultGaps.push([sourceOrderedCards.at(-1)!.sourceEnd, parentContentEnd]);
+  }
+  if (resultGaps.some(([start, end]) => sourceGapMatches(html, start, end, ADOPTION_FORMATTING_SOURCE_PATTERN))) {
+    throw new CcelSearchFailure('parser');
+  }
   return { kind: 'results', cards };
 }
 
@@ -973,7 +1028,44 @@ function isResultMetadataElement(element: ReviewedElement): boolean {
     || (element.name === 'a' && elementText(element, 32).toLocaleLowerCase('en-US') === 'read online');
 }
 
-function parseResultCard(card: ReviewedElement): {
+function hasValidSourceBounds(element: ReviewedElement): boolean {
+  return element.sourceStart >= 0
+    && element.sourceContentStart >= element.sourceStart
+    && element.sourceContentEnd >= element.sourceContentStart
+    && element.sourceEnd >= element.sourceContentEnd;
+}
+
+function hasDirectSourceContainment(parent: ReviewedElement | undefined, child: ReviewedElement): boolean {
+  return parent !== undefined
+    && hasValidSourceBounds(parent)
+    && hasValidSourceBounds(child)
+    && child.sourceStart >= parent.sourceContentStart
+    && child.sourceEnd <= parent.sourceContentEnd;
+}
+
+function assertNoNonAncestorSourceWrapper(document: ReviewedDocument, element: ReviewedElement): void {
+  const hasWrapper = document.elements.some(candidate => candidate !== element
+    && hasValidSourceBounds(candidate)
+    && candidate.sourceStart <= element.sourceStart
+    && candidate.sourceEnd >= element.sourceEnd
+    && !isAncestor(candidate, element));
+  if (hasWrapper) throw new CcelSearchFailure('parser');
+}
+
+function isAncestor(candidate: ReviewedElement, element: ReviewedElement): boolean {
+  let current = element.parent;
+  while (current) {
+    if (current === candidate) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function sourceGapMatches(html: string, start: number, end: number, pattern: RegExp): boolean {
+  return start < 0 || end < start || end > html.length || pattern.test(html.slice(start, end));
+}
+
+function parseResultCard(html: string, document: ReviewedDocument, card: ReviewedElement): {
   title: string;
   author: string;
   snippet: string;
@@ -983,18 +1075,30 @@ function parseResultCard(card: ReviewedElement): {
   const nestedCards = descendants.filter(element => element.name === 'div' && hasElementClass(element, 'card'));
   if (nestedCards.length > 0) throw new CcelSearchFailure('parser');
   const bodies = descendants.filter(element => element.name === 'div' && hasElementClass(element, 'card-body'));
-  if (bodies.length !== 1 || bodies[0].parent !== card || !isExplicitlyClosed(bodies[0])) {
+  if (bodies.length !== 1
+    || bodies[0].parent !== card
+    || !isExplicitlyClosed(bodies[0])
+    || !hasDirectSourceContainment(card, bodies[0])) {
     throw new CcelSearchFailure('parser');
   }
   const body = bodies[0];
+  assertNoNonAncestorSourceWrapper(document, body);
   const bodyDescendants = descendantElements(body);
 
   const headings = body.children.filter(element => element.name === 'h5' && hasElementClass(element, 'card-title'));
-  if (headings.length !== 1 || !isExplicitlyClosed(headings[0])) throw new CcelSearchFailure('parser');
-  const spans = descendantElements(headings[0]).filter(element => element.name === 'span');
-  if (spans.length !== 2 || spans.some(element => element.parent !== headings[0] || !isExplicitlyClosed(element))) {
+  if (headings.length !== 1
+    || !isExplicitlyClosed(headings[0])
+    || !hasDirectSourceContainment(body, headings[0])) {
     throw new CcelSearchFailure('parser');
   }
+  assertNoNonAncestorSourceWrapper(document, headings[0]);
+  const spans = descendantElements(headings[0]).filter(element => element.name === 'span');
+  if (spans.length !== 2 || spans.some(element => element.parent !== headings[0]
+    || !isExplicitlyClosed(element)
+    || !hasDirectSourceContainment(headings[0], element))) {
+    throw new CcelSearchFailure('parser');
+  }
+  spans.forEach(element => assertNoNonAncestorSourceWrapper(document, element));
   const titleSpans = spans.filter(element => hasElementClass(element, 'title'));
   const authorSpans = spans.filter(element => hasElementClass(element, 'author'));
   if (titleSpans.length !== 1 || authorSpans.length !== 1
@@ -1008,14 +1112,23 @@ function parseResultCard(card: ReviewedElement): {
   if (!author) throw new CcelSearchFailure('parser');
 
   const paragraphs = body.children.filter(element => element.name === 'p');
-  if (paragraphs.length !== 1 || !hasElementClass(paragraphs[0], 'card-text') || !isExplicitlyClosed(paragraphs[0])) {
+  if (paragraphs.length !== 1
+    || !hasElementClass(paragraphs[0], 'card-text')
+    || !isExplicitlyClosed(paragraphs[0])
+    || !hasDirectSourceContainment(body, paragraphs[0])) {
     throw new CcelSearchFailure('parser');
   }
+  assertNoNonAncestorSourceWrapper(document, paragraphs[0]);
   const snippet = elementText(paragraphs[0], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
 
   const readLinks = body.children.filter(element => element.name === 'a'
     && elementText(element, 32).toLocaleLowerCase('en-US') === 'read online');
-  if (readLinks.length !== 1 || !isExplicitlyClosed(readLinks[0])) throw new CcelSearchFailure('parser');
+  if (readLinks.length !== 1
+    || !isExplicitlyClosed(readLinks[0])
+    || !hasDirectSourceContainment(body, readLinks[0])) {
+    throw new CcelSearchFailure('parser');
+  }
+  assertNoNonAncestorSourceWrapper(document, readLinks[0]);
   if (bodyDescendants.some(element => isResultMetadataElement(element)
     && element !== headings[0]
     && element !== paragraphs[0]
@@ -1025,6 +1138,21 @@ function parseResultCard(card: ReviewedElement): {
   const href = readLinks[0].attributes.get('href');
   const locator = href === undefined ? undefined : normalizeCcelSectionLocator(href);
   if (!locator) throw new CcelSearchFailure('parser');
+  const orderedSpans = [...spans].sort((left, right) => left.sourceStart - right.sourceStart);
+  const structuralGaps: Array<[number, number]> = [
+    [card.sourceContentStart, body.sourceStart],
+    [body.sourceEnd, card.sourceContentEnd],
+    [body.sourceContentStart, headings[0].sourceStart],
+    [headings[0].sourceEnd, paragraphs[0].sourceStart],
+    [paragraphs[0].sourceEnd, readLinks[0].sourceStart],
+    [readLinks[0].sourceEnd, body.sourceContentEnd],
+    [headings[0].sourceContentStart, orderedSpans[0].sourceStart],
+    [orderedSpans[0].sourceEnd, orderedSpans[1].sourceStart],
+    [orderedSpans[1].sourceEnd, headings[0].sourceContentEnd],
+  ];
+  if (structuralGaps.some(([start, end]) => sourceGapMatches(html, start, end, ADOPTION_FORMATTING_SOURCE_PATTERN))) {
+    throw new CcelSearchFailure('parser');
+  }
   return { title, author, snippet, locator };
 }
 

--- a/src/adapters/commentary/CcelSearchAdapter.ts
+++ b/src/adapters/commentary/CcelSearchAdapter.ts
@@ -25,14 +25,14 @@ export const CCEL_SEARCH_LIMITS = Object.freeze({
   maxWorkCharacters: 160,
   maxTerms: 12,
   maxComposedQueryCharacters: 768,
-  maxPage: 3,
-  maxHitsPerResponse: 8,
+  maxPage: 1,
+  maxHitsPerResponse: 5,
   maxCandidateResults: 50,
   maxResponseBytes: 1024 * 1024,
   maxTitleCharacters: 300,
   maxAuthorResultCharacters: 200,
   maxSectionCharacters: 300,
-  maxSnippetCharacters: 500,
+  maxSnippetCharacters: 240,
   maxLocatorUrlCharacters: 1024,
   maxLocatorSegmentCharacters: 128,
   maxLocatorWorkCharacters: 256,
@@ -41,8 +41,8 @@ export const CCEL_SEARCH_LIMITS = Object.freeze({
   maxAggregateResultCharacters: 12_000,
   timeoutMs: 8_000,
   totalRequestMs: 12_000,
-  maxRetries: 1,
-  maxRedirects: 2,
+  maxRetries: 0,
+  maxRedirects: 0,
   cacheTtlMs: 10 * 60 * 1000,
   negativeCacheTtlMs: 60 * 1000,
   cacheMaxEntries: 100,
@@ -470,90 +470,69 @@ export class CcelSearchAdapter {
     }
   }
 
-  private async fetchSearchHtml(initialUrl: string, deadline: number): Promise<string> {
-    for (let attempt = 0; attempt <= CCEL_SEARCH_LIMITS.maxRetries; attempt++) {
-      try {
-        return await this.fetchSearchHtmlAttempt(initialUrl, deadline);
-      } catch (error) {
-        if (!(error instanceof CcelSearchFailure) || error.kind !== 'network' || attempt === CCEL_SEARCH_LIMITS.maxRetries || this.now() >= deadline) throw error;
-      }
+  private async fetchSearchHtml(url: string, deadline: number): Promise<string> {
+    if (this.now() >= deadline) throw new CcelSearchFailure('network');
+    const validated = validateSearchUrl(url, this.baseUrl);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(TIMEOUT_ABORT_REASON), Math.min(CCEL_SEARCH_LIMITS.timeoutMs, Math.max(1, deadline - this.now())));
+    let response: Response;
+    try {
+      // One admitted provider search is one upstream GET. Redirects remain
+      // manual and are rejected; network and 5xx responses are never retried.
+      response = await this.fetchImpl(validated, {
+        method: 'GET',
+        headers: { 'Accept': 'text/html, application/xhtml+xml', 'User-Agent': USER_AGENT },
+        redirect: 'manual',
+        signal: controller.signal,
+      });
+    } catch {
+      clearTimeout(timeout);
+      if (controller.signal.reason === TIMEOUT_ABORT_REASON) throw new CcelSearchFailure('timeout');
+      throw new CcelSearchFailure('network');
     }
-    throw new CcelSearchFailure('network');
-  }
 
-  private async fetchSearchHtmlAttempt(initialUrl: string, deadline: number): Promise<string> {
-    let url = initialUrl;
-    for (let redirect = 0; redirect <= CCEL_SEARCH_LIMITS.maxRedirects; redirect++) {
-      if (this.now() >= deadline) throw new CcelSearchFailure('network');
-      const validated = validateSearchUrl(url, this.baseUrl);
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(TIMEOUT_ABORT_REASON), Math.min(CCEL_SEARCH_LIMITS.timeoutMs, Math.max(1, deadline - this.now())));
-      let response: Response;
-      try {
-        response = await this.fetchImpl(validated, {
-          method: 'GET',
-          headers: { 'Accept': 'text/html, application/xhtml+xml', 'User-Agent': USER_AGENT },
-          redirect: 'manual',
-          signal: controller.signal,
-        });
-      } catch {
-        clearTimeout(timeout);
-        if (controller.signal.reason === TIMEOUT_ABORT_REASON) throw new CcelSearchFailure('timeout');
-        if (redirect === 0) throw new CcelSearchFailure('network');
-        throw new CcelSearchFailure('policy');
-      }
-
-      if (response.status >= 300 && response.status <= 399 && response.status !== 304) {
-        const location = response.headers.get('Location');
-        await discardResponseBody(response);
-        clearTimeout(timeout);
-        if (!location || redirect === CCEL_SEARCH_LIMITS.maxRedirects) throw new CcelSearchFailure('policy');
-        try {
-          url = new URL(location, validated).toString();
-        } catch {
-          throw new CcelSearchFailure('policy');
-        }
-        continue;
-      }
-
-      if (response.status === 403) {
-        await discardResponseBody(response);
-        clearTimeout(timeout);
-        throw new CcelSearchFailure('forbidden');
-      }
-      if (response.status === 429) {
-        const retryAfter = parseRetryAfter(response.headers.get('Retry-After'), this.now());
-        await discardResponseBody(response);
-        clearTimeout(timeout);
-        throw new CcelSearchFailure('rate_limited', retryAfter);
-      }
-      if (response.status >= 500) {
-        await discardResponseBody(response);
-        clearTimeout(timeout);
-        throw new CcelSearchFailure('network');
-      }
-      if (response.status < 200 || response.status >= 300) {
-        await discardResponseBody(response);
-        clearTimeout(timeout);
-        throw new CcelSearchFailure('upstream');
-      }
-
-      const contentType = response.headers.get('Content-Type')?.toLowerCase() ?? '';
-      if (!contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
-        await discardResponseBody(response);
-        clearTimeout(timeout);
-        throw new CcelSearchFailure('parser');
-      }
-      try {
-        return await readBoundedBody(response, controller.signal);
-      } catch (error) {
-        if (error instanceof CcelSearchFailure) throw error;
-        throw new CcelSearchFailure('network');
-      } finally {
-        clearTimeout(timeout);
-      }
+    if (response.status >= 300 && response.status <= 399 && response.status !== 304) {
+      discardResponseBody(response);
+      clearTimeout(timeout);
+      throw new CcelSearchFailure('policy');
     }
-    throw new CcelSearchFailure('policy');
+
+    if (response.status === 403) {
+      discardResponseBody(response);
+      clearTimeout(timeout);
+      throw new CcelSearchFailure('forbidden');
+    }
+    if (response.status === 429) {
+      const retryAfter = parseRetryAfter(response.headers.get('Retry-After'), this.now());
+      discardResponseBody(response);
+      clearTimeout(timeout);
+      throw new CcelSearchFailure('rate_limited', retryAfter);
+    }
+    if (response.status >= 500) {
+      discardResponseBody(response);
+      clearTimeout(timeout);
+      throw new CcelSearchFailure('network');
+    }
+    if (response.status < 200 || response.status >= 300) {
+      discardResponseBody(response);
+      clearTimeout(timeout);
+      throw new CcelSearchFailure('upstream');
+    }
+
+    const contentType = response.headers.get('Content-Type')?.toLowerCase() ?? '';
+    if (!contentType.includes('text/html') && !contentType.includes('application/xhtml+xml')) {
+      discardResponseBody(response);
+      clearTimeout(timeout);
+      throw new CcelSearchFailure('parser');
+    }
+    try {
+      return await readBoundedBody(response, controller.signal);
+    } catch (error) {
+      if (error instanceof CcelSearchFailure) throw error;
+      throw new CcelSearchFailure('network');
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   private claimCircuitSlot(): CircuitClaim | undefined {
@@ -729,28 +708,17 @@ export function parseCcelSearchHtml(html: string, page: number): ParsedSearch {
   if (hasReviewedPolicyMarker(sanitizedHtml)) throw new CcelSearchFailure('policy');
   if (hasReviewedNoResultsMarker(sanitizedHtml)) return { hits: [], notices: [] };
 
-  const blocks = extractResultBlocks(sanitizedHtml).slice(0, CCEL_SEARCH_LIMITS.maxCandidateResults);
+  const blocks = extractResultCards(sanitizedHtml).slice(0, CCEL_SEARCH_LIMITS.maxCandidateResults);
   if (blocks.length === 0) throw new CcelSearchFailure('parser');
 
   const hits: PrimarySourceSearchHit[] = [];
   const seen = new Set<string>();
   let aggregateCharacters = 0;
   for (const block of blocks) {
-    const links = [...block.matchAll(/<a\b[^>]*href\s*=\s*(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi)];
-    const link = links.find(candidate => normalizeCcelSectionLocator(candidate[2]));
-    if (!link) continue;
-    const locator = normalizeCcelSectionLocator(link[2]);
-    if (!locator || seen.has(locator.url)) continue;
-    const title = sanitizePlainText(extractClassText(block, /(?:result[-_ ]title|ccel[-_ ]title|title)/i) ?? link[3], CCEL_SEARCH_LIMITS.maxTitleCharacters);
-    if (!title) throw new CcelSearchFailure('parser');
-    const paragraphs = extractElementTexts(block, 'p');
-    const author = optionalText(block, /(?:result[-_ ]author|ccel[-_ ]author|author)/i, CCEL_SEARCH_LIMITS.maxAuthorResultCharacters)
-      ?? extractHeadingAuthor(block);
-    const sectionLabel = optionalText(block, /(?:result[-_ ]section|ccel[-_ ]section|section[-_ ]label)/i, CCEL_SEARCH_LIMITS.maxSectionCharacters)
-      ?? (paragraphs.length > 1 ? paragraphs[0] : undefined);
-    const snippet = optionalText(block, /(?:result[-_ ]snippet|ccel[-_ ]snippet|snippet|summary|description)/i, CCEL_SEARCH_LIMITS.maxSnippetCharacters)
-      ?? (paragraphs.length > 1 ? paragraphs[1] : paragraphs[0] ?? '');
-    const hitCharacters = title.length + (author?.length ?? 0) + (sectionLabel?.length ?? 0) + snippet.length
+    const card = parseResultCard(block);
+    if (seen.has(card.locator.url)) continue;
+    const { locator, title, author, snippet } = card;
+    const hitCharacters = title.length + author.length + snippet.length
       + locator.url.length + locator.work.length + locator.section.length;
     if (aggregateCharacters + hitCharacters > CCEL_SEARCH_LIMITS.maxAggregateResultCharacters) {
       throw new CcelSearchFailure('too_large');
@@ -760,8 +728,7 @@ export function parseCcelSearchHtml(html: string, page: number): ParsedSearch {
     hits.push({
       provider: 'ccel_live',
       title,
-      ...(author ? { author } : {}),
-      ...(sectionLabel ? { sectionLabel } : {}),
+      author,
       snippet,
       locator,
       rankWithinProvider: hits.length + 1,
@@ -780,54 +747,59 @@ function hasReviewedPolicyMarker(html: string): boolean {
 }
 
 function hasReviewedNoResultsMarker(html: string): boolean {
-  return /<h2\b[^>]*>\s*CCEL Search results\s*<\/h2>\s*<p\b[^>]*>\s*No results found\.\s*<\/p>/i.test(html);
+  return /<h2\b[^>]*\bid\s*=\s*(["'])CCEL_Search_results\1[^>]*>\s*CCEL Search results\s*<\/h2>\s*<p\b[^>]*>\s*No results found\.\s*<\/p>/i.test(html);
 }
 
-function extractResultBlocks(html: string): string[] {
-  const blocks: string[] = [];
-  const headings = /<h5\b[^>]*>[\s\S]*?<\/h5>/gi;
+function extractResultCards(html: string): string[] {
+  const heading = /<h2\b[^>]*\bid\s*=\s*(["'])CCEL_Search_results\1[^>]*>\s*CCEL Search results\s*<\/h2>/i.exec(html);
+  if (!heading) return [];
+  const resultsHtml = html.slice(heading.index + heading[0].length);
+  const cards: string[] = [];
+  const cardOpenings = /<div\b[^>]*\bclass\s*=\s*(["'])([^"']*)\1[^>]*>/gi;
   let match: RegExpExecArray | null;
-  const matches: Array<{ start: number; end: number }> = [];
-  while ((match = headings.exec(html)) !== null && matches.length < CCEL_SEARCH_LIMITS.maxCandidateResults) {
-    matches.push({ start: match.index, end: headings.lastIndex });
+  const starts: number[] = [];
+  while ((match = cardOpenings.exec(resultsHtml)) !== null && starts.length < CCEL_SEARCH_LIMITS.maxCandidateResults + 1) {
+    if (hasClassToken(match[2], 'card')) starts.push(match.index);
   }
-  for (let index = 0; index < matches.length; index++) {
-    const start = matches[index].start;
-    const nextStart = matches[index + 1]?.start ?? html.length;
+  for (let index = 0; index < Math.min(starts.length, CCEL_SEARCH_LIMITS.maxCandidateResults); index++) {
+    const start = starts[index];
+    const nextStart = starts[index + 1] ?? resultsHtml.length;
     const end = Math.min(nextStart, start + CCEL_SEARCH_LIMITS.maxAggregateResultCharacters);
-    const block = html.slice(start, end);
-    if (/<a\b[^>]*href\s*=\s*(["'])[^"']+\1[^>]*>/i.test(block)) blocks.push(block);
+    cards.push(resultsHtml.slice(start, end));
   }
-  return blocks;
+  return cards;
 }
 
-function extractClassText(block: string, classPattern: RegExp): string | undefined {
-  const element = new RegExp(`<([a-z0-9]+)\\b[^>]*class\\s*=\\s*(["'])[^"']*${classPattern.source}[^"']*\\2[^>]*>([\\s\\S]*?)<\\/\\1>`, 'i').exec(block);
-  return element?.[3];
+function parseResultCard(block: string): {
+  title: string;
+  author: string;
+  snippet: string;
+  locator: NonNullable<ReturnType<typeof normalizeCcelSectionLocator>>;
+} {
+  const headings = [...block.matchAll(/<h5\b[^>]*\bclass\s*=\s*(["'])([^"']*)\1[^>]*>([\s\S]*?)<\/h5>/gi)]
+    .filter(heading => hasClassToken(heading[2], 'card-title'));
+  if (headings.length !== 1) throw new CcelSearchFailure('parser');
+  const spans = [...headings[0][3].matchAll(/<span\b[^>]*>([\s\S]*?)<\/span>/gi)];
+  if (spans.length !== 2) throw new CcelSearchFailure('parser');
+  const title = sanitizePlainText(spans[0][1], CCEL_SEARCH_LIMITS.maxTitleCharacters);
+  const author = sanitizePlainText(spans[1][1], CCEL_SEARCH_LIMITS.maxAuthorResultCharacters)
+    .replace(/^\s*by\s+/i, '');
+  if (!title || !author) throw new CcelSearchFailure('parser');
+
+  const paragraphs = [...block.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)];
+  if (paragraphs.length !== 1) throw new CcelSearchFailure('parser');
+  const snippet = sanitizePlainText(paragraphs[0][1], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
+
+  const readLinks = [...block.matchAll(/<a\b[^>]*href\s*=\s*(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi)]
+    .filter(link => sanitizePlainText(link[3], 32).toLocaleLowerCase('en-US') === 'read online');
+  if (readLinks.length !== 1) throw new CcelSearchFailure('parser');
+  const locator = normalizeCcelSectionLocator(readLinks[0][2]);
+  if (!locator) throw new CcelSearchFailure('parser');
+  return { title, author, snippet, locator };
 }
 
-function optionalText(block: string, classPattern: RegExp, max: number): string | undefined {
-  const raw = extractClassText(block, classPattern);
-  return raw === undefined ? undefined : sanitizePlainText(raw, max);
-}
-
-function extractHeadingAuthor(block: string): string | undefined {
-  const heading = /<h5\b[^>]*>([\s\S]*?)<\/h5>/i.exec(block)?.[1];
-  if (!heading) return undefined;
-  const text = sanitizePlainText(heading, CCEL_SEARCH_LIMITS.maxAuthorResultCharacters + CCEL_SEARCH_LIMITS.maxTitleCharacters);
-  const author = /\s+by\s+(.+)$/i.exec(text)?.[1];
-  return author ? sanitizePlainText(author, CCEL_SEARCH_LIMITS.maxAuthorResultCharacters) : undefined;
-}
-
-function extractElementTexts(block: string, tag: 'p'): string[] {
-  const values: string[] = [];
-  const elements = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, 'gi');
-  let match: RegExpExecArray | null;
-  while ((match = elements.exec(block)) !== null && values.length < 3) {
-    const value = sanitizePlainText(match[1], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
-    if (value) values.push(value);
-  }
-  return values;
+function hasClassToken(classValue: string, token: string): boolean {
+  return classValue.split(/\s+/u).includes(token);
 }
 
 function removeUnsafeMarkup(html: string): string {
@@ -849,14 +821,19 @@ function sanitizePlainText(html: string, maxCharacters: number): string {
 
 /** Normalize only exact CCEL section paths; this never follows the link. */
 export function normalizeCcelSectionLocator(input: string): { kind: 'ccel_section'; url: string; work: string; section: string } | undefined {
-  if (typeof input !== 'string' || input.length === 0 || input.length > CCEL_SEARCH_LIMITS.maxLocatorUrlCharacters || /%/i.test(input) || /(?:^|\/)\.\.?(?:\/|$)/.test(input)) return undefined;
+  if (typeof input !== 'string' || input.length === 0 || input.length > CCEL_SEARCH_LIMITS.maxLocatorUrlCharacters) return undefined;
+  const untrustedPath = input.split(/[?#]/u, 1)[0];
+  if (/%/i.test(untrustedPath) || /(?:^|\/)\.\.?(?:\/|$)/.test(untrustedPath)) return undefined;
   let url: URL;
   try {
     url = new URL(input, CCEL_SEARCH_URL);
   } catch {
     return undefined;
   }
-  if (url.protocol !== 'https:' || !['ccel.org', 'www.ccel.org'].includes(url.hostname.toLowerCase()) || url.username || url.password || url.port || url.search || url.hash) return undefined;
+  // The search UI adds opaque tracking query/hash values to its Read online
+  // link. Only the reviewed path becomes a locator; the entire query and hash
+  // are discarded and never copied into a result, cache entry, or log.
+  if (url.protocol !== 'https:' || !['ccel.org', 'www.ccel.org'].includes(url.hostname.toLowerCase()) || url.username || url.password || url.port) return undefined;
   if (!url.pathname.startsWith('/') || url.pathname.includes('//')) return undefined;
   const segments = url.pathname.slice(1).split('/');
   if (segments.length !== CCEL_SEARCH_LIMITS.maxLocatorSegments || segments[0] !== 'ccel' || segments.slice(0, -1).some(segment => segment.length > CCEL_SEARCH_LIMITS.maxLocatorSegmentCharacters || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment) || segment === '.' || segment === '..')) return undefined;

--- a/src/adapters/commentary/CcelSearchAdapter.ts
+++ b/src/adapters/commentary/CcelSearchAdapter.ts
@@ -28,6 +28,8 @@ export const CCEL_SEARCH_LIMITS = Object.freeze({
   maxPage: 1,
   maxHitsPerResponse: 5,
   maxCandidateResults: 50,
+  maxStructuralTokens: 20_000,
+  maxStructuralDepth: 128,
   maxResponseBytes: 1024 * 1024,
   maxTitleCharacters: 300,
   maxAuthorResultCharacters: 200,
@@ -705,17 +707,19 @@ function tokenizeWords(value: string): string[] {
 export function parseCcelSearchHtml(html: string, page: number): ParsedSearch {
   if (html.length === 0) throw new CcelSearchFailure('parser');
   const sanitizedHtml = removeUnsafeMarkup(html);
+  if (/<!--|-->|<\/?(?:script|style|form|nav|header|footer)\b/iu.test(sanitizedHtml)) {
+    throw new CcelSearchFailure('parser');
+  }
   if (hasReviewedPolicyMarker(sanitizedHtml)) throw new CcelSearchFailure('policy');
-  if (hasReviewedNoResultsMarker(sanitizedHtml)) return { hits: [], notices: [] };
-
-  const blocks = extractResultCards(sanitizedHtml).slice(0, CCEL_SEARCH_LIMITS.maxCandidateResults);
-  if (blocks.length === 0) throw new CcelSearchFailure('parser');
+  const document = tokenizeReviewedStructure(sanitizedHtml);
+  const searchState = identifySearchState(sanitizedHtml, document);
+  if (searchState.kind === 'empty') return { hits: [], notices: [] };
 
   const hits: PrimarySourceSearchHit[] = [];
   const seen = new Set<string>();
   let aggregateCharacters = 0;
-  for (const block of blocks) {
-    const card = parseResultCard(block);
+  for (const element of searchState.cards) {
+    const card = parseResultCard(sanitizedHtml, element);
     if (seen.has(card.locator.url)) continue;
     const { locator, title, author, snippet } = card;
     const hitCharacters = title.length + author.length + snippet.length
@@ -746,56 +750,265 @@ function hasReviewedPolicyMarker(html: string): boolean {
   return /<h1\b[^>]*>\s*Access denied\s*<\/h1>\s*<p\b[^>]*>\s*Please complete the CAPTCHA to continue\.\s*<\/p>/i.test(html);
 }
 
-function hasReviewedNoResultsMarker(html: string): boolean {
-  return /<h2\b[^>]*\bid\s*=\s*(["'])CCEL_Search_results\1[^>]*>\s*CCEL Search results\s*<\/h2>\s*<p\b[^>]*>\s*No results found\.\s*<\/p>/i.test(html);
+type ReviewedTagName = 'div' | 'h2' | 'h5' | 'p' | 'a' | 'span';
+
+interface ReviewedElement {
+  name: ReviewedTagName;
+  attributes: ReadonlyMap<string, string>;
+  start: number;
+  contentStart: number;
+  contentEnd: number;
+  end: number;
+  parent?: ReviewedElement;
+  children: ReviewedElement[];
 }
 
-function extractResultCards(html: string): string[] {
-  const heading = /<h2\b[^>]*\bid\s*=\s*(["'])CCEL_Search_results\1[^>]*>\s*CCEL Search results\s*<\/h2>/i.exec(html);
-  if (!heading) return [];
-  const resultsHtml = html.slice(heading.index + heading[0].length);
-  const cards: string[] = [];
-  const cardOpenings = /<div\b[^>]*\bclass\s*=\s*(["'])([^"']*)\1[^>]*>/gi;
-  let match: RegExpExecArray | null;
-  const starts: number[] = [];
-  while ((match = cardOpenings.exec(resultsHtml)) !== null && starts.length < CCEL_SEARCH_LIMITS.maxCandidateResults + 1) {
-    if (hasClassToken(match[2], 'card')) starts.push(match.index);
-  }
-  for (let index = 0; index < Math.min(starts.length, CCEL_SEARCH_LIMITS.maxCandidateResults); index++) {
-    const start = starts[index];
-    const nextStart = starts[index + 1] ?? resultsHtml.length;
-    const end = Math.min(nextStart, start + CCEL_SEARCH_LIMITS.maxAggregateResultCharacters);
-    cards.push(resultsHtml.slice(start, end));
-  }
-  return cards;
+interface ReviewedDocument {
+  elements: ReviewedElement[];
 }
 
-function parseResultCard(block: string): {
+type ReviewedSearchState =
+  | { kind: 'empty' }
+  | { kind: 'results'; cards: ReviewedElement[] };
+
+const REVIEWED_TAGS = new Set<ReviewedTagName>(['div', 'h2', 'h5', 'p', 'a', 'span']);
+
+/**
+ * Tokenize only the reviewed search-structure tags. This deliberately avoids
+ * DOMParser/HTMLRewriter so the same fail-closed parser runs in Node and a
+ * Worker. Quoted `>` characters are respected and every tracked element must
+ * be balanced within bounded token/depth budgets.
+ */
+function tokenizeReviewedStructure(html: string): ReviewedDocument {
+  const elements: ReviewedElement[] = [];
+  const stack: ReviewedElement[] = [];
+  let cursor = 0;
+  let tokenCount = 0;
+  while (cursor < html.length) {
+    const start = html.indexOf('<', cursor);
+    if (start < 0) break;
+    const end = scanTagEnd(html, start);
+    if (end < 0) throw new CcelSearchFailure('parser');
+    tokenCount++;
+    if (tokenCount > CCEL_SEARCH_LIMITS.maxStructuralTokens) throw new CcelSearchFailure('too_large');
+    const raw = html.slice(start + 1, end);
+    cursor = end + 1;
+    if (/^\s*[!?]/u.test(raw)) continue;
+
+    const closing = /^\s*\/\s*([A-Za-z][A-Za-z0-9:-]*)\s*$/u.exec(raw);
+    if (closing) {
+      const name = closing[1].toLocaleLowerCase('en-US');
+      if (!isReviewedTag(name)) continue;
+      const open = stack.at(-1);
+      if (!open || open.name !== name) throw new CcelSearchFailure('parser');
+      open.contentEnd = start;
+      open.end = end + 1;
+      stack.pop();
+      continue;
+    }
+
+    const opening = /^\s*([A-Za-z][A-Za-z0-9:-]*)([\s\S]*?)\s*(\/)?\s*$/u.exec(raw);
+    if (!opening) throw new CcelSearchFailure('parser');
+    const name = opening[1].toLocaleLowerCase('en-US');
+    if (!isReviewedTag(name)) continue;
+    const attributes = parseReviewedAttributes(opening[2]);
+    const parent = stack.at(-1);
+    const element: ReviewedElement = {
+      name,
+      attributes,
+      start,
+      contentStart: end + 1,
+      contentEnd: end + 1,
+      end: end + 1,
+      ...(parent ? { parent } : {}),
+      children: [],
+    };
+    parent?.children.push(element);
+    elements.push(element);
+    if (opening[3]) continue;
+    stack.push(element);
+    if (stack.length > CCEL_SEARCH_LIMITS.maxStructuralDepth) throw new CcelSearchFailure('too_large');
+  }
+  if (stack.length !== 0) throw new CcelSearchFailure('parser');
+  return { elements };
+}
+
+function scanTagEnd(html: string, start: number): number {
+  let quote: '"' | "'" | undefined;
+  for (let index = start + 1; index < html.length; index++) {
+    const character = html[index];
+    if (quote) {
+      if (character === quote) quote = undefined;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function parseReviewedAttributes(source: string): ReadonlyMap<string, string> {
+  const attributes = new Map<string, string>();
+  let cursor = 0;
+  while (cursor < source.length) {
+    while (/\s/u.test(source[cursor] ?? '')) cursor++;
+    if (cursor >= source.length) break;
+    const nameMatch = /^[^\s=/>]+/u.exec(source.slice(cursor));
+    if (!nameMatch) throw new CcelSearchFailure('parser');
+    const name = nameMatch[0].toLocaleLowerCase('en-US');
+    cursor += nameMatch[0].length;
+    while (/\s/u.test(source[cursor] ?? '')) cursor++;
+    let value = '';
+    if (source[cursor] === '=') {
+      cursor++;
+      while (/\s/u.test(source[cursor] ?? '')) cursor++;
+      const quote = source[cursor];
+      if (quote === '"' || quote === "'") {
+        cursor++;
+        const valueEnd = source.indexOf(quote, cursor);
+        if (valueEnd < 0) throw new CcelSearchFailure('parser');
+        value = source.slice(cursor, valueEnd);
+        cursor = valueEnd + 1;
+      } else {
+        const valueMatch = /^[^\s>]+/u.exec(source.slice(cursor));
+        if (!valueMatch) throw new CcelSearchFailure('parser');
+        value = valueMatch[0];
+        cursor += value.length;
+      }
+    }
+    if (attributes.has(name)) throw new CcelSearchFailure('parser');
+    attributes.set(name, decodeHtmlEntities(value));
+  }
+  return attributes;
+}
+
+function isReviewedTag(value: string): value is ReviewedTagName {
+  return REVIEWED_TAGS.has(value as ReviewedTagName);
+}
+
+function identifySearchState(html: string, document: ReviewedDocument): ReviewedSearchState {
+  const resultHeadings = document.elements.filter(element => element.name === 'h2' && (
+    element.attributes.get('id') === 'CCEL_Search_results'
+    || elementText(html, element, CCEL_SEARCH_LIMITS.maxTitleCharacters) === 'CCEL Search results'
+  ));
+  if (resultHeadings.length !== 1) throw new CcelSearchFailure('parser');
+  const heading = resultHeadings[0];
+  if (heading.attributes.get('id') !== 'CCEL_Search_results'
+    || elementText(html, heading, CCEL_SEARCH_LIMITS.maxTitleCharacters) !== 'CCEL Search results') {
+    throw new CcelSearchFailure('parser');
+  }
+
+  const emptyMarkers = document.elements.filter(element => element.name === 'p'
+    && elementText(html, element, 64) === 'No results found.');
+  const cards = document.elements.filter(element => element.name === 'div'
+    && element.start >= heading.end
+    && hasElementClass(element, 'card'));
+  if (cards.length > CCEL_SEARCH_LIMITS.maxCandidateResults) throw new CcelSearchFailure('too_large');
+  for (const card of cards) {
+    if (card.end - card.start > CCEL_SEARCH_LIMITS.maxAggregateResultCharacters) throw new CcelSearchFailure('too_large');
+    if (ancestorWithClass(card.parent, 'card')) throw new CcelSearchFailure('parser');
+  }
+
+  const resultLikeOutsideCard = document.elements.some(element => element.start > heading.end
+    && isResultMetadataElement(html, element)
+    && !ancestorWithClass(element.parent, 'card'));
+  if (resultLikeOutsideCard) throw new CcelSearchFailure('parser');
+
+  if (emptyMarkers.length > 0) {
+    const marker = emptyMarkers.length === 1 ? emptyMarkers[0] : undefined;
+    const immediate = marker !== undefined
+      && marker.parent === heading.parent
+      && /^\s*$/u.test(html.slice(heading.end, marker.start));
+    if (!immediate || cards.length > 0 || hasAnyResultMetadata(html, document, heading.end)) {
+      throw new CcelSearchFailure('parser');
+    }
+    return { kind: 'empty' };
+  }
+  if (cards.length === 0) throw new CcelSearchFailure('parser');
+  return { kind: 'results', cards };
+}
+
+function hasAnyResultMetadata(html: string, document: ReviewedDocument, after: number): boolean {
+  return document.elements.some(element => element.start > after && isResultMetadataElement(html, element));
+}
+
+function isResultMetadataElement(html: string, element: ReviewedElement): boolean {
+  return (element.name === 'h5' && hasElementClass(element, 'card-title'))
+    || (element.name === 'p' && hasElementClass(element, 'card-text'))
+    || (element.name === 'a' && elementText(html, element, 32).toLocaleLowerCase('en-US') === 'read online');
+}
+
+function parseResultCard(html: string, card: ReviewedElement): {
   title: string;
   author: string;
   snippet: string;
   locator: NonNullable<ReturnType<typeof normalizeCcelSectionLocator>>;
 } {
-  const headings = [...block.matchAll(/<h5\b[^>]*\bclass\s*=\s*(["'])([^"']*)\1[^>]*>([\s\S]*?)<\/h5>/gi)]
-    .filter(heading => hasClassToken(heading[2], 'card-title'));
+  const descendants = descendantElements(card);
+  const nestedCards = descendants.filter(element => element.name === 'div' && hasElementClass(element, 'card'));
+  if (nestedCards.length > 0) throw new CcelSearchFailure('parser');
+  const bodies = card.children.filter(element => element.name === 'div' && hasElementClass(element, 'card-body'));
+  if (bodies.length !== 1) throw new CcelSearchFailure('parser');
+  const body = bodies[0];
+  const bodyDescendants = descendantElements(body);
+
+  const headings = bodyDescendants.filter(element => element.name === 'h5' && hasElementClass(element, 'card-title'));
   if (headings.length !== 1) throw new CcelSearchFailure('parser');
-  const spans = [...headings[0][3].matchAll(/<span\b[^>]*>([\s\S]*?)<\/span>/gi)];
+  const spans = descendantElements(headings[0]).filter(element => element.name === 'span');
   if (spans.length !== 2) throw new CcelSearchFailure('parser');
-  const title = sanitizePlainText(spans[0][1], CCEL_SEARCH_LIMITS.maxTitleCharacters);
-  const author = sanitizePlainText(spans[1][1], CCEL_SEARCH_LIMITS.maxAuthorResultCharacters)
-    .replace(/^\s*by\s+/i, '');
-  if (!title || !author) throw new CcelSearchFailure('parser');
+  const titleSpans = spans.filter(element => hasElementClass(element, 'title'));
+  const authorSpans = spans.filter(element => hasElementClass(element, 'author'));
+  if (titleSpans.length !== 1 || authorSpans.length !== 1
+    || spans.some(element => Number(hasElementClass(element, 'title')) + Number(hasElementClass(element, 'author')) !== 1)) {
+    throw new CcelSearchFailure('parser');
+  }
+  const title = elementText(html, titleSpans[0], CCEL_SEARCH_LIMITS.maxTitleCharacters);
+  const authorMarker = elementText(html, authorSpans[0], CCEL_SEARCH_LIMITS.maxAuthorResultCharacters + 3);
+  if (!title || /^by\s+/iu.test(title) || !/^by\s+\S/iu.test(authorMarker)) throw new CcelSearchFailure('parser');
+  const author = sanitizePlainText(authorMarker.replace(/^by\s+/iu, ''), CCEL_SEARCH_LIMITS.maxAuthorResultCharacters);
+  if (!author) throw new CcelSearchFailure('parser');
 
-  const paragraphs = [...block.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/gi)];
-  if (paragraphs.length !== 1) throw new CcelSearchFailure('parser');
-  const snippet = sanitizePlainText(paragraphs[0][1], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
+  const paragraphs = bodyDescendants.filter(element => element.name === 'p');
+  if (paragraphs.length !== 1 || !hasElementClass(paragraphs[0], 'card-text')) throw new CcelSearchFailure('parser');
+  const snippet = elementText(html, paragraphs[0], CCEL_SEARCH_LIMITS.maxSnippetCharacters);
 
-  const readLinks = [...block.matchAll(/<a\b[^>]*href\s*=\s*(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi)]
-    .filter(link => sanitizePlainText(link[3], 32).toLocaleLowerCase('en-US') === 'read online');
+  const readLinks = bodyDescendants.filter(element => element.name === 'a'
+    && elementText(html, element, 32).toLocaleLowerCase('en-US') === 'read online');
   if (readLinks.length !== 1) throw new CcelSearchFailure('parser');
-  const locator = normalizeCcelSectionLocator(readLinks[0][2]);
+  const href = readLinks[0].attributes.get('href');
+  const locator = href === undefined ? undefined : normalizeCcelSectionLocator(href);
   if (!locator) throw new CcelSearchFailure('parser');
   return { title, author, snippet, locator };
+}
+
+function descendantElements(element: ReviewedElement): ReviewedElement[] {
+  const descendants: ReviewedElement[] = [];
+  const pending = [...element.children].reverse();
+  while (pending.length > 0) {
+    const child = pending.pop();
+    if (!child) break;
+    descendants.push(child);
+    for (let index = child.children.length - 1; index >= 0; index--) pending.push(child.children[index]);
+  }
+  return descendants;
+}
+
+function elementText(html: string, element: ReviewedElement, maxCharacters: number): string {
+  return sanitizePlainText(html.slice(element.contentStart, element.contentEnd), maxCharacters);
+}
+
+function hasElementClass(element: ReviewedElement, token: string): boolean {
+  return hasClassToken(element.attributes.get('class') ?? '', token);
+}
+
+function ancestorWithClass(element: ReviewedElement | undefined, token: string): ReviewedElement | undefined {
+  let current = element;
+  while (current) {
+    if (hasElementClass(current, token)) return current;
+    current = current.parent;
+  }
+  return undefined;
 }
 
 function hasClassToken(classValue: string, token: string): boolean {

--- a/src/services/historical/primarySourceTypes.ts
+++ b/src/services/historical/primarySourceTypes.ts
@@ -36,6 +36,7 @@ export interface PrimarySourceSearchQuery {
 
 export interface CcelSectionLocator {
   kind: 'ccel_section';
+  /** Canonical exact-section URL; provider tracking query/hash values are never retained. */
   url: string;
   work: string;
   section: string;

--- a/test/fixtures/ccel-search/interface-drift.html
+++ b/test/fixtures/ccel-search/interface-drift.html
@@ -1,9 +1,8 @@
-<!-- Frozen drift sentinel: 2026-07-11; provenance: CCEL public search surface;
-     result-card selector intentionally changed to verify fail-closed parsing. -->
+<!-- Synthetic selector-drift sentinel. -->
 <!doctype html>
 <html><body>
-  <main id="search-results">
-    <h2>CCEL Search results</h2>
-    <div class="new-result-card"><a href="/ccel/calvin/institutes/iv.xvii.html">Unexpected selector shape</a></div>
+  <main>
+    <h2 id="CCEL_Search_results">CCEL Search results</h2>
+    <div class="new-result-card"><a href="/ccel/example/work/section.html">Unexpected selector shape</a></div>
   </main>
 </body></html>

--- a/test/fixtures/ccel-search/malicious.html
+++ b/test/fixtures/ccel-search/malicious.html
@@ -1,16 +1,20 @@
-<!-- Adversarial-only fixture: synthetic hostile markup for parser/security tests.
-     This is not an upstream capture and must not be used as provenance. -->
+<!-- Synthetic adversarial fixture; no upstream content or identifiers. -->
 <!doctype html>
 <html><body>
-  <main id="search-results">
-    <h2>CCEL Search results</h2>
-    <article class="ccel-search-result">
-      <h5 class="ccel-result-title"><a href="/ccel/calvin/institutes/iv.xvii.html">Institutes of the Christian Religion</a></h5>
-      <div class="ccel-result-author">Calvin, John</div>
-      <div class="ccel-result-section">Book IV, Chapter XVII</div>
-      <p class="ccel-result-snippet" onclick="alert('removed')">The Lord's Supper &amp; the church. &lt;script&gt;alert('encoded')&lt;/script&gt;</p>
-      <div hidden>Hidden non-result content</div>
-    </article>
+  <main>
+    <h2 id="CCEL_Search_results">CCEL Search results</h2>
+    <div class="card mb-3">
+      <a href="https://evil.example/ccel/example/work/cover.html"><img alt="Untrusted earlier link"></a>
+      <div class="card-body">
+        <h5 class="card-title">
+          <span class="title">Synthetic &lt;script&gt;alert('title')&lt;/script&gt;</span>
+          <span class="author">by Alex Example</span>
+        </h5>
+        <p class="card-text" onclick="alert('removed')">A safe snippet &amp; &lt;script&gt;alert('encoded')&lt;/script&gt;.</p>
+        <div hidden>Hidden non-result content</div>
+        <a class="btn" href="/ccel/example/work/section.one.html?token=do-not-return&amp;queryID=do-not-return&amp;resultID=do-not-return#fragment">Read online</a>
+      </div>
+    </div>
     <script>window.session = 'secret';</script>
     <style>.secret { display: block }</style>
     <form><input type="hidden" name="csrf" value="secret"></form>

--- a/test/fixtures/ccel-search/no-results.html
+++ b/test/fixtures/ccel-search/no-results.html
@@ -1,10 +1,8 @@
-<!-- Frozen sanitized capture: 2026-07-11; provenance: CCEL public search
-     surface; redacted navigation/account/session markup. The reviewed state
-     is the search-results heading followed by the empty-state paragraph. -->
+<!-- Synthetic reviewed empty-state fixture. -->
 <!doctype html>
 <html><body>
   <main>
-    <h2>CCEL Search results</h2>
+    <h2 id="CCEL_Search_results">CCEL Search results</h2>
     <p>No results found.</p>
   </main>
 </body></html>

--- a/test/fixtures/ccel-search/search-results.html
+++ b/test/fixtures/ccel-search/search-results.html
@@ -1,25 +1,35 @@
 <!--
-  Frozen sanitized capture: 2026-07-11.
-  Provenance: CCEL public HTML search surface, https://ccel.org/?page=1&text=union%20with%20Christ,
-  captured and reviewed 2026-07-11. This is a sanitized, dated capture of the
-  visible search-results structure: the CCEL Search results heading, h5 result
-  headings with section links, author text, and snippets. Redactions: site
-  navigation, analytics, account/session values, request-specific boilerplate,
-  and unrelated result cards were removed; no document body is included.
-  Adversarial markup cases are maintained in malicious.html, not in this
-  upstream-shaped capture.
+  Synthetic structural fixture, reviewed 2026-07-15.
+  It models the observed CCEL Bootstrap search-card anatomy without copying a
+  real work title, author, snippet, request token, or result identifier.
 -->
 <!doctype html>
 <html lang="en">
   <body>
     <main>
-      <h2>CCEL Search results</h2>
-      <h5><a href="/ccel/calvin/institutes/iv.xvii.html">Institutes of the Christian Religion</a> by Calvin, John</h5>
-      <p>Book IV, Chapter XVII</p>
-      <p>The Lord's Supper is a sign and seal of union with Christ &amp; the church.</p>
-      <h5><a href="https://www.ccel.org/ccel/schaff/hcc3/hcc3.iii.xii.iv.html">History of the Christian Church, Volume III</a> by Schaff, Philip</h5>
-      <p>§ 120. The Council of Nicaea, 325.</p>
-      <p>A bounded discovery snippet with <em>entities</em> and no document body.</p>
+      <h2 id="CCEL_Search_results">CCEL Search results</h2>
+      <div class="card mb-3">
+        <a href="/ccel/example/treatise/cover.html"><img alt="Synthetic cover"></a>
+        <div class="card-body">
+          <h5 class="card-title">
+            <span class="title">Treatise on Shared Life</span>
+            <span class="author">by Alex Example</span>
+          </h5>
+          <p class="card-text">A synthetic discovery snippet about shared life &amp; community.</p>
+          <a class="btn btn-primary" href="/ccel/example/treatise/part.one.html?token=synthetic-redacted&amp;queryID=synthetic-query&amp;resultID=1#match">Read online</a>
+        </div>
+      </div>
+      <div class="card mb-3">
+        <a href="/ccel/sample/history/cover.html"><img alt="Synthetic cover"></a>
+        <div class="card-body">
+          <h5 class="card-title">
+            <span class="title">A Synthetic Historical Survey</span>
+            <span class="author">by Sam Sample</span>
+          </h5>
+          <p class="card-text">A second bounded discovery snippet with <em>markup</em> but no document body.</p>
+          <a class="btn btn-primary" href="https://www.ccel.org/ccel/sample/history/chapter.two.html?token=synthetic-redacted&amp;queryID=synthetic-query&amp;resultID=2">Read online</a>
+        </div>
+      </div>
     </main>
   </body>
 </html>

--- a/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
+++ b/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
@@ -28,18 +28,16 @@ const resultCard = (index: number, options: {
   author?: string;
   work?: string;
   title?: string;
-  section?: string;
   snippet?: string;
 } = {}): string => {
   const author = options.author ?? 'Calvin, John';
   const work = options.work ?? 'institutes';
   const title = options.title ?? 'Institutes of the Christian Religion';
-  const section = options.section ?? `Book IV, Chapter ${index}`;
   const snippet = options.snippet ?? `A bounded discovery result ${index}.`;
-  return `<article class="ccel-search-result"><h5 class="ccel-result-title"><a href="/ccel/calvin/${work}/section${index}.html">${title}</a></h5><div class="ccel-result-author">${author}</div><div class="ccel-result-section">${section}</div><p class="ccel-result-snippet">${snippet}</p></article>`;
+  return `<div class="card mb-3"><a href="/ccel/calvin/${work}/cover.html"><img alt="cover"></a><div class="card-body"><h5 class="card-title"><span class="title">${title}</span><span class="author">by ${author}</span></h5><p class="card-text">${snippet}</p><a class="btn" href="/ccel/calvin/${work}/section${index}.html?token=synthetic&amp;queryID=query&amp;resultID=${index}#match">Read online</a></div></div>`;
 };
 
-const resultPage = (cards: string): string => `<html><body><main id="search-results"><h2>CCEL Search results</h2>${cards}</main></body></html>`;
+const resultPage = (cards: string): string => `<html><body><main id="search-results"><h2 id="CCEL_Search_results">CCEL Search results</h2>${cards}</main></body></html>`;
 
 function discardableResponse(status: number, headers: Record<string, string> = {}): { response: Response; cancel: ReturnType<typeof vi.spyOn> } {
   const body = new ReadableStream<Uint8Array>({
@@ -64,11 +62,11 @@ describe('primary-source feature flags', () => {
 
 describe('composeCcelSearchRequest', () => {
   it('uses URLSearchParams encoding and escapes Lucene syntax as literals', () => {
-    const composed = composeCcelSearchRequest({ text: '  (grace) + truth  ', match: 'all_terms', page: 2, limit: 8 });
+    const composed = composeCcelSearchRequest({ text: '  (grace) + truth  ', match: 'all_terms', page: 1, limit: 5 });
     const url = new URL(composed.url);
     expect(url.origin).toBe('https://ccel.org');
     expect(url.pathname).toBe('/');
-    expect(url.searchParams.get('page')).toBe('2');
+    expect(url.searchParams.get('page')).toBe('1');
     expect(url.searchParams.get('text')).toBe('\\(grace\\) AND \\+ AND truth');
     expect(composed.url).not.toContain('(grace)');
     expect(composeCcelSearchRequest({ text: 'love OR truth' }).luceneQuery).toBe('love AND "OR" AND truth');
@@ -91,8 +89,8 @@ describe('composeCcelSearchRequest', () => {
       match: 'phrase',
     }).luceneQuery).toBe('"one two three four five six seven eight nine ten eleven twelve thirteen"');
     expect(() => composeCcelSearchRequest({ text: 'x'.repeat(201) })).toThrow('safe length');
-    expect(() => composeCcelSearchRequest({ text: 'x', page: 4 })).toThrow('page');
-    expect(() => composeCcelSearchRequest({ text: 'x', limit: 9 })).toThrow('limit');
+    expect(() => composeCcelSearchRequest({ text: 'x', page: 2 })).toThrow('page');
+    expect(() => composeCcelSearchRequest({ text: 'x', limit: 6 })).toThrow('limit');
     expect(() => composeCcelSearchRequest({ text: 'x', bogus: true } as never)).toThrow('Unknown');
   });
 
@@ -112,6 +110,12 @@ describe('normalizeCcelSectionLocator', () => {
     });
     expect(normalizeCcelSectionLocator('https://www.ccel.org/ccel/schaff/hcc3/hcc3.iii.xii.iv.html')?.url)
       .toBe('https://ccel.org/ccel/schaff/hcc3/hcc3.iii.xii.iv.html');
+    expect(normalizeCcelSectionLocator('/ccel/example/work/section.html?token=opaque%2Fvalue&queryID=q&resultID=r#match')).toEqual({
+      kind: 'ccel_section',
+      url: 'https://ccel.org/ccel/example/work/section.html',
+      work: 'example/work',
+      section: 'section',
+    });
   });
 
   it.each([
@@ -123,7 +127,6 @@ describe('normalizeCcelSectionLocator', () => {
     '/ccel/a/b.html',
     '/ccel/a/b/c/d.html',
     `/ccel/${'a'.repeat(CCEL_SEARCH_LIMITS.maxLocatorSegmentCharacters + 1)}/b/c.html`,
-    '/ccel/a/b/c.html?next=https://evil.example',
     '/ccel/a/b/.html',
     '/ccel/a/b/c.html/extra',
   ])('rejects unsafe locator %s', input => {
@@ -144,37 +147,77 @@ describe('CcelSearchAdapter', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('locks the dormant rollout to page 1, five hits, 240 Unicode snippet characters, and zero retries or redirects', () => {
+    expect(CCEL_SEARCH_LIMITS).toMatchObject({
+      maxPage: 1,
+      maxHitsPerResponse: 5,
+      maxSnippetCharacters: 240,
+      maxRetries: 0,
+      maxRedirects: 0,
+    });
+  });
+
   it('parses bounded metadata, sanitizes entities, labels snippets as discovery-only, and never follows links', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultsFixture));
     const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
     const result = await adapter.search(query({ limit: 2 }));
     expect(result).toMatchObject({ provider: 'ccel_live', status: 'ok', searched: true, hitCount: 2 });
     expect(result.hits[0]).toMatchObject({
-      title: 'Institutes of the Christian Religion',
-      author: 'Calvin, John',
-      sectionLabel: 'Book IV, Chapter XVII',
-      snippet: "The Lord's Supper is a sign and seal of union with Christ & the church.",
+      title: 'Treatise on Shared Life',
+      author: 'Alex Example',
+      snippet: 'A synthetic discovery snippet about shared life & community.',
       snippetOnly: true,
       attribution: 'CCEL (Christian Classics Ethereal Library)',
-      locator: { kind: 'ccel_section', work: 'calvin/institutes', section: 'iv.xvii' },
+      locator: { kind: 'ccel_section', url: 'https://ccel.org/ccel/example/treatise/part.one.html', work: 'example/treatise', section: 'part.one' },
     });
     expect(result.hits[0].snippet).not.toContain('<');
+    expect(JSON.stringify(result)).not.toMatch(/token|queryID|resultID|synthetic-redacted/);
     expect(fetchImpl).toHaveBeenCalledOnce();
     expect(fetchImpl.mock.calls[0][0]).toMatch(/^https:\/\/ccel\.org\/\?page=1&text=/);
     expect(fetchImpl.mock.calls[0][1]).toMatchObject({ method: 'GET', redirect: 'manual', signal: expect.any(AbortSignal) });
   });
 
+  it('fails closed when a current-shape card has ambiguous anatomy or a noncanonical Read online URL', async () => {
+    const ambiguous = resultCard(1).replace('</h5>', '<span class="extra">ambiguous</span></h5>');
+    await expect(new CcelSearchAdapter({
+      enabled: true,
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(ambiguous))),
+    }).search(query({ text: 'ambiguous card' }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+
+    const foreign = resultCard(1).replace(
+      /href="\/ccel\/calvin\/institutes\/section1\.html[^"]*"/u,
+      'href="https://evil.example/ccel/calvin/institutes/section1.html?token=secret"',
+    );
+    await expect(new CcelSearchAdapter({
+      enabled: true,
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(foreign))),
+    }).search(query({ text: 'foreign locator' }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+  });
+
+  it('caps the current-shape card output at five 240-code-point snippets without leaking tracking values', async () => {
+    const cards = Array.from({ length: 6 }, (_, index) => resultCard(index, { snippet: '🙂'.repeat(241) })).join('');
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(cards)));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const result = await adapter.search(query({ text: 'unicode cap' }));
+    expect(result).toMatchObject({ status: 'ok', hitCount: 5 });
+    expect(result.hits).toHaveLength(5);
+    expect(result.hits.every(hit => Array.from(hit.snippet).length === 240)).toBe(true);
+    expect(JSON.stringify(result)).not.toMatch(/token=|queryID|resultID|#match|synthetic/);
+    await expect(adapter.search(query({ text: 'unicode cap' }))).resolves.toEqual(result);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it('composes author/work restrictions into the request without broadening them', async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultsFixture));
     const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
-    const result = await adapter.search({ text: 'union with Christ', author: 'Calvin', work: 'Institutes' });
+    const result = await adapter.search({ text: 'union with Christ', author: 'Example', work: 'Treatise' });
     expect(result).toMatchObject({ status: 'unsupported_filter', hitCount: 1 });
-    expect(result.hits[0].locator).toMatchObject({ work: 'calvin/institutes' });
+    expect(result.hits[0].locator).toMatchObject({ work: 'example/treatise' });
     const requested = new URL(String(fetchImpl.mock.calls[0][0])).searchParams.get('text');
     expect(requested).toContain('author:');
     expect(requested).toContain('title:');
-    expect(requested).toContain('Calvin');
-    expect(requested).toContain('Institutes');
+    expect(requested).toContain('Example');
+    expect(requested).toContain('Treatise');
   });
 
   it('verifies unrestricted metadata as an ordered normalized phrase', async () => {
@@ -304,8 +347,6 @@ describe('CcelSearchAdapter', () => {
     const fetchImpl = vi.fn<typeof fetch>()
       .mockReturnValueOnce(policy)
       .mockReturnValueOnce(later)
-      // A 5xx is retried once. Keep that retry deterministic without allowing
-      // it to weaken the policy state established by the first request.
       .mockImplementation(async () => htmlResponse('server error', 503));
     const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
 
@@ -490,18 +531,15 @@ describe('CcelSearchAdapter', () => {
     expect(adapter.getCircuitState()).toMatchObject({ status: 'closed', operatorReviewRequired: false });
   });
 
-  it('retries one network/5xx failure, then opens after three final network failures', async () => {
+  it('never retries network/5xx failures and opens after three admitted failures', async () => {
     let now = 3_000_000;
-    const fetchImpl = vi.fn<typeof fetch>()
-      .mockResolvedValueOnce(htmlResponse('server error', 503))
-      .mockResolvedValueOnce(htmlResponse(resultsFixture))
-      .mockResolvedValue(htmlResponse('server error', 503));
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse('server error', 503));
     const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl, now: () => now });
-    await expect(adapter.search(query({ text: 'retry success' }))).resolves.toMatchObject({ status: 'ok' });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    await adapter.search(query({ text: 'failure one' }));
+    await expect(adapter.search(query({ text: 'failure one' }))).resolves.toMatchObject({ status: 'unavailable' });
+    expect(fetchImpl).toHaveBeenCalledOnce();
     await adapter.search(query({ text: 'failure two' }));
     await adapter.search(query({ text: 'failure three' }));
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'network', recentNetworkFailures: 3 });
     now += CCEL_SEARCH_LIMITS.networkOpenMs + 1;
     expect(adapter.getCircuitState().status).toBe('half_open');
@@ -591,7 +629,7 @@ describe('CcelSearchAdapter', () => {
     await Promise.all([activeOne, activeTwo]);
   });
 
-  it('cancels every discarded redirect, non-2xx, wrong-type, and retry response body', async () => {
+  it('cancels every discarded redirect, non-2xx, wrong-type, and 5xx response body', async () => {
     for (const status of [403, 429, 404]) {
       const cancels: Array<ReturnType<typeof vi.spyOn>> = [];
       const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
@@ -604,15 +642,15 @@ describe('CcelSearchAdapter', () => {
       expect(cancels[0]).toHaveBeenCalled();
     }
 
-    const retryCancels: Array<ReturnType<typeof vi.spyOn>> = [];
-    const retryFetch = vi.fn<typeof fetch>().mockImplementation(async () => {
+    const failureCancels: Array<ReturnType<typeof vi.spyOn>> = [];
+    const failureFetch = vi.fn<typeof fetch>().mockImplementation(async () => {
       const discarded = discardableResponse(503);
-      retryCancels.push(discarded.cancel);
+      failureCancels.push(discarded.cancel);
       return discarded.response;
     });
-    await new CcelSearchAdapter({ enabled: true, fetchImpl: retryFetch }).search(query({ text: 'retry bodies' }));
-    expect(retryCancels).toHaveLength(2);
-    expect(retryCancels.every(cancel => cancel.mock.calls.length > 0)).toBe(true);
+    await new CcelSearchAdapter({ enabled: true, fetchImpl: failureFetch }).search(query({ text: 'single failure body' }));
+    expect(failureCancels).toHaveLength(1);
+    expect(failureCancels[0]).toHaveBeenCalled();
 
     const wrongType = discardableResponse(200, { 'content-type': 'application/json' });
     await new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(wrongType.response) }).search(query({ text: 'wrong type body' }));
@@ -624,9 +662,10 @@ describe('CcelSearchAdapter', () => {
       .mockImplementationOnce(async () => htmlResponse(resultsFixture));
     await new CcelSearchAdapter({ enabled: true, fetchImpl: redirectFetch }).search(query({ text: 'same host redirect' }));
     expect(redirect.cancel).toHaveBeenCalled();
+    expect(redirectFetch).toHaveBeenCalledOnce();
   });
 
-  it('caps same-host redirects without following a fourth request', async () => {
+  it('never follows same-host redirects', async () => {
     const cancels: Array<ReturnType<typeof vi.spyOn>> = [];
     const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
       const redirect = discardableResponse(302, { location: 'https://ccel.org/?page=1&text=redirect' });
@@ -635,7 +674,7 @@ describe('CcelSearchAdapter', () => {
     });
     await expect(new CcelSearchAdapter({ enabled: true, fetchImpl }).search(query({ text: 'redirect cap' })))
       .resolves.toMatchObject({ status: 'unavailable' });
-    expect(fetchImpl).toHaveBeenCalledTimes(CCEL_SEARCH_LIMITS.maxRedirects + 1);
+    expect(fetchImpl).toHaveBeenCalledOnce();
     expect(cancels.every(cancel => cancel.mock.calls.length > 0)).toBe(true);
   });
 
@@ -661,32 +700,26 @@ describe('CcelSearchAdapter', () => {
     expect(result.hits[0].snippet).toContain('&lt;script&gt;');
   });
 
-  it('enforces field, result, candidate, and aggregate output caps', async () => {
+  it('enforces field, result, and candidate output caps', async () => {
     const longCard = resultCard(1, {
       title: 'T'.repeat(CCEL_SEARCH_LIMITS.maxTitleCharacters + 50),
       author: 'A'.repeat(CCEL_SEARCH_LIMITS.maxAuthorResultCharacters + 50),
-      section: 'S'.repeat(CCEL_SEARCH_LIMITS.maxSectionCharacters + 50),
       snippet: 'N'.repeat(CCEL_SEARCH_LIMITS.maxSnippetCharacters + 50),
     });
     const bounded = await new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(longCard))) }).search(query({ text: 'field caps' }));
     expect(bounded).toMatchObject({ status: 'ok', hitCount: 1 });
     expect(bounded.hits[0].title.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxTitleCharacters);
     expect(bounded.hits[0].author?.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxAuthorResultCharacters);
-    expect(bounded.hits[0].sectionLabel?.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxSectionCharacters);
     expect(bounded.hits[0].snippet.length).toBeLessThanOrEqual(CCEL_SEARCH_LIMITS.maxSnippetCharacters);
 
     const nineCards = Array.from({ length: 9 }, (_, index) => resultCard(index)).join('');
-    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(nineCards))) }).search(query({ text: 'result cap', limit: 8 })))
-      .resolves.toMatchObject({ status: 'ok', hitCount: 8 });
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(nineCards))) }).search(query({ text: 'result cap', limit: 5 })))
+      .resolves.toMatchObject({ status: 'ok', hitCount: 5 });
 
     const fiftyCardsAndMalformed = `${Array.from({ length: 50 }, (_, index) => resultCard(index)).join('')}<article class="ccel-search-result"><a href="/ccel/calvin/institutes/unclosed.html">unclosed`;
     await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(fiftyCardsAndMalformed))) }).search(query({ text: 'candidate cap' })))
       .resolves.toMatchObject({ status: 'ok', hitCount: 5 });
 
-    const longSegment = 'b'.repeat(127);
-    const longFields = Array.from({ length: 8 }, (_, index) => `<article class="ccel-search-result"><h5 class="ccel-result-title"><a href="/ccel/${'a'.repeat(127)}/${longSegment}/${'c'.repeat(127)}${index}.html">${'T'.repeat(300)}</a></h5><div class="ccel-result-author">${'A'.repeat(200)}</div><div class="ccel-result-section">${'S'.repeat(300)}</div><p class="ccel-result-snippet">${'N'.repeat(500)}</p></article>`).join('');
-    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(longFields))) }).search(query({ text: 'aggregate cap' })))
-      .resolves.toMatchObject({ status: 'unavailable' });
   });
 
   it('enforces streaming response overflow without retaining the body', async () => {
@@ -771,11 +804,9 @@ describe('CcelSearchAdapter', () => {
     await adapter.search(query({ limit: 5 }));
     await adapter.search(query({ limit: 1 }));
     await adapter.search(query({ match: 'phrase' }));
-    await adapter.search(query({ page: 2 }));
     await adapter.search(query({ author: 'Calvin' }));
     await adapter.search(query({ work: 'Institutes' }));
-    expect(fetchImpl.mock.calls.length).toBe(5);
-    expect(fetchImpl.mock.calls.length).toBe(5);
+    expect(fetchImpl.mock.calls.length).toBe(4);
 
     let ttlNow = 60_000;
     const ttlFetch = vi.fn<typeof fetch>().mockImplementation(async () => htmlResponse(single));
@@ -836,7 +867,7 @@ describe('CcelSearchAdapter', () => {
     const firstProbe = adapter.search({ text: 'half open one' });
     const secondProbe = adapter.search({ text: 'half open two' });
     await Promise.resolve();
-    expect(failures).toHaveBeenCalledTimes(7);
+    expect(failures).toHaveBeenCalledTimes(4);
     release();
     await expect(secondProbe).resolves.toMatchObject({ status: 'unavailable', searched: false });
     await expect(firstProbe).resolves.toMatchObject({ status: 'ok' });
@@ -856,7 +887,7 @@ describe('CcelSearchAdapter', () => {
       response: () => htmlResponse('server error', 503),
       reason: 'network' as const,
       backoffMs: CCEL_SEARCH_LIMITS.networkOpenMs,
-      fetchCount: 3,
+      fetchCount: 2,
     },
     {
       name: 'declared oversized response',

--- a/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
+++ b/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
@@ -269,6 +269,27 @@ describe('CcelSearchAdapter', () => {
     });
   });
 
+  it('treats boolean inert and ASCII-trimmed aria-hidden on result ancestry as excluded', async () => {
+    const inertCard = resultCard(1).replace('<div class="card mb-3">', '<div class="card mb-3" inert>');
+    const inertBody = resultCard(1).replace('<div class="card-body">', '<div class="card-body" inert>');
+    const inertAncestor = resultPage(resultCard(1)).replace('<main id="search-results">', '<main id="search-results" inert>');
+    const whitespaceAriaHidden = resultCard(1).replace(
+      '<div class="card mb-3">',
+      '<div class="card mb-3" aria-hidden=" \tTRUE\n ">',
+    );
+    for (const [index, markup] of [
+      resultPage(inertCard),
+      resultPage(inertBody),
+      inertAncestor,
+      resultPage(whitespaceAriaHidden),
+    ].entries()) {
+      await expect(new CcelSearchAdapter({
+        enabled: true,
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(markup)),
+      }).search(query({ text: `inert ancestry ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    }
+  });
+
   it('fails closed when an unreviewed section changes the heading-to-card or card-to-body path', async () => {
     const wrappedCard = `<section>${resultCard(1)}</section>`;
     const wrappedBody = resultCard(1)
@@ -288,6 +309,26 @@ describe('CcelSearchAdapter', () => {
       enabled: true,
       fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(duplicateClass))),
     }).search(query({ text: 'duplicate attribute' }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+  });
+
+  it('rejects table-source foster parenting and ignored table-context wrappers after the heading', async () => {
+    const fosterParentedCard = `<table>${resultCard(1)}</table>`;
+    const ignoredTableContext = `<tr><td>ignored by the HTML parser</td></tr>${resultCard(1)}`;
+    for (const [index, markup] of [fosterParentedCard, ignoredTableContext].entries()) {
+      await expect(new CcelSearchAdapter({
+        enabled: true,
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(markup))),
+      }).search(query({ text: `table repair ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    }
+  });
+
+  it('rejects adoption-agency repair that creates a direct card path absent from source', async () => {
+    const repairedCard = resultCard(1).replace('<div class="card-body">', '<div class="card-body"></i>');
+    const adoptionSourceWrapper = `<b><i>formatting wrapper</b>${repairedCard}</i>`;
+    await expect(new CcelSearchAdapter({
+      enabled: true,
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(adoptionSourceWrapper))),
+    }).search(query({ text: 'adoption source wrapper' }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
   });
 
   it('matches a browser DOM oracle for HTML5 entity decoding before plain-text escaping', () => {

--- a/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
+++ b/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { Window } from 'happy-dom';
 import {
   CCEL_SEARCH_LIMITS,
   CcelSearchAdapter,
   composeCcelSearchRequest,
   normalizeCcelSectionLocator,
+  parseCcelSearchHtml,
 } from '../../../../src/adapters/commentary/CcelSearchAdapter.js';
 import {
   DEFAULT_PRIMARY_SOURCE_FEATURE_FLAGS,
@@ -246,6 +248,78 @@ describe('CcelSearchAdapter', () => {
         fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(markup))),
       }).search(query({ text: `structural ambiguity ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
     }
+  });
+
+  it('uses the HTML5 tree while excluding inert, raw-text, foreign, and hidden subtrees', () => {
+    const decoy = '<h5 class="card-title"><span class="title">Decoy</span><span class="author">by Decoy</span></h5><p class="card-text">Decoy.</p><a href="/ccel/decoy/work/section.html">Read online</a>';
+    const inertSubtrees = [
+      `<template>${decoy}</template>`,
+      `<noscript>${decoy}</noscript>`,
+      `<textarea>${decoy}</textarea>`,
+      '<svg xmlns="http://www.w3.org/2000/svg"><g><text>Read online Decoy</text></g></svg>',
+      '<math xmlns="http://www.w3.org/1998/Math/MathML"><mtext>Read online Decoy</mtext></math>',
+      `<div hidden>${decoy}</div>`,
+      `<div aria-hidden="TRUE">${decoy}</div>`,
+    ].join('');
+    const parsed = parseCcelSearchHtml(resultPage(`${inertSubtrees}${resultCard(1)}`), 1);
+    expect(parsed.hits).toHaveLength(1);
+    expect(parsed.hits[0]).toMatchObject({
+      title: 'Institutes of the Christian Religion',
+      author: 'Calvin, John',
+    });
+  });
+
+  it('fails closed when an unreviewed section changes the heading-to-card or card-to-body path', async () => {
+    const wrappedCard = `<section>${resultCard(1)}</section>`;
+    const wrappedBody = resultCard(1)
+      .replace('<div class="card-body">', '<section><div class="card-body">')
+      .replace('</div></div>', '</div></section></div>');
+    for (const [index, markup] of [wrappedCard, wrappedBody].entries()) {
+      await expect(new CcelSearchAdapter({
+        enabled: true,
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(markup))),
+      }).search(query({ text: `wrapper drift ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    }
+  });
+
+  it('rejects duplicate attributes instead of accepting the HTML5 first-value recovery', async () => {
+    const duplicateClass = resultCard(1).replace('class="card-body"', 'class="card-body" class="ignored"');
+    await expect(new CcelSearchAdapter({
+      enabled: true,
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(duplicateClass))),
+    }).search(query({ text: 'duplicate attribute' }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+  });
+
+  it('matches a browser DOM oracle for HTML5 entity decoding before plain-text escaping', () => {
+    const encodedTitle = 'Fish &amp; Bread &#x1F642; &notin; &lt;Witness&gt;';
+    const markup = resultPage(resultCard(1, { title: encodedTitle }));
+    const oracleWindow = new Window();
+    oracleWindow.document.write(markup);
+    const oracleText = oracleWindow.document.querySelector('span.title')?.textContent ?? '';
+    const expected = oracleText.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    expect(parseCcelSearchHtml(markup, 1).hits[0].title).toBe(expected);
+  });
+
+  it('bounds parse5 input and tree work for 100k attributes, deep wrappers, text, and nested headings', () => {
+    const hundredThousandAttributes = Array.from({ length: 100_000 }, (_, index) => ` a${index}=""`).join('');
+    const oversizedAttributeMarkup = `<html><body><main${hundredThousandAttributes}></main></body></html>`;
+    const startedAt = performance.now();
+    expect(() => parseCcelSearchHtml(oversizedAttributeMarkup, 1)).toThrow();
+    expect(performance.now() - startedAt).toBeLessThan(2_000);
+
+    const tooManyAttributes = `<main ${Array.from({ length: CCEL_SEARCH_LIMITS.maxAttributesPerElement + 1 }, (_, index) => `a${index}=""`).join(' ')}></main>`;
+    expect(() => parseCcelSearchHtml(tooManyAttributes, 1)).toThrow();
+
+    const deeplyWrapped = `${'<section>'.repeat(CCEL_SEARCH_LIMITS.maxTreeDepth + 1)}${resultPage(resultCard(1))}${'</section>'.repeat(CCEL_SEARCH_LIMITS.maxTreeDepth + 1)}`;
+    expect(() => parseCcelSearchHtml(deeplyWrapped, 1)).toThrow();
+
+    const excessiveText = `<html><body><div>${'x'.repeat(CCEL_SEARCH_LIMITS.maxTreeTextCharacters + 1)}</div></body></html>`;
+    expect(() => parseCcelSearchHtml(excessiveText, 1)).toThrow();
+
+    const nestedHeadings = `${'<h2>'.repeat(CCEL_SEARCH_LIMITS.maxTreeNodes)}${'</h2>'.repeat(CCEL_SEARCH_LIMITS.maxTreeNodes)}`;
+    const headingsStartedAt = performance.now();
+    expect(() => parseCcelSearchHtml(nestedHeadings, 1)).toThrow();
+    expect(performance.now() - headingsStartedAt).toBeLessThan(2_000);
   });
 
   it('caps the current-shape card output at five 240-code-point snippets without leaking tracking values', async () => {

--- a/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
+++ b/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
@@ -179,10 +179,17 @@ describe('CcelSearchAdapter', () => {
 
   it('fails closed when a current-shape card has ambiguous anatomy or a noncanonical Read online URL', async () => {
     const ambiguous = resultCard(1).replace('</h5>', '<span class="extra">ambiguous</span></h5>');
-    await expect(new CcelSearchAdapter({
-      enabled: true,
-      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(ambiguous))),
-    }).search(query({ text: 'ambiguous card' }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    const duplicateSnippet = resultCard(1).replace('</p>', '</p><p class="card-text">second snippet</p>');
+    const duplicateReadLink = resultCard(1).replace(
+      '</div></div>',
+      '<a href="/ccel/example/duplicate/section.html">Read online</a></div></div>',
+    );
+    for (const [index, card] of [ambiguous, duplicateSnippet, duplicateReadLink].entries()) {
+      await expect(new CcelSearchAdapter({
+        enabled: true,
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(card))),
+      }).search(query({ text: `ambiguous card ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    }
 
     const foreign = resultCard(1).replace(
       /href="\/ccel\/calvin\/institutes\/section1\.html[^"]*"/u,
@@ -192,6 +199,53 @@ describe('CcelSearchAdapter', () => {
       enabled: true,
       fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(foreign))),
     }).search(query({ text: 'foreign locator' }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+  });
+
+  it('uses explicit span roles and rejects swapped, missing, wrong, or duplicate role classes', async () => {
+    const swappedOrder = resultCard(1).replace(
+      /(<span class="title">[\s\S]*?<\/span>)(<span class="author">[\s\S]*?<\/span>)/u,
+      '$2$1',
+    );
+    const orderIndependent = await new CcelSearchAdapter({
+      enabled: true,
+      fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(swappedOrder))),
+    }).search(query({ text: 'role order' }));
+    expect(orderIndependent.hits[0]).toMatchObject({
+      title: 'Institutes of the Christian Religion',
+      author: 'Calvin, John',
+    });
+
+    const swappedRoles = resultCard(1)
+      .replace('class="title"', 'class="temporary-role"')
+      .replace('class="author"', 'class="title"')
+      .replace('class="temporary-role"', 'class="author"');
+    const invalidCards = [
+      swappedRoles,
+      resultCard(1).replace('class="title"', 'class="subtitle"'),
+      resultCard(1).replace('class="author"', 'class="creator"'),
+      resultCard(1).replace('class="author"', 'class="title"'),
+      resultCard(1).replace('class="author"', 'class="title author"'),
+    ];
+    for (const [index, card] of invalidCards.entries()) {
+      await expect(new CcelSearchAdapter({
+        enabled: true,
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(card))),
+      }).search(query({ text: `invalid role ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    }
+  });
+
+  it('rejects balanced trailing result metadata and nested or unbalanced card/div ambiguity', async () => {
+    const trailing = `${resultCard(1)}<h5 class="card-title"><span class="title">Trailing title</span><span class="author">by Trailing Author</span></h5><p class="card-text">Trailing snippet.</p><a href="/ccel/example/trailing/section.html">Read online</a>`;
+    const nestedCard = resultCard(1)
+      .replace('<div class="card-body">', '<div class="card-body"><div class="card">')
+      .replace('</div></div>', '</div></div></div>');
+    const unbalancedDiv = resultCard(1).replace('<h5 class="card-title">', '<div><h5 class="card-title">');
+    for (const [index, markup] of [trailing, nestedCard, unbalancedDiv].entries()) {
+      await expect(new CcelSearchAdapter({
+        enabled: true,
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(markup))),
+      }).search(query({ text: `structural ambiguity ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    }
   });
 
   it('caps the current-shape card output at five 240-code-point snippets without leaking tracking values', async () => {
@@ -245,6 +299,34 @@ describe('CcelSearchAdapter', () => {
     await expect(adapter.search(query({ text: 'drift one' }))).resolves.toMatchObject({ status: 'interface_changed' });
     await expect(adapter.search(query({ text: 'drift two' }))).resolves.toMatchObject({ status: 'interface_changed' });
     expect(adapter.getCircuitState()).toMatchObject({ status: 'open', reason: 'interface_changed' });
+  });
+
+  it('recognizes no-results only when the unique heading/adjacent marker has no contradictory result structure', async () => {
+    const validCard = resultCard(1);
+    const competingHeading = '<h2 id="CCEL_Search_results">CCEL Search results</h2>';
+    const duplicateEmpty = '<p>No results found.</p>';
+    const malformedCard = '<div class="card"><div class="card-body"><h5 class="card-title">';
+    const contradictions = [
+      noResultsFixture.replace('</main>', `${validCard}</main>`),
+      noResultsFixture.replace('</main>', `${competingHeading}</main>`),
+      noResultsFixture.replace('</main>', `${duplicateEmpty}</main>`),
+      noResultsFixture.replace('</main>', `${malformedCard}</main>`),
+      resultPage(`${validCard}<p>No results found.</p>`),
+    ];
+    for (const [index, markup] of contradictions.entries()) {
+      await expect(new CcelSearchAdapter({
+        enabled: true,
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(markup)),
+      }).search(query({ text: `empty contradiction ${index}` }))).resolves.toMatchObject({ status: 'interface_changed', hits: [] });
+    }
+
+    const contradictoryThenEmpty = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(htmlResponse(contradictions[0]))
+      .mockResolvedValueOnce(htmlResponse(noResultsFixture));
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl: contradictoryThenEmpty });
+    await expect(adapter.search(query({ text: 'not negative cached' }))).resolves.toMatchObject({ status: 'interface_changed' });
+    await expect(adapter.search(query({ text: 'not negative cached' }))).resolves.toMatchObject({ status: 'no_results' });
+    expect(contradictoryThenEmpty).toHaveBeenCalledTimes(2);
   });
 
   it('caches successful and negative metadata briefly, but not failures', async () => {
@@ -716,8 +798,8 @@ describe('CcelSearchAdapter', () => {
     await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(nineCards))) }).search(query({ text: 'result cap', limit: 5 })))
       .resolves.toMatchObject({ status: 'ok', hitCount: 5 });
 
-    const fiftyCardsAndMalformed = `${Array.from({ length: 50 }, (_, index) => resultCard(index)).join('')}<article class="ccel-search-result"><a href="/ccel/calvin/institutes/unclosed.html">unclosed`;
-    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(fiftyCardsAndMalformed))) }).search(query({ text: 'candidate cap' })))
+    const fiftyCards = Array.from({ length: 50 }, (_, index) => resultCard(index)).join('');
+    await expect(new CcelSearchAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(resultPage(fiftyCards))) }).search(query({ text: 'candidate cap' })))
       .resolves.toMatchObject({ status: 'ok', hitCount: 5 });
 
   });


### PR DESCRIPTION
## What changed

- repairs the dormant CCEL search parser for the current Bootstrap-card interface using standards-based HTML5 parsing
- caps discovery output at page one, five results, and 240 Unicode characters per snippet
- guarantees one upstream GET per admitted cache miss, with no retry and no followed redirect
- removes tracking query/hash values and permits only clean allowlisted exact-section locators
- fails closed on ambiguous, inert, hidden, foreign, foster-parented, adoption-repaired, or structurally contradictory markup
- adds explicit input, node, attribute, depth, text, and traversal-time budgets

## Public behavior

This slice remains dormant infrastructure:

- `primary_source_search` remains strictly local-only in its public schema, handler, presenter, prompts, and resources
- production and preview CCEL flags remain `false`
- no CCEL body retrieval, mirroring, durable content storage, or republication is introduced
- no preview or deployment authorization is requested by this PR

## Dependency

- exact `parse5@8.0.1` (MIT; pure ESM)
- nested `entities@8.0.0` (BSD-2-Clause)
- lockfile changes contain only the genuine exact dependency edges

## Verification and review

- focused final review tests: 104/104
- full implementation unit verification: 1,400 passed, one expected skip
- integration: 3/3
- Worker runtime: 21/21
- Node, Worker, and Worker-runtime typechecks
- build, docs contract, generated Worker types, UBS-exclusion bundle check
- production and preview Wrangler dry runs
- independent final review: P0 0 / P1 0 / P2 0 / P3 0
- no live CCEL request, deployment, feature enablement, or database mutation

The Worker bundle increases by approximately 61.7 KiB gzip due to the standards-compliant parser; both Worker dry bundles remain valid.
