### PR TITLE
Scale primary-source catalog capacity safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Centralized the historical-work catalog and search-scope capacity at the
+  existing 100-work hard ceiling, using one D1-safe JSON/`json_each` bind for
+  scoped work IDs. The hosted corpus and readiness inventory remain 17 works;
+  this changes no database schema, public contract version, or transform.
+
 - Updated the v4 guided primary-source workflow for CCEL's lack of reviewed
   composition-date filtering. Requested year bounds remain exact on hosted-
   local queries; the one external discovery call omits them and repeats a

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,6 +88,18 @@ is local source context only and does not define the current product contract.
   output for the curated local collection, merged as
   `9250bbd393ed99530e52ee656eee11fb8e841c7e` from reviewed source culminating
   in `ec2ae6480f372d2b8869592e51c199c66894508a`. Merge evidence alone does not establish a runtime deployment.
+- **TBESH Meaning suppression / PR #53:** withheld the Online-Bible-derived
+  Hebrew `Meaning` field while preserving safely sourced identity, form,
+  morphology, lemma, and brief-gloss evidence, merged as
+  `5588a1fdf2e4d8a4203aba0bba3eb3cdc205837e`.
+- **Guarded CCEL readiness / PR #54:** shipped the protected operator and
+  release architecture inertly, with production flags `000` and no live CCEL
+  request, merged as `c3f4b8df82104eb7a32002e2ed820026a1d6dc4c`.
+- **Guided CCEL date fallback / PR #55:** kept hosted-local date bounds exact,
+  made the single guided external query explicitly unbounded by date, and
+  added search-and-synthesis warnings. Production remained at flags `000` and
+  made zero live CCEL calls; merged as
+  `671a0f3fd632358f001dd5ac8e1721e32c09d39e`.
 
 These entries describe merged repository state. Deployment state is established
 only by the relevant protected workflow and post-deployment smoke evidence; a
@@ -366,7 +378,7 @@ Code readiness and operational readiness are deliberately separate:
 4. Preview deployment requires the repository's authorization label and
    protected environment approval. The live PR must still be open, non-draft,
    and authorized immediately before deployment.
-5. Preview smoke and a functional audit must cover all eleven tools, the ten
+5. Preview smoke and a functional audit must cover all eleven tools, the eleven
    structured-output contracts, UBS default and explicit-source behavior,
    Strong's extended identities, local primary-source search, language study,
    resources, all six prompts, and failure/privacy boundaries.
@@ -381,6 +393,14 @@ Code readiness and operational readiness are deliberately separate:
 
 ## Next work
 
+- Land the migration-free catalog-capacity prerequisite before either data
+  slice: keep the existing 100-work hard ceiling centralized and use a single
+  D1-safe JSON/`json_each` scope bind while the hosted corpus remains 17 works.
+  After explicit license and vendoring approval, the planned UBS semantic
+  runtime uses migration `0004` and transform 7. Corpus provenance follows in
+  migration `0005` and transform 8 only after a stable canonical section-key
+  compatibility design; current display section numbers are not unique. Keep
+  the existing 32-source provenance cap as a required pack-sizing check.
 - Review a bounded, discovery-only public rollout of the retained CCEL search
   adapter. The owner accepts free, donation-independent discovery with at most
   five attributed 240-character provider snippets and clean links, with no

--- a/scripts/historical-document-catalog.ts
+++ b/scripts/historical-document-catalog.ts
@@ -1,3 +1,5 @@
+import { CLASSIC_TEXT_LIMITS } from '../src/kernel/classicTextContract.js';
+
 export type HistoricalMetadataStatus = 'reviewed' | 'anonymous' | 'collective' | 'unknown';
 
 export const HISTORICAL_CREATOR_ROLES = [
@@ -40,8 +42,9 @@ export function parseHistoricalDocumentCatalog(value: unknown): HistoricalCatalo
   const root = value as Record<string, unknown>;
   assertExactKeys(root, ['schemaVersion', 'lookupAliasPolicy', 'documents'], 'catalog root');
   if (root.schemaVersion !== 3 || root.lookupAliasPolicy !== HISTORICAL_LOOKUP_ALIAS_POLICY
-    || !Array.isArray(root.documents) || root.documents.length !== 17) {
-    throw new Error('Historical-document catalog must contain exactly 17 schema-v3 documents with the exact lookup-only alias policy');
+    || !Array.isArray(root.documents) || root.documents.length < 1
+    || root.documents.length > CLASSIC_TEXT_LIMITS.workCount) {
+    throw new Error(`Historical-document catalog must contain 1..${CLASSIC_TEXT_LIMITS.workCount} schema-v3 documents with the exact lookup-only alias policy`);
   }
   const ids = new Set<string>();
   const aliases = new Set<string>();

--- a/src/adapters/d1/D1HistoricalDocumentRepository.ts
+++ b/src/adapters/d1/D1HistoricalDocumentRepository.ts
@@ -18,6 +18,7 @@ import {
   localPrimarySourceSearchSql,
 } from '../shared/primarySourceSearchSql.js';
 import { mapDocumentDatabaseRow, mapDocumentSectionDatabaseRow } from '../shared/historicalDocumentMetadata.js';
+import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 export class D1HistoricalDocumentRepository implements IHistoricalDocumentRepository {
   constructor(private db: D1Database) {}
@@ -90,7 +91,7 @@ export class D1HistoricalDocumentRepository implements IHistoricalDocumentReposi
     const ftsQuery = composeLocalPrimarySourceFtsQuery(options.text, options.match);
     const statement = this.db.prepare(localPrimarySourceSearchSql(options.selection ?? 'relevance', options.documentIds?.length));
     const bound = options.documentIds
-      ? statement.bind(ftsQuery, ...options.documentIds, options.limit)
+      ? statement.bind(ftsQuery, JSON.stringify(options.documentIds), options.limit)
       : statement.bind(ftsQuery, options.limit);
     const { results } = await bound.all<PrimarySourceSearchDatabaseRow>();
     return results.map(mapPrimarySourceRow);
@@ -139,7 +140,7 @@ function validatePrimarySourceOptions(options: PrimarySourceLocalSearchOptions):
   if (options.selection !== undefined && options.selection !== 'relevance' && options.selection !== 'work_diversity') throw new Error('Primary-source selection is invalid');
   if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 9) throw new Error('Primary-source internal limit must be 1..9');
   if (options.documentIds !== undefined && (!Array.isArray(options.documentIds)
-    || options.documentIds.length < 1 || options.documentIds.length > 17
+    || options.documentIds.length < 1 || options.documentIds.length > CLASSIC_TEXT_LIMITS.workCount
     || options.documentIds.some(id => typeof id !== 'string' || id.length < 1)
     || new Set(options.documentIds).size !== options.documentIds.length)) {
     throw new Error('Primary-source document scope is invalid');

--- a/src/adapters/data/HistoricalDocumentRepository.ts
+++ b/src/adapters/data/HistoricalDocumentRepository.ts
@@ -20,6 +20,7 @@ import {
   localPrimarySourceSearchSql,
 } from '../shared/primarySourceSearchSql.js';
 import { mapDocumentDatabaseRow, mapDocumentSectionDatabaseRow } from '../shared/historicalDocumentMetadata.js';
+import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 export type { DocumentInfo, DocumentSection } from '../../kernel/repositories.js';
 
@@ -120,7 +121,7 @@ export class HistoricalDocumentRepository implements IHistoricalDocumentReposito
       ? this.stmtPrimarySourceSearch
       : this.db.prepare(sql);
     const rows = options.documentIds
-      ? statement.all(ftsQuery, ...options.documentIds, options.limit)
+      ? statement.all(ftsQuery, JSON.stringify(options.documentIds), options.limit)
       : statement.all(ftsQuery, options.limit);
     return (rows as PrimarySourceSearchDatabaseRow[]).map(mapPrimarySourceRow);
   }
@@ -172,7 +173,7 @@ function validatePrimarySourceOptions(options: PrimarySourceLocalSearchOptions):
   if (options.selection !== undefined && options.selection !== 'relevance' && options.selection !== 'work_diversity') throw new Error('Primary-source selection is invalid');
   if (!Number.isSafeInteger(options.limit) || options.limit < 1 || options.limit > 9) throw new Error('Primary-source internal limit must be 1..9');
   if (options.documentIds !== undefined && (!Array.isArray(options.documentIds)
-    || options.documentIds.length < 1 || options.documentIds.length > 17
+    || options.documentIds.length < 1 || options.documentIds.length > CLASSIC_TEXT_LIMITS.workCount
     || options.documentIds.some(id => typeof id !== 'string' || id.length < 1)
     || new Set(options.documentIds).size !== options.documentIds.length)) {
     throw new Error('Primary-source document scope is invalid');

--- a/src/adapters/shared/primarySourceSearchSql.ts
+++ b/src/adapters/shared/primarySourceSearchSql.ts
@@ -1,4 +1,5 @@
 import type { PrimarySourceSearchMatch, PrimarySourceSelection } from '../../services/historical/primarySourceTypes.js';
+import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 export const LOCAL_PRIMARY_SOURCE_SEARCH_SQL = `SELECT ds.id, ds.document_id, ds.section_number, ds.title, ds.content, ds.topics,
        d.title AS document_title, d.type AS document_type, d.date AS document_date, d.metadata AS document_metadata
@@ -11,25 +12,29 @@ export const LOCAL_PRIMARY_SOURCE_SEARCH_SQL = `SELECT ds.id, ds.document_id, ds
 
 export const LOCAL_PRIMARY_SOURCE_WORK_DIVERSE_SEARCH_SQL = workDiverseSql();
 
+// One JSON-array bind keeps scoped searches below D1's 100-parameter ceiling;
+// json_each is available in both Cloudflare D1 and the local SQLite runtime.
 export function localPrimarySourceScopedSearchSql(documentCount: number): string {
-  if (!Number.isSafeInteger(documentCount) || documentCount < 1 || documentCount > 17) {
-    throw new Error('Local primary-source document scope must contain 1..17 documents');
+  if (!Number.isSafeInteger(documentCount) || documentCount < 1 || documentCount > CLASSIC_TEXT_LIMITS.workCount) {
+    throw new Error(`Local primary-source document scope must contain 1..${CLASSIC_TEXT_LIMITS.workCount} documents`);
   }
   return `SELECT ds.id, ds.document_id, ds.section_number, ds.title, ds.content, ds.topics,
        d.title AS document_title, d.type AS document_type, d.date AS document_date, d.metadata AS document_metadata
   FROM sections_fts
   JOIN document_sections ds ON ds.id = sections_fts.rowid
   JOIN documents d ON d.id = ds.document_id
- WHERE sections_fts MATCH ? AND ds.document_id IN (${Array(documentCount).fill('?').join(', ')})
+ WHERE sections_fts MATCH ?
+   AND ds.document_id IN (SELECT value FROM json_each(?) WHERE type = 'text')
  ORDER BY rank, ds.id
  LIMIT ?`;
 }
 
 export function localPrimarySourceWorkDiverseScopedSearchSql(documentCount: number): string {
-  if (!Number.isSafeInteger(documentCount) || documentCount < 1 || documentCount > 17) {
-    throw new Error('Local primary-source document scope must contain 1..17 documents');
+  if (!Number.isSafeInteger(documentCount) || documentCount < 1 || documentCount > CLASSIC_TEXT_LIMITS.workCount) {
+    throw new Error(`Local primary-source document scope must contain 1..${CLASSIC_TEXT_LIMITS.workCount} documents`);
   }
-  return workDiverseSql(` AND ds.document_id IN (${Array(documentCount).fill('?').join(', ')})`);
+  return workDiverseSql(`
+       AND ds.document_id IN (SELECT value FROM json_each(?) WHERE type = 'text')`);
 }
 
 export function localPrimarySourceSearchSql(selection: PrimarySourceSelection, documentCount?: number): string {

--- a/src/mcp/schemas/primarySourceSearch.ts
+++ b/src/mcp/schemas/primarySourceSearch.ts
@@ -1,4 +1,5 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 const status = {
   type: 'string',
@@ -56,7 +57,7 @@ const catalogScope = {
         endYear: { type: 'integer', minimum: -5000, maximum: 3000 },
       }, additionalProperties: false,
     },
-    eligibleDocumentCount: { type: 'integer', minimum: 0, maximum: 17 },
+    eligibleDocumentCount: { type: 'integer', minimum: 0, maximum: CLASSIC_TEXT_LIMITS.workCount },
     eligibleDocuments: {
       type: 'array', maxItems: 8, items: {
         type: 'object', properties: {

--- a/src/mcp/schemas/primarySourceSearchV4.ts
+++ b/src/mcp/schemas/primarySourceSearchV4.ts
@@ -1,4 +1,5 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 const status = {
   type: 'string',
@@ -99,7 +100,7 @@ const catalogScope = {
         endYear: { type: 'integer', minimum: -5000, maximum: 3000 },
       }, additionalProperties: false,
     },
-    eligibleDocumentCount: { type: 'integer', minimum: 0, maximum: 17 },
+    eligibleDocumentCount: { type: 'integer', minimum: 0, maximum: CLASSIC_TEXT_LIMITS.workCount },
     eligibleDocuments: {
       type: 'array', maxItems: 5, items: {
         type: 'object', properties: {

--- a/src/presenters/primarySourceSearchStructured.ts
+++ b/src/presenters/primarySourceSearchStructured.ts
@@ -1,4 +1,5 @@
 import { buildLocalDocumentResourceUri } from '../kernel/documentResource.js';
+import { CLASSIC_TEXT_LIMITS } from '../kernel/classicTextContract.js';
 import type {
   PrimarySourcePlanHit,
   PrimarySourceProviderStatus,
@@ -331,7 +332,8 @@ function aggregateStatus(providers: PresentedPrimarySourceProvider[]): PrimarySo
 
 function presentScope(scope: PrimarySourceSearchPlanResult['queries'][number]['providers'][number]['scope']): PresentedPrimarySourceProvider['scope'] | undefined {
   if (!scope || !['matched', 'catalog_miss', 'metadata_incomplete'].includes(scope.status)
-    || !Number.isSafeInteger(scope.eligibleDocumentCount) || scope.eligibleDocumentCount < 0 || scope.eligibleDocumentCount > 17) return undefined;
+    || !Number.isSafeInteger(scope.eligibleDocumentCount) || scope.eligibleDocumentCount < 0
+    || scope.eligibleDocumentCount > CLASSIC_TEXT_LIMITS.workCount) return undefined;
   const eligibleDocuments = scope.eligibleDocuments.slice(0, 8).flatMap(document => {
     const id = boundedText(document.id, 160);
     const title = boundedText(document.title, 300);

--- a/src/presenters/primarySourceSearchV4Structured.ts
+++ b/src/presenters/primarySourceSearchV4Structured.ts
@@ -1,4 +1,5 @@
 import { buildLocalDocumentResourceUri } from '../kernel/documentResource.js';
+import { CLASSIC_TEXT_LIMITS } from '../kernel/classicTextContract.js';
 import {
   CCEL_COMPOSITION_DATE_NOTICE,
   type PrimarySourcePlanHit,
@@ -367,7 +368,8 @@ function canonicalExternalUrl(value: string): string | undefined {
 
 function presentScope(scope: PrimarySourceSearchPlanResult['queries'][number]['providers'][number]['scope']): PresentedProvider['scope'] | undefined {
   if (!scope || !['matched', 'catalog_miss', 'metadata_incomplete'].includes(scope.status)
-    || !Number.isSafeInteger(scope.eligibleDocumentCount) || scope.eligibleDocumentCount < 0 || scope.eligibleDocumentCount > 17) return undefined;
+    || !Number.isSafeInteger(scope.eligibleDocumentCount) || scope.eligibleDocumentCount < 0
+    || scope.eligibleDocumentCount > CLASSIC_TEXT_LIMITS.workCount) return undefined;
   const eligibleDocuments = scope.eligibleDocuments.slice(0, 5).flatMap(document => {
     const id = boundedText(document.id, 160);
     const title = boundedText(document.title, 300);

--- a/test/unit/adapters/d1/D1HistoricalDocumentRepository.test.ts
+++ b/test/unit/adapters/d1/D1HistoricalDocumentRepository.test.ts
@@ -256,7 +256,9 @@ describe('D1HistoricalDocumentRepository', () => {
       const result = await new D1HistoricalDocumentRepository(db as any).searchPrimarySources({
         text: 'grace OR faith', match: 'all_terms', documentIds: ['nicene-creed'], limit: 8,
       });
-      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('"grace" AND "OR" AND "faith"', 'nicene-creed', 8);
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith(
+        '"grace" AND "OR" AND "faith"', JSON.stringify(['nicene-creed']), 8,
+      );
       expect(result[0]).toMatchObject({
         document: { id: 'nicene-creed', title: 'Nicene Creed', topics: ['trinity', 'christology'] },
         section: { section_number: '1', content: 'We believe in one God...' },
@@ -270,8 +272,40 @@ describe('D1HistoricalDocumentRepository', () => {
       });
       const sql = db.prepare.mock.calls[0][0] as string;
       expect(sql).toMatch(/ROW_NUMBER\(\) OVER \([\s\S]*PARTITION BY document_id/);
-      expect(sql).toMatch(/ds\.document_id IN \(\?\)[\s\S]*ORDER BY work_rank, relevance_rank, id/);
-      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith('"grace"', 'nicene-creed', 9);
+      expect(sql).toMatch(/ds\.document_id IN \(SELECT value FROM json_each\(\?\) WHERE type = 'text'\)[\s\S]*ORDER BY work_rank, relevance_rank, id/);
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith(
+        '"grace"', JSON.stringify(['nicene-creed']), 9,
+      );
+    });
+
+    it('accepts a 100-work scope and rejects 101 works before querying D1', async () => {
+      const db = createSimpleD1([]);
+      const repo = new D1HistoricalDocumentRepository(db as any);
+      const documentIds = Array.from({ length: 100 }, (_, index) => `doc-${index + 1}`);
+
+      await expect(repo.searchPrimarySources({ text: 'grace', match: 'all_terms', documentIds, limit: 8 }))
+        .resolves.toEqual([]);
+      expect((db.prepare.mock.calls[0][0] as string).match(/\?/g)).toHaveLength(3);
+      expect(db.prepare.mock.results[0].value.bind).toHaveBeenCalledWith(
+        '"grace"', JSON.stringify(documentIds), 8,
+      );
+
+      await expect(repo.searchPrimarySources({
+        text: 'grace', match: 'all_terms', selection: 'work_diversity', documentIds, limit: 8,
+      })).resolves.toEqual([]);
+      expect((db.prepare.mock.calls[1][0] as string).match(/\?/g)).toHaveLength(3);
+      expect(db.prepare.mock.results[1].value.bind).toHaveBeenCalledWith(
+        '"grace"', JSON.stringify(documentIds), 8,
+      );
+
+      const preparesBeforeInvalid = db.prepare.mock.calls.length;
+      await expect(repo.searchPrimarySources({
+        text: 'grace', match: 'all_terms', documentIds: [...documentIds, 'doc-101'], limit: 8,
+      })).rejects.toThrow('Primary-source document scope is invalid');
+      await expect(repo.searchPrimarySources({
+        text: 'grace', match: 'all_terms', documentIds: ['doc-1', 42] as unknown as string[], limit: 8,
+      })).rejects.toThrow('Primary-source document scope is invalid');
+      expect(db.prepare).toHaveBeenCalledTimes(preparesBeforeInvalid);
     });
   });
 });

--- a/test/unit/adapters/data/HistoricalDocumentRepository.test.ts
+++ b/test/unit/adapters/data/HistoricalDocumentRepository.test.ts
@@ -123,7 +123,9 @@ describe('HistoricalDocumentRepository', () => {
       document: { id: documentRow.id, title: documentRow.title, type: documentRow.type, date: documentRow.date, topics: ['Scripture', 'God'] },
       section: { id: 7, document_id: documentRow.id, section_number: '1.1', title: '', content: sectionRow.content, topics: ['revelation'] },
     }]);
-    expect(db.statement('AND ds.document_id IN (?)').all).toHaveBeenCalledWith('"grace" AND "OR" AND "faith"', documentRow.id, 8);
+    expect(db.statement('json_each(?)').all).toHaveBeenCalledWith(
+      '"grace" AND "OR" AND "faith"', JSON.stringify([documentRow.id]), 8,
+    );
     repo.searchPrimarySources({ text: 'union with Christ', match: 'phrase', limit: 3 });
     expect(db.statement(/JOIN documents d[\s\S]*ORDER BY rank/).all).toHaveBeenCalledWith('"union with Christ"', 3);
   });
@@ -138,6 +140,33 @@ describe('HistoricalDocumentRepository', () => {
     expect(statement.sql).toMatch(/ROW_NUMBER\(\) OVER \([\s\S]*PARTITION BY document_id[\s\S]*ORDER BY relevance_rank, id/);
     expect(statement.sql).toMatch(/ORDER BY work_rank, relevance_rank, id/);
     expect(statement.all).toHaveBeenCalledWith('"grace"', 9);
+  });
+
+  it('accepts a 100-work primary-source scope and rejects 101 works', () => {
+    const db = new FakeSqliteDatabase([{ match: 'JOIN documents d', all: [] }]);
+    const repo = new HistoricalDocumentRepository(db.asDatabase());
+    const documentIds = Array.from({ length: 100 }, (_, index) => `doc-${index + 1}`);
+
+    expect(repo.searchPrimarySources({ text: 'grace', match: 'all_terms', documentIds, limit: 8 })).toEqual([]);
+    const relevance = db.statement('json_each(?)');
+    expect(relevance.sql.match(/\?/g)).toHaveLength(3);
+    expect(relevance.all).toHaveBeenCalledWith('"grace"', JSON.stringify(documentIds), 8);
+
+    repo.searchPrimarySources({
+      text: 'grace', match: 'all_terms', selection: 'work_diversity', documentIds, limit: 8,
+    });
+    const diverse = db.statement('ranked_sections');
+    expect(diverse.sql.match(/\?/g)).toHaveLength(3);
+    expect(diverse.all).toHaveBeenCalledWith('"grace"', JSON.stringify(documentIds), 8);
+
+    const preparesBeforeInvalid = db.prepare.mock.calls.length;
+    expect(() => repo.searchPrimarySources({
+      text: 'grace', match: 'all_terms', documentIds: [...documentIds, 'doc-101'], limit: 8,
+    })).toThrow('Primary-source document scope is invalid');
+    expect(() => repo.searchPrimarySources({
+      text: 'grace', match: 'all_terms', documentIds: ['doc-1', 42] as unknown as string[], limit: 8,
+    })).toThrow('Primary-source document scope is invalid');
+    expect(db.prepare).toHaveBeenCalledTimes(preparesBeforeInvalid);
   });
 
   it('finds documents by exact id, title fragment, then id fragment', () => {

--- a/test/unit/adapters/repositoryParity.test.ts
+++ b/test/unit/adapters/repositoryParity.test.ts
@@ -259,7 +259,8 @@ describe('SQLite and D1 repository parity with identical real data', () => {
       section: { section_number: '1' },
     });
     const workDiverseOptions = {
-      text: 'one', match: 'all_terms' as const, selection: 'work_diversity' as const, limit: 3,
+      text: 'one', match: 'all_terms' as const, selection: 'work_diversity' as const,
+      documentIds: ['nicene-creed', 'augsburg-confession'], limit: 3,
     };
     const sqliteDiverse = sqliteHistorical.searchPrimarySources(workDiverseOptions);
     await expect(d1Historical.searchPrimarySources(workDiverseOptions)).resolves.toEqual(sqliteDiverse);

--- a/test/unit/adapters/shared/primarySourceSearchSql.test.ts
+++ b/test/unit/adapters/shared/primarySourceSearchSql.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import {
+  localPrimarySourceScopedSearchSql,
+  localPrimarySourceWorkDiverseScopedSearchSql,
+} from '../../../../src/adapters/shared/primarySourceSearchSql.js';
+
+describe('primary-source scoped SQL bounds', () => {
+  it.each([
+    localPrimarySourceScopedSearchSql,
+    localPrimarySourceWorkDiverseScopedSearchSql,
+  ])('accepts 1..100 documents with one JSON scope bind and rejects values outside that bound', buildSql => {
+    const sql = buildSql(100);
+    expect(sql.match(/\?/g)).toHaveLength(3);
+    expect(sql).toContain("ds.document_id IN (SELECT value FROM json_each(?) WHERE type = 'text')");
+    for (const invalid of [0, 101, 1.5, Number.NaN]) {
+      expect(() => buildSql(invalid)).toThrow('1..100 documents');
+    }
+  });
+});

--- a/test/unit/formatters/primarySourceFormatter.test.ts
+++ b/test/unit/formatters/primarySourceFormatter.test.ts
@@ -87,4 +87,26 @@ describe('formatPrimarySourceSearch', () => {
     expect(presented.coverage).not.toHaveProperty('ccelStatus');
     expect(presented.coverage).not.toHaveProperty('ccelHitCount');
   });
+
+  it('preserves a 100-work catalog scope and fails closed at 101', () => {
+    const makeResult = (eligibleDocumentCount: number): PrimarySourceSearchPlanResult => ({
+      planStatus: 'complete',
+      queries: [{ id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [{
+        provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0,
+        resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'no_additional_match_observed' },
+        hits: [], notices: [],
+        scope: {
+          status: 'matched', requested: {}, eligibleDocumentCount,
+          eligibleDocuments: [], eligibleDocumentsTruncated: true,
+        },
+      }] }],
+      coverage: { localAttempted: true, localStatus: 'no_results', localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    });
+
+    expect(presentPrimarySourceSearch(makeResult(100)).queries[0]!.providers[0]!.scope?.eligibleDocumentCount).toBe(100);
+    expect(presentPrimarySourceSearch(makeResult(101)).queries[0]!.providers[0]).toMatchObject({
+      status: 'interface_changed',
+      scope: { status: 'metadata_incomplete', eligibleDocumentCount: 0 },
+    });
+  });
 });

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -17,6 +17,8 @@ import { createDeterministicMcpFixture } from '../../fixtures/mcpCompositionRoot
 import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../../src/kernel/featureFlags.js';
 import { classicTextsOutputSchema } from '../../../src/mcp/schemas/classicTexts.js';
 import { validateClassicTextsOutputSemantics } from '../../../src/presenters/classicTextsStructured.js';
+import { primarySourceSearchOutputSchema } from '../../../src/mcp/schemas/primarySourceSearch.js';
+import { primarySourceSearchV4OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
 
 const connected: Array<{ client: Client; server: Server }> = [];
 type LogMessage = { level: string; logger?: string; data: unknown };
@@ -63,6 +65,61 @@ describe('MCP structured output validation', () => {
     const bytes = new TextEncoder().encode(JSON.stringify(classicTextsOutputSchema)).byteLength;
     expect(bytes).toBeGreaterThan(15_000);
     expect(bytes).toBeLessThanOrEqual(16_384);
+  });
+
+  it.each([
+    ['v3', primarySourceSearchOutputSchema],
+    ['v4', primarySourceSearchV4OutputSchema],
+  ] as const)('accepts 100 eligible works and rejects 101 at the %s output-schema boundary', async (version, outputSchema) => {
+    const structuredContent = (eligibleDocumentCount: number) => ({
+      schemaVersion: version === 'v3' ? '3' : '4',
+      kind: 'primary_source_search',
+      planStatus: 'complete',
+      ...(version === 'v4' ? { responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false } } : {}),
+      queries: [{
+        id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance',
+        providers: [{
+          provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0,
+          resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'no_additional_match_observed' },
+          hits: [], notices: [],
+          scope: {
+            status: 'matched', requested: {}, eligibleDocumentCount,
+            eligibleDocuments: [], eligibleDocumentsTruncated: true,
+          },
+        }],
+      }],
+      coverage: {
+        localAttempted: true, localStatus: 'no_results', localHitCount: 0,
+        ...(version === 'v4' ? { ccelAttempted: false, ccelHitCount: 0 } : {}),
+        notices: [],
+      },
+      evidencePolicy: version === 'v4'
+        ? {
+          snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', externalSectionAccess: 'direct_url_only',
+          coverageScope: 'bounded_non_exhaustive', externalRightsStatus: 'not_determined',
+          lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+        }
+        : {
+          snippetUse: 'discovery_only', selectedSectionAccess: 'mcp_resource_read', coverageScope: 'bounded_non_exhaustive',
+          editionProvenance: 'incomplete', lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+        },
+    });
+    let count = 100;
+    const client = await connect([{
+      name: `primary_scope_${version}`,
+      description: 'Primary-source scope boundary fixture',
+      inputSchema: { type: 'object', additionalProperties: false },
+      outputSchema,
+      handler: async () => ({
+        content: [{ type: 'text' as const, text: 'safe fallback' }],
+        structuredContent: structuredContent(count),
+      }),
+    }]);
+
+    await expect(client.callTool({ name: `primary_scope_${version}`, arguments: {} })).resolves.not.toMatchObject({ isError: true });
+    count = 101;
+    await expect(client.callTool({ name: `primary_scope_${version}`, arguments: {} }))
+      .rejects.toMatchObject({ code: -32603, message: expect.stringContaining('Internal server error') });
   });
 
   it('advertises output schemas for exactly the converted tools', async () => {

--- a/test/unit/presenters/primarySourceSearchV4Structured.test.ts
+++ b/test/unit/presenters/primarySourceSearchV4Structured.test.ts
@@ -127,6 +127,25 @@ describe('primary-source v4 structured presentation', () => {
     expect(provider.notices).not.toContain(CCEL_COMPOSITION_DATE_NOTICE);
   });
 
+  it('preserves a 100-work local scope and rejects 101 as interface drift', () => {
+    const plan = largePlan();
+    plan.queries = [plan.queries[0]!];
+    const provider = plan.queries[0]!.providers[0]!;
+    provider.status = 'no_results';
+    provider.hitCount = 0;
+    provider.hits = [];
+    provider.resultWindow = { returnedHitCount: 0, additionalMatchStatus: 'no_additional_match_observed' };
+    provider.scope!.eligibleDocumentCount = 100;
+    provider.scope!.eligibleDocuments = [];
+    provider.scope!.eligibleDocumentsTruncated = true;
+
+    expect(presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!.scope?.eligibleDocumentCount).toBe(100);
+    provider.scope!.eligibleDocumentCount = 101;
+    const rejected = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    expect(rejected.status).toBe('interface_changed');
+    expect(rejected).not.toHaveProperty('scope');
+  });
+
   it('publishes bounded retry guidance only for a rate-limited external provider', () => {
     const plan = largePlan();
     const external = externalProvider('external', 0) as ReturnType<typeof externalProvider> & { retryAfterSeconds?: number };

--- a/test/unit/scripts/historicalDocumentCatalog.test.ts
+++ b/test/unit/scripts/historicalDocumentCatalog.test.ts
@@ -23,6 +23,27 @@ describe('reviewed historical-document catalog', () => {
     expect(HISTORICAL_LOOKUP_ALIAS_POLICY).toBe('exact_routing_only_not_metadata_evidence');
   });
 
+  it('accepts 1..100 catalog entries and rejects empty or oversized catalogs', () => {
+    const raw = JSON.parse(readFileSync('data/historical-document-catalog.json', 'utf8'));
+    const template = raw.documents[0];
+    const documents = Array.from({ length: 100 }, (_, index) => ({
+      ...structuredClone(template),
+      documentId: `boundary-document-${index + 1}`,
+      lookupAliases: [`Boundary Document ${index + 1}`],
+    }));
+
+    expect(parseHistoricalDocumentCatalog({ ...raw, documents })).toHaveLength(100);
+    expect(() => parseHistoricalDocumentCatalog({ ...raw, documents: [] })).toThrow('1..100');
+    expect(() => parseHistoricalDocumentCatalog({
+      ...raw,
+      documents: [...documents, {
+        ...structuredClone(template),
+        documentId: 'boundary-document-101',
+        lookupAliases: ['Boundary Document 101'],
+      }],
+    })).toThrow('1..100');
+  });
+
   it('keeps uncertainty explicit and never relabels collective roles as authorship', () => {
     expect(catalog.find(entry => entry.documentId === 'apostles-creed')).toMatchObject({
       composition: { label: 'Before the end of the 4th century (present form)' }, creators: [], metadataStatus: 'anonymous',


### PR DESCRIPTION
Summary:
- centralize catalog and primary-source scope capacity on the existing 100-work hard limit
- use one JSON array expanded with json_each for D1-safe scoped filtering
- align Node/D1 repositories, SQL builders, v3/v4 presenters, and v3/v4 output schemas
- reconcile the Phase 3 release ledger and future migration sequence

Invariants:
- current hosted corpus, catalog, provenance, and readiness count remain exactly 17
- no data, migration, schema version, transform, locator, feature flag, workflow, database, or deployment change
- no CCEL request or activation

Verification:
- full unit: 1,649 passed, 1 skipped
- focused review: 110 passed
- integration: 3 passed
- Worker runtime: 24 passed
- Node/Worker typechecks, build, docs, and diff-check passed
- independent code and docs review: GO, no P0-P3 findings

Review note:
The initial 100-ID placeholder approach would have exceeded D1's 100-parameter limit. The reviewed implementation binds the full ID array once through json_each, for exactly three parameters in both selection paths.