### PR TITLE
Guide unbounded CCEL date fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated the v4 guided primary-source workflow for CCEL's lack of reviewed
+  composition-date filtering. Requested year bounds remain exact on hosted-
+  local queries; the one external discovery call omits them and repeats a
+  bounded warning at search and synthesis. Direct CCEL queries containing a
+  year bound remain `unsupported_filter` before adapter or coordinator
+  admission. No contract version, rollout flag, or live authorization changed.
+
 - Withheld the Online-Bible-derived TBESH Hebrew `Meaning` field from lookup,
   study, and Strong's-resource output. Exact identities, Hebrew forms,
   transliteration, morphology, lemma, and Tyndale-created brief glosses remain;

--- a/README.md
+++ b/README.md
@@ -239,6 +239,13 @@ link to a canonical allowlisted CCEL exact-section path; tracking query and hash
 values are discarded. Balanced-card parsing uses explicit title/author roles,
 and a no-results marker is accepted only when no competing result structure is
 present. These safeguards do not authorize or enable live use.
+CCEL does not provide reviewed composition-year filtering. The v4 guided
+primary-source workflow therefore keeps any requested year bounds on its local
+queries, sends its single external discovery query without year fields, and
+repeats an explicit warning that CCEL results cannot establish membership in
+the requested historical period. Direct v4 queries that combine CCEL with
+either year field remain `unsupported_filter` before adapter or coordinator
+admission; the public tool schema documents that strict boundary.
 Any future external provider rollout must remain discovery-only until
 edition-specific rights and provider-policy gates are satisfied.
 

--- a/docs/CCEL-UPSTREAM-COORDINATOR.md
+++ b/docs/CCEL-UPSTREAM-COORDINATOR.md
@@ -252,4 +252,13 @@ Local corpus search remains independent if the circuit latches.
 The adapter returns a bounded integer `retryAfterSeconds` on every v4
 `rate_limited` provider result. Guided primary-source research issues at most
 one CCEL-bearing call per prompt materialization and defers additional creator
-scopes to later turns after that interval.
+scopes to later turns after that interval. CCEL cannot enforce reviewed
+composition-year bounds. Guided research retains exact requested bounds on
+hosted-local queries but deliberately omits `startYear` and `endYear` from that
+single external call. Every executable unbounded CCEL provider result begins
+with the invariant notice `CCEL discovery was not composition-date filtered;
+its results cannot establish membership in a requested historical period.`
+The generated workflow repeats the warning while searching and synthesizing
+and names the requested local range. A direct CCEL-bearing query with either
+year field still returns `unsupported_filter` before adapter invocation or
+coordinator admission. This fallback does not infer, add, or validate dates.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -387,6 +387,12 @@ Code readiness and operational readiness are deliberately separate:
   full-content scraping, body retrieval, mirroring, hosting, republication, or
   durable CCEL content storage. This does not claim CCEL separately licenses
   snippets. Applicable operational and terms boundaries remain release gates.
+  Because CCEL cannot enforce composition-year bounds, the owner approved a
+  guided broad topical fallback: retain exact year bounds on hosted-local
+  queries, omit them from the one external call, and warn at search and
+  synthesis that CCEL results cannot establish membership in the requested
+  historical period. Direct CCEL-plus-year tool input remains fail-closed as
+  `unsupported_filter` before adapter or coordinator admission.
   Immediately before any live preview canary, recheck the current CCEL search
   interface, robots guidance, copyright policy, and operational/terms boundary;
   record that evidence and repeat the owner decision. Until then preview stays
@@ -433,6 +439,7 @@ Code readiness and operational readiness are deliberately separate:
   only; production remains v3/local-only. A future live discovery rollout
   requires the explicit owner policy decision above and separate review, and
   must not become crawling, catalog mirroring, body republication, or permanent
-  storage.
+  storage. Date-fallback contract work does not change any rollout flag or
+  authorize a live request.
 - Public Ethereum RPC endpoints are light-use defaults, not an uptime SLO.
   Donation verification remains fail-closed.

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -14,6 +14,8 @@ export interface RecommendedToolCall {
 }
 
 const TRANSLATIONS = new Set(['ESV', 'NET', 'KJV', 'WEB', 'BSB', 'ASV', 'YLT', 'DBY']);
+const CCEL_DATE_CAPABILITY_NOTICE = 'CCEL does not provide composition-date filtering; any returned hit is not composition-date evidence.';
+const CCEL_DATED_FALLBACK_NOTICE = 'The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range.';
 
 /**
  * The upstream SDK's strict string record throws an unclassified ZodError before
@@ -143,6 +145,9 @@ export function recommendedToolCallsForPrompt(
         ...(startYear !== undefined ? { startYear } : {}),
         ...(endYear !== undefined ? { endYear } : {}),
       };
+      const externalScope = {
+        ...(work ? { work } : {}),
+      };
       const localCall: RecommendedToolCall = {
         tool: 'primary_source_search',
         arguments: {
@@ -162,20 +167,20 @@ export function recommendedToolCallsForPrompt(
       // A prompt materialization may authorize only one cold CCEL attempt. The
       // shared coordinator enforces a global origin interval, so additional
       // creator scopes belong in later, independently paced turns.
-      const externalScope = authors[0];
+      const externalAuthor = authors[0];
       return [
         localCall,
         {
           tool: 'primary_source_search',
           arguments: {
             queries: [{
-              id: externalScope ? 'external-creator-1' : 'external-topic',
+              id: externalAuthor ? 'external-creator-1' : 'external-topic',
               text: topic,
               providers: ['ccel'],
               match: 'all_terms',
               selection: 'relevance',
-              ...scoped,
-              ...(externalScope ? { author: externalScope } : {}),
+              ...externalScope,
+              ...(externalAuthor ? { author: externalAuthor } : {}),
               limit,
             }],
           },
@@ -262,14 +267,14 @@ export function registerPromptHandlers(
           {
             name: 'startYear',
             description: contract.contractVersion === '4'
-              ? 'Optional inclusive local composition-year lower bound as an integer string. CCEL does not support this filter, so external calls return unsupported_filter without upstream admission.'
+              ? 'Optional inclusive hosted-local composition-year lower bound as an integer string. The guided external fallback deliberately omits this bound and warns that CCEL results are not date-filtered; a direct CCEL query containing it returns unsupported_filter without upstream admission.'
               : 'Optional inclusive composition-year lower bound as an integer string.',
             required: false,
           },
           {
             name: 'endYear',
             description: contract.contractVersion === '4'
-              ? 'Optional inclusive local composition-year upper bound as an integer string. CCEL does not support this filter, so external calls return unsupported_filter without upstream admission.'
+              ? 'Optional inclusive hosted-local composition-year upper bound as an integer string. The guided external fallback deliberately omits this bound and warns that CCEL results are not date-filtered; a direct CCEL query containing it returns unsupported_filter without upstream admission.'
               : 'Optional inclusive composition-year upper bound as an integer string.',
             required: false,
           },
@@ -348,11 +353,11 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
           ? `Cross-tradition doctrinal comparison on "${topic}".${hint}
 
 1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Its reviewed metadata applies only to the hosted local collection.
-2. **Run bounded discovery** — ${callText(calls[0])}. Preserve local and external provider groups separately. The requested traditions are comparison interests, not creator filters or inferred metadata.
+2. **Run bounded discovery** — ${callText(calls[0])}. ${CCEL_DATE_CAPABILITY_NOTICE} Preserve local and external provider groups separately. The requested traditions are comparison interests, not creator filters or inferred metadata.
 3. **Use snippets only to select evidence** — Every snippet is discovery-only. For a local \`mcp_resource\` locator, read the exact URI with MCP \`resources/read\` before quotation or substantive comparison. For an external \`external_url\` locator, open the direct URL independently; it is not an MCP resource and its rights status is not determined.
 4. **Do not promote external metadata** — CCEL titles, creators, section labels, and snippets are unreviewed provider search results. Never quote, attribute doctrine, or compare positions from those snippets alone.
 5. **Read exact evidence** — Read at most five unique selected sections total. Confirm each local resource URI or external page identity before using its content, and keep local reviewed metadata distinct from external provider metadata.
-6. **Compare cautiously** — Explain agreement, divergence, Scripture use, and historical context only from exact sections actually read. Missing hits are not historical silence.`
+6. **Compare cautiously** — ${CCEL_DATE_CAPABILITY_NOTICE} Name any disabled, unavailable, or unsupported provider before drawing conclusions. Explain agreement, divergence, Scripture use, and historical context only from exact sections actually read. Missing hits are not historical silence.`
           : `Cross-tradition doctrinal comparison on "${topic}".${hint}
 
 1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Use only its reviewed work and creator metadata to plan the comparison; aliases route exact work lookups but are not metadata evidence. Do not substitute another creator or work for one absent from this catalog.
@@ -369,15 +374,30 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
         const authors = args?.authors?.split(',').map(value => value.trim()).filter(Boolean) ?? [];
         const externalCalls = calls.slice(1).map(call => callText(call)).join('; then ');
         const deferredAuthors = authors.slice(1);
+        const startYear = args?.startYear === undefined ? undefined : Number(args.startYear.trim());
+        const endYear = args?.endYear === undefined ? undefined : Number(args.endYear.trim());
+        const localDateScope = startYear !== undefined && endYear !== undefined
+          ? `The requested hosted-local composition range is ${startYear} through ${endYear}, inclusive.`
+          : startYear !== undefined
+            ? `The requested hosted-local composition range begins at ${startYear} and has no upper bound.`
+            : endYear !== undefined
+              ? `The requested hosted-local composition range ends at ${endYear} and has no lower bound.`
+              : 'No hosted-local composition-year range was requested.';
+        const externalDateSafeguard = startYear !== undefined || endYear !== undefined
+          ? CCEL_DATED_FALLBACK_NOTICE
+          : CCEL_DATE_CAPABILITY_NOTICE;
+        const externalDateCallInstruction = startYear !== undefined || endYear !== undefined
+          ? 'Do not add either year field to the external call.'
+          : 'Do not add `startYear` or `endYear` to the external call because CCEL cannot enforce them.';
         text = contract.contractVersion === '4'
           ? `Research primary-source evidence about "${topic}"${work ? ` within the requested work "${work}"` : ''}${authors.length ? ` for the separately scoped creators ${authors.map(value => `"${value}"`).join(', ')}` : ''}.
 
 1. **Inspect local scope** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Its reviewed work and creator metadata describes only the hosted local collection; an absent creator is a local catalog gap, not evidence that no external source exists.
-2. **Search local evidence** — ${callText(calls[0])}. Use local catalog scope and deterministic selection as returned.
-3. **Search one external scope now** — ${externalCalls || 'No external query is needed.'} This prompt authorizes at most one CCEL-bearing call. Each call contains at most one CCEL-bearing query.${deferredAuthors.length ? ` Defer ${deferredAuthors.map(value => `"${value}"`).join(', ')} to separate later turns.` : ''} If the provider returns \`rate_limited\`, wait at least its structured \`retryAfterSeconds\` before a later call; never retry immediately. Do not combine creator comparisons into multiple CCEL queries in one call.
+2. **Search local evidence** — ${callText(calls[0])}. Use local catalog scope and deterministic selection as returned. ${localDateScope}
+3. **Search one external scope now** — ${externalCalls || 'No external query is needed.'} ${externalDateSafeguard} ${externalDateCallInstruction} This prompt authorizes at most one CCEL-bearing call. Each call contains at most one CCEL-bearing query.${deferredAuthors.length ? ` Defer ${deferredAuthors.map(value => `"${value}"`).join(', ')} to separate later turns.` : ''} If the provider returns \`rate_limited\`, wait at least its structured \`retryAfterSeconds\` before a later call; never retry immediately. Do not combine creator comparisons into multiple CCEL queries in one call.
 4. **Use the v4 contract** — Preserve query/provider/rank order, provider status, notices, \`responseWindow\`, and \`evidencePolicy\`. Local locators are exact readable MCP resources. External locators are direct CCEL URLs only, with unreviewed provider-search metadata and rights status not determined.
 5. **Read before evidence use** — Follow at most ${args?.maxSections?.trim() || '3'} selected locators. Use MCP \`resources/read\` only for local \`mcp_resource\` URIs. Open external \`external_url\` pages directly and verify the page independently. Never quote, compare creators or works, or draw substantive conclusions from any search snippet alone.
-6. **Synthesize with provenance** — Keep reviewed local metadata separate from external provider metadata. Distinguish exact text read from interpretation, name unavailable/unsupported searches, and do not treat missing results as historical silence.`
+6. **Synthesize with provenance** — ${localDateScope} ${externalDateSafeguard} Keep reviewed local metadata separate from external provider metadata. Distinguish exact text read from interpretation, name disabled, unavailable, or unsupported searches, and do not treat missing results as historical silence.`
           : `Research primary-source evidence about "${topic}"${work ? ` within the exact local work "${work}"` : ' across the locally indexed collection'}${authors.length ? ` for the separately scoped creators ${authors.map(value => `"${value}"`).join(', ')}` : ''}.
 
 1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Confirm requested exact works and creator names there before searching. If Calvin, Erasmus, Luther, or any other requested creator is absent, report that catalog gap; never use a confession or similarly themed work as a proxy.

--- a/src/presenters/primarySourceSearchV4Structured.ts
+++ b/src/presenters/primarySourceSearchV4Structured.ts
@@ -1,8 +1,9 @@
 import { buildLocalDocumentResourceUri } from '../kernel/documentResource.js';
-import type {
-  PrimarySourcePlanHit,
-  PrimarySourceProviderStatus,
-  PrimarySourceSearchPlanResult,
+import {
+  CCEL_COMPOSITION_DATE_NOTICE,
+  type PrimarySourcePlanHit,
+  type PrimarySourceProviderStatus,
+  type PrimarySourceSearchPlanResult,
 } from '../services/historical/primarySourceTypes.js';
 
 export const PRIMARY_SOURCE_V4_MAX_BYTES = 32_768;
@@ -194,6 +195,10 @@ function providerDraft(
     searched: provider.searched === true,
     page: Number.isSafeInteger(provider.page) && provider.page >= 1 && provider.page <= 3 ? provider.page : 1,
     notices: uniqueBounded([
+      ...(providerKind === 'ccel_live'
+        && provider.status !== 'unsupported_filter' && provider.status !== 'disabled'
+        ? [CCEL_COMPOSITION_DATE_NOTICE]
+        : []),
       ...(invalidCandidates ? ['One or more unsafe or mismatched provider hits were omitted.'] : []),
       ...(countMismatch ? ['Provider-reported hit count did not match its returned hit array.'] : []),
       ...(!validWindow ? ['Provider result-window metadata was invalid.'] : []),
@@ -201,7 +206,7 @@ function providerDraft(
       ...(pageInvalid ? ['Provider page metadata was invalid.'] : []),
       ...(!retryAfterValid ? ['Provider retry-after metadata was absent or invalid.'] : []),
       ...(optionalMetadataInvalid ? ['One or more empty optional metadata fields were omitted after sanitization.'] : []),
-      ...provider.notices,
+      ...provider.notices.filter(notice => notice !== CCEL_COMPOSITION_DATE_NOTICE),
     ], 4, 240),
     ...(scope ? { scope } : {}),
     ...(retryAfterValid && provider.retryAfterSeconds !== undefined

--- a/src/services/historical/PrimarySourceSearchService.ts
+++ b/src/services/historical/PrimarySourceSearchService.ts
@@ -12,6 +12,7 @@ import {
   type PrimarySourceSearchMatch,
   type PrimarySourceSearchPlanQuery,
   type PrimarySourceSearchPlanResult,
+  CCEL_COMPOSITION_DATE_NOTICE,
 } from './primarySourceTypes.js';
 
 const MAX_QUERIES = 4;
@@ -107,6 +108,16 @@ export class PrimarySourceSearchService {
           resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' },
         };
       }
+    }
+    if (provider === 'ccel' && result.status !== 'disabled' && query.page === 1
+      && query.startYear === undefined && query.endYear === undefined) {
+      result = {
+        ...result,
+        notices: [
+          CCEL_COMPOSITION_DATE_NOTICE,
+          ...result.notices.filter(notice => notice !== CCEL_COMPOSITION_DATE_NOTICE),
+        ],
+      };
     }
     return {
       ...result,

--- a/src/services/historical/primarySourceTypes.ts
+++ b/src/services/historical/primarySourceTypes.ts
@@ -5,6 +5,8 @@
  * MCP tool or a fetch/batch orchestration service.
  */
 
+export const CCEL_COMPOSITION_DATE_NOTICE = 'CCEL discovery was not composition-date filtered; its results cannot establish membership in a requested historical period.';
+
 export type PrimarySourceSearchMatch = 'all_terms' | 'phrase';
 export type PrimarySourceSelection = 'relevance' | 'work_diversity';
 

--- a/src/tools/v2/primarySourceSearch.ts
+++ b/src/tools/v2/primarySourceSearch.ts
@@ -66,13 +66,13 @@ export function createPrimarySourceSearchHandler(
               startYear: {
                 type: 'integer', minimum: -5000, maximum: 3000,
                 description: v4
-                  ? 'Local inclusive composition-overlap lower bound. Unsupported for CCEL and reported as unsupported_filter without an upstream request.'
+                  ? 'Hosted-local inclusive composition-overlap lower bound. A direct query whose providers include ccel cannot use this field: it returns unsupported_filter before adapter or coordinator admission.'
                   : 'Inclusive lower bound. A work is eligible when its reviewed composition interval overlaps the requested interval.',
               },
               endYear: {
                 type: 'integer', minimum: -5000, maximum: 3000,
                 description: v4
-                  ? 'Local inclusive composition-overlap upper bound; must be >= startYear. Unsupported for CCEL and never silently ignored.'
+                  ? 'Hosted-local inclusive composition-overlap upper bound; must be >= startYear. A direct query whose providers include ccel cannot use this field: it returns unsupported_filter before adapter or coordinator admission.'
                   : 'Inclusive upper bound. Must be greater than or equal to startYear when both are provided.',
               },
               page: {

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -169,12 +169,14 @@ describe('published project contract', () => {
   });
 
   it('does not reintroduce retired scope claims', async () => {
-    const [readme, historicalTestReport, historicalArchitecture, historicalDevelopment, workerConfig] = await Promise.all([
+    const [readme, historicalTestReport, historicalArchitecture, historicalDevelopment, workerConfig, coordinatorGuide, roadmap] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('TEST_REPORT.md'),
       readProjectFile('docs/bible-mcp-architecture.md'),
       readProjectFile('docs/bible-mcp-development-plan.md'),
       readProjectFile('wrangler.toml'),
+      readProjectFile('docs/CCEL-UPSTREAM-COORDINATOR.md'),
+      readProjectFile('docs/ROADMAP.md'),
     ]);
 
     expect(readme).not.toMatch(/1,000\+.*CCEL/i);
@@ -188,6 +190,12 @@ describe('published project contract', () => {
     expect(readme).toContain('Durable Object lookup/RPC, or fetch');
     expect(readme).toContain('reconnect');
     expect(readme).toContain('reinitialize');
+    expect(readme).toMatch(/keeps any requested year bounds on its local\s+queries/);
+    expect(readme).toMatch(/Direct v4 queries that combine CCEL with\s+either year field/);
+    expect(coordinatorGuide).toContain('Every executable unbounded CCEL provider result begins');
+    expect(coordinatorGuide).toContain('A direct CCEL-bearing query with either');
+    expect(roadmap).toContain('guided broad topical fallback');
+    expect(roadmap).toContain('Direct CCEL-plus-year tool input remains fail-closed');
     const primarySourceToolRow = readme.split('\n')
       .find(line => line.startsWith('| `primary_source_search` |'));
     expect(primarySourceToolRow).toContain('Production is v3/local-only');

--- a/test/unit/mcp/promptContracts.test.ts
+++ b/test/unit/mcp/promptContracts.test.ts
@@ -190,24 +190,47 @@ describe('prompt-recommended tool-call contracts', () => {
     }]);
   });
 
-  it('branches v4 workflows into readable local evidence and sequential external discovery', () => {
+  it.each([
+    ['no dates', {}, {}],
+    ['lower bound only', { startYear: '500' }, { startYear: 500 }],
+    ['upper bound only', { endYear: '1500' }, { endYear: 1500 }],
+    ['both bounds', { startYear: '500', endYear: '1500' }, { startYear: 500, endYear: 1500 }],
+  ])('keeps %s on local calls while making one unbounded, sequential v4 external discovery call', (_label, dateArgs, expectedLocalDates) => {
     const v4 = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
       contractVersion: '4' as const, liveCcelEnabled: false,
     };
     const calls = recommendedToolCallsForPrompt('primary-source-research', {
       topic: 'eucharist', authors: 'Erasmus of Rotterdam, Martin Luther',
-      startYear: '500', endYear: '1500',
+      ...dateArgs,
     }, v4);
-    expect((calls[0]!.arguments.queries as Array<{ providers: string[] }>).every(query => query.providers[0] === 'local')).toBe(true);
+    const localQueries = calls[0]!.arguments.queries as Array<Record<string, unknown>>;
+    expect(localQueries.every(query => (query.providers as string[])[0] === 'local')).toBe(true);
+    expect(localQueries).toHaveLength(2);
+    for (const localQuery of localQueries) expect(localQuery).toMatchObject(expectedLocalDates);
     expect(calls.slice(1)).toHaveLength(1);
-    for (const call of calls.slice(1)) {
-      const queries = call.arguments.queries as Array<{ providers: string[] }>;
-      expect(queries).toHaveLength(1);
-      expect(queries[0]!.providers).toEqual(['ccel']);
-      expect(queries[0]).toMatchObject({ startYear: 500, endYear: 1500 });
-    }
-    expect((calls[1]!.arguments.queries as Array<{ author?: string }>)[0]!.author).toBe('Erasmus of Rotterdam');
+    const externalQueries = calls[1]!.arguments.queries as Array<Record<string, unknown>>;
+    expect(externalQueries).toHaveLength(1);
+    expect(externalQueries[0]).toMatchObject({ providers: ['ccel'], author: 'Erasmus of Rotterdam' });
+    expect(externalQueries[0]).not.toHaveProperty('startYear');
+    expect(externalQueries[0]).not.toHaveProperty('endYear');
+    const validateV4 = validatorFor(createPrimarySourceSearchHandler(unused, v4).inputSchema);
+    for (const call of calls) expect(validateV4(call.arguments).valid).toBe(true);
+  });
+
+  it('retains the optional work restriction in both guided scopes without copying date bounds to CCEL', () => {
+    const v4 = {
+      exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
+      contractVersion: '4' as const, liveCcelEnabled: false,
+    };
+    const calls = recommendedToolCallsForPrompt('primary-source-research', {
+      topic: 'sacraments', work: 'Institutes', startYear: '1536', endYear: '1559',
+    }, v4);
+    expect(calls[0]!.arguments).toMatchObject({ queries: [{ work: 'Institutes', startYear: 1536, endYear: 1559 }] });
+    expect(calls[1]!.arguments).toEqual({ queries: [{
+      id: 'external-topic', text: 'sacraments', providers: ['ccel'], match: 'all_terms',
+      selection: 'relevance', work: 'Institutes', limit: 3,
+    }] });
     expect(recommendedToolCallsForPrompt('confession-study', { topic: 'justification' }, v4)[0]!.arguments)
       .toMatchObject({ queries: [{ providers: ['local', 'ccel'] }] });
   });

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -892,8 +892,10 @@ describe('shared MCP registration', () => {
     expect(argumentDescription('work')).toContain('unreviewed external provider work restriction');
     expect(argumentDescription('authors')).toContain('only the first creator is the immediate unreviewed external scope');
     expect(argumentDescription('authors')).toContain('independently paced follow-up calls');
-    expect(argumentDescription('startYear')).toContain('return unsupported_filter without upstream admission');
-    expect(argumentDescription('endYear')).toContain('return unsupported_filter without upstream admission');
+    expect(argumentDescription('startYear')).toContain('guided external fallback deliberately omits this bound');
+    expect(argumentDescription('startYear')).toContain('direct CCEL query containing it returns unsupported_filter');
+    expect(argumentDescription('endYear')).toContain('guided external fallback deliberately omits this bound');
+    expect(argumentDescription('endYear')).toContain('direct CCEL query containing it returns unsupported_filter');
     const primary = await client.getPrompt({
       name: 'primary-source-research',
       arguments: {
@@ -905,14 +907,40 @@ describe('shared MCP registration', () => {
     expect(primaryText).toContain('Use MCP `resources/read` only for local `mcp_resource` URIs');
     expect(primaryText).toContain('Open external `external_url` pages directly');
     expect(primaryText).toContain('Each call contains at most one CCEL-bearing query');
-    expect(primaryText).toContain('"startYear":500,"endYear":1500');
+    expect(primaryText).toContain('"providers":["local"],"match":"all_terms","selection":"work_diversity","startYear":500,"endYear":1500');
+    expect(primaryText).toContain('"providers":["ccel"],"match":"all_terms","selection":"relevance","author":"Erasmus of Rotterdam"');
+    expect(primaryText.match(/The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range\./g)).toHaveLength(2);
+    expect(primaryText).not.toContain('CCEL discovery was not composition-date filtered');
+    expect(primaryText.match(/The requested hosted-local composition range is 500 through 1500, inclusive\./g)).toHaveLength(2);
+    expect(primaryText).toContain('name disabled, unavailable, or unsupported searches');
     expect(primaryText).toContain('Never quote, compare creators or works, or draw substantive conclusions from any search snippet alone');
+
+    for (const [dateArguments, localJson, scopeText, warningText] of [
+      [{}, '', 'No hosted-local composition-year range was requested.', 'CCEL does not provide composition-date filtering; any returned hit is not composition-date evidence.'],
+      [{ startYear: '500' }, ',"startYear":500', 'The requested hosted-local composition range begins at 500 and has no upper bound.', 'The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range.'],
+      [{ endYear: '1500' }, ',"endYear":1500', 'The requested hosted-local composition range ends at 1500 and has no lower bound.', 'The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range.'],
+    ] as const) {
+      const rendered = await client.getPrompt({
+        name: 'primary-source-research',
+        arguments: { topic: 'eucharist', ...dateArguments },
+      });
+      const text = rendered.messages[0]?.content.type === 'text' ? rendered.messages[0].content.text : '';
+      expect(text).toContain(`"selection":"work_diversity"${localJson},"limit":3`);
+      expect(text).toContain('"providers":["ccel"],"match":"all_terms","selection":"relevance","limit":3');
+      expect(text.match(new RegExp(scopeText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))).toHaveLength(2);
+      expect(text.match(new RegExp(warningText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'))).toHaveLength(2);
+      expect(text).not.toContain('CCEL discovery was not composition-date filtered');
+      expect(text).toContain('name disabled, unavailable, or unsupported searches');
+    }
 
     const confession = await client.getPrompt({ name: 'confession-study', arguments: { topic: 'justification' } });
     const confessionText = confession.messages[0]?.content.type === 'text' ? confession.messages[0].content.text : '';
     expect(confessionText).toContain('external `external_url` locator');
     expect(confessionText).toContain('it is not an MCP resource');
     expect(confessionText).toContain('rights status is not determined');
+    expect(confessionText.match(/CCEL does not provide composition-date filtering; any returned hit is not composition-date evidence\./g)).toHaveLength(2);
+    expect(confessionText).not.toContain('CCEL discovery was not composition-date filtered');
+    expect(confessionText).toContain('Name any disabled, unavailable, or unsupported provider');
   });
 
   it('rejects tool/prompt contract divergence at server construction', () => {

--- a/test/unit/presenters/primarySourceSearchV4Structured.test.ts
+++ b/test/unit/presenters/primarySourceSearchV4Structured.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { presentPrimarySourceSearchV4 } from '../../../src/presenters/primarySourceSearchV4Structured.js';
 import type { PrimarySourceSearchPlanResult } from '../../../src/services/historical/primarySourceTypes.js';
+import { CCEL_COMPOSITION_DATE_NOTICE } from '../../../src/services/historical/primarySourceTypes.js';
 
 function localHit(queryId: string, rank: number, marker = '') {
   const sectionId = `${queryId}-${rank}`;
@@ -86,6 +87,46 @@ function largePlan(): PrimarySourceSearchPlanResult {
 }
 
 describe('primary-source v4 structured presentation', () => {
+  it('defensively prepends the date invariant to every executable external provider result', () => {
+    const plan = largePlan();
+    const external = externalProvider('external', 1);
+    external.notices = ['Provider-specific notice.'];
+    plan.queries = [{ id: 'external', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [external] }];
+    plan.coverage = { localAttempted: false, localHitCount: 0, ccelAttempted: true, ccelStatus: 'ok', ccelHitCount: 1, notices: [] };
+
+    const presented = presentPrimarySourceSearchV4(plan);
+
+    expect(presented.queries[0]!.providers[0]!.notices).toEqual([
+      CCEL_COMPOSITION_DATE_NOTICE,
+      'Provider-specific notice.',
+    ]);
+    expect(presented.coverage.notices[0]).toBe(CCEL_COMPOSITION_DATE_NOTICE);
+  });
+
+  it('does not attach the unbounded-search warning to a rejected date-filtered CCEL query', () => {
+    const plan = largePlan();
+    const external = externalProvider('external', 0);
+    external.status = 'unsupported_filter';
+    external.searched = false;
+    external.notices = ['Live CCEL discovery does not expose reviewed composition-date bounds.'];
+    plan.queries = [{ id: 'external', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [external] }];
+
+    const provider = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    expect(provider.notices).not.toContain(CCEL_COMPOSITION_DATE_NOTICE);
+  });
+
+  it('does not imply an unbounded search occurred when the external provider is disabled', () => {
+    const plan = largePlan();
+    const external = externalProvider('external', 0);
+    external.status = 'disabled' as never;
+    external.searched = false;
+    external.notices = ['Live CCEL search is disabled. No remote request was made.'];
+    plan.queries = [{ id: 'external', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [external] }];
+
+    const provider = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    expect(provider.notices).not.toContain(CCEL_COMPOSITION_DATE_NOTICE);
+  });
+
   it('publishes bounded retry guidance only for a rate-limited external provider', () => {
     const plan = largePlan();
     const external = externalProvider('external', 0) as ReturnType<typeof externalProvider> & { retryAfterSeconds?: number };

--- a/test/unit/services/historical/PrimarySourceSearchService.test.ts
+++ b/test/unit/services/historical/PrimarySourceSearchService.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { PrimarySourceSearchService } from '../../../../src/services/historical/PrimarySourceSearchService.js';
 import type { PrimarySourceProviderResult } from '../../../../src/services/historical/primarySourceTypes.js';
+import { CCEL_COMPOSITION_DATE_NOTICE } from '../../../../src/services/historical/primarySourceTypes.js';
 import { readPrimarySourceContractConfig } from '../../../../src/kernel/featureFlags.js';
 
 function providerResult(provider: 'local' | 'ccel_live', status: PrimarySourceProviderResult['status'] = 'ok', count = 1): PrimarySourceProviderResult {
@@ -107,6 +108,7 @@ describe('PrimarySourceSearchService', () => {
     const service = new PrimarySourceSearchService({ search: vi.fn() } as any, ccel as any, dormant);
     const result = await service.search(plan([query({ providers: ['ccel'] })]));
     expect(result).toMatchObject({ planStatus: 'unavailable', coverage: { ccelAttempted: false, ccelStatus: 'disabled' } });
+    expect(result.queries[0]!.providers[0]!.notices).not.toContain(CCEL_COMPOSITION_DATE_NOTICE);
     expect(ccel.search).not.toHaveBeenCalled();
   });
 
@@ -114,15 +116,59 @@ describe('PrimarySourceSearchService', () => {
     { page: 2 },
     { startYear: 1200 },
     { endYear: 1600 },
+    { startYear: 1200, endYear: 1600 },
   ])('classifies unsupported CCEL filters before admission or provider work (%o)', async unsupported => {
     const ccel = { search: vi.fn() };
     const gate = { admit: vi.fn(), recordOutcome: vi.fn(), snapshot: vi.fn() } as any;
     const service = new PrimarySourceSearchService({ search: vi.fn() } as any, ccel as any, live, gate);
     const result = await service.search(plan([query({ providers: ['ccel'], ...unsupported })]));
     expect(result).toMatchObject({ planStatus: 'partial', queries: [{ providers: [{ status: 'unsupported_filter', searched: false }] }] });
+    expect(result.queries[0]!.providers[0]!.notices).not.toContain(CCEL_COMPOSITION_DATE_NOTICE);
     expect(ccel.search).not.toHaveBeenCalled();
     expect(gate.admit).not.toHaveBeenCalled();
   });
+
+  it('executes the local half of a direct mixed date query but rejects its CCEL half before admission', async () => {
+    const local = { search: vi.fn().mockResolvedValue(providerResult('local', 'no_results', 0)) };
+    const ccel = { search: vi.fn() };
+    const gate = { admit: vi.fn(), recordOutcome: vi.fn(), snapshot: vi.fn() } as any;
+    const service = new PrimarySourceSearchService(local as any, ccel as any, live, gate);
+
+    const result = await service.search(plan([query({
+      providers: ['local', 'ccel'], startYear: 500, endYear: 1500,
+    })]));
+
+    expect(result.queries[0]!.providers).toMatchObject([
+      { provider: 'local', status: 'no_results', searched: true },
+      { provider: 'ccel_live', status: 'unsupported_filter', searched: false },
+    ]);
+    expect(local.search).toHaveBeenCalledWith(expect.objectContaining({ startYear: 500, endYear: 1500 }));
+    expect(ccel.search).not.toHaveBeenCalled();
+    expect(gate.admit).not.toHaveBeenCalled();
+  });
+
+  it.each(['ok', 'no_results', 'unavailable', 'rate_limited', 'interface_changed'] as const)(
+    'prepends the composition-date invariant to an executable unbounded CCEL %s result',
+    async status => {
+      const returned = providerResult('ccel_live', status, status === 'ok' ? 1 : 0);
+      returned.notices = ['Provider-specific notice.'];
+      if (status === 'rate_limited') returned.retryAfterSeconds = 10;
+      const ccel = { search: vi.fn().mockResolvedValue(returned) };
+      const service = new PrimarySourceSearchService({ search: vi.fn() } as any, ccel as any, live, coordinator);
+
+      const result = await service.search(plan([query({ providers: ['ccel'] })]));
+
+      expect(ccel.search).toHaveBeenCalledTimes(1);
+      const [adapterQuery, passedCoordinator] = ccel.search.mock.calls[0]!;
+      expect(adapterQuery).not.toHaveProperty('startYear');
+      expect(adapterQuery).not.toHaveProperty('endYear');
+      expect(passedCoordinator).toBe(coordinator);
+      expect(result.queries[0]!.providers[0]!.notices).toEqual([
+        CCEL_COMPOSITION_DATE_NOTICE,
+        'Provider-specific notice.',
+      ]);
+    },
+  );
 
   it('isolates failures and never turns local no-results plus CCEL failure into complete no-results', async () => {
     const local = { search: vi.fn().mockResolvedValue(providerResult('local', 'no_results', 0)) };

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -508,8 +508,10 @@ describe('primary_source_search v4 contract', () => {
     expect(query.properties.selection.description).toContain('CCEL discovery');
     expect(query.properties.author.description).toContain('unreviewed provider search restriction');
     expect(query.properties.work.description).toContain('unreviewed provider');
-    expect(query.properties.startYear.description).toContain('Unsupported for CCEL');
-    expect(query.properties.endYear.description).toContain('Unsupported for CCEL');
+    expect(query.properties.startYear.description).toContain('direct query whose providers include ccel');
+    expect(query.properties.startYear.description).toContain('before adapter or coordinator admission');
+    expect(query.properties.endYear.description).toContain('direct query whose providers include ccel');
+    expect(query.properties.endYear.description).toContain('before adapter or coordinator admission');
     expect(query.properties.page.description).toContain('page 1 only');
     expect(query.properties.limit.description).toContain('capped at 5');
     expect(validatorFor(handler.inputSchema)({ queries: [{ id: 'q', text: 'faith', providers: ['ccel'] }] }).valid).toBe(true);

--- a/test/unit/tools/worker/compositionRoot.test.ts
+++ b/test/unit/tools/worker/compositionRoot.test.ts
@@ -227,6 +227,32 @@ describe('createWorkerCompositionRoot', () => {
       // itself never instantiates the named object.
       expect(getByName).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { startYear: 500 },
+      { endYear: 1500 },
+      { startYear: 500, endYear: 1500 },
+    ])('rejects direct date-filtered CCEL input before Worker adapter or coordinator admission (%o)', async dateBounds => {
+      const getByName = vi.fn();
+      const root = createWorkerCompositionRoot(makeEnv({
+        THEOLOGAI_EXPOSE_CCEL_DISCOVERY: 'true',
+        THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH: 'true',
+        THEOLOGAI_ENABLE_CCEL_COORDINATOR: 'true',
+        THEOLOGAI_CCEL_COORDINATOR: { getByName } as any,
+      }));
+      const tool = root.tools.find(candidate => candidate.name === 'primary_source_search')!;
+
+      const result = await tool.handler({
+        queries: [{ id: 'remote', text: 'grace', providers: ['ccel'], ...dateBounds }],
+      });
+
+      expect(result.structuredContent).toMatchObject({
+        queries: [{ providers: [{ provider: 'ccel_live', status: 'unsupported_filter', searched: false }] }],
+      });
+      expect(JSON.stringify(result)).not.toContain('CCEL discovery was not composition-date filtered');
+      expect(primarySourceMocks.search).not.toHaveBeenCalled();
+      expect(getByName).not.toHaveBeenCalled();
+    });
   });
 
   describe('service exposure', () => {


### PR DESCRIPTION
Summary:
- retain exact composition-year bounds for guided local primary-source searches
- issue at most one guided CCEL discovery query without unsupported year fields
- clearly distinguish local date scope from unfiltered external discovery
- preserve direct CCEL-plus-year fail-closed behavior before upstream admission

Safety:
- live CCEL flags remain unchanged and disabled
- no schema, database, secret, or deployment changes
- no live CCEL requests were made
- CCEL snippets remain bounded, attributed, and discovery-only

Verification:
- full unit suite: 1,640 passed, 1 skipped
- focused independent review suite: 172 passed
- Worker runtime: 24 passed
- Node and Worker typechecks passed
- independent re-review: GO, no P0-P3 findings