### PR TITLE
feat: harden UBS semantic draft contracts

### DIFF
--- a/docs/UBS-SEMANTICS-FOUNDATION.md
+++ b/docs/UBS-SEMANTICS-FOUNDATION.md
@@ -12,14 +12,22 @@ one-to-many `H####`/`A####` identities, senses, lexical domains, and
 source-attested reference evidence as separate records with per-artifact
 provenance. A dictionary reference is evidence about a source sense; it does
 not establish that a local morphology token has that sense. Public output may
-say `exact_context` only when a separately versioned verifier proves both the
-source sense/reference and exact local token alignment. Otherwise output is
-`lexical_candidates` with an explicit reason or `unavailable`.
+say `reference_aligned_source_candidate` only when a separately versioned
+verifier proves both the source sense/reference and exact local token alignment.
+That status still reports a source candidate, not an adjudicated contextual
+meaning. Otherwise output is `lexical_candidates` with an explicit reason or
+`unavailable`.
 
-Internal compilation preserves both `H####` and `A####`. Public Hebrew v1
-exposes only `H####` and explicitly reports that `A####` is withheld from the
-public scope. TBESH `Meaning` remains separately withheld at the rights
-boundary.
+Internal compilation and repository cursors preserve and may query both fixed-
+width `H####` and `A####` source identities. The future public boundary does
+not broaden the shared Strong's parser: a user-facing identity remains the
+existing unpadded `H430`, mapped explicitly to the source/internal `H0430`.
+Repository entry lookup accepts only a validated, branded fixed-width internal
+identity, including on the cursor-free first page; invalid raw strings fail at
+the boundary instead of reaching a future adapter.
+Public Hebrew v1 never accepts or emits `A####`; it explicitly reports that
+those identities are withheld from the public scope. TBESH `Meaning` remains
+separately withheld at the rights boundary.
 
 ## Bounded implementation slices A–H
 
@@ -89,25 +97,53 @@ honest totals, stable ordering, deterministic keyset cursors bound to the exact
 operation, query scope, and semantic artifact identity (preventing replay after
 a corpus or environment change), and no Worker-bundle inclusion of source
 artifacts. The repository returns evidence and candidates; it never resolves a
-contextual token sense.
+contextual token sense. Every page records the count returned by prior pages;
+`prior + showing` may never exceed the honest total, and a continuation is
+present if and only if more rows remain. This makes a short terminal page
+honest instead of comparing the global total only with the current page.
 
 ### G. Structured contract and presentation
 
 Review and version the draft fixture before registering it. Every
-`exact_context` result includes a human-readable definition, glosses, structured
-domain evidence, source-attested reference evidence, and verified token
-alignment. Beginner output always gives a plain-language explanation. Candidate
-output gives an explicit ambiguity reason. Expert provenance retains both exact
-artifact versions, commits, blobs, hashes, modification descriptions, publisher,
-license, and transformation identity.
+`reference_aligned_source_candidate` result includes a human-readable
+definition, glosses, structured domain evidence, source-attested reference
+evidence, and verified token alignment while explicitly denying that this
+settles contextual meaning. Beginner output always gives a plain-language
+explanation. Candidate output gives an explicit ambiguity reason. Expert
+provenance retains both exact artifact versions, commits, blobs, hashes,
+modification descriptions, publisher, license, and transformation identity.
 Public provenance includes each exact HTTPS source URL. Reference evidence
 always carries its exact `sourceId` and `senseId`; an evidence row cannot be
 presented without both identities.
 
-The public identity list is `H####` only. Its exact two-item withholding array
+The public identity boundary labels both forms without conflating them:
+`publicStrongs` uses existing unpadded user syntax such as `H430`, while
+`sourceIdentity` records the matched fixed-width UBS key such as `H0430`.
+Only H identities cross that boundary. Its exact two-item withholding array
 reports both the `A####` public-scope withholding and TBESH `Meaning` rights
 withholding; extra or missing entries fail validation. Neither withheld field
 may be blended into UBS definitions or glosses. Markdown remains compatible.
+
+The inactive draft caps the serialized semantic response at 32 KiB UTF-8 and
+also bounds every definition, gloss, identifier, reference, domain, candidate
+array, and provenance field. Every branch carries an honest result window.
+A continuation is allowed exactly when `hasMore` is true and carries the opaque
+cursor plus its exact operation, artifact identity, public/source identity pair,
+and normalized-reference binding. JSON Schema enforces the structural and field
+bounds only; it cannot enforce relational arithmetic or the total serialized
+byte size. The inactive pure presenter guard separately binds the request,
+top-level identity/reference, continuation, and provenance artifact, validates
+status-specific counts and window arithmetic, and returns the exact serialized
+string after enforcing the 32 KiB UTF-8 cap. Runtime registration and actual
+presentation remain later work. The stronger reference-aligned status also
+requires the output token identity and verifier version to match a trusted
+caller-supplied alignment assertion. That assertion also binds the exact source,
+sense, and evidence-row identities, so a valid token/verifier pair cannot
+authorize swapped semantic evidence. None of those values is trusted merely
+because it appears in the proposed output. One shared bounded normalized-
+reference validator is used by compiler ingestion, repository cursor
+creation/parsing, and the presenter request; it rejects control, format,
+bidirectional, line-separator, noncharacter, and malformed non-scalar Unicode.
 
 ### H. Release and audit
 

--- a/scripts/ubs-semantics/compiler.ts
+++ b/scripts/ubs-semantics/compiler.ts
@@ -3,6 +3,7 @@ import type {
   UbsSemanticDomain,
   UbsSemanticDomainRef,
   UbsSemanticEntry,
+  UbsInternalLexicalIdentity,
   UbsSemanticReferenceEvidence,
   UbsSemanticSense,
   UbsSemanticSource,
@@ -11,6 +12,7 @@ import type {
 import {
   UBS_SEMANTIC_ARTIFACT_VERSION,
   UBS_SEMANTIC_TRANSFORM_VERSION,
+  requireUbsSemanticNormalizedReference,
 } from '../../src/kernel/ubsSemanticDomain.js';
 
 export const UBS_SEMANTIC_INTERMEDIATE_SCHEMA = 'theologai-ubs-semantics-intermediate.synthetic-v1';
@@ -183,7 +185,9 @@ function parseEntries(input: unknown, sourceId: string, domainSourceId: string):
     exactKeys(value, ['entryId', 'sourceOrdinal', 'lemma', 'transliteration', 'partOfSpeech', 'lexicalIdentities', 'senses'], path);
     const entryId = identifier(value.entryId, `${path}.entryId`);
     const lexicalIdentities = stringArray(value.lexicalIdentities, `${path}.lexicalIdentities`)
-      .map((identity, index) => patternString(identity, LEXICAL_IDENTITY, `${path}.lexicalIdentities[${index}]`));
+      .map((identity, index) => patternString(
+        identity, LEXICAL_IDENTITY, `${path}.lexicalIdentities[${index}]`,
+      ) as UbsInternalLexicalIdentity);
     if (lexicalIdentities.length === 0) throw new Error(`${path}.lexicalIdentities must not be empty`);
     unique(lexicalIdentities, `${path} lexical identity`);
     lexicalIdentities.sort(compareCodePoints);
@@ -237,7 +241,10 @@ function parseEntries(input: unknown, sourceId: string, domainSourceId: string):
           senseId: referenceSenseId,
           sourceOrdinal: positiveInteger(reference.sourceOrdinal, `${referencePath}.sourceOrdinal`),
           sourceReference: cleanString(reference.sourceReference, `${referencePath}.sourceReference`),
-          normalizedReference: cleanString(reference.normalizedReference, `${referencePath}.normalizedReference`),
+          normalizedReference: requireUbsSemanticNormalizedReference(
+            reference.normalizedReference,
+            `${referencePath}.normalizedReference`,
+          ),
           evidenceKind: 'source_attested_sense_reference',
         });
       }

--- a/src/kernel/ubsSemanticDomain.ts
+++ b/src/kernel/ubsSemanticDomain.ts
@@ -9,8 +9,88 @@
 export type UbsSemanticLanguage = 'Hebrew';
 export type UbsSemanticPublicLanguage = 'Hebrew';
 export type UbsLexicalIdentityPrefix = 'H' | 'A';
+declare const UBS_INTERNAL_LEXICAL_IDENTITY: unique symbol;
+/** Source/internal identity. A#### never crosses the future public boundary. */
+export type UbsInternalLexicalIdentity = (`${UbsLexicalIdentityPrefix}${string}` & {
+  readonly [UBS_INTERNAL_LEXICAL_IDENTITY]: true;
+});
+export type UbsInternalHebrewLexicalIdentity = UbsInternalLexicalIdentity & `H${string}`;
+/** Existing user-facing Strong's grammar remains unpadded (for example H430). */
+export type UbsPublicHebrewStrongs = `H${number}`;
 export const UBS_SEMANTIC_ARTIFACT_VERSION = '0.9.2' as const;
 export const UBS_SEMANTIC_TRANSFORM_VERSION = 7 as const;
+export const UBS_SEMANTIC_CURSOR_MAX_LENGTH = 4096;
+export const UBS_SEMANTIC_NORMALIZED_REFERENCE_MAX_CHARACTERS = 100;
+
+export const UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS = Object.freeze({
+  responseBytes: 32 * 1024,
+  plainLanguageCharacters: 2_000,
+  definitionCharacters: 20_000,
+  glossCharacters: 1_000,
+  glossesPerSense: 16,
+  domainsPerSense: 16,
+  candidatesPerResponse: 8,
+  identifierCharacters: 128,
+  referenceCharacters: UBS_SEMANTIC_NORMALIZED_REFERENCE_MAX_CHARACTERS,
+  sourceUrlCharacters: 1_000,
+  modificationDescriptionCharacters: 1_000,
+} as const);
+
+export interface UbsPublicHebrewIdentityBoundary {
+  publicStrongs: UbsPublicHebrewStrongs;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+}
+
+/**
+ * Map the existing public Strong's grammar to the fixed-width UBS source key.
+ * This is deliberately Hebrew-only, suffix-free, and limited to the source's
+ * four decimal digits. It does not broaden the shared public Strong's parser.
+ */
+export function parseUbsPublicHebrewIdentity(input: string): UbsPublicHebrewIdentityBoundary | undefined {
+  const match = /^H([0-9]{1,4})$/i.exec(input.trim());
+  if (!match) return undefined;
+  const number = Number(match[1]);
+  if (!Number.isSafeInteger(number) || number < 1) return undefined;
+  return {
+    publicStrongs: `H${number}` as UbsPublicHebrewStrongs,
+    sourceIdentity: requireUbsInternalLexicalIdentity(
+      `H${String(number).padStart(4, '0')}`,
+    ) as UbsInternalHebrewLexicalIdentity,
+  };
+}
+
+export function isUbsInternalLexicalIdentity(value: string): value is UbsInternalLexicalIdentity {
+  return /^[HA](?!0000$)[0-9]{4}$/.test(value);
+}
+
+/** Fail-closed constructor used before an untrusted identity reaches a repository. */
+export function requireUbsInternalLexicalIdentity(value: string): UbsInternalLexicalIdentity {
+  if (!isUbsInternalLexicalIdentity(value)) {
+    throw new Error('UBS semantic repository identity must be a canonical fixed-width H#### or A#### source identity');
+  }
+  return value;
+}
+
+/** Shared fail-closed boundary for every normalized-reference seam. */
+export function requireUbsSemanticNormalizedReference(value: unknown, label = 'UBS semantic normalized reference'): string {
+  if (typeof value !== 'string'
+    || !value
+    || value !== value.trim()
+    || [...value].length > UBS_SEMANTIC_NORMALIZED_REFERENCE_MAX_CHARACTERS
+    || value !== value.normalize('NFC')) {
+    throw new Error(`${label} must be non-empty, trimmed, NFC, and at most ${UBS_SEMANTIC_NORMALIZED_REFERENCE_MAX_CHARACTERS} Unicode characters`);
+  }
+  if (/[\p{Cc}\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/u.test(value)) {
+    throw new Error(`${label} contains a forbidden control, format, bidi, line-separator, or non-scalar character`);
+  }
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if ((codePoint >= 0xfdd0 && codePoint <= 0xfdef) || (codePoint & 0xffff) >= 0xfffe) {
+      throw new Error(`${label} contains a forbidden Unicode noncharacter`);
+    }
+  }
+  return value;
+}
 
 interface UbsSemanticSourceCommonProvenance {
   sourceId: string;
@@ -47,7 +127,7 @@ export interface UbsSemanticEntry {
   transliteration?: string;
   partOfSpeech?: string;
   /** One Hebrew source entry can retain multiple H#### and/or A#### identities. */
-  lexicalIdentities: string[];
+  lexicalIdentities: UbsInternalLexicalIdentity[];
 }
 
 export interface UbsSemanticSense {
@@ -111,6 +191,8 @@ export interface UbsSemanticRepositoryCollection<
   items: T[];
   total: number;
   showing: number;
+  priorShowing: number;
+  consumed: number;
   hasMore: boolean;
   nextCursor?: string;
   order: Order;
@@ -126,30 +208,49 @@ export function createUbsSemanticRepositoryCollection<
   total: number,
   order: Order,
   limit: Limit,
-  continuation?: {
-    nextCursor: string;
-    operation: UbsSemanticPaginatedOperation;
-    artifactIdentity: string;
-    queryScope: readonly string[];
+  page: {
+    /** Number of rows returned by all preceding pages for this exact query. */
+    priorShowing: number;
+    continuation?: {
+      nextCursor: string;
+      operation: UbsSemanticPaginatedOperation;
+      artifactIdentity: string;
+      queryScope: readonly string[];
+    };
   },
 ): UbsSemanticRepositoryCollection<T, Order, Limit> {
   if (!Number.isSafeInteger(limit) || limit <= 0) throw new Error('UBS semantic repository limit must be a positive safe integer');
   if (items.length > limit) throw new Error(`UBS semantic repository returned ${items.length} items above its ${limit}-item cap`);
-  if (!Number.isSafeInteger(total) || total < items.length) {
-    throw new Error('UBS semantic repository total must be a safe integer at least as large as the returned window');
+  if (!Number.isSafeInteger(total) || total < 0) {
+    throw new Error('UBS semantic repository total must be a non-negative safe integer');
+  }
+  if (!Number.isSafeInteger(page.priorShowing) || page.priorShowing < 0) {
+    throw new Error('UBS semantic repository priorShowing must be a non-negative safe integer');
+  }
+  const consumed = page.priorShowing + items.length;
+  if (!Number.isSafeInteger(consumed) || consumed > total) {
+    throw new Error('UBS semantic repository prior and current windows cannot exceed total matches');
+  }
+  const hasMore = consumed < total;
+  const continuation = page.continuation;
+  if (hasMore !== (continuation !== undefined)) {
+    throw new Error('UBS semantic repository continuation must be present if and only if more matches remain');
   }
   if (continuation !== undefined) {
-    if (total <= items.length) throw new Error('UBS semantic repository continuation requires more total matches than the returned page');
     if (CURSOR_OPERATION_CONTRACT[continuation.operation].order !== order) {
       throw new Error('UBS semantic cursor operation does not match the collection order');
     }
-    parseUbsSemanticCursor(
+    const parsedContinuation = parseUbsSemanticCursor(
       continuation.nextCursor, continuation.operation, continuation.artifactIdentity, continuation.queryScope,
     );
+    if (parsedContinuation.priorShowing !== consumed) {
+      throw new Error('UBS semantic continuation prior position must equal the consumed result count');
+    }
     if (items.length === 0) throw new Error('UBS semantic repository cannot continue an empty page');
   }
   return {
-    items: [...items], total, showing: items.length, hasMore: continuation !== undefined, order, limit,
+    items: [...items], total, showing: items.length, priorShowing: page.priorShowing,
+    consumed, hasMore, order, limit,
     ...(continuation === undefined ? {} : { nextCursor: continuation.nextCursor }),
   };
 }
@@ -179,13 +280,17 @@ export function createUbsSemanticCursor(
   artifactIdentity: string,
   queryScope: readonly string[],
   keyset: readonly string[],
+  priorShowing: number,
 ): string {
   const contract = CURSOR_OPERATION_CONTRACT[operation];
   validateArtifactIdentity(artifactIdentity);
   validateOperationCursorValues(operation, queryScope, keyset);
-  const payload = JSON.stringify({ version: 1, operation, order: contract.order, artifactIdentity, queryScope, keyset });
+  validateCursorPriorShowing(priorShowing);
+  const payload = JSON.stringify({
+    version: 1, operation, order: contract.order, artifactIdentity, queryScope, keyset, priorShowing,
+  });
   const cursor = `ubs1_${[...new TextEncoder().encode(payload)].map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
-  if (cursor.length > 4096) throw new Error('UBS semantic cursor exceeds the 4096-character limit');
+  if (cursor.length > UBS_SEMANTIC_CURSOR_MAX_LENGTH) throw new Error('UBS semantic cursor exceeds the 4096-character limit');
   return cursor;
 }
 
@@ -194,9 +299,9 @@ export function parseUbsSemanticCursor(
   expectedOperation: UbsSemanticPaginatedOperation,
   expectedArtifactIdentity: string,
   expectedQueryScope: readonly string[],
-): string[] {
+): { keyset: string[]; priorShowing: number } {
   validateArtifactIdentity(expectedArtifactIdentity);
-  if (cursor.length > 4096) throw new Error('UBS semantic cursor exceeds the 4096-character limit');
+  if (cursor.length > UBS_SEMANTIC_CURSOR_MAX_LENGTH) throw new Error('UBS semantic cursor exceeds the 4096-character limit');
   if (!/^ubs1_(?:[0-9a-f]{2})+$/.test(cursor)) throw new Error('UBS semantic cursor has an invalid encoding');
   const bytes = cursor.slice(5).match(/../g)!.map(byte => Number.parseInt(byte, 16));
   let value: unknown;
@@ -208,26 +313,38 @@ export function parseUbsSemanticCursor(
   if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('UBS semantic cursor payload must be an object');
   const record = value as Record<string, unknown>;
   const contract = CURSOR_OPERATION_CONTRACT[expectedOperation];
-  if (JSON.stringify(Object.keys(record)) !== JSON.stringify(['version', 'operation', 'order', 'artifactIdentity', 'queryScope', 'keyset'])
+  if (JSON.stringify(Object.keys(record)) !== JSON.stringify([
+    'version', 'operation', 'order', 'artifactIdentity', 'queryScope', 'keyset', 'priorShowing',
+  ])
     || record.version !== 1 || record.operation !== expectedOperation || record.order !== contract.order
     || record.artifactIdentity !== expectedArtifactIdentity
     || !Array.isArray(record.queryScope) || !Array.isArray(record.keyset)) {
     throw new Error('UBS semantic cursor does not match the requested operation or semantic artifact');
   }
   validateOperationCursorValues(expectedOperation, record.queryScope, record.keyset);
+  validateCursorPriorShowing(record.priorShowing);
   if (JSON.stringify(record.queryScope) !== JSON.stringify(expectedQueryScope)) {
     throw new Error('UBS semantic cursor does not match the requested query scope');
   }
   const keyset = record.keyset as string[];
-  if (createUbsSemanticCursor(expectedOperation, expectedArtifactIdentity, expectedQueryScope, keyset) !== cursor) {
+  const priorShowing = record.priorShowing as number;
+  if (createUbsSemanticCursor(
+    expectedOperation, expectedArtifactIdentity, expectedQueryScope, keyset, priorShowing,
+  ) !== cursor) {
     throw new Error('UBS semantic cursor is not canonical');
   }
-  return [...keyset];
+  return { keyset: [...keyset], priorShowing };
+}
+
+function validateCursorPriorShowing(value: unknown): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new Error('UBS semantic cursor priorShowing must be a positive safe integer');
+  }
 }
 
 function validateCursorValues(values: readonly unknown[], expectedArity: number, label: string): asserts values is string[] {
   if (values.length !== expectedArity || values.some(value => typeof value !== 'string'
-    || !value || value !== value.trim() || value.length > 512 || /[\u0000-\u001f\u007f]/.test(value))) {
+    || !value || value !== value.trim() || value.length > 512)) {
     throw new Error(`UBS semantic cursor ${label} must contain exactly ${expectedArity} bounded canonical values`);
   }
 }
@@ -252,11 +369,10 @@ function validateOperationCursorValues(
       throw new Error('UBS semantic cursor ordinal is not a canonical positive decimal');
     }
   };
-  const reference = (value: string): void => {
-    if (value !== value.normalize('NFC')) throw new Error('UBS semantic cursor normalized reference must be NFC');
-  };
   if (operation === 'getEntriesByLexicalIdentity') {
-    if (!/^H(?!0000$)[0-9]{4}$/.test(queryScope[0]!)) throw new Error('UBS semantic cursor requires a canonical H#### identity');
+    if (!isUbsInternalLexicalIdentity(queryScope[0]!)) {
+      throw new Error('UBS semantic internal cursor requires a canonical H#### or A#### source identity');
+    }
     id(keyset[0] as string, 'source ID'); ordinal(keyset[1] as string); id(keyset[2] as string, 'entry ID');
   } else if (operation === 'getSensesForEntry') {
     id(queryScope[0]!, 'source ID'); id(queryScope[1]!, 'entry ID');
@@ -266,7 +382,9 @@ function validateOperationCursorValues(
     ordinal(keyset[0] as string); id(keyset[1] as string, 'domain ID');
   } else {
     id(queryScope[0]!, 'source ID'); id(queryScope[1]!, 'sense ID');
-    if (operation === 'findReferenceEvidence') reference(queryScope[2]!);
+    if (operation === 'findReferenceEvidence') {
+      requireUbsSemanticNormalizedReference(queryScope[2], 'UBS semantic cursor normalized reference');
+    }
     ordinal(keyset[0] as string); id(keyset[1] as string, 'evidence ID');
   }
 }
@@ -279,7 +397,7 @@ function validateOperationCursorValues(
 export interface IUbsSemanticRepository {
   getSource(sourceId: string): Promise<UbsSemanticSource | undefined>;
   getEntry(sourceId: string, entryId: string): Promise<UbsSemanticEntry | undefined>;
-  getEntriesByLexicalIdentity(identity: string, page?: UbsSemanticPageRequest): Promise<UbsSemanticRepositoryCollection<
+  getEntriesByLexicalIdentity(identity: UbsInternalLexicalIdentity, page?: UbsSemanticPageRequest): Promise<UbsSemanticRepositoryCollection<
     UbsSemanticEntry,
     typeof UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
     typeof UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity
@@ -320,7 +438,8 @@ export interface UbsLexicalSenseCandidate {
 
 export type UbsSemanticResolution =
   | {
-      status: 'exact_context';
+      /** A source candidate is attested at the reference and aligned locally; it is not an adjudicated meaning. */
+      status: 'reference_aligned_source_candidate';
       sense: UbsSemanticSense;
       domains: UbsSemanticDomain[];
       referenceEvidence: UbsSemanticReferenceEvidence;

--- a/src/kernel/ubsSemanticDraftOutput.ts
+++ b/src/kernel/ubsSemanticDraftOutput.ts
@@ -1,0 +1,233 @@
+/** Inactive, source-free guard for the future UBS semantic output contract. */
+import {
+  UBS_SEMANTIC_CURSOR_MAX_LENGTH,
+  UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS,
+  parseUbsPublicHebrewIdentity,
+  requireUbsSemanticNormalizedReference,
+} from './ubsSemanticDomain.js';
+import type { UbsPublicHebrewIdentityBoundary } from './ubsSemanticDomain.js';
+
+export interface UbsSemanticDraftOutputRequest {
+  publicStrongs: string;
+  normalizedReference: string;
+  artifactIdentity: string;
+  /** Trusted verifier assertion required before the stronger aligned status may be emitted. */
+  expectedAlignment?: {
+    morphologyTokenIdentity: string;
+    verifierVersion: number;
+    sourceId: string;
+    senseId: string;
+    evidenceId: string;
+  };
+}
+
+export function createUbsSemanticDraftContinuationCursor(
+  request: UbsSemanticDraftOutputRequest,
+  priorCount: number,
+): string {
+  const identity = validateUbsSemanticDraftRequest(request);
+  if (!Number.isSafeInteger(priorCount) || priorCount <= 0) {
+    throw new Error('UBS semantic draft continuation priorCount must be a positive safe integer');
+  }
+  const payload = JSON.stringify({
+    version: 1,
+    operation: 'semantic_candidates',
+    artifactIdentity: request.artifactIdentity,
+    publicStrongs: identity.publicStrongs,
+    sourceIdentity: identity.sourceIdentity,
+    normalizedReference: request.normalizedReference,
+    priorCount,
+  });
+  const cursor = `ubs1_${[...new TextEncoder().encode(payload)]
+    .map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
+  if (cursor.length > UBS_SEMANTIC_CURSOR_MAX_LENGTH) {
+    throw new Error('UBS semantic draft continuation exceeds the 4096-character limit');
+  }
+  return cursor;
+}
+
+/**
+ * JSON Schema remains responsible for structural validation. This presenter
+ * guard enforces relational invariants and returns the exact serialization
+ * whose UTF-8 size was checked; callers must emit it rather than reserialize.
+ */
+export function serializeValidatedUbsSemanticDraftOutput(
+  output: unknown,
+  request: UbsSemanticDraftOutputRequest,
+): string {
+  const expectedIdentity = validateUbsSemanticDraftRequest(request);
+  let serialized: string;
+  try {
+    const value = JSON.stringify(output);
+    if (value === undefined) throw new Error('undefined');
+    serialized = value;
+  } catch {
+    throw new Error('UBS semantic draft output must be JSON serializable');
+  }
+  const serializedBytes = new TextEncoder().encode(serialized).byteLength;
+  if (serializedBytes > UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.responseBytes) {
+    throw new Error(`UBS semantic draft output exceeds ${UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.responseBytes} serialized UTF-8 bytes`);
+  }
+
+  const root = draftObject(JSON.parse(serialized), 'output');
+  const status = draftString(root.status, 'output.status');
+  const resultWindow = draftObject(root.resultWindow, 'output.resultWindow');
+  const priorCount = draftInteger(resultWindow.priorCount, 'output.resultWindow.priorCount');
+  const returnedCount = draftInteger(resultWindow.returnedCount, 'output.resultWindow.returnedCount');
+  const consumedCount = draftInteger(resultWindow.consumedCount, 'output.resultWindow.consumedCount');
+  const totalCount = draftInteger(resultWindow.totalCount, 'output.resultWindow.totalCount');
+  const hasMore = resultWindow.hasMore;
+  if (typeof hasMore !== 'boolean') throw new Error('output.resultWindow.hasMore must be boolean');
+  if (priorCount + returnedCount !== consumedCount || consumedCount > totalCount) {
+    throw new Error('UBS semantic draft result window arithmetic is inconsistent');
+  }
+  if (hasMore !== (consumedCount < totalCount)) {
+    throw new Error('UBS semantic draft hasMore must be true if and only if results remain');
+  }
+  const continuation = resultWindow.continuation;
+  if (hasMore !== (continuation !== undefined)) {
+    throw new Error('UBS semantic draft continuation must be present if and only if results remain');
+  }
+  const responseWindow = draftObject(root.responseWindow, 'output.responseWindow');
+  if (responseWindow.unit !== 'utf8_bytes'
+    || responseWindow.maximum !== UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.responseBytes
+    || typeof responseWindow.truncated !== 'boolean') {
+    throw new Error('UBS semantic draft response window does not describe the enforced UTF-8 bound');
+  }
+
+  if (status === 'unavailable') {
+    if (priorCount !== 0 || returnedCount !== 0 || consumedCount !== 0 || totalCount !== 0) {
+      throw new Error('UBS semantic unavailable output must report an empty terminal result window');
+    }
+    return serialized;
+  }
+  if (status !== 'lexical_candidates' && status !== 'reference_aligned_source_candidate') {
+    throw new Error('UBS semantic draft output has an unsupported status');
+  }
+
+  const identity = draftObject(root.identity, 'output.identity');
+  if (identity.publicStrongs !== expectedIdentity.publicStrongs
+    || identity.sourceIdentity !== expectedIdentity.sourceIdentity) {
+    throw new Error('UBS semantic draft public/source identity pair does not match its derived request identity');
+  }
+  if (root.normalizedReference !== request.normalizedReference) {
+    throw new Error('UBS semantic draft normalized reference does not match its request');
+  }
+  const provenance = draftObject(root.provenance, 'output.provenance');
+  const transformation = draftObject(provenance.transformation, 'output.provenance.transformation');
+  if (transformation.artifactIdentity !== request.artifactIdentity) {
+    throw new Error('UBS semantic draft provenance artifact does not match its request');
+  }
+
+  if (status === 'lexical_candidates') {
+    if (!Array.isArray(root.candidates) || returnedCount !== root.candidates.length) {
+      throw new Error('UBS semantic candidate count must equal resultWindow.returnedCount');
+    }
+  } else {
+    if (priorCount !== 0 || returnedCount !== 1 || consumedCount !== 1 || totalCount !== 1 || hasMore) {
+      throw new Error('UBS semantic aligned source candidate must report exactly one terminal item');
+    }
+    const evidence = draftObject(root.referenceEvidence, 'output.referenceEvidence');
+    if (evidence.normalizedReference !== request.normalizedReference || evidence.senseId !== root.senseId) {
+      throw new Error('UBS semantic reference evidence does not match its top-level sense and normalized reference');
+    }
+    const expectedAlignment = request.expectedAlignment;
+    if (expectedAlignment === undefined) {
+      throw new Error('UBS semantic aligned source candidate requires a trusted expected alignment assertion');
+    }
+    const alignment = draftObject(root.alignmentEvidence, 'output.alignmentEvidence');
+    if (alignment.status !== 'verified_token_alignment'
+      || alignment.morphologyTokenIdentity !== expectedAlignment.morphologyTokenIdentity
+      || alignment.verifierVersion !== expectedAlignment.verifierVersion
+      || root.senseId !== expectedAlignment.senseId
+      || evidence.sourceId !== expectedAlignment.sourceId
+      || evidence.senseId !== expectedAlignment.senseId
+      || evidence.evidenceId !== expectedAlignment.evidenceId) {
+      throw new Error('UBS semantic selected sense and evidence do not match the trusted alignment proof identity');
+    }
+  }
+
+  if (continuation !== undefined) {
+    const continuationRecord = draftObject(continuation, 'output.resultWindow.continuation');
+    const query = draftObject(continuationRecord.query, 'output.resultWindow.continuation.query');
+    const expectedCursor = createUbsSemanticDraftContinuationCursor(request, consumedCount);
+    if (continuationRecord.cursor !== expectedCursor
+      || continuationRecord.operation !== 'semantic_candidates'
+      || continuationRecord.artifactIdentity !== request.artifactIdentity
+      || continuationRecord.artifactIdentity !== transformation.artifactIdentity
+      || query.publicStrongs !== expectedIdentity.publicStrongs
+      || query.sourceIdentity !== expectedIdentity.sourceIdentity
+      || query.publicStrongs !== identity.publicStrongs
+      || query.sourceIdentity !== identity.sourceIdentity
+      || query.normalizedReference !== request.normalizedReference
+      || query.normalizedReference !== root.normalizedReference) {
+      throw new Error('UBS semantic continuation is not bound to its request, output, and provenance');
+    }
+  }
+  return serialized;
+}
+
+function validateUbsSemanticDraftRequest(
+  request: UbsSemanticDraftOutputRequest,
+): UbsPublicHebrewIdentityBoundary {
+  const expectedIdentity = parseUbsPublicHebrewIdentity(request.publicStrongs);
+  if (!expectedIdentity || expectedIdentity.publicStrongs !== request.publicStrongs) {
+    throw new Error('UBS semantic draft request publicStrongs must be canonical unpadded H-number public syntax');
+  }
+  requireUbsSemanticNormalizedReference(
+    request.normalizedReference,
+    'UBS semantic draft request normalizedReference',
+  );
+  if (!/^[0-9a-f]{64}$/.test(request.artifactIdentity)) {
+    throw new Error('UBS semantic draft artifact identity must be a lowercase SHA-256');
+  }
+  if (request.expectedAlignment !== undefined) {
+    const tokenIdentity = request.expectedAlignment.morphologyTokenIdentity;
+    if (!tokenIdentity
+      || tokenIdentity !== tokenIdentity.trim()
+      || tokenIdentity !== tokenIdentity.normalize('NFC')
+      || [...tokenIdentity].length > 512
+      || hasHostileUnicode(tokenIdentity)) {
+      throw new Error('UBS semantic draft expected morphology token identity must be non-empty, trimmed, NFC, bounded, and control-free');
+    }
+    if (!Number.isSafeInteger(request.expectedAlignment.verifierVersion)
+      || request.expectedAlignment.verifierVersion < 1
+      || request.expectedAlignment.verifierVersion > 1_000_000) {
+      throw new Error('UBS semantic draft expected verifier version must be a bounded positive safe integer');
+    }
+    for (const [field, value] of [
+      ['sourceId', request.expectedAlignment.sourceId],
+      ['senseId', request.expectedAlignment.senseId],
+      ['evidenceId', request.expectedAlignment.evidenceId],
+    ] as const) {
+      if (!/^[a-z][a-z0-9]*(?:[-_.][a-z0-9]+)*$/.test(value) || value.length > 128) {
+        throw new Error(`UBS semantic draft expected alignment ${field} must be a canonical bounded identifier`);
+      }
+    }
+  }
+  return expectedIdentity;
+}
+
+function hasHostileUnicode(value: string): boolean {
+  if (/[\p{Cc}\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/u.test(value)) return true;
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if ((codePoint >= 0xfdd0 && codePoint <= 0xfdef) || (codePoint & 0xffff) >= 0xfffe) return true;
+  }
+  return false;
+}
+
+function draftObject(value: unknown, path: string): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${path} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function draftString(value: unknown, path: string): string {
+  if (typeof value !== 'string') throw new Error(`${path} must be a string`);
+  return value;
+}
+
+function draftInteger(value: unknown, path: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) throw new Error(`${path} must be a non-negative safe integer`);
+  return value as number;
+}

--- a/test/fixtures/ubs-semantics/structured-output-contract.draft.json
+++ b/test/fixtures/ubs-semantics/structured-output-contract.draft.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "DESIGN FIXTURE ONLY. Hebrew-only public v1; not registered by any MCP tool.",
-  "contractVersion": "ubs-hebrew-semantic-evidence.draft-v1",
+  "$comment": "DESIGN FIXTURE ONLY. Hebrew-only public v1; not registered by any MCP tool. JSON Schema validates structure; the inactive pure presenter guard separately enforces relational bindings, arithmetic, and the serialized UTF-8 byte cap.",
+  "contractVersion": "ubs-hebrew-semantic-evidence.draft-v2",
   "schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
@@ -8,70 +8,82 @@
       {
         "properties": {
           "audience": { "enum": ["beginner", "expert"] },
-          "status": { "const": "exact_context" },
-          "plainLanguage": { "type": "string", "minLength": 1 },
-          "senseId": { "type": "string", "minLength": 1 },
-          "lexicalIdentities": { "$ref": "#/$defs/publicHebrewIdentities" },
+          "status": { "const": "reference_aligned_source_candidate" },
+          "plainLanguage": { "type": "string", "minLength": 1, "maxLength": 2000 },
+          "identity": { "$ref": "#/$defs/publicIdentityBoundary" },
+          "normalizedReference": { "type": "string", "minLength": 1, "maxLength": 100 },
+          "senseId": { "type": "string", "minLength": 1, "maxLength": 128 },
           "meaning": { "$ref": "#/$defs/meaning" },
           "referenceEvidence": { "$ref": "#/$defs/referenceEvidence" },
           "alignmentEvidence": { "$ref": "#/$defs/alignmentEvidence" },
+          "resultWindow": { "$ref": "#/$defs/resultWindow" },
+          "responseWindow": { "$ref": "#/$defs/responseWindow" },
           "withheldEvidence": { "$ref": "#/$defs/withheldEvidence" },
           "provenance": { "$ref": "#/$defs/provenance" }
         },
-        "required": ["audience", "status", "plainLanguage", "senseId", "lexicalIdentities", "meaning", "referenceEvidence", "alignmentEvidence", "withheldEvidence", "provenance"],
+        "required": ["audience", "status", "plainLanguage", "identity", "normalizedReference", "senseId", "meaning", "referenceEvidence", "alignmentEvidence", "resultWindow", "responseWindow", "withheldEvidence", "provenance"],
         "additionalProperties": false
       },
       {
         "properties": {
           "audience": { "enum": ["beginner", "expert"] },
           "status": { "const": "lexical_candidates" },
-          "plainLanguage": { "type": "string", "minLength": 1 },
+          "plainLanguage": { "type": "string", "minLength": 1, "maxLength": 2000 },
           "reason": { "enum": ["no_reference_evidence", "reference_alignment_unproven", "ambiguous_reference_alignment"] },
-          "lexicalIdentities": { "$ref": "#/$defs/publicHebrewIdentities" },
+          "identity": { "$ref": "#/$defs/publicIdentityBoundary" },
+          "normalizedReference": { "type": "string", "minLength": 1, "maxLength": 100 },
           "candidates": {
             "type": "array",
             "minItems": 1,
+            "maxItems": 8,
             "items": {
               "type": "object",
               "properties": {
-                "senseId": { "type": "string", "minLength": 1 },
+                "senseId": { "type": "string", "minLength": 1, "maxLength": 128 },
                 "meaning": { "$ref": "#/$defs/meaning" }
               },
               "required": ["senseId", "meaning"],
               "additionalProperties": false
             }
           },
+          "resultWindow": { "$ref": "#/$defs/resultWindow" },
+          "responseWindow": { "$ref": "#/$defs/responseWindow" },
           "withheldEvidence": { "$ref": "#/$defs/withheldEvidence" },
           "provenance": { "$ref": "#/$defs/provenance" }
         },
-        "required": ["audience", "status", "plainLanguage", "reason", "lexicalIdentities", "candidates", "withheldEvidence", "provenance"],
+        "required": ["audience", "status", "plainLanguage", "reason", "identity", "normalizedReference", "candidates", "resultWindow", "responseWindow", "withheldEvidence", "provenance"],
         "additionalProperties": false
       },
       {
         "properties": {
           "audience": { "enum": ["beginner", "expert"] },
           "status": { "const": "unavailable" },
-          "plainLanguage": { "type": "string", "minLength": 1 },
+          "plainLanguage": { "type": "string", "minLength": 1, "maxLength": 2000 },
           "reason": { "enum": ["no_lexical_entry", "no_publishable_semantic_evidence"] },
+          "resultWindow": { "$ref": "#/$defs/resultWindow" },
+          "responseWindow": { "$ref": "#/$defs/responseWindow" },
           "withheldEvidence": { "$ref": "#/$defs/withheldEvidence" }
         },
-        "required": ["audience", "status", "plainLanguage", "reason", "withheldEvidence"],
+        "required": ["audience", "status", "plainLanguage", "reason", "resultWindow", "responseWindow", "withheldEvidence"],
         "additionalProperties": false
       }
     ],
     "$defs": {
-      "publicHebrewIdentities": {
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "items": { "type": "string", "pattern": "^H(?!0000$)[0-9]{4}$" }
+      "publicIdentityBoundary": {
+        "type": "object",
+        "properties": {
+          "publicStrongs": { "type": "string", "pattern": "^H(?:[1-9][0-9]{0,3})$", "maxLength": 5 },
+          "sourceIdentity": { "type": "string", "pattern": "^H(?!0000$)[0-9]{4}$", "minLength": 5, "maxLength": 5 }
+        },
+        "required": ["publicStrongs", "sourceIdentity"],
+        "additionalProperties": false
       },
       "domainEvidence": {
         "type": "object",
         "properties": {
-          "domainId": { "type": "string", "minLength": 1 },
-          "label": { "type": "string", "minLength": 1 },
-          "description": { "type": "string", "minLength": 1 }
+          "domainId": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "label": { "type": "string", "minLength": 1, "maxLength": 1000 },
+          "description": { "type": "string", "minLength": 1, "maxLength": 5000 }
         },
         "required": ["domainId", "label"],
         "additionalProperties": false
@@ -79,9 +91,9 @@
       "meaning": {
         "type": "object",
         "properties": {
-          "definition": { "type": "string", "minLength": 1 },
-          "glosses": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "minLength": 1 } },
-          "domains": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/domainEvidence" } }
+          "definition": { "type": "string", "minLength": 1, "maxLength": 20000 },
+          "glosses": { "type": "array", "minItems": 1, "maxItems": 16, "uniqueItems": true, "items": { "type": "string", "minLength": 1, "maxLength": 1000 } },
+          "domains": { "type": "array", "minItems": 1, "maxItems": 16, "items": { "$ref": "#/$defs/domainEvidence" } }
         },
         "required": ["definition", "glosses", "domains"],
         "additionalProperties": false
@@ -89,11 +101,11 @@
       "referenceEvidence": {
         "type": "object",
         "properties": {
-          "sourceId": { "type": "string", "minLength": 1 },
-          "senseId": { "type": "string", "minLength": 1 },
-          "evidenceId": { "type": "string", "minLength": 1 },
-          "sourceReference": { "type": "string", "minLength": 1 },
-          "normalizedReference": { "type": "string", "minLength": 1 },
+          "sourceId": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "senseId": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "evidenceId": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "sourceReference": { "type": "string", "minLength": 1, "maxLength": 100 },
+          "normalizedReference": { "type": "string", "minLength": 1, "maxLength": 100 },
           "kind": { "const": "source_attested_sense_reference" }
         },
         "required": ["sourceId", "senseId", "evidenceId", "sourceReference", "normalizedReference", "kind"],
@@ -103,10 +115,69 @@
         "type": "object",
         "properties": {
           "status": { "const": "verified_token_alignment" },
-          "morphologyTokenIdentity": { "type": "string", "minLength": 1 },
-          "verifierVersion": { "type": "integer", "minimum": 1 }
+          "morphologyTokenIdentity": { "type": "string", "minLength": 1, "maxLength": 512 },
+          "verifierVersion": { "type": "integer", "minimum": 1, "maximum": 1000000 }
         },
         "required": ["status", "morphologyTokenIdentity", "verifierVersion"],
+        "additionalProperties": false
+      },
+      "continuation": {
+        "type": "object",
+        "properties": {
+          "cursor": { "type": "string", "minLength": 1, "maxLength": 4096, "pattern": "^ubs1_(?:[0-9a-f]{2})+$" },
+          "operation": { "const": "semantic_candidates" },
+          "artifactIdentity": { "type": "string", "pattern": "^[0-9a-f]{64}$", "minLength": 64, "maxLength": 64 },
+          "query": {
+            "type": "object",
+            "properties": {
+              "publicStrongs": { "type": "string", "pattern": "^H(?:[1-9][0-9]{0,3})$", "maxLength": 5 },
+              "sourceIdentity": { "type": "string", "pattern": "^H(?!0000$)[0-9]{4}$", "minLength": 5, "maxLength": 5 },
+              "normalizedReference": { "type": "string", "minLength": 1, "maxLength": 100 }
+            },
+            "required": ["publicStrongs", "sourceIdentity", "normalizedReference"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["cursor", "operation", "artifactIdentity", "query"],
+        "additionalProperties": false
+      },
+      "resultWindow": {
+        "type": "object",
+        "properties": {
+          "priorCount": { "type": "integer", "minimum": 0, "maximum": 1000000 },
+          "returnedCount": { "type": "integer", "minimum": 0, "maximum": 8 },
+          "consumedCount": { "type": "integer", "minimum": 0, "maximum": 1000000 },
+          "totalCount": { "type": "integer", "minimum": 0, "maximum": 1000000 },
+          "hasMore": { "type": "boolean" },
+          "continuation": { "$ref": "#/$defs/continuation" }
+        },
+        "required": ["priorCount", "returnedCount", "consumedCount", "totalCount", "hasMore"],
+        "oneOf": [
+          {
+            "properties": {
+              "hasMore": { "const": false },
+              "continuation": false
+            },
+            "required": ["hasMore"]
+          },
+          {
+            "properties": {
+              "hasMore": { "const": true },
+              "continuation": { "$ref": "#/$defs/continuation" }
+            },
+            "required": ["hasMore", "continuation"]
+          }
+        ],
+        "additionalProperties": false
+      },
+      "responseWindow": {
+        "type": "object",
+        "properties": {
+          "unit": { "const": "utf8_bytes" },
+          "maximum": { "const": 32768 },
+          "truncated": { "type": "boolean" }
+        },
+        "required": ["unit", "maximum", "truncated"],
         "additionalProperties": false
       },
       "withheldEvidence": {
@@ -143,14 +214,14 @@
           "sourceRole": { "enum": ["dictionary", "lexical_domains"] },
           "artifactName": { "enum": ["UBSHebrewDic-v0.9.2-en.JSON", "UBSHebrewDicLexicalDomains-v0.9.2-en.JSON"] },
           "sourceVersion": { "const": "0.9.2" },
-          "sourceUrl": { "type": "string", "pattern": "^https://" },
+          "sourceUrl": { "type": "string", "pattern": "^https://", "maxLength": 1000 },
           "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "sourceBlob": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
           "sourceSha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
           "publisher": { "const": "United Bible Societies" },
           "license": { "const": "CC BY-SA 4.0" },
           "licenseUrl": { "const": "https://creativecommons.org/licenses/by-sa/4.0/" },
-          "modificationDescription": { "type": "string", "minLength": 1 }
+          "modificationDescription": { "type": "string", "minLength": 1, "maxLength": 1000 }
         },
         "required": ["sourceRole", "artifactName", "sourceVersion", "sourceUrl", "sourceCommit", "sourceBlob", "sourceSha256", "publisher", "license", "licenseUrl", "modificationDescription"],
         "additionalProperties": false
@@ -208,11 +279,14 @@
       }
     }
   },
-  "statusValues": ["exact_context", "lexical_candidates", "unavailable"],
+  "statusValues": ["reference_aligned_source_candidate", "lexical_candidates", "unavailable"],
   "invariants": [
-    "exact_context requires readable definition, gloss, structured domain evidence, source-attested reference evidence, and verified local token alignment",
-    "a lexical identity match alone returns lexical_candidates with an explicit ambiguity reason, never exact_context",
-    "public v1 exposes only H#### identities; A#### identities are retained internally and explicitly withheld",
+    "reference_aligned_source_candidate reports one source candidate attested at the reference and separately aligned to the local token; it does not claim that the source adjudicates contextual meaning",
+    "a lexical identity match alone returns lexical_candidates with an explicit ambiguity reason, never reference_aligned_source_candidate",
+    "public/user identity remains unpadded H430 while source/internal identity is H0430; A#### identities are retained internally and explicitly withheld",
+    "a continuation is present if and only if resultWindow.hasMore is true and is bound to the exact operation, artifact identity, public/source identity pair, and normalized reference",
+    "resultWindow requires priorCount + returnedCount = consumedCount <= totalCount, and hasMore is true if and only if consumedCount is less than totalCount",
+    "the serialized UTF-8 response is capped at responseWindow.maximum and every field/item cap is independently enforced",
     "TBESH Meaning is withheld and never copied into a definition, gloss, or fallback"
   ],
   "beginnerExample": {
@@ -220,7 +294,8 @@
     "status": "lexical_candidates",
     "plainLanguage": "This Hebrew word has more than one possible dictionary sense, and the available evidence does not prove which one applies here.",
     "reason": "reference_alignment_unproven",
-    "lexicalIdentities": ["H0001"],
+    "identity": { "publicStrongs": "H1", "sourceIdentity": "H0001" },
+    "normalizedReference": "Synthetic 1:1",
     "candidates": [
       {
         "senseId": "synthetic-sense-one",
@@ -233,6 +308,24 @@
         }
       }
     ],
+    "resultWindow": {
+      "priorCount": 0,
+      "returnedCount": 1,
+      "consumedCount": 1,
+      "totalCount": 2,
+      "hasMore": true,
+      "continuation": {
+        "cursor": "ubs1_7b2276657273696f6e223a312c226f7065726174696f6e223a2273656d616e7469635f63616e64696461746573222c2261727469666163744964656e74697479223a2237373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737222c227075626c69635374726f6e6773223a224831222c22736f757263654964656e74697479223a224830303031222c226e6f726d616c697a65645265666572656e6365223a2253796e74686574696320313a31222c227072696f72436f756e74223a317d",
+        "operation": "semantic_candidates",
+        "artifactIdentity": "7777777777777777777777777777777777777777777777777777777777777777",
+        "query": {
+          "publicStrongs": "H1",
+          "sourceIdentity": "H0001",
+          "normalizedReference": "Synthetic 1:1"
+        }
+      }
+    },
+    "responseWindow": { "unit": "utf8_bytes", "maximum": 32768, "truncated": false },
     "withheldEvidence": [
       { "source": "TBESH", "field": "Meaning", "status": "withheld_rights_boundary" },
       { "source": "UBS Hebrew dictionary", "field": "A#### lexical identities", "status": "withheld_public_v1_scope" }
@@ -275,10 +368,11 @@
   },
   "expertExample": {
     "audience": "expert",
-    "status": "exact_context",
-    "plainLanguage": "The source sense is attested at this reference and separately aligned to this exact local morphology token.",
+    "status": "reference_aligned_source_candidate",
+    "plainLanguage": "This source candidate is attested at the reference and separately aligned to the local morphology token; that evidence does not by itself settle the word's contextual meaning.",
     "senseId": "synthetic-sense-one",
-    "lexicalIdentities": ["H0001"],
+    "identity": { "publicStrongs": "H1", "sourceIdentity": "H0001" },
+    "normalizedReference": "Synthetic 1:1",
     "meaning": {
       "definition": "SYNTHETIC DEFINITION — NOT UBS CONTENT",
       "glosses": ["SYNTHETIC GLOSS"],
@@ -303,6 +397,8 @@
       "morphologyTokenIdentity": "synthetic-token-1",
       "verifierVersion": 1
     },
+    "resultWindow": { "priorCount": 0, "returnedCount": 1, "consumedCount": 1, "totalCount": 1, "hasMore": false },
+    "responseWindow": { "unit": "utf8_bytes", "maximum": 32768, "truncated": false },
     "withheldEvidence": [
       { "source": "TBESH", "field": "Meaning", "status": "withheld_rights_boundary" },
       { "source": "UBS Hebrew dictionary", "field": "A#### lexical identities", "status": "withheld_public_v1_scope" }

--- a/test/unit/kernel/ubsSemanticDomain.test.ts
+++ b/test/unit/kernel/ubsSemanticDomain.test.ts
@@ -4,13 +4,19 @@ import {
   UBS_SEMANTIC_REPOSITORY_ORDER,
   createUbsSemanticCursor,
   createUbsSemanticRepositoryCollection,
+  isUbsInternalLexicalIdentity,
+  parseUbsPublicHebrewIdentity,
   parseUbsSemanticCursor,
+  requireUbsInternalLexicalIdentity,
+  requireUbsSemanticNormalizedReference,
 } from '../../../src/kernel/ubsSemanticDomain.js';
 import type {
   IUbsSemanticRepository,
+  UbsInternalLexicalIdentity,
   UbsSemanticResolution,
   UbsSemanticSource,
 } from '../../../src/kernel/ubsSemanticDomain.js';
+import { parseStrongsIdentity } from '../../../src/kernel/strongs.js';
 
 describe('UBS semantic domain contract', () => {
   const artifactIdentity = 'a'.repeat(64);
@@ -21,6 +27,8 @@ describe('UBS semantic domain contract', () => {
       .returns.toEqualTypeOf<Promise<Awaited<ReturnType<IUbsSemanticRepository['getEntriesByLexicalIdentity']>>>>();
     expectTypeOf<IUbsSemanticRepository['findReferenceEvidence']>()
       .returns.toEqualTypeOf<Promise<Awaited<ReturnType<IUbsSemanticRepository['findReferenceEvidence']>>>>();
+    expectTypeOf<Parameters<IUbsSemanticRepository['getEntriesByLexicalIdentity']>[0]>()
+      .toEqualTypeOf<UbsInternalLexicalIdentity>();
   });
 
   it('shares explicit bounded deterministic repository contracts', () => {
@@ -46,72 +54,165 @@ describe('UBS semantic domain contract', () => {
       artifactIdentity,
       ['H0001'],
       ['synthetic-source', '2', 'synthetic-entry'],
+      2,
     );
     const result = createUbsSemanticRepositoryCollection(
       ['first', 'second'], 3,
       UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
       UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
-      { nextCursor, operation: 'getEntriesByLexicalIdentity', artifactIdentity, queryScope: ['H0001'] },
+      { priorShowing: 0, continuation: {
+        nextCursor, operation: 'getEntriesByLexicalIdentity', artifactIdentity, queryScope: ['H0001'],
+      } },
     );
-    expect(result).toMatchObject({ showing: 2, total: 3, hasMore: true, limit: 16, nextCursor });
+    expect(result).toMatchObject({ showing: 2, priorShowing: 0, consumed: 2, total: 3, hasMore: true, limit: 16, nextCursor });
     expect(() => createUbsSemanticRepositoryCollection(
       Array.from({ length: 17 }, (_, index) => index), 17,
       UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
       UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+      { priorShowing: 0 },
     )).toThrow('above its 16-item cap');
     expect(() => createUbsSemanticRepositoryCollection(
       ['first', 'second'], 1,
       UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
       UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
-    )).toThrow('at least as large as the returned window');
+      { priorShowing: 0 },
+    )).toThrow('cannot exceed total matches');
+    expect(() => createUbsSemanticRepositoryCollection(
+      ['first'], 2,
+      UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+      { priorShowing: 0 },
+    )).toThrow('if and only if more matches remain');
+    expect(() => createUbsSemanticRepositoryCollection(
+      ['last'], 2,
+      UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+      { priorShowing: 1, continuation: {
+        nextCursor, operation: 'getEntriesByLexicalIdentity', artifactIdentity, queryScope: ['H0001'],
+      } },
+    )).toThrow('if and only if more matches remain');
+    const wrongPositionCursor = createUbsSemanticCursor(
+      'getEntriesByLexicalIdentity', artifactIdentity, ['H0001'],
+      ['synthetic-source', '1', 'synthetic-entry'], 1,
+    );
+    expect(() => createUbsSemanticRepositoryCollection(
+      ['first', 'second'], 3,
+      UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+      { priorShowing: 0, continuation: {
+        nextCursor: wrongPositionCursor,
+        operation: 'getEntriesByLexicalIdentity', artifactIdentity, queryScope: ['H0001'],
+      } },
+    )).toThrow('prior position');
   });
 
   it('round-trips deterministic order-bound cursors and makes continuation explicit', () => {
     const order = UBS_SEMANTIC_REPOSITORY_ORDER.referenceEvidencePerSense;
     const query = ['synthetic-source', 'synthetic-sense'];
     const keyset = ['7', 'synthetic-evidence'];
-    const first = createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, keyset);
-    const second = createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, keyset);
+    const first = createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, keyset, 7);
+    const second = createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, keyset, 7);
     expect(first).toBe(second);
-    expect(parseUbsSemanticCursor(first, 'getReferenceEvidenceForSense', artifactIdentity, query)).toEqual(keyset);
+    expect(parseUbsSemanticCursor(first, 'getReferenceEvidenceForSense', artifactIdentity, query))
+      .toEqual({ keyset, priorShowing: 7 });
     expect(() => parseUbsSemanticCursor(first, 'getReferenceEvidenceForSense', artifactIdentity, ['synthetic-source', 'other-sense']))
       .toThrow('query scope');
     expect(() => parseUbsSemanticCursor(first, 'findReferenceEvidence', artifactIdentity, [...query, 'Synthetic 1:1']))
       .toThrow('requested operation');
     expect(() => parseUbsSemanticCursor(first, 'getReferenceEvidenceForSense', 'b'.repeat(64), query))
       .toThrow('semantic artifact');
-    expect(() => createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, ['only-one']))
+    expect(() => createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, ['only-one'], 7))
       .toThrow('exactly 2');
-    expect(() => createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, ['7', 'x'.repeat(513)]))
+    expect(() => createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, ['7', 'x'.repeat(513)], 7))
       .toThrow('bounded canonical values');
+    expect(() => createUbsSemanticCursor('getReferenceEvidenceForSense', artifactIdentity, query, keyset, 0))
+      .toThrow('positive safe integer');
     expect(() => parseUbsSemanticCursor(`${first}00`.padEnd(4097, '0'), 'getReferenceEvidenceForSense', artifactIdentity, query))
       .toThrow('4096-character limit');
     expect(() => parseUbsSemanticCursor(first.replace(/[a-f]/, match => match.toUpperCase()), 'getReferenceEvidenceForSense', artifactIdentity, query))
       .toThrow('invalid encoding');
     expect(createUbsSemanticRepositoryCollection(
       ['last'], 3, order, UBS_SEMANTIC_REPOSITORY_LIMITS.referenceEvidencePerSense,
-    )).toMatchObject({ hasMore: false });
+      { priorShowing: 2 },
+    )).toMatchObject({ showing: 1, priorShowing: 2, consumed: 3, total: 3, hasMore: false });
+    expect(createUbsSemanticRepositoryCollection(
+      [], 0, order, UBS_SEMANTIC_REPOSITORY_LIMITS.referenceEvidencePerSense,
+      { priorShowing: 0 },
+    )).toMatchObject({ showing: 0, consumed: 0, total: 0, hasMore: false });
+  });
+
+  it('separates public Hebrew Strong\'s identities from internal H/A source identities', () => {
+    expect(parseUbsPublicHebrewIdentity('H430')).toEqual({ publicStrongs: 'H430', sourceIdentity: 'H0430' });
+    expect(parseUbsPublicHebrewIdentity('h0430')).toEqual({ publicStrongs: 'H430', sourceIdentity: 'H0430' });
+    for (const unavailable of ['A0001', 'G430', 'H430A', 'H0000', 'H10000']) {
+      expect(parseUbsPublicHebrewIdentity(unavailable)).toBeUndefined();
+    }
+    expect(isUbsInternalLexicalIdentity('H0430')).toBe(true);
+    expect(isUbsInternalLexicalIdentity('A0001')).toBe(true);
+    expect(isUbsInternalLexicalIdentity('H430')).toBe(false);
+    expect(parseStrongsIdentity('A0001')).toBeUndefined();
+    expect(requireUbsInternalLexicalIdentity('H0430')).toBe('H0430');
+    expect(requireUbsInternalLexicalIdentity('A0001')).toBe('A0001');
+    for (const invalidFirstPageIdentity of ['H430', 'h0430', 'A1', 'G0430', 'H0000', 'A0000', 'H10000']) {
+      expect(() => requireUbsInternalLexicalIdentity(invalidFirstPageIdentity))
+        .toThrow('canonical fixed-width H#### or A####');
+    }
   });
 
   it('enforces operation-specific canonical cursor fields at creation and roundtrip', () => {
-    expect(() => createUbsSemanticCursor('getEntriesByLexicalIdentity', artifactIdentity, ['A0001'], ['source', '1', 'entry']))
-      .toThrow('canonical H####');
-    expect(() => createUbsSemanticCursor('getSensesForEntry', artifactIdentity, ['Source', 'entry'], ['1', 'sense']))
+    const internalA = createUbsSemanticCursor(
+      'getEntriesByLexicalIdentity', artifactIdentity, ['A0001'], ['source', '1', 'entry'], 1,
+    );
+    expect(parseUbsSemanticCursor(internalA, 'getEntriesByLexicalIdentity', artifactIdentity, ['A0001']))
+      .toEqual({ keyset: ['source', '1', 'entry'], priorShowing: 1 });
+    expect(() => createUbsSemanticCursor('getEntriesByLexicalIdentity', artifactIdentity, ['G0001'], ['source', '1', 'entry'], 1))
+      .toThrow('H#### or A####');
+    expect(() => createUbsSemanticCursor('getSensesForEntry', artifactIdentity, ['Source', 'entry'], ['1', 'sense'], 1))
       .toThrow('canonical identifier');
-    expect(() => createUbsSemanticCursor('getSensesForEntry', artifactIdentity, ['source', 'entry'], ['007', 'sense']))
+    expect(() => createUbsSemanticCursor('getSensesForEntry', artifactIdentity, ['source', 'entry'], ['007', 'sense'], 1))
       .toThrow('canonical positive decimal');
     const decomposed = 'Synthetic e\u0301 1:1';
     expect(() => createUbsSemanticCursor(
-      'findReferenceEvidence', artifactIdentity, ['source', 'sense', decomposed], ['1', 'evidence'],
-    )).toThrow('must be NFC');
-    expect(() => createUbsSemanticCursor(
-      'findReferenceEvidence', artifactIdentity, ['s'.repeat(512), 'n'.repeat(512), 'x'.repeat(512)], ['1', 'e'.repeat(512)],
-    )).toThrow('4096-character limit');
+      'findReferenceEvidence', artifactIdentity, ['source', 'sense', decomposed], ['1', 'evidence'], 1,
+    )).toThrow(/trimmed, NFC/);
+    const maximumBoundedCursor = createUbsSemanticCursor(
+      'findReferenceEvidence', artifactIdentity, ['s'.repeat(512), 'n'.repeat(512), 'x'.repeat(100)], ['1', 'e'.repeat(512)], 1,
+    );
+    expect(maximumBoundedCursor.length).toBeLessThanOrEqual(4096);
   });
 
-  it('requires verified token alignment in the exact-context branch', () => {
-    type Exact = Extract<UbsSemanticResolution, { status: 'exact_context' }>;
-    expectTypeOf<Exact['alignmentEvidence']['status']>().toEqualTypeOf<'verified_token_alignment'>();
-    expectTypeOf<Exact>().toHaveProperty('referenceEvidence');
+  it('uses one hostile-Unicode normalized-reference boundary at cursor creation and parsing', () => {
+    expect(requireUbsSemanticNormalizedReference('Synthetic 1:1')).toBe('Synthetic 1:1');
+    for (const hostileReference of [
+      'Synthetic\u0000 1:1', 'Synthetic\u0085 1:1', 'Synthetic\u202e 1:1',
+      'Synthetic\u200b 1:1', 'Synthetic\ud800 1:1', 'Synthetic\u2028 1:1',
+      `Synthetic${String.fromCodePoint(0x10ffff)} 1:1`,
+    ]) {
+      expect(() => createUbsSemanticCursor(
+        'findReferenceEvidence', artifactIdentity,
+        ['synthetic-source', 'synthetic-sense', hostileReference], ['1', 'synthetic-evidence'], 1,
+      )).toThrow(/forbidden control|forbidden Unicode noncharacter/);
+    }
+
+    const valid = createUbsSemanticCursor(
+      'findReferenceEvidence', artifactIdentity,
+      ['synthetic-source', 'synthetic-sense', 'Synthetic 1:1'], ['1', 'synthetic-evidence'], 1,
+    );
+    const payload = JSON.parse(new TextDecoder().decode(new Uint8Array(
+      valid.slice(5).match(/../g)!.map(byte => Number.parseInt(byte, 16)),
+    ))) as { queryScope: string[] };
+    payload.queryScope[2] = 'Synthetic\u202e 1:1';
+    const hostileCursor = `ubs1_${[...new TextEncoder().encode(JSON.stringify(payload))]
+      .map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
+    expect(() => parseUbsSemanticCursor(
+      hostileCursor, 'findReferenceEvidence', artifactIdentity,
+      ['synthetic-source', 'synthetic-sense', 'Synthetic\u202e 1:1'],
+    )).toThrow(/forbidden control/);
+  });
+
+  it('requires verified token alignment without claiming an adjudicated contextual meaning', () => {
+    type Aligned = Extract<UbsSemanticResolution, { status: 'reference_aligned_source_candidate' }>;
+    expectTypeOf<Aligned['alignmentEvidence']['status']>().toEqualTypeOf<'verified_token_alignment'>();
+    expectTypeOf<Aligned>().toHaveProperty('referenceEvidence');
   });
 });

--- a/test/unit/scripts/ubsSemanticCompiler.test.ts
+++ b/test/unit/scripts/ubsSemanticCompiler.test.ts
@@ -152,6 +152,20 @@ describe('source-free Hebrew UBS semantic compiler skeleton', () => {
     expect(() => compile(input)).toThrow();
   });
 
+  it.each([
+    'Synthetic\u0000 1:1',
+    'Synthetic\u0085 1:1',
+    'Synthetic\u202e 1:1',
+    'Synthetic\u200b 1:1',
+    'Synthetic\ud800 1:1',
+    'Synthetic\u2028 1:1',
+    `Synthetic${String.fromCodePoint(0x10ffff)} 1:1`,
+  ])('rejects hostile normalized-reference input at compiler ingestion: %j', normalizedReference => {
+    const input = fixture();
+    input.entries[0].senses[0].references[0].normalizedReference = normalizedReference;
+    expect(() => compile(input)).toThrow(/normalizedReference/);
+  });
+
   it('requires exactly one dictionary and one lexical-domain source', () => {
     const missing = fixture(); missing.sources.pop();
     expect(() => compile(missing)).toThrow('exactly the dictionary and lexical-domain artifacts');

--- a/test/unit/scripts/ubsSemanticDesignGuards.test.ts
+++ b/test/unit/scripts/ubsSemanticDesignGuards.test.ts
@@ -2,6 +2,13 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import Ajv2020 from 'ajv/dist/2020.js';
 import Database from 'better-sqlite3';
+import {
+  UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS,
+} from '../../../src/kernel/ubsSemanticDomain.js';
+import {
+  createUbsSemanticDraftContinuationCursor,
+  serializeValidatedUbsSemanticDraftOutput,
+} from '../../../src/kernel/ubsSemanticDraftOutput.js';
 
 const repo = new URL('../../../', import.meta.url);
 
@@ -89,22 +96,55 @@ describe('source-free UBS semantic design guards', () => {
   it('keeps the draft output honest for beginners and experts', () => {
     const contract = JSON.parse(readFileSync(new URL('test/fixtures/ubs-semantics/structured-output-contract.draft.json', repo), 'utf8')) as any;
     expect(contract.$comment).toContain('DESIGN FIXTURE ONLY');
-    expect(contract.statusValues).toEqual(['exact_context', 'lexical_candidates', 'unavailable']);
+    expect(contract.statusValues).toEqual(['reference_aligned_source_candidate', 'lexical_candidates', 'unavailable']);
     expect(contract.invariants.join(' ')).toContain('TBESH Meaning is withheld');
     expect(contract.beginnerExample.status).toBe('lexical_candidates');
-    expect(contract.expertExample.status).toBe('exact_context');
+    expect(contract.expertExample.status).toBe('reference_aligned_source_candidate');
     expect(contract.expertExample.alignmentEvidence.status).toBe('verified_token_alignment');
     expect(contract.expertExample.referenceEvidence).toMatchObject({
       sourceId: 'synthetic-hebrew-dictionary',
       senseId: contract.expertExample.senseId,
     });
     const validate = new Ajv2020({ strict: true }).compile(contract.schema);
+    const request = {
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1',
+      artifactIdentity: contract.expertExample.provenance.transformation.artifactIdentity,
+      expectedAlignment: {
+        morphologyTokenIdentity: 'synthetic-token-1', verifierVersion: 1,
+        sourceId: 'synthetic-hebrew-dictionary', senseId: 'synthetic-sense-one',
+        evidenceId: 'synthetic-reference-one',
+      },
+    };
     expect(validate(contract.beginnerExample), validate.errors?.map((error: any) => error.message).join('; ')).toBe(true);
     expect(validate(contract.expertExample), validate.errors?.map((error: any) => error.message).join('; ')).toBe(true);
+    expect(serializeValidatedUbsSemanticDraftOutput(contract.beginnerExample, request))
+      .toBe(JSON.stringify(contract.beginnerExample));
+    expect(serializeValidatedUbsSemanticDraftOutput(contract.expertExample, request))
+      .toBe(JSON.stringify(contract.expertExample));
     expect(contract.beginnerExample.reason).toBe('reference_alignment_unproven');
     expect(contract.expertExample.meaning.domains[0].label).toBeTruthy();
-    expect(contract.expertExample.lexicalIdentities).toEqual(['H0001']);
-    expect(JSON.stringify(contract.expertExample.lexicalIdentities)).not.toContain('A0001');
+    expect(contract.expertExample.identity).toEqual({ publicStrongs: 'H1', sourceIdentity: 'H0001' });
+    expect(JSON.stringify(contract.expertExample.identity)).not.toContain('A0001');
+    expect(contract.beginnerExample.resultWindow).toMatchObject({
+      priorCount: 0, returnedCount: 1, consumedCount: 1, totalCount: 2, hasMore: true,
+    });
+    expect(contract.beginnerExample.resultWindow.continuation).toMatchObject({
+      operation: 'semantic_candidates', artifactIdentity: contract.beginnerExample.provenance.transformation.artifactIdentity,
+      query: { publicStrongs: 'H1', sourceIdentity: 'H0001', normalizedReference: 'Synthetic 1:1' },
+    });
+    expect(contract.beginnerExample.resultWindow.continuation.cursor)
+      .toBe(createUbsSemanticDraftContinuationCursor(request, 1));
+    expect(contract.expertExample.resultWindow).toEqual({
+      priorCount: 0, returnedCount: 1, consumedCount: 1, totalCount: 1, hasMore: false,
+    });
+    for (const example of [contract.beginnerExample, contract.expertExample]) {
+      expect(example.resultWindow.priorCount + example.resultWindow.returnedCount)
+        .toBe(example.resultWindow.consumedCount);
+      expect(example.resultWindow.hasMore)
+        .toBe(example.resultWindow.consumedCount < example.resultWindow.totalCount);
+      expect(Buffer.byteLength(JSON.stringify(example), 'utf8')).toBeLessThanOrEqual(UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.responseBytes);
+      expect(example.responseWindow).toEqual({ unit: 'utf8_bytes', maximum: 32768, truncated: false });
+    }
     expect(contract.expertExample.withheldEvidence).toEqual([
       { source: 'TBESH', field: 'Meaning', status: 'withheld_rights_boundary' },
       { source: 'UBS Hebrew dictionary', field: 'A#### lexical identities', status: 'withheld_public_v1_scope' },
@@ -121,6 +161,32 @@ describe('source-free UBS semantic design guards', () => {
     expect(validate(noPlainLanguage)).toBe(false);
     const noReason = structuredClone(contract.beginnerExample); delete noReason.reason;
     expect(validate(noReason)).toBe(false);
+    const publicPadding = structuredClone(contract.expertExample); publicPadding.identity.publicStrongs = 'H0001';
+    expect(validate(publicPadding)).toBe(false);
+    const publicA = structuredClone(contract.expertExample); publicA.identity.sourceIdentity = 'A0001';
+    expect(validate(publicA)).toBe(false);
+    const missingContinuation = structuredClone(contract.beginnerExample); delete missingContinuation.resultWindow.continuation;
+    expect(validate(missingContinuation)).toBe(false);
+    const terminalContinuation = structuredClone(contract.expertExample);
+    terminalContinuation.resultWindow.continuation = contract.beginnerExample.resultWindow.continuation;
+    expect(validate(terminalContinuation)).toBe(false);
+    const oversizedPlainLanguage = structuredClone(contract.expertExample);
+    oversizedPlainLanguage.plainLanguage = 'x'.repeat(UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.plainLanguageCharacters + 1);
+    expect(validate(oversizedPlainLanguage)).toBe(false);
+    const tooManyCandidates = structuredClone(contract.beginnerExample);
+    tooManyCandidates.candidates = Array.from(
+      { length: UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.candidatesPerResponse + 1 },
+      () => structuredClone(contract.beginnerExample.candidates[0]),
+    );
+    expect(validate(tooManyCandidates)).toBe(false);
+    const oversizedDefinition = structuredClone(contract.expertExample);
+    oversizedDefinition.meaning.definition = 'x'.repeat(UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.definitionCharacters + 1);
+    expect(validate(oversizedDefinition)).toBe(false);
+    const tooManyGlosses = structuredClone(contract.expertExample);
+    tooManyGlosses.meaning.glosses = Array.from(
+      { length: UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.glossesPerSense + 1 }, (_, index) => `gloss-${index}`,
+    );
+    expect(validate(tooManyGlosses)).toBe(false);
     const wrongSourcePair = structuredClone(contract.expertExample);
     wrongSourcePair.provenance.sources.reverse();
     expect(validate(wrongSourcePair)).toBe(false);
@@ -140,6 +206,151 @@ describe('source-free UBS semantic design guards', () => {
     delete missingEvidenceIdentity.referenceEvidence.senseId;
     expect(validate(missingEvidenceIdentity)).toBe(false);
     expect(contract.expertExample.provenance.transformation.artifactIdentity).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('guards relational and serialized-byte invariants that JSON Schema cannot express', () => {
+    const contract = JSON.parse(readFileSync(new URL('test/fixtures/ubs-semantics/structured-output-contract.draft.json', repo), 'utf8')) as any;
+    const validate = new Ajv2020({ strict: true }).compile(contract.schema);
+    const request = {
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1',
+      artifactIdentity: contract.beginnerExample.provenance.transformation.artifactIdentity,
+      expectedAlignment: {
+        morphologyTokenIdentity: 'synthetic-token-1', verifierVersion: 1,
+        sourceId: 'synthetic-hebrew-dictionary', senseId: 'synthetic-sense-one',
+        evidenceId: 'synthetic-reference-one',
+      },
+    };
+    const guard = (output: unknown, expected: RegExp): void => {
+      expect(validate(output), validate.errors?.map((error: any) => error.message).join('; ')).toBe(true);
+      expect(() => serializeValidatedUbsSemanticDraftOutput(output, request)).toThrow(expected);
+    };
+
+    const wrongDerivedIdentity = structuredClone(contract.beginnerExample);
+    wrongDerivedIdentity.identity.sourceIdentity = 'H0002';
+    guard(wrongDerivedIdentity, /derived request identity/);
+
+    const wrongTopReference = structuredClone(contract.beginnerExample);
+    wrongTopReference.normalizedReference = 'Synthetic 1:2';
+    guard(wrongTopReference, /normalized reference does not match/);
+
+    const wrongProvenanceArtifact = structuredClone(contract.beginnerExample);
+    wrongProvenanceArtifact.provenance.transformation.artifactIdentity = '8'.repeat(64);
+    guard(wrongProvenanceArtifact, /provenance artifact/);
+
+    for (const mutate of [
+      (value: any) => { value.resultWindow.continuation.cursor = value.resultWindow.continuation.cursor.replace(/.$/, '0'); },
+      (value: any) => { value.resultWindow.continuation.artifactIdentity = '8'.repeat(64); },
+      (value: any) => { value.resultWindow.continuation.query.publicStrongs = 'H2'; },
+      (value: any) => { value.resultWindow.continuation.query.sourceIdentity = 'H0002'; },
+      (value: any) => { value.resultWindow.continuation.query.normalizedReference = 'Synthetic 1:2'; },
+    ]) {
+      const wrongContinuationBinding = structuredClone(contract.beginnerExample);
+      mutate(wrongContinuationBinding);
+      guard(wrongContinuationBinding, /continuation is not bound/);
+    }
+
+    const wrongArithmetic = structuredClone(contract.beginnerExample);
+    wrongArithmetic.resultWindow.consumedCount = 2;
+    guard(wrongArithmetic, /arithmetic/);
+
+    const wrongHasMore = structuredClone(contract.beginnerExample);
+    wrongHasMore.resultWindow.totalCount = 1;
+    guard(wrongHasMore, /hasMore/);
+
+    const missingContinuation = structuredClone(contract.beginnerExample);
+    delete missingContinuation.resultWindow.continuation;
+    expect(() => serializeValidatedUbsSemanticDraftOutput(missingContinuation, request))
+      .toThrow(/continuation must be present if and only if/);
+
+    const unexpectedContinuation = structuredClone(contract.expertExample);
+    unexpectedContinuation.resultWindow.continuation = contract.beginnerExample.resultWindow.continuation;
+    expect(() => serializeValidatedUbsSemanticDraftOutput(unexpectedContinuation, request))
+      .toThrow(/continuation must be present if and only if/);
+
+    const wrongCandidateCount = structuredClone(contract.beginnerExample);
+    wrongCandidateCount.resultWindow.returnedCount = 2;
+    wrongCandidateCount.resultWindow.consumedCount = 2;
+    wrongCandidateCount.resultWindow.totalCount = 3;
+    guard(wrongCandidateCount, /candidate count/);
+
+    const wrongAlignedCount = structuredClone(contract.expertExample);
+    wrongAlignedCount.resultWindow.priorCount = 1;
+    wrongAlignedCount.resultWindow.consumedCount = 2;
+    wrongAlignedCount.resultWindow.totalCount = 2;
+    guard(wrongAlignedCount, /exactly one terminal item/);
+
+    const wrongEvidenceReference = structuredClone(contract.expertExample);
+    wrongEvidenceReference.referenceEvidence.normalizedReference = 'Synthetic 1:2';
+    guard(wrongEvidenceReference, /reference evidence/);
+
+    const unrelatedToken = structuredClone(contract.expertExample);
+    unrelatedToken.alignmentEvidence.morphologyTokenIdentity = 'attacker-chosen-token';
+    guard(unrelatedToken, /trusted alignment proof identity/);
+
+    const unrelatedVerifier = structuredClone(contract.expertExample);
+    unrelatedVerifier.alignmentEvidence.verifierVersion = 2;
+    guard(unrelatedVerifier, /trusted alignment proof identity/);
+
+    const swappedSource = structuredClone(contract.expertExample);
+    swappedSource.referenceEvidence.sourceId = 'other-dictionary-source';
+    guard(swappedSource, /trusted alignment proof identity/);
+
+    const swappedEvidence = structuredClone(contract.expertExample);
+    swappedEvidence.referenceEvidence.evidenceId = 'other-reference-evidence';
+    guard(swappedEvidence, /trusted alignment proof identity/);
+
+    const swappedSense = structuredClone(contract.expertExample);
+    swappedSense.senseId = 'other-sense';
+    swappedSense.referenceEvidence.senseId = 'other-sense';
+    guard(swappedSense, /trusted alignment proof identity/);
+
+    const noTrustedAlignment = { ...request, expectedAlignment: undefined };
+    expect(() => serializeValidatedUbsSemanticDraftOutput(contract.expertExample, noTrustedAlignment))
+      .toThrow(/requires a trusted expected alignment assertion/);
+
+    for (const hostileReference of [
+      'Synthetic\u0085 1:1',
+      'Synthetic\u202e 1:1',
+      'Synthetic\u200e 1:1',
+      'Synthetic\u200b 1:1',
+      'Synthetic\ud800 1:1',
+      `Synthetic${String.fromCodePoint(0x10ffff)} 1:1`,
+    ]) {
+      expect(() => serializeValidatedUbsSemanticDraftOutput(
+        contract.expertExample, { ...request, normalizedReference: hostileReference },
+      )).toThrow(/forbidden control|forbidden Unicode noncharacter/);
+    }
+
+    const unavailableWithItem = {
+      audience: 'beginner', status: 'unavailable', plainLanguage: 'No publishable evidence.',
+      reason: 'no_publishable_semantic_evidence',
+      resultWindow: { priorCount: 0, returnedCount: 1, consumedCount: 1, totalCount: 1, hasMore: false },
+      responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
+      withheldEvidence: structuredClone(contract.beginnerExample.withheldEvidence),
+    };
+    guard(unavailableWithItem, /empty terminal result window/);
+
+    const oversizedButSchemaValid = structuredClone(contract.beginnerExample);
+    oversizedButSchemaValid.candidates = Array.from({ length: 8 }, (_, candidateIndex) => ({
+      senseId: `synthetic-sense-${candidateIndex}`,
+      meaning: {
+        definition: 'd'.repeat(UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.definitionCharacters),
+        glosses: Array.from({ length: 16 }, (_, index) => `${String(index).padStart(2, '0')}${'g'.repeat(998)}`),
+        domains: Array.from({ length: 16 }, (_, index) => ({
+          domainId: `synthetic-domain-${candidateIndex}-${index}`,
+          label: 'l'.repeat(1_000),
+          description: 'x'.repeat(5_000),
+        })),
+      },
+    }));
+    Object.assign(oversizedButSchemaValid.resultWindow, {
+      priorCount: 0, returnedCount: 8, consumedCount: 8, totalCount: 8, hasMore: false,
+    });
+    delete oversizedButSchemaValid.resultWindow.continuation;
+    expect(validate(oversizedButSchemaValid), validate.errors?.map((error: any) => error.message).join('; ')).toBe(true);
+    expect(Buffer.byteLength(JSON.stringify(oversizedButSchemaValid), 'utf8')).toBeGreaterThan(1_048_576);
+    expect(() => serializeValidatedUbsSemanticDraftOutput(oversizedButSchemaValid, request))
+      .toThrow(/serialized UTF-8 bytes/);
   });
 
   it('marks both named future source artifacts as unapproved and not vendored', () => {


### PR DESCRIPTION
## Summary
- correct public-versus-internal UBS lexical identity and result-window semantics
- add a source-free, unregistered structured-output guard with exact byte, cursor, evidence, and trusted-alignment bindings
- use one hostile-Unicode-safe normalized-reference boundary across compiler, cursor, and presentation seams
- expand synthetic/adversarial contract coverage

## Inactive boundary
- no UBS source artifacts or corpus bytes
- no D1 migration or transform advancement
- no MCP tool, prompt, resource, service, Worker, or deployment registration

## Review and verification
- independent final review: GO (P0-P3 zero)
- focused UBS review suite: 84/84
- kernel review suite: 223/223
- coordinator focused rerun after documentation-only rebase: 61/61
- isolated strict TypeScript and Worker bundle-exclusion checks passed
- `git diff --check`