### PR TITLE
feat: add inactive Hebrew semantic resolution seam

### DIFF
--- a/docs/UBS-SEMANTICS-FOUNDATION.md
+++ b/docs/UBS-SEMANTICS-FOUNDATION.md
@@ -102,6 +102,40 @@ contextual token sense. Every page records the count returned by prior pages;
 present if and only if more rows remain. This makes a short terminal page
 honest instead of comparing the global total only with the current page.
 
+An inactive, source-free `HebrewSemanticEvidenceService` now exercises this
+boundary only with invented synthetic fixtures. It is deliberately absent from
+all composition roots and public exports. The seam accepts only the existing
+public Hebrew H-number grammar, forwards an internal repository page request,
+and returns candidates or unavailable evidence by default. The stronger
+`reference_aligned_source_candidate` status requires a separately versioned
+assertion bound to one exact morphology token, H#### identity, normalized
+reference, source, entry, sense, and reference-evidence row. Exact reference
+matching does not infer overlap for ranges. Multiple exact assertions remain
+ambiguous; every supplied assertion must match one exact returned evidence row,
+and missing, off-page, or mismatched trusted evidence fails closed rather than
+promoting a sense. Caller-controlled request fields and each alignment assertion
+are copied into immutable primitive snapshots before the first repository await,
+so later caller mutation cannot change a validated result. Each request,
+cursor, alignment-array element, and exact alignment property is read only once;
+accessor- or Proxy-backed records therefore cannot swap a value between
+validation, matching, and presentation. The alignment collection must also be
+a dense zero-to-eight-element array with an honest safe-integer length and no
+own assertion index hidden beyond that reported length.
+
+The seam inspects at most 16 senses and returns at most eight publishable
+candidates per call, with explicit incomplete-coverage metadata when those
+bounds intervene. It never reports evidence as unavailable from an offset,
+partial, or capped window, and its unpaged sense, domain, and exact-reference
+queries must return internally consistent complete first pages. This
+deliberately temporary per-operation choreography is
+not the future aggregate repository query: OL-S2 must replace its bounded N+1
+shape before any runtime composition or public registration.
+
+Repository validation also mirrors compiler identity guarantees: lexical
+identities and source ordinals are unique where their schema defines them, and
+source-qualified sense and reference-evidence identities cannot recur across a
+single resolution.
+
 ### G. Structured contract and presentation
 
 Review and version the draft fixture before registering it. Every

--- a/src/services/languages/HebrewSemanticEvidenceService.ts
+++ b/src/services/languages/HebrewSemanticEvidenceService.ts
@@ -1,0 +1,696 @@
+/**
+ * Inactive, source-free resolution seam for future UBS Hebrew evidence.
+ *
+ * This file is intentionally absent from every composition root and public
+ * export. It coordinates already-attested repository evidence; it never
+ * infers a contextual sense from morphology, frequency, gloss similarity, or
+ * any separately withheld TBESH field.
+ */
+import {
+  UBS_SEMANTIC_REPOSITORY_LIMITS,
+  UBS_SEMANTIC_REPOSITORY_ORDER,
+  parseUbsPublicHebrewIdentity,
+  requireUbsInternalLexicalIdentity,
+  requireUbsSemanticNormalizedReference,
+} from '../../kernel/ubsSemanticDomain.js';
+import type {
+  IUbsSemanticRepository,
+  UbsInternalHebrewLexicalIdentity,
+  UbsLexicalSenseCandidate,
+  UbsPublicHebrewIdentityBoundary,
+  UbsSemanticDomain,
+  UbsSemanticEntry,
+  UbsSemanticPageRequest,
+  UbsSemanticReferenceEvidence,
+  UbsSemanticRepositoryCollection,
+  UbsSemanticRepositoryOrder,
+  UbsSemanticResolution,
+  UbsSemanticSense,
+  UbsSemanticSource,
+} from '../../kernel/ubsSemanticDomain.js';
+
+export const HEBREW_SEMANTIC_EVIDENCE_LIMITS = Object.freeze({
+  candidates: 8,
+  sensesInspected: 16,
+  trustedAlignments: 8,
+  morphologyTokenIdentityCharacters: 512,
+  entryLemmaCharacters: 2_000,
+  entryTransliterationCharacters: 2_000,
+  entryPartOfSpeechCharacters: 512,
+  verifierVersionMaximum: 1_000_000,
+} as const);
+
+export type HebrewSemanticEvidenceAudience = 'beginner' | 'expert';
+
+/** A separately versioned verifier must explicitly attest this exact row. */
+export interface TrustedHebrewTokenAlignment {
+  status: 'verified_token_alignment';
+  morphologyTokenIdentity: string;
+  verifierVersion: number;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  normalizedReference: string;
+  sourceId: string;
+  entryId: string;
+  senseId: string;
+  evidenceId: string;
+}
+
+export interface HebrewSemanticEvidenceRequest {
+  publicStrongs: string;
+  normalizedReference: string;
+  audience: HebrewSemanticEvidenceAudience;
+  /** Internal repository continuation only; this is not a public result cursor. */
+  entryPage?: UbsSemanticPageRequest;
+  trustedAlignments?: readonly TrustedHebrewTokenAlignment[];
+}
+
+export interface HebrewSemanticEvidenceCoverage {
+  entryWindow: {
+    priorCount: number;
+    returnedCount: number;
+    consumedCount: number;
+    totalCount: number;
+    hasMore: boolean;
+    nextCursor?: string;
+  };
+  inspectedEntryCount: number;
+  inspectedSenseCount: number;
+  publishableCandidateCount: number;
+  candidateLimit: typeof HEBREW_SEMANTIC_EVIDENCE_LIMITS.candidates;
+  senseInspectionLimit: typeof HEBREW_SEMANTIC_EVIDENCE_LIMITS.sensesInspected;
+  completeForReturnedEntryWindow: boolean;
+}
+
+export interface HebrewSemanticEvidenceResult {
+  audience: HebrewSemanticEvidenceAudience;
+  plainLanguage: string;
+  identity: UbsPublicHebrewIdentityBoundary;
+  normalizedReference: string;
+  resolution: UbsSemanticResolution;
+  coverage: HebrewSemanticEvidenceCoverage;
+  /** Exact source records required by every returned candidate. */
+  provenanceSources: readonly UbsSemanticSource[];
+}
+
+interface CandidateEvidence extends UbsLexicalSenseCandidate {
+  entry: UbsSemanticEntry;
+  matchingReferences: UbsSemanticReferenceEvidence[];
+}
+
+interface HebrewSemanticEvidenceRequestSnapshot {
+  publicStrongs: string;
+  normalizedReference: string;
+  audience: HebrewSemanticEvidenceAudience;
+  entryPage?: Readonly<UbsSemanticPageRequest>;
+  trustedAlignments: unknown;
+}
+
+export class HebrewSemanticEvidenceService {
+  constructor(private readonly repository: IUbsSemanticRepository) {}
+
+  async resolve(request: HebrewSemanticEvidenceRequest): Promise<HebrewSemanticEvidenceResult> {
+    const requestSnapshot = snapshotRequest(request);
+    const identity = parseUbsPublicHebrewIdentity(requestSnapshot.publicStrongs);
+    if (!identity) throw new Error('UBS Hebrew semantic evidence requires an existing public H-number from H1 through H9999');
+    const audience = requestSnapshot.audience;
+    if (audience !== 'beginner' && audience !== 'expert') {
+      throw new Error('UBS Hebrew semantic evidence audience must be beginner or expert');
+    }
+    const normalizedReference = requireUbsSemanticNormalizedReference(requestSnapshot.normalizedReference);
+    const trustedAlignments = validateTrustedAlignments(
+      requestSnapshot.trustedAlignments, identity.sourceIdentity, normalizedReference,
+    );
+    const entryPage = requestSnapshot.entryPage;
+    const entries = await this.repository.getEntriesByLexicalIdentity(identity.sourceIdentity, entryPage);
+    validateCollection(entries, UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity, 'entry');
+    validateEntries(entries.items, identity.sourceIdentity);
+
+    const candidates: CandidateEvidence[] = [];
+    let inspectedEntryCount = 0;
+    let inspectedSenseCount = 0;
+    let evidenceIncomplete = entryPage !== undefined || entries.priorShowing > 0 || entries.hasMore;
+    const seenSenseIdentities = new Set<string>();
+    const seenEvidenceIdentities = new Set<string>();
+
+    outer: for (const entry of entries.items) {
+      inspectedEntryCount += 1;
+      const senses = await this.repository.getSensesForEntry(entry.sourceId, entry.entryId);
+      validateCollection(senses, UBS_SEMANTIC_REPOSITORY_ORDER.sensesPerEntry,
+        UBS_SEMANTIC_REPOSITORY_LIMITS.sensesPerEntry, 'sense');
+      validateCompleteFirstPage(senses, 'sense');
+      validateSenses(senses.items, entry, seenSenseIdentities);
+      if (senses.hasMore) evidenceIncomplete = true;
+      for (const sense of prioritizeTrustedSenses(senses.items, entry, trustedAlignments)) {
+        if (candidates.length >= HEBREW_SEMANTIC_EVIDENCE_LIMITS.candidates) {
+          evidenceIncomplete = true;
+          break outer;
+        }
+        if (inspectedSenseCount >= HEBREW_SEMANTIC_EVIDENCE_LIMITS.sensesInspected) {
+          evidenceIncomplete = true;
+          break outer;
+        }
+        inspectedSenseCount += 1;
+        const domains = await this.repository.getDomainsForSense(sense.sourceId, sense.senseId);
+        validateCollection(domains, UBS_SEMANTIC_REPOSITORY_ORDER.domainsPerSense,
+          UBS_SEMANTIC_REPOSITORY_LIMITS.domainsPerSense, 'domain');
+        validateCompleteFirstPage(domains, 'domain');
+        validateDomains(domains.items, sense);
+        if (domains.priorShowing !== 0 || domains.total !== sense.domainRefs.length) {
+          throw new Error('repository domain collection does not completely represent the sense domain references');
+        }
+        if (domains.hasMore) evidenceIncomplete = true;
+        if (domains.items.length === 0) continue;
+
+        const references = await this.repository.findReferenceEvidence(
+          sense.sourceId, sense.senseId, normalizedReference,
+        );
+        validateCollection(references, UBS_SEMANTIC_REPOSITORY_ORDER.matchingReferenceEvidence,
+          UBS_SEMANTIC_REPOSITORY_LIMITS.matchingReferenceEvidence, 'reference evidence');
+        validateCompleteFirstPage(references, 'reference evidence');
+        validateReferences(references.items, sense, normalizedReference, seenEvidenceIdentities);
+        if (references.hasMore) evidenceIncomplete = true;
+        candidates.push({ entry, sense, domains: [...domains.items], matchingReferences: [...references.items] });
+      }
+    }
+    if (inspectedEntryCount < entries.items.length) evidenceIncomplete = true;
+    candidates.sort((left, right) => compare(
+      [left.entry.sourceId, left.entry.sourceOrdinal, left.entry.entryId, left.sense.sourceOrdinal, left.sense.senseId],
+      [right.entry.sourceId, right.entry.sourceOrdinal, right.entry.entryId, right.sense.sourceOrdinal, right.sense.senseId],
+    ));
+
+    const coverage = coverageFor(entries, inspectedEntryCount, inspectedSenseCount, candidates.length, evidenceIncomplete);
+    if (entries.items.length === 0) {
+      if (entryPage !== undefined || entries.priorShowing !== 0 || entries.total !== 0 || entries.hasMore) {
+        throw new Error('incomplete entry evidence cannot establish that no lexical entry exists');
+      }
+      return result(identity, normalizedReference, audience, {
+        status: 'unavailable', reason: 'no_lexical_entry',
+      }, coverage, []);
+    }
+    if (candidates.length === 0) {
+      if (trustedAlignments.length > 0) throw new Error('trusted alignment does not match publishable repository evidence');
+      if (evidenceIncomplete) {
+        throw new Error('incomplete repository evidence cannot establish that publishable semantic evidence is unavailable');
+      }
+      return result(identity, normalizedReference, audience, {
+        status: 'unavailable', reason: 'no_publishable_semantic_evidence',
+      }, coverage, []);
+    }
+
+    const matches = matchTrustedAlignments(candidates, trustedAlignments);
+    if (matches.length !== trustedAlignments.length) {
+      throw new Error('every trusted alignment must match one exact returned entry, sense, reference evidence row, and query scope');
+    }
+    const provenanceSources = await loadExactCandidateProvenance(this.repository, candidates);
+    const matchedCandidateCount = new Set(matches.map(match => [
+      match.candidate.entry.sourceId, match.candidate.entry.entryId, match.candidate.sense.senseId,
+    ].join('\0'))).size;
+    if (matchedCandidateCount === 1) {
+      const match = [...matches].sort((left, right) => compare(
+        [left.referenceEvidence.sourceOrdinal, left.referenceEvidence.evidenceId],
+        [right.referenceEvidence.sourceOrdinal, right.referenceEvidence.evidenceId],
+      ))[0]!;
+      return result(identity, normalizedReference, audience, {
+        status: 'reference_aligned_source_candidate',
+        sense: match.candidate.sense,
+        domains: [...match.candidate.domains],
+        referenceEvidence: match.referenceEvidence,
+        alignmentEvidence: {
+          status: 'verified_token_alignment',
+          morphologyTokenIdentity: match.alignment.morphologyTokenIdentity,
+          verifierVersion: match.alignment.verifierVersion,
+        },
+      }, coverage, provenanceSources);
+    }
+
+    const hasReferenceEvidence = candidates.some(candidate => candidate.matchingReferences.length > 0);
+    return result(identity, normalizedReference, audience, {
+      status: 'lexical_candidates',
+      candidates: candidates.map(({ sense, domains }) => ({ sense, domains: [...domains] })),
+      reason: matchedCandidateCount > 1
+        ? 'ambiguous_reference_alignment'
+        : hasReferenceEvidence || evidenceIncomplete ? 'reference_alignment_unproven' : 'no_reference_evidence',
+    }, coverage, provenanceSources);
+  }
+}
+
+function snapshotRequest(request: HebrewSemanticEvidenceRequest): Readonly<HebrewSemanticEvidenceRequestSnapshot> {
+  if (!request || typeof request !== 'object') throw new Error('UBS Hebrew semantic evidence request must be a record');
+  const publicStrongs = request.publicStrongs;
+  const normalizedReference = request.normalizedReference;
+  const audience = request.audience;
+  const trustedAlignments = request.trustedAlignments;
+  const rawEntryPage = request.entryPage;
+  let entryPage: Readonly<UbsSemanticPageRequest> | undefined;
+  if (rawEntryPage !== undefined) {
+    if (!rawEntryPage || typeof rawEntryPage !== 'object') {
+      throw new Error('UBS Hebrew semantic entry page must be a record');
+    }
+    const cursor = rawEntryPage.cursor;
+    entryPage = Object.freeze({ cursor });
+  }
+  return Object.freeze({
+    publicStrongs,
+    normalizedReference,
+    audience,
+    trustedAlignments: trustedAlignments ?? Object.freeze([]),
+    ...(entryPage ? { entryPage } : {}),
+  });
+}
+
+function result(
+  identity: UbsPublicHebrewIdentityBoundary,
+  normalizedReference: string,
+  audience: HebrewSemanticEvidenceAudience,
+  resolution: UbsSemanticResolution,
+  coverage: HebrewSemanticEvidenceCoverage,
+  provenanceSources: readonly UbsSemanticSource[],
+): HebrewSemanticEvidenceResult {
+  return {
+    audience,
+    plainLanguage: explanation(resolution, audience),
+    identity,
+    normalizedReference,
+    resolution,
+    coverage,
+    provenanceSources: [...provenanceSources],
+  };
+}
+
+function explanation(resolution: UbsSemanticResolution, audience: HebrewSemanticEvidenceAudience): string {
+  if (resolution.status === 'reference_aligned_source_candidate') {
+    return audience === 'beginner'
+      ? 'This dictionary sense is attested at the passage and separately aligned to the selected Hebrew token, but that does not by itself prove its meaning in context.'
+      : 'This source candidate has exact sense-reference evidence plus separately versioned token alignment; it remains a candidate, not an adjudicated contextual sense.';
+  }
+  if (resolution.status === 'lexical_candidates') {
+    if (resolution.reason === 'no_reference_evidence') {
+      return 'The dictionary has possible senses for this Hebrew identity, but none is source-attested at the exact requested reference.';
+    }
+    if (resolution.reason === 'ambiguous_reference_alignment') {
+      return 'More than one exact source candidate is aligned to the selected token, so the available evidence does not settle which candidate applies.';
+    }
+    return 'The dictionary has source candidates, but no trusted token alignment proves which candidate applies here.';
+  }
+  return resolution.reason === 'no_lexical_entry'
+    ? 'No dictionary entry is available for this Hebrew identity.'
+    : 'No complete, publishable semantic evidence is available for this Hebrew identity.';
+}
+
+function validateTrustedAlignments(
+  values: unknown,
+  sourceIdentity: UbsInternalHebrewLexicalIdentity,
+  normalizedReference: string,
+): readonly Readonly<TrustedHebrewTokenAlignment>[] {
+  if (!Array.isArray(values)) {
+    throw new Error('trusted alignments exceed the reviewed eight-assertion bound');
+  }
+  const length = values.length;
+  if (!Number.isSafeInteger(length) || length < 0
+    || length > HEBREW_SEMANTIC_EVIDENCE_LIMITS.trustedAlignments) {
+    throw new Error('trusted alignments must have an honest safe-integer length from zero through eight');
+  }
+  for (const key of Reflect.ownKeys(values)) {
+    if (typeof key !== 'string' || !isCanonicalArrayIndex(key)) continue;
+    if (Number(key) >= length) {
+      throw new Error('trusted alignments must be a dense array with no assertion hidden beyond its reported length');
+    }
+  }
+  const callerRecords: unknown[] = [];
+  for (let index = 0; index < length; index += 1) {
+    if (!Object.prototype.hasOwnProperty.call(values, index)) {
+      throw new Error('trusted alignments must be a dense array with every reported index present');
+    }
+    callerRecords.push(values[index]);
+  }
+  const snapshots: Readonly<TrustedHebrewTokenAlignment>[] = [];
+  const tokenIdentities = new Set<string>();
+  const exactKeys = new Set<string>();
+  for (const value of callerRecords) {
+    if (!value || typeof value !== 'object') {
+      throw new Error('trusted alignment is not bound to the exact token, source identity, normalized reference, and verifier version');
+    }
+    const caller = value as Record<keyof TrustedHebrewTokenAlignment, unknown>;
+    const status = caller.status;
+    const morphologyTokenIdentity = caller.morphologyTokenIdentity;
+    const verifierVersion = caller.verifierVersion;
+    const callerSourceIdentity = caller.sourceIdentity;
+    const callerNormalizedReference = caller.normalizedReference;
+    const sourceId = caller.sourceId;
+    const entryId = caller.entryId;
+    const senseId = caller.senseId;
+    const evidenceId = caller.evidenceId;
+    if (typeof status !== 'string' || typeof morphologyTokenIdentity !== 'string'
+      || typeof verifierVersion !== 'number' || typeof callerSourceIdentity !== 'string'
+      || typeof callerNormalizedReference !== 'string' || typeof sourceId !== 'string'
+      || typeof entryId !== 'string' || typeof senseId !== 'string' || typeof evidenceId !== 'string') {
+      throw new Error('trusted alignment exact-key fields must be primitive strings plus one numeric verifier version');
+    }
+    const snapshot = Object.freeze({
+      status,
+      morphologyTokenIdentity,
+      verifierVersion,
+      sourceIdentity: callerSourceIdentity,
+      normalizedReference: callerNormalizedReference,
+      sourceId,
+      entryId,
+      senseId,
+      evidenceId,
+    }) as Readonly<TrustedHebrewTokenAlignment>;
+    if (Object.keys(value).sort().join(',') !== 'entryId,evidenceId,morphologyTokenIdentity,normalizedReference,senseId,sourceId,sourceIdentity,status,verifierVersion'
+      || snapshot.status !== 'verified_token_alignment'
+      || snapshot.sourceIdentity !== sourceIdentity
+      || requireUbsSemanticNormalizedReference(snapshot.normalizedReference, 'trusted alignment normalized reference') !== normalizedReference
+      || !Number.isSafeInteger(snapshot.verifierVersion) || snapshot.verifierVersion < 1
+      || snapshot.verifierVersion > HEBREW_SEMANTIC_EVIDENCE_LIMITS.verifierVersionMaximum) {
+      throw new Error('trusted alignment is not bound to the exact token, source identity, normalized reference, and verifier version');
+    }
+    boundedText(
+      snapshot.morphologyTokenIdentity,
+      HEBREW_SEMANTIC_EVIDENCE_LIMITS.morphologyTokenIdentityCharacters,
+      'trusted alignment morphology token identity',
+    );
+    for (const [label, identifier] of [
+      ['source', snapshot.sourceId], ['entry', snapshot.entryId], ['sense', snapshot.senseId], ['evidence', snapshot.evidenceId],
+    ] as const) requireIdentifier(identifier, `trusted alignment ${label} ID`);
+    tokenIdentities.add(snapshot.morphologyTokenIdentity);
+    const exactKey = [snapshot.sourceId, snapshot.entryId, snapshot.senseId, snapshot.evidenceId].join('\0');
+    if (exactKeys.has(exactKey)) throw new Error('trusted alignments contain a duplicate exact assertion');
+    exactKeys.add(exactKey);
+    snapshots.push(snapshot);
+  }
+  if (tokenIdentities.size > 1) throw new Error('trusted alignments must describe one exact local morphology token');
+  return Object.freeze(snapshots);
+}
+
+function isCanonicalArrayIndex(value: string): boolean {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(value)) return false;
+  const numeric = Number(value);
+  return Number.isSafeInteger(numeric) && numeric >= 0 && numeric < 0xffff_ffff
+    && String(numeric) === value;
+}
+
+function prioritizeTrustedSenses(
+  senses: readonly UbsSemanticSense[],
+  entry: UbsSemanticEntry,
+  alignments: readonly TrustedHebrewTokenAlignment[],
+): UbsSemanticSense[] {
+  const trustedSenseIds = new Set(alignments
+    .filter(alignment => alignment.sourceId === entry.sourceId && alignment.entryId === entry.entryId)
+    .map(alignment => alignment.senseId));
+  return [
+    ...senses.filter(sense => trustedSenseIds.has(sense.senseId)),
+    ...senses.filter(sense => !trustedSenseIds.has(sense.senseId)),
+  ];
+}
+
+function validateEntries(items: readonly UbsSemanticEntry[], identity: UbsInternalHebrewLexicalIdentity): void {
+  let prior: UbsSemanticEntry | undefined;
+  const identities = new Set<string>();
+  const ordinals = new Set<number>();
+  for (const entry of items) {
+    requireIdentifier(entry.sourceId, 'entry source ID');
+    requireIdentifier(entry.entryId, 'entry ID');
+    positiveInteger(entry.sourceOrdinal, 'entry source ordinal');
+    boundedText(entry.lemma, HEBREW_SEMANTIC_EVIDENCE_LIMITS.entryLemmaCharacters, 'entry lemma');
+    if (entry.transliteration !== undefined) boundedText(
+      entry.transliteration,
+      HEBREW_SEMANTIC_EVIDENCE_LIMITS.entryTransliterationCharacters,
+      'entry transliteration',
+    );
+    if (entry.partOfSpeech !== undefined) boundedText(
+      entry.partOfSpeech,
+      HEBREW_SEMANTIC_EVIDENCE_LIMITS.entryPartOfSpeechCharacters,
+      'entry part of speech',
+    );
+    if (!Array.isArray(entry.lexicalIdentities) || !entry.lexicalIdentities.includes(identity)) {
+      throw new Error('repository entry is not attached to the requested branded lexical identity');
+    }
+    if (new Set(entry.lexicalIdentities).size !== entry.lexicalIdentities.length) {
+      throw new Error('repository entry lexical identities must be unique');
+    }
+    for (const lexicalIdentity of entry.lexicalIdentities) requireUbsInternalLexicalIdentity(lexicalIdentity);
+    const exactIdentity = `${entry.sourceId}\0${entry.entryId}`;
+    if (identities.has(exactIdentity)) throw new Error('repository entries contain a duplicate exact identity');
+    identities.add(exactIdentity);
+    if (ordinals.has(entry.sourceOrdinal)) throw new Error('repository entries contain a duplicate source ordinal');
+    ordinals.add(entry.sourceOrdinal);
+    if (prior && compare([prior.sourceId, prior.sourceOrdinal, prior.entryId], [entry.sourceId, entry.sourceOrdinal, entry.entryId]) >= 0) {
+      throw new Error('repository entries are not in strict canonical order');
+    }
+    prior = entry;
+  }
+}
+
+function validateSenses(
+  items: readonly UbsSemanticSense[],
+  entry: UbsSemanticEntry,
+  resolutionIdentities: Set<string>,
+): void {
+  let prior: UbsSemanticSense | undefined;
+  const ordinals = new Set<number>();
+  for (const sense of items) {
+    requireIdentifier(sense.senseId, 'sense ID');
+    if (sense.sourceId !== entry.sourceId || sense.entryId !== entry.entryId) {
+      throw new Error('repository sense does not belong to its requested entry');
+    }
+    positiveInteger(sense.sourceOrdinal, 'sense source ordinal');
+    const exactIdentity = `${sense.sourceId}\0${sense.senseId}`;
+    if (resolutionIdentities.has(exactIdentity)) throw new Error('repository senses contain a duplicate cross-resolution identity');
+    resolutionIdentities.add(exactIdentity);
+    if (ordinals.has(sense.sourceOrdinal)) throw new Error('repository senses contain a duplicate source ordinal within an entry');
+    ordinals.add(sense.sourceOrdinal);
+    boundedText(sense.definition, 20_000, 'sense definition');
+    if (!Array.isArray(sense.glosses) || sense.glosses.length < 1 || sense.glosses.length > 16) {
+      throw new Error('sense glosses must contain one to sixteen publishable values');
+    }
+    for (const gloss of sense.glosses) boundedText(gloss, 1_000, 'sense gloss');
+    if (new Set(sense.glosses).size !== sense.glosses.length) throw new Error('sense glosses must be unique');
+    if (!Array.isArray(sense.domainRefs) || sense.domainRefs.length < 1 || sense.domainRefs.length > 16
+      || new Set(sense.domainRefs.map(ref => `${ref.sourceId}\0${ref.domainId}`)).size !== sense.domainRefs.length) {
+      throw new Error('sense domain references must contain one to sixteen unique source/domain identities');
+    }
+    if (prior && compare([prior.sourceOrdinal, prior.senseId], [sense.sourceOrdinal, sense.senseId]) >= 0) {
+      throw new Error('repository senses are not in strict canonical order');
+    }
+    prior = sense;
+  }
+}
+
+function validateDomains(items: readonly UbsSemanticDomain[], sense: UbsSemanticSense): void {
+  const expected = new Set(sense.domainRefs.map(ref => `${ref.sourceId}\0${ref.domainId}`));
+  let prior: UbsSemanticDomain | undefined;
+  const identities = new Set<string>();
+  const ordinals = new Set<number>();
+  for (const domain of items) {
+    requireIdentifier(domain.sourceId, 'domain source ID');
+    requireIdentifier(domain.domainId, 'domain ID');
+    if (!expected.has(`${domain.sourceId}\0${domain.domainId}`)) {
+      throw new Error('repository domain is not attested by the requested sense');
+    }
+    const exactIdentity = `${domain.sourceId}\0${domain.domainId}`;
+    if (identities.has(exactIdentity)) throw new Error('repository domains contain a duplicate exact identity');
+    identities.add(exactIdentity);
+    positiveInteger(domain.sourceOrdinal, 'domain source ordinal');
+    if (ordinals.has(domain.sourceOrdinal)) throw new Error('repository domains contain a duplicate source ordinal');
+    ordinals.add(domain.sourceOrdinal);
+    if (domain.parentDomainId !== undefined) requireIdentifier(domain.parentDomainId, 'parent domain ID');
+    boundedText(domain.label, 1_000, 'domain label');
+    if (domain.description !== undefined) boundedText(domain.description, 5_000, 'domain description');
+    if (prior && compare([prior.sourceOrdinal, prior.domainId], [domain.sourceOrdinal, domain.domainId]) >= 0) {
+      throw new Error('repository domains are not in strict canonical order');
+    }
+    prior = domain;
+  }
+}
+
+function validateReferences(
+  items: readonly UbsSemanticReferenceEvidence[],
+  sense: UbsSemanticSense,
+  normalizedReference: string,
+  resolutionIdentities: Set<string>,
+): void {
+  let prior: UbsSemanticReferenceEvidence | undefined;
+  const ordinals = new Set<number>();
+  for (const evidence of items) {
+    requireIdentifier(evidence.evidenceId, 'reference evidence ID');
+    if (evidence.sourceId !== sense.sourceId || evidence.senseId !== sense.senseId
+      || evidence.normalizedReference !== normalizedReference
+      || evidence.evidenceKind !== 'source_attested_sense_reference') {
+      throw new Error('repository reference evidence does not match the exact sense and normalized reference');
+    }
+    positiveInteger(evidence.sourceOrdinal, 'reference evidence source ordinal');
+    const exactIdentity = `${evidence.sourceId}\0${evidence.evidenceId}`;
+    if (resolutionIdentities.has(exactIdentity)) throw new Error('repository reference evidence contains a duplicate cross-resolution identity');
+    resolutionIdentities.add(exactIdentity);
+    if (ordinals.has(evidence.sourceOrdinal)) throw new Error('repository reference evidence contains a duplicate source ordinal within a sense');
+    ordinals.add(evidence.sourceOrdinal);
+    requireUbsSemanticNormalizedReference(evidence.sourceReference, 'source reference');
+    if (prior && compare([prior.sourceOrdinal, prior.evidenceId], [evidence.sourceOrdinal, evidence.evidenceId]) >= 0) {
+      throw new Error('repository reference evidence is not in strict canonical order');
+    }
+    prior = evidence;
+  }
+}
+
+async function loadExactCandidateProvenance(
+  repository: IUbsSemanticRepository,
+  candidates: readonly CandidateEvidence[],
+): Promise<UbsSemanticSource[]> {
+  const ids: string[] = [];
+  for (const candidate of candidates) {
+    for (const id of [candidate.sense.sourceId, ...candidate.domains.map(domain => domain.sourceId)]) {
+      if (!ids.includes(id)) ids.push(id);
+    }
+  }
+  if (ids.length !== 2) throw new Error('publishable semantic candidates require exactly the dictionary and lexical-domain sources');
+  const sources: UbsSemanticSource[] = [];
+  for (const id of ids) {
+    const source = await repository.getSource(id);
+    if (!source || source.sourceId !== id) {
+      throw new Error('publishable semantic candidate provenance is missing or incompatible');
+    }
+    validateSource(source);
+    sources.push(source);
+  }
+  sources.sort((left, right) => roleOrder(left.sourceRole) - roleOrder(right.sourceRole));
+  if (sources[0]?.sourceRole !== 'dictionary' || sources[1]?.sourceRole !== 'lexical_domains') {
+    throw new Error('publishable semantic provenance must contain dictionary then lexical-domain source roles');
+  }
+  if (sources[0].artifactIdentity !== sources[1].artifactIdentity) {
+    throw new Error('publishable semantic provenance sources do not share one exact semantic artifact identity');
+  }
+  return sources;
+}
+
+function validateSource(source: UbsSemanticSource): void {
+  requireIdentifier(source.sourceId, 'provenance source ID');
+  if (source.schemaVersion !== 'ubs-semantics.v1' || source.artifactVersion !== '0.9.2'
+    || source.language !== 'Hebrew' || source.publisher !== 'United Bible Societies'
+    || source.license !== 'CC BY-SA 4.0'
+    || source.licenseUrl !== 'https://creativecommons.org/licenses/by-sa/4.0/'
+    || source.transformVersion !== 7 || source.modified !== true
+    || !/^[0-9a-f]{64}$/.test(source.artifactIdentity)
+    || !validHttpsUrl(source.sourceUrl)
+    || !/^[0-9a-f]{40}$/.test(source.sourceCommit)
+    || !/^[0-9a-f]{40}$/.test(source.sourceBlob)
+    || !/^[0-9a-f]{64}$/.test(source.sourceSha256)
+    || (source.sourceRole === 'dictionary' && source.artifactName !== 'UBSHebrewDic-v0.9.2-en.JSON')
+    || (source.sourceRole === 'lexical_domains' && source.artifactName !== 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON')) {
+    throw new Error('publishable semantic candidate provenance is missing or incompatible');
+  }
+  boundedText(source.title, 1_000, 'provenance source title');
+  boundedText(source.modificationNote, 1_000, 'provenance modification note');
+}
+
+function validHttpsUrl(value: unknown): boolean {
+  if (typeof value !== 'string' || value.length > 1_000 || hasUnicodeNoncharacter(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function matchTrustedAlignments(candidates: readonly CandidateEvidence[], alignments: readonly TrustedHebrewTokenAlignment[]) {
+  return alignments.flatMap(alignment => candidates.flatMap(candidate => {
+    if (candidate.entry.sourceId !== alignment.sourceId || candidate.entry.entryId !== alignment.entryId
+      || candidate.sense.senseId !== alignment.senseId) return [];
+    const referenceEvidence = candidate.matchingReferences.find(evidence => evidence.evidenceId === alignment.evidenceId);
+    return referenceEvidence ? [{ candidate, referenceEvidence, alignment }] : [];
+  }));
+}
+
+function coverageFor(
+  entries: UbsSemanticRepositoryCollection<UbsSemanticEntry, typeof UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity, typeof UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity>,
+  inspectedEntryCount: number,
+  inspectedSenseCount: number,
+  publishableCandidateCount: number,
+  incomplete: boolean,
+): HebrewSemanticEvidenceCoverage {
+  return {
+    entryWindow: {
+      priorCount: entries.priorShowing,
+      returnedCount: entries.showing,
+      consumedCount: entries.consumed,
+      totalCount: entries.total,
+      hasMore: entries.hasMore,
+      ...(entries.nextCursor ? { nextCursor: entries.nextCursor } : {}),
+    },
+    inspectedEntryCount,
+    inspectedSenseCount,
+    publishableCandidateCount,
+    candidateLimit: HEBREW_SEMANTIC_EVIDENCE_LIMITS.candidates,
+    senseInspectionLimit: HEBREW_SEMANTIC_EVIDENCE_LIMITS.sensesInspected,
+    completeForReturnedEntryWindow: !incomplete,
+  };
+}
+
+function validateCollection<T>(
+  collection: UbsSemanticRepositoryCollection<T, UbsSemanticRepositoryOrder, number>,
+  order: string,
+  limit: number,
+  label: string,
+): void {
+  if (!collection || !Array.isArray(collection.items) || collection.order !== order || collection.limit !== limit
+    || collection.showing !== collection.items.length || collection.showing > limit
+    || !Number.isSafeInteger(collection.total) || collection.total < 0
+    || !Number.isSafeInteger(collection.priorShowing) || collection.priorShowing < 0
+    || collection.consumed !== collection.priorShowing + collection.showing
+    || collection.consumed > collection.total || collection.hasMore !== (collection.consumed < collection.total)
+    || collection.hasMore !== (typeof collection.nextCursor === 'string')
+    || (collection.hasMore && (collection.items.length === 0 || !collection.nextCursor
+      || collection.nextCursor.length > 4_096 || hasUnicodeNoncharacter(collection.nextCursor)))) {
+    throw new Error(`repository ${label} collection violates its bounded honest-window contract`);
+  }
+}
+
+function validateCompleteFirstPage<T>(
+  collection: UbsSemanticRepositoryCollection<T, UbsSemanticRepositoryOrder, number>,
+  label: string,
+): void {
+  if (collection.priorShowing !== 0 || collection.consumed !== collection.showing
+    || collection.showing !== collection.total || collection.hasMore || collection.nextCursor !== undefined) {
+    throw new Error(`repository ${label} first-page collection must be complete before evidence can be resolved`);
+  }
+}
+
+function requireIdentifier(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !/^[a-z][a-z0-9]*(?:[-_.][a-z0-9]+)*$/.test(value) || value.length > 128) {
+    throw new Error(`${label} must be a bounded canonical identifier`);
+  }
+}
+
+function positiveInteger(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) throw new Error(`${label} must be a positive safe integer`);
+}
+
+function boundedText(value: unknown, maximum: number, label: string): asserts value is string {
+  if (typeof value !== 'string' || !value || value !== value.trim() || value !== value.normalize('NFC')
+    || [...value].length > maximum || /[\p{Cc}\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/u.test(value)
+    || hasUnicodeNoncharacter(value)) {
+    throw new Error(`${label} must be non-empty, trimmed, NFC, permitted Unicode, and within its character bound`);
+  }
+}
+
+function hasUnicodeNoncharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if ((codePoint >= 0xfdd0 && codePoint <= 0xfdef) || (codePoint & 0xffff) >= 0xfffe) return true;
+  }
+  return false;
+}
+
+function compare(left: readonly (string | number)[], right: readonly (string | number)[]): number {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] === right[index]) continue;
+    return left[index]! < right[index]! ? -1 : 1;
+  }
+  return 0;
+}
+
+function roleOrder(role: UbsSemanticSource['sourceRole']): number {
+  return role === 'dictionary' ? 0 : 1;
+}

--- a/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
@@ -1,0 +1,62 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const repo = new URL('../../../', import.meta.url);
+const serviceName = 'HebrewSemanticEvidenceService';
+
+const activeIdentityPins = {
+  'src/tools/toolRegistry.ts': '6847062cd5c9e131f17c5146c5e070283925bed5606a7b68b06538129c92c7f0',
+  'src/tools/v2/index.ts': '2bdf52660313eea971ed51253120288488938812c014c7764d6bb85c233251bd',
+  'src/tools/worker/index.ts': 'feb1679a520185d11f2b6082b70ea3ef6c2b87652ff49c97c0acedfb76d83b90',
+  'src/server.ts': '6b372c049cb7741344bc446b2409524739cc9acba5a3121bc09dbdc8e90acd22',
+  'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
+  'src/worker.ts': '07a439b6f5f20be1e6651ceaad71b4ca189579592c743e5e0f3770d80ba12d44',
+  'src/mcp/prompts.ts': '6122a305d1a6025f1c980e1f105f78c02b4eb156061d12c44942d163c40002da',
+  'src/mcp/schemas/originalLanguageStudy.ts': 'a98e5966d8a2a850487b4882c49f04c48fc697eee308f6e89c67e06af50fefac',
+  'src/presenters/originalLanguageStudyStructured.ts': '49818eb62e89980498669442a4bfc1886944d7751fc675940b17368a030995d9',
+  'src/formatters/originalLanguageStudyFormatter.ts': '30a10bf826c6c3174f2e0fb00907f6104735b165fdbfd5915a0ff22bc09b2536',
+  'data/data-manifest.json': 'ba4f6fc73086716bd03f8e8d65a181719fba834aa61a90e65b168169744fa424',
+  'wrangler.toml': '512128beeb51f9134381f06cebd822b3402a3f99c6622410989bd3d188f711bc',
+  'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
+  'package.json': '4a9e337f9ee795a2d962ad9d6b5161fb36d166a7bf5547aca0c69813709f1ec4',
+  'test/fixtures/ubs-semantics/structured-output-contract.draft.json': '4564884999aee552c4d1560c442c38b373fb19626a88da5af6455c892628e181',
+} as const;
+
+describe('inactive UBS semantic resolution seam', () => {
+  it('does not enter Node, Worker, tool, prompt, resource, or configuration composition', () => {
+    for (const path of [
+      'src/tools/toolRegistry.ts', 'src/tools/v2/index.ts', 'src/tools/worker/index.ts',
+      'src/server.ts', 'src/worker-server.ts', 'src/mcp/prompts.ts', 'src/kernel/index.ts',
+      'src/services/index.ts', 'wrangler.toml', 'package.json',
+    ]) {
+      let source: string;
+      try {
+        source = readFileSync(new URL(path, repo), 'utf8');
+      } catch {
+        continue;
+      }
+      expect(source, path).not.toContain(serviceName);
+    }
+  });
+
+  it('pins active bundle inputs, inventory roots, config, and data identity to the reviewed stack base', () => {
+    for (const [path, expected] of Object.entries(activeIdentityPins)) {
+      const actual = createHash('sha256').update(readFileSync(new URL(path, repo))).digest('hex');
+      expect(actual, path).toBe(expected);
+    }
+  });
+
+  it('does not add executable migration, source artifact, or active transform identity', () => {
+    const service = readFileSync(new URL('src/services/languages/HebrewSemanticEvidenceService.ts', repo), 'utf8');
+    expect(service).not.toMatch(/from ['"][^'"]*(?:data\/|migrations\/|adapters\/d1|adapters\/data)/);
+    const manifest = JSON.parse(readFileSync(new URL('data/data-manifest.json', repo), 'utf8')) as {
+      schemaVersion: string;
+      materializations: { d1: { transformVersion: number } };
+    };
+    expect(manifest).toMatchObject({
+      schemaVersion: '0003_original_language_usage',
+      materializations: { d1: { transformVersion: 6 } },
+    });
+  });
+});

--- a/test/unit/services/languages/HebrewSemanticEvidenceService.test.ts
+++ b/test/unit/services/languages/HebrewSemanticEvidenceService.test.ts
@@ -1,0 +1,782 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UBS_SEMANTIC_REPOSITORY_LIMITS,
+  UBS_SEMANTIC_REPOSITORY_ORDER,
+  createUbsSemanticRepositoryCollection,
+  requireUbsInternalLexicalIdentity,
+} from '../../../../src/kernel/ubsSemanticDomain.js';
+import type {
+  IUbsSemanticRepository,
+  UbsInternalHebrewLexicalIdentity,
+  UbsInternalLexicalIdentity,
+  UbsSemanticDomain,
+  UbsSemanticEntry,
+  UbsSemanticPageRequest,
+  UbsSemanticReferenceEvidence,
+  UbsSemanticSense,
+  UbsSemanticSource,
+} from '../../../../src/kernel/ubsSemanticDomain.js';
+import {
+  HEBREW_SEMANTIC_EVIDENCE_LIMITS,
+  HebrewSemanticEvidenceService,
+  type HebrewSemanticEvidenceRequest,
+  type TrustedHebrewTokenAlignment,
+} from '../../../../src/services/languages/HebrewSemanticEvidenceService.js';
+
+const H0001 = requireUbsInternalLexicalIdentity('H0001') as UbsInternalHebrewLexicalIdentity;
+const H0002 = requireUbsInternalLexicalIdentity('H0002') as UbsInternalHebrewLexicalIdentity;
+const A0001 = requireUbsInternalLexicalIdentity('A0001');
+const A0002 = requireUbsInternalLexicalIdentity('A0002');
+const ARTIFACT = '7'.repeat(64);
+
+interface SyntheticData {
+  sources: UbsSemanticSource[];
+  entries: UbsSemanticEntry[];
+  senses: UbsSemanticSense[];
+  domains: UbsSemanticDomain[];
+  references: UbsSemanticReferenceEvidence[];
+}
+
+function source(sourceRole: 'dictionary' | 'lexical_domains'): UbsSemanticSource {
+  return {
+    sourceId: sourceRole === 'dictionary' ? 'synthetic-dictionary' : 'synthetic-domains',
+    sourceRole,
+    schemaVersion: 'ubs-semantics.v1', artifactIdentity: ARTIFACT,
+    title: sourceRole === 'dictionary' ? 'SYNTHETIC DICTIONARY' : 'SYNTHETIC DOMAINS',
+    artifactName: sourceRole === 'dictionary'
+      ? 'UBSHebrewDic-v0.9.2-en.JSON' : 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON',
+    artifactVersion: '0.9.2', language: 'Hebrew', publisher: 'United Bible Societies',
+    license: 'CC BY-SA 4.0', licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
+    sourceUrl: `https://example.invalid/no-source-bytes/${sourceRole}`,
+    sourceCommit: (sourceRole === 'dictionary' ? '1' : '2').repeat(40),
+    sourceBlob: (sourceRole === 'dictionary' ? '3' : '4').repeat(40),
+    sourceSha256: (sourceRole === 'dictionary' ? '5' : '6').repeat(64),
+    transformVersion: 7, modified: true, modificationNote: 'Invented synthetic evidence only.',
+  } as UbsSemanticSource;
+}
+
+function data(): SyntheticData {
+  const entries: UbsSemanticEntry[] = [
+    { entryId: 'entry-one', sourceId: 'synthetic-dictionary', sourceOrdinal: 1, lemma: 'SYNTHETIC LEMMA ONE', lexicalIdentities: [H0001, A0001] },
+    { entryId: 'entry-two', sourceId: 'synthetic-dictionary', sourceOrdinal: 2, lemma: 'SYNTHETIC LEMMA TWO', lexicalIdentities: [H0001] },
+    { entryId: 'entry-range', sourceId: 'synthetic-dictionary', sourceOrdinal: 3, lemma: 'SYNTHETIC RANGE LEMMA', lexicalIdentities: [H0002] },
+    { entryId: 'entry-a-only', sourceId: 'synthetic-dictionary', sourceOrdinal: 4, lemma: 'SYNTHETIC A ONLY', lexicalIdentities: [A0002] },
+  ];
+  const senses: UbsSemanticSense[] = [
+    sense('sense-one', 'entry-one', 1, 'domain-one'),
+    sense('sense-two', 'entry-one', 2, 'domain-two'),
+    sense('sense-three', 'entry-two', 1, 'domain-three'),
+    sense('sense-range', 'entry-range', 1, 'domain-range'),
+    sense('sense-a-only', 'entry-a-only', 1, 'domain-a-only'),
+  ];
+  const domains = ['one', 'two', 'three', 'range', 'a-only'].map((suffix, index) => ({
+    domainId: `domain-${suffix}`, sourceId: 'synthetic-domains', sourceOrdinal: index + 1,
+    label: `SYNTHETIC DOMAIN ${suffix.toUpperCase()}`,
+  } satisfies UbsSemanticDomain));
+  const references: UbsSemanticReferenceEvidence[] = [
+    evidence('reference-one', 'sense-one', 1, 'Synthetic 1:1'),
+    evidence('reference-two', 'sense-two', 1, 'Synthetic 1:1-2'),
+    evidence('reference-three', 'sense-three', 1, 'Synthetic 1:1'),
+    evidence('reference-range', 'sense-range', 1, 'Synthetic 1:1-2'),
+  ];
+  return { sources: [source('dictionary'), source('lexical_domains')], entries, senses, domains, references };
+}
+
+function sense(senseId: string, entryId: string, sourceOrdinal: number, domainId: string): UbsSemanticSense {
+  return {
+    senseId, entryId, sourceId: 'synthetic-dictionary', sourceOrdinal,
+    definition: `SYNTHETIC DEFINITION ${senseId.toUpperCase()}`,
+    glosses: [`SYNTHETIC GLOSS ${senseId.toUpperCase()}`],
+    domainRefs: [{ sourceId: 'synthetic-domains', domainId }],
+  };
+}
+
+function evidence(evidenceId: string, senseId: string, sourceOrdinal: number, normalizedReference: string): UbsSemanticReferenceEvidence {
+  return {
+    evidenceId, senseId, sourceId: 'synthetic-dictionary', sourceOrdinal,
+    sourceReference: normalizedReference.replace('Synthetic', 'SYN'), normalizedReference,
+    evidenceKind: 'source_attested_sense_reference',
+  };
+}
+
+class SyntheticRepository implements IUbsSemanticRepository {
+  readonly calls: string[] = [];
+  constructor(readonly values: SyntheticData, private readonly shape: 'node' | 'd1' = 'node') {}
+
+  async getSource(sourceId: string) {
+    this.calls.push(`source:${sourceId}`);
+    return clone(this.values.sources.find(item => item.sourceId === sourceId), this.shape);
+  }
+  async getEntry(sourceId: string, entryId: string) {
+    return clone(this.values.entries.find(item => item.sourceId === sourceId && item.entryId === entryId), this.shape);
+  }
+  async getEntriesByLexicalIdentity(identity: UbsInternalLexicalIdentity, page?: UbsSemanticPageRequest) {
+    this.calls.push(`entries:${identity}:${page?.cursor ?? 'first'}`);
+    if (page?.cursor) throw new Error('UBS semantic cursor is stale or synthetic-invalid');
+    const items = this.values.entries.filter(item => item.lexicalIdentities.includes(identity));
+    return createUbsSemanticRepositoryCollection(clone(items, this.shape), items.length,
+      UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity, { priorShowing: 0 });
+  }
+  async getSense(sourceId: string, senseId: string) {
+    return clone(this.values.senses.find(item => item.sourceId === sourceId && item.senseId === senseId), this.shape);
+  }
+  async getSensesForEntry(sourceId: string, entryId: string) {
+    this.calls.push(`senses:${sourceId}:${entryId}`);
+    const items = this.values.senses.filter(item => item.sourceId === sourceId && item.entryId === entryId);
+    return createUbsSemanticRepositoryCollection(clone(items, this.shape), items.length,
+      UBS_SEMANTIC_REPOSITORY_ORDER.sensesPerEntry,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.sensesPerEntry, { priorShowing: 0 });
+  }
+  async getDomain(sourceId: string, domainId: string) {
+    return clone(this.values.domains.find(item => item.sourceId === sourceId && item.domainId === domainId), this.shape);
+  }
+  async getDomainsForSense(sourceId: string, senseId: string) {
+    this.calls.push(`domains:${sourceId}:${senseId}`);
+    const senseValue = this.values.senses.find(item => item.sourceId === sourceId && item.senseId === senseId);
+    const keys = new Set(senseValue?.domainRefs.map(ref => `${ref.sourceId}\0${ref.domainId}`));
+    const items = this.values.domains.filter(item => keys.has(`${item.sourceId}\0${item.domainId}`));
+    return createUbsSemanticRepositoryCollection(clone(items, this.shape), items.length,
+      UBS_SEMANTIC_REPOSITORY_ORDER.domainsPerSense,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.domainsPerSense, { priorShowing: 0 });
+  }
+  async getReferenceEvidenceForSense(sourceId: string, senseId: string) {
+    const items = this.values.references.filter(item => item.sourceId === sourceId && item.senseId === senseId);
+    return createUbsSemanticRepositoryCollection(clone(items, this.shape), items.length,
+      UBS_SEMANTIC_REPOSITORY_ORDER.referenceEvidencePerSense,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.referenceEvidencePerSense, { priorShowing: 0 });
+  }
+  async findReferenceEvidence(sourceId: string, senseId: string, normalizedReference: string) {
+    this.calls.push(`references:${sourceId}:${senseId}:${normalizedReference}`);
+    const items = this.values.references.filter(item => item.sourceId === sourceId
+      && item.senseId === senseId && item.normalizedReference === normalizedReference);
+    return createUbsSemanticRepositoryCollection(clone(items, this.shape), items.length,
+      UBS_SEMANTIC_REPOSITORY_ORDER.matchingReferenceEvidence,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.matchingReferenceEvidence, { priorShowing: 0 });
+  }
+}
+
+function clone<T>(value: T, shape: 'node' | 'd1'): T {
+  if (value === undefined) return value;
+  const copy = structuredClone(value);
+  if (shape === 'node') return copy;
+  // Simulate D1's row serialization boundary instead of sharing object identity.
+  return JSON.parse(JSON.stringify(copy)) as T;
+}
+
+function alignment(senseId = 'sense-one', evidenceId = 'reference-one', token = 'synthetic-token-1', entryId = 'entry-one'): TrustedHebrewTokenAlignment {
+  return {
+    status: 'verified_token_alignment', morphologyTokenIdentity: token, verifierVersion: 1,
+    sourceIdentity: H0001, normalizedReference: 'Synthetic 1:1',
+    sourceId: 'synthetic-dictionary', entryId, senseId, evidenceId,
+  };
+}
+
+describe('HebrewSemanticEvidenceService inactive resolution seam', () => {
+  it('produces identical bounded Node- and D1-shaped candidate evidence without adjudicating meaning', async () => {
+    const node = new SyntheticRepository(data(), 'node');
+    const d1 = new SyntheticRepository(data(), 'd1');
+    const request = { publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner' as const };
+    const [nodeResult, d1Result] = await Promise.all([
+      new HebrewSemanticEvidenceService(node).resolve(request),
+      new HebrewSemanticEvidenceService(d1).resolve(request),
+    ]);
+    expect(d1Result).toEqual(nodeResult);
+    expect(node.calls).toEqual(d1.calls);
+    expect(nodeResult.resolution).toMatchObject({
+      status: 'lexical_candidates', reason: 'reference_alignment_unproven',
+    });
+    expect(nodeResult.identity).toEqual({ publicStrongs: 'H1', sourceIdentity: 'H0001' });
+    expect(nodeResult.plainLanguage).toContain('no trusted token alignment');
+    expect(nodeResult.provenanceSources.map(item => item.sourceRole)).toEqual(['dictionary', 'lexical_domains']);
+    expect(JSON.stringify(nodeResult)).not.toContain('A0001');
+  });
+
+  it('emits the stronger status only for one exact separately verified evidence row', async () => {
+    const result = await new HebrewSemanticEvidenceService(new SyntheticRepository(data())).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment()],
+    });
+    expect(result.resolution).toMatchObject({
+      status: 'reference_aligned_source_candidate',
+      sense: { senseId: 'sense-one' },
+      referenceEvidence: { evidenceId: 'reference-one', normalizedReference: 'Synthetic 1:1' },
+      alignmentEvidence: { morphologyTokenIdentity: 'synthetic-token-1', verifierVersion: 1 },
+    });
+    expect(result.plainLanguage).toContain('candidate, not an adjudicated contextual sense');
+  });
+
+  it('keeps repeated local tokens distinct without caching or transferring alignment', async () => {
+    const service = new HebrewSemanticEvidenceService(new SyntheticRepository(data()));
+    const first = await service.resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment('sense-one', 'reference-one', 'synthetic-token-1')],
+    });
+    const second = await service.resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment('sense-one', 'reference-one', 'synthetic-token-2')],
+    });
+    expect(first.resolution).toMatchObject({ alignmentEvidence: { morphologyTokenIdentity: 'synthetic-token-1' } });
+    expect(second.resolution).toMatchObject({ alignmentEvidence: { morphologyTokenIdentity: 'synthetic-token-2' } });
+  });
+
+  it('snapshots caller-controlled inputs before awaiting repository evidence', async () => {
+    const repository = new SyntheticRepository(data());
+    const originalEntries = repository.getEntriesByLexicalIdentity.bind(repository);
+    let release!: () => void;
+    let markEntered!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const entered = new Promise<void>(resolve => { markEntered = resolve; });
+    let receivedPage: UbsSemanticPageRequest | undefined;
+    repository.getEntriesByLexicalIdentity = async (identity, page) => {
+      receivedPage = page;
+      markEntered();
+      await gate;
+      return originalEntries(identity);
+    };
+    const trusted = alignment();
+    const request: HebrewSemanticEvidenceRequest = {
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      entryPage: { cursor: 'original-synthetic-cursor' },
+      trustedAlignments: [trusted],
+    };
+    const pending = new HebrewSemanticEvidenceService(repository).resolve(request);
+    await entered;
+    request.audience = 'beginner';
+    request.publicStrongs = 'A1';
+    request.normalizedReference = 'Mutated 9:9';
+    request.entryPage!.cursor = `mutated-${'y'.repeat(5_000)}`;
+    request.trustedAlignments = [];
+    trusted.morphologyTokenIdentity = `mutated-${'x'.repeat(1_000)}`;
+    trusted.verifierVersion = HEBREW_SEMANTIC_EVIDENCE_LIMITS.verifierVersionMaximum + 1;
+    trusted.senseId = 'sense-three';
+    trusted.evidenceId = 'reference-three';
+    release();
+    const resolved = await pending;
+    expect(resolved.audience).toBe('expert');
+    expect(resolved.identity.publicStrongs).toBe('H1');
+    expect(resolved.normalizedReference).toBe('Synthetic 1:1');
+    expect(receivedPage).toEqual({ cursor: 'original-synthetic-cursor' });
+    expect(resolved.resolution).toMatchObject({
+      status: 'reference_aligned_source_candidate',
+      sense: { senseId: 'sense-one' },
+      referenceEvidence: { evidenceId: 'reference-one' },
+      alignmentEvidence: { morphologyTokenIdentity: 'synthetic-token-1', verifierVersion: 1 },
+    });
+    expect(JSON.stringify(resolved)).not.toContain('mutated-');
+  });
+
+  it('reads an accessor-backed alignment token exactly once before validation', async () => {
+    let tokenReads = 0;
+    const accessorAlignment = {
+      ...alignment(),
+      get morphologyTokenIdentity() {
+        tokenReads += 1;
+        return tokenReads === 1 ? 'synthetic-token-1' : `leaked-${'x'.repeat(1_000)}`;
+      },
+    } as TrustedHebrewTokenAlignment;
+    const resolved = await new HebrewSemanticEvidenceService(new SyntheticRepository(data())).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [accessorAlignment],
+    });
+    expect(tokenReads).toBe(1);
+    expect(resolved.resolution).toMatchObject({
+      status: 'reference_aligned_source_candidate',
+      sense: { senseId: 'sense-one' },
+      alignmentEvidence: { morphologyTokenIdentity: 'synthetic-token-1' },
+    });
+    expect(JSON.stringify(resolved)).not.toContain('leaked-');
+  });
+
+  it('reads every Proxy-backed exact alignment property once and uses only that snapshot', async () => {
+    const first = alignment();
+    const later: Record<keyof TrustedHebrewTokenAlignment, unknown> = {
+      status: 'not-verified',
+      morphologyTokenIdentity: `leaked-${'x'.repeat(1_000)}`,
+      verifierVersion: HEBREW_SEMANTIC_EVIDENCE_LIMITS.verifierVersionMaximum + 1,
+      sourceIdentity: H0002,
+      normalizedReference: 'Mutated 9:9',
+      sourceId: 'synthetic-other',
+      entryId: 'entry-two',
+      senseId: 'sense-three',
+      evidenceId: 'reference-three',
+    };
+    const reads = new Map<PropertyKey, number>();
+    const proxied = new Proxy(first, {
+      get(target, property, receiver) {
+        const count = (reads.get(property) ?? 0) + 1;
+        reads.set(property, count);
+        return count === 1
+          ? Reflect.get(target, property, receiver)
+          : later[property as keyof TrustedHebrewTokenAlignment];
+      },
+    });
+    const resolved = await new HebrewSemanticEvidenceService(new SyntheticRepository(data())).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [proxied],
+    });
+    expect([...reads.entries()]).toEqual([
+      ['status', 1],
+      ['morphologyTokenIdentity', 1],
+      ['verifierVersion', 1],
+      ['sourceIdentity', 1],
+      ['normalizedReference', 1],
+      ['sourceId', 1],
+      ['entryId', 1],
+      ['senseId', 1],
+      ['evidenceId', 1],
+    ]);
+    expect(resolved.resolution).toMatchObject({
+      status: 'reference_aligned_source_candidate',
+      sense: { senseId: 'sense-one' },
+      referenceEvidence: { evidenceId: 'reference-one' },
+      alignmentEvidence: { morphologyTokenIdentity: 'synthetic-token-1', verifierVersion: 1 },
+    });
+    expect(JSON.stringify(resolved)).not.toContain('leaked-');
+  });
+
+  it('rejects dishonest Proxy array lengths before reaching the repository', async () => {
+    for (const reportedLength of [Number.NaN, -1, 1.5, 9]) {
+      const repository = new SyntheticRepository(data());
+      let lengthReads = 0;
+      const alignments = new Proxy([alignment()], {
+        get(target, property, receiver) {
+          if (property === 'length') {
+            lengthReads += 1;
+            return reportedLength;
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+      await expect(new HebrewSemanticEvidenceService(repository).resolve({
+        publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+        trustedAlignments: alignments,
+      })).rejects.toThrow('honest safe-integer length');
+      expect(lengthReads).toBe(1);
+      expect(repository.calls).toEqual([]);
+    }
+  });
+
+  it('rejects a Proxy-truncated mixed assertion set before a valid assertion can promote', async () => {
+    const repository = new SyntheticRepository(data());
+    let lengthReads = 0;
+    const mixed = [
+      alignment(),
+      alignment('sense-three', 'missing-reference', 'synthetic-token-1', 'entry-two'),
+    ];
+    const truncated = new Proxy(mixed, {
+      get(target, property, receiver) {
+        if (property === 'length') {
+          lengthReads += 1;
+          return 1;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    await expect(new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: truncated,
+    })).rejects.toThrow('no assertion hidden beyond its reported length');
+    expect(lengthReads).toBe(1);
+    expect(repository.calls).toEqual([]);
+  });
+
+  it('rejects zero-length dishonesty and sparse or missing assertion indices', async () => {
+    const hiddenRepository = new SyntheticRepository(data());
+    const hidden = new Proxy([alignment()], {
+      get(target, property, receiver) {
+        return property === 'length' ? 0 : Reflect.get(target, property, receiver);
+      },
+    });
+    await expect(new HebrewSemanticEvidenceService(hiddenRepository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: hidden,
+    })).rejects.toThrow('no assertion hidden beyond its reported length');
+    expect(hiddenRepository.calls).toEqual([]);
+
+    const sparseRepository = new SyntheticRepository(data());
+    const sparse = new Array<TrustedHebrewTokenAlignment>(2);
+    sparse[0] = alignment();
+    await expect(new HebrewSemanticEvidenceService(sparseRepository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: sparse,
+    })).rejects.toThrow('every reported index present');
+    expect(sparseRepository.calls).toEqual([]);
+  });
+
+  it('reads each Proxy-backed request field and page cursor exactly once', async () => {
+    const repository = new SyntheticRepository(data());
+    const originalEntries = repository.getEntriesByLexicalIdentity.bind(repository);
+    repository.getEntriesByLexicalIdentity = async identity => originalEntries(identity);
+    let cursorReads = 0;
+    const page = {
+      get cursor() {
+        cursorReads += 1;
+        return cursorReads === 1 ? 'original-synthetic-cursor' : `leaked-${'y'.repeat(5_000)}`;
+      },
+    } as UbsSemanticPageRequest;
+    const first: HebrewSemanticEvidenceRequest = {
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      entryPage: page, trustedAlignments: [alignment()],
+    };
+    const later: Record<keyof HebrewSemanticEvidenceRequest, unknown> = {
+      publicStrongs: 'A1', normalizedReference: 'Mutated 9:9', audience: 'beginner',
+      entryPage: undefined, trustedAlignments: [],
+    };
+    const reads = new Map<PropertyKey, number>();
+    const request = new Proxy(first, {
+      get(target, property, receiver) {
+        const count = (reads.get(property) ?? 0) + 1;
+        reads.set(property, count);
+        return count === 1
+          ? Reflect.get(target, property, receiver)
+          : later[property as keyof HebrewSemanticEvidenceRequest];
+      },
+    });
+    const resolved = await new HebrewSemanticEvidenceService(repository).resolve(request);
+    expect([...reads.values()].every(count => count === 1)).toBe(true);
+    expect([...reads.keys()].sort()).toEqual([
+      'audience', 'entryPage', 'normalizedReference', 'publicStrongs', 'trustedAlignments',
+    ]);
+    expect(cursorReads).toBe(1);
+    expect(resolved).toMatchObject({
+      audience: 'expert', identity: { publicStrongs: 'H1' }, normalizedReference: 'Synthetic 1:1',
+      resolution: { status: 'reference_aligned_source_candidate', sense: { senseId: 'sense-one' } },
+    });
+  });
+
+  it('preserves ambiguity when two exact source candidates are separately aligned', async () => {
+    const result = await new HebrewSemanticEvidenceService(new SyntheticRepository(data())).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment(), alignment('sense-three', 'reference-three', 'synthetic-token-1', 'entry-two')],
+    });
+    expect(result.resolution).toMatchObject({ status: 'lexical_candidates', reason: 'ambiguous_reference_alignment' });
+  });
+
+  it('does not invent sense ambiguity from two exact evidence rows for the same sense', async () => {
+    const values = data();
+    values.references.splice(1, 0, evidence('reference-one-b', 'sense-one', 2, 'Synthetic 1:1'));
+    const result = await new HebrewSemanticEvidenceService(new SyntheticRepository(values)).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment(), alignment('sense-one', 'reference-one-b')],
+    });
+    expect(result.resolution).toMatchObject({
+      status: 'reference_aligned_source_candidate', referenceEvidence: { evidenceId: 'reference-one' },
+    });
+  });
+
+  it('does not infer range overlap and distinguishes absent reference evidence', async () => {
+    const service = new HebrewSemanticEvidenceService(new SyntheticRepository(data()));
+    const exact = await service.resolve({ publicStrongs: 'H2', normalizedReference: 'Synthetic 1:1', audience: 'beginner' });
+    expect(exact.resolution).toMatchObject({ status: 'lexical_candidates', reason: 'no_reference_evidence' });
+    const range = await service.resolve({ publicStrongs: 'H2', normalizedReference: 'Synthetic 1:1-2', audience: 'beginner' });
+    expect(range.resolution).toMatchObject({ status: 'lexical_candidates', reason: 'reference_alignment_unproven' });
+  });
+
+  it('preserves H+A internally, rejects public A input, and never promotes an A-only entry', async () => {
+    const service = new HebrewSemanticEvidenceService(new SyntheticRepository(data()));
+    await expect(service.resolve({ publicStrongs: 'A0002', normalizedReference: 'Synthetic 1:1', audience: 'beginner' }))
+      .rejects.toThrow('public H-number');
+    const missing = await service.resolve({ publicStrongs: 'H3', normalizedReference: 'Synthetic 1:1', audience: 'beginner' });
+    expect(missing.resolution).toEqual({ status: 'unavailable', reason: 'no_lexical_entry' });
+  });
+
+  it('distinguishes a lexical entry with no publishable senses from no lexical entry', async () => {
+    const values = data();
+    values.senses = values.senses.filter(item => item.entryId !== 'entry-range');
+    const unavailable = await new HebrewSemanticEvidenceService(new SyntheticRepository(values)).resolve({
+      publicStrongs: 'H2', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    });
+    expect(unavailable.resolution).toEqual({
+      status: 'unavailable', reason: 'no_publishable_semantic_evidence',
+    });
+  });
+
+  it('propagates stale internal repository cursors before sense or provenance work', async () => {
+    const repository = new SyntheticRepository(data());
+    await expect(new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+      entryPage: { cursor: 'stale-synthetic-cursor' },
+    })).rejects.toThrow('cursor is stale');
+    expect(repository.calls).toEqual(['entries:H0001:stale-synthetic-cursor']);
+  });
+
+  it('fails closed on missing or mismatched trusted alignment evidence', async () => {
+    const service = new HebrewSemanticEvidenceService(new SyntheticRepository(data()));
+    await expect(service.resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment('sense-two', 'missing-reference')],
+    })).rejects.toThrow('every trusted alignment must match one exact returned');
+    await expect(service.resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [{ ...alignment(), normalizedReference: 'Synthetic 1:2' }],
+    })).rejects.toThrow('exact token, source identity, normalized reference');
+  });
+
+  it('bounds candidate inspection and deterministic calls even with many senses', async () => {
+    const values = data();
+    values.entries = [values.entries[0]];
+    values.senses = Array.from({ length: 20 }, (_, index) => sense(
+      `sense-many-${String(index + 1).padStart(2, '0')}`, 'entry-one', index + 1, 'domain-one',
+    ));
+    values.references = [];
+    const repository = new SyntheticRepository(values);
+    const result = await new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 9:9', audience: 'beginner',
+    });
+    expect(result.resolution).toMatchObject({ status: 'lexical_candidates', reason: 'reference_alignment_unproven' });
+    expect(result.coverage).toMatchObject({
+      inspectedSenseCount: 8,
+      publishableCandidateCount: HEBREW_SEMANTIC_EVIDENCE_LIMITS.candidates,
+      completeForReturnedEntryWindow: false,
+    });
+    expect(repository.calls.filter(call => call.startsWith('domains:'))).toHaveLength(8);
+    expect(repository.calls.filter(call => call.startsWith('references:'))).toHaveLength(8);
+  });
+
+  it('prioritizes an exact trusted sense within a bounded returned sense page', async () => {
+    const values = data();
+    values.entries = [values.entries[0]];
+    values.senses = Array.from({ length: 12 }, (_, index) => sense(
+      `sense-priority-${String(index + 1).padStart(2, '0')}`, 'entry-one', index + 1, 'domain-one',
+    ));
+    values.references = [evidence('reference-priority', 'sense-priority-12', 1, 'Synthetic 1:1')];
+    const result = await new HebrewSemanticEvidenceService(new SyntheticRepository(values)).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [{
+        ...alignment('sense-priority-12', 'reference-priority'), entryId: 'entry-one',
+      }],
+    });
+    expect(result.resolution).toMatchObject({
+      status: 'reference_aligned_source_candidate', sense: { senseId: 'sense-priority-12' },
+    });
+    expect(result.coverage.completeForReturnedEntryWindow).toBe(false);
+  });
+
+  it('fails closed when a mixed trusted-assertion set contains even one unmatched row', async () => {
+    await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(data())).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment(), alignment('sense-three', 'missing-reference', 'synthetic-token-1', 'entry-two')],
+    })).rejects.toThrow('every trusted alignment must match one exact returned');
+  });
+
+  it('fails closed when a trusted assertion is outside the bounded candidate window', async () => {
+    const values = data();
+    values.entries = values.entries.slice(0, 2);
+    values.senses = [
+      ...Array.from({ length: 8 }, (_, index) => sense(
+        `sense-window-${String(index + 1).padStart(2, '0')}`, 'entry-one', index + 1, 'domain-one',
+      )),
+      sense('sense-three', 'entry-two', 1, 'domain-three'),
+    ];
+    values.references = [evidence('reference-three', 'sense-three', 1, 'Synthetic 1:1')];
+    await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(values)).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+      trustedAlignments: [alignment('sense-three', 'reference-three', 'synthetic-token-1', 'entry-two')],
+    })).rejects.toThrow('every trusted alignment must match one exact returned');
+  });
+
+  it('never treats an empty offset window as proof that no lexical entry exists', async () => {
+    const repository = new SyntheticRepository(data());
+    repository.getEntriesByLexicalIdentity = async () => ({
+      items: [], total: 1, showing: 0, priorShowing: 1, consumed: 1, hasMore: false,
+      order: UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      limit: UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+    });
+    await expect(new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+      entryPage: { cursor: 'synthetic-offset-window' },
+    })).rejects.toThrow('incomplete entry evidence cannot establish');
+  });
+
+  it('rejects incomplete first-page sense, domain, and reference evidence', async () => {
+    const cases = ['sense', 'domain', 'reference'] as const;
+    for (const kind of cases) {
+      const repository = new SyntheticRepository(data());
+      if (kind === 'sense') {
+        repository.getSensesForEntry = async (sourceId, entryId) => ({
+          items: [sense('sense-one', entryId, 1, 'domain-one')], total: 2, showing: 1,
+          priorShowing: 0, consumed: 1, hasMore: true, nextCursor: 'synthetic-more-senses',
+          order: UBS_SEMANTIC_REPOSITORY_ORDER.sensesPerEntry,
+          limit: UBS_SEMANTIC_REPOSITORY_LIMITS.sensesPerEntry,
+        });
+      } else if (kind === 'domain') {
+        repository.getDomainsForSense = async () => ({
+          items: [data().domains[0]], total: 2, showing: 1, priorShowing: 0, consumed: 1,
+          hasMore: true, nextCursor: 'synthetic-more-domains',
+          order: UBS_SEMANTIC_REPOSITORY_ORDER.domainsPerSense,
+          limit: UBS_SEMANTIC_REPOSITORY_LIMITS.domainsPerSense,
+        });
+      } else {
+        repository.findReferenceEvidence = async () => ({
+          items: [evidence('reference-one', 'sense-one', 1, 'Synthetic 1:1')], total: 2,
+          showing: 1, priorShowing: 0, consumed: 1, hasMore: true, nextCursor: 'synthetic-more-references',
+          order: UBS_SEMANTIC_REPOSITORY_ORDER.matchingReferenceEvidence,
+          limit: UBS_SEMANTIC_REPOSITORY_LIMITS.matchingReferenceEvidence,
+        });
+      }
+      await expect(new HebrewSemanticEvidenceService(repository).resolve({
+        publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+      })).rejects.toThrow(`repository ${kind === 'reference' ? 'reference evidence' : kind} first-page collection must be complete`);
+    }
+  });
+
+  it('rejects internally inconsistent short-page counts rather than publishing partial evidence', async () => {
+    const repository = new SyntheticRepository(data());
+    repository.getSensesForEntry = async (_sourceId, entryId) => ({
+      items: [sense('sense-one', entryId, 1, 'domain-one')], total: 2, showing: 1,
+      priorShowing: 0, consumed: 1, hasMore: false,
+      order: UBS_SEMANTIC_REPOSITORY_ORDER.sensesPerEntry,
+      limit: UBS_SEMANTIC_REPOSITORY_LIMITS.sensesPerEntry,
+    });
+    await expect(new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('bounded honest-window contract');
+  });
+
+  it('does not assert unavailability when an entry window is incomplete', async () => {
+    const values = data();
+    values.senses = [];
+    const repository = new SyntheticRepository(values);
+    repository.getEntriesByLexicalIdentity = async () => ({
+      items: [values.entries[0]], total: 2, showing: 1, priorShowing: 0, consumed: 1,
+      hasMore: true, nextCursor: 'synthetic-more-entries',
+      order: UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      limit: UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+    });
+    await expect(new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('incomplete repository evidence cannot establish');
+  });
+
+  it('rejects all 66 Unicode noncharacters in trusted token identities', async () => {
+    const noncharacters = [
+      ...Array.from({ length: 0x20 }, (_, index) => 0xfdd0 + index),
+      ...Array.from({ length: 17 }, (_, plane) => [0xfffe + plane * 0x10000, 0xffff + plane * 0x10000]).flat(),
+    ];
+    expect(noncharacters).toHaveLength(66);
+    for (const codePoint of noncharacters) {
+      await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(data())).resolve({
+        publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'expert',
+        trustedAlignments: [alignment('sense-one', 'reference-one', `token-${String.fromCodePoint(codePoint)}`)],
+      })).rejects.toThrow('morphology token identity');
+    }
+  });
+
+  it('rejects Unicode noncharacters across repository and provenance text fields', async () => {
+    const bad = String.fromCodePoint(0x10ffff);
+    const mutations: Array<(values: SyntheticData) => void> = [
+      values => { values.entries[0].lemma = `lemma-${bad}`; },
+      values => { values.entries[0].transliteration = `transliteration-${bad}`; },
+      values => { values.entries[0].partOfSpeech = `part-${bad}`; },
+      values => { values.senses[0].definition = `definition-${bad}`; },
+      values => { values.senses[0].glosses = [`gloss-${bad}`]; },
+      values => { values.domains[0].label = `label-${bad}`; },
+      values => { values.domains[0].description = `description-${bad}`; },
+      values => { values.sources[0].title = `title-${bad}`; },
+      values => { values.sources[0].modificationNote = `note-${bad}`; },
+      values => { values.sources[0].sourceUrl = `https://example.invalid/${bad}`; },
+    ];
+    for (const mutate of mutations) {
+      const values = data();
+      mutate(values);
+      await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(values)).resolve({
+        publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+      })).rejects.toThrow();
+    }
+  });
+
+  it('rejects a Unicode noncharacter in a bounded repository cursor token', async () => {
+    const repository = new SyntheticRepository(data());
+    repository.getEntriesByLexicalIdentity = async () => ({
+      items: [data().entries[0]], total: 2, showing: 1, priorShowing: 0, consumed: 1,
+      hasMore: true, nextCursor: `cursor-${String.fromCodePoint(0xffff)}`,
+      order: UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      limit: UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+    });
+    await expect(new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('bounded honest-window contract');
+  });
+
+  it('fails closed on incomplete provenance and malformed repository identity evidence', async () => {
+    const missingSource = data();
+    missingSource.sources.pop();
+    await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(missingSource)).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('provenance is missing');
+
+    const wrongIdentity = data();
+    wrongIdentity.entries[0].lexicalIdentities = [A0001];
+    const repository = new SyntheticRepository(wrongIdentity);
+    repository.getEntriesByLexicalIdentity = async () => createUbsSemanticRepositoryCollection(
+      [wrongIdentity.entries[0]], 1,
+      UBS_SEMANTIC_REPOSITORY_ORDER.entriesByLexicalIdentity,
+      UBS_SEMANTIC_REPOSITORY_LIMITS.entriesByLexicalIdentity,
+      { priorShowing: 0 },
+    );
+    await expect(new HebrewSemanticEvidenceService(repository).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('requested branded lexical identity');
+  });
+
+  it('enforces compiler identity uniqueness across the complete resolution', async () => {
+    const duplicateLexicalIdentity = data();
+    duplicateLexicalIdentity.entries[0].lexicalIdentities = [H0001, H0001];
+    await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(duplicateLexicalIdentity)).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('lexical identities must be unique');
+
+    const duplicateSenseIdentity = data();
+    duplicateSenseIdentity.senses = [
+      sense('sense-duplicate', 'entry-one', 1, 'domain-one'),
+      sense('sense-duplicate', 'entry-two', 1, 'domain-three'),
+    ];
+    duplicateSenseIdentity.references = [];
+    await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(duplicateSenseIdentity)).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('duplicate cross-resolution identity');
+
+    const duplicateEvidenceIdentity = data();
+    duplicateEvidenceIdentity.references = [
+      evidence('reference-duplicate', 'sense-one', 1, 'Synthetic 1:1'),
+      evidence('reference-duplicate', 'sense-three', 1, 'Synthetic 1:1'),
+    ];
+    await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(duplicateEvidenceIdentity)).resolve({
+      publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+    })).rejects.toThrow('duplicate cross-resolution identity');
+  });
+
+  it('enforces compiler ordinal uniqueness for entries, senses, domains, and references', async () => {
+    const cases: Array<{ mutate: (values: SyntheticData) => void; message: string }> = [
+      {
+        mutate: values => { values.entries[1].sourceOrdinal = values.entries[0].sourceOrdinal; },
+        message: 'entries contain a duplicate source ordinal',
+      },
+      {
+        mutate: values => { values.senses[1].sourceOrdinal = values.senses[0].sourceOrdinal; },
+        message: 'senses contain a duplicate source ordinal',
+      },
+      {
+        mutate: values => {
+          values.senses[0].domainRefs.push({ sourceId: 'synthetic-domains', domainId: 'domain-two' });
+          values.domains[1].sourceOrdinal = values.domains[0].sourceOrdinal;
+        },
+        message: 'domains contain a duplicate source ordinal',
+      },
+      {
+        mutate: values => {
+          values.references.splice(1, 0, evidence('reference-one-b', 'sense-one', 1, 'Synthetic 1:1'));
+        },
+        message: 'reference evidence contains a duplicate source ordinal',
+      },
+    ];
+    for (const testCase of cases) {
+      const values = data();
+      testCase.mutate(values);
+      await expect(new HebrewSemanticEvidenceService(new SyntheticRepository(values)).resolve({
+        publicStrongs: 'H1', normalizedReference: 'Synthetic 1:1', audience: 'beginner',
+      })).rejects.toThrow(testCase.message);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a source-free, unregistered HebrewSemanticEvidenceService over the reviewed UBS repository contracts
- require exact reference evidence and separately trusted exact token alignment; preserve ambiguity and default to candidate/unavailable outcomes
- fail closed on incomplete evidence windows, malformed repository identities, asynchronous caller mutation, hostile accessors/proxies, and Unicode noncharacters
- add deterministic caps, synthetic Node/D1-shaped parity, adversarial service tests, and explicit inertness guards

## Inactive boundary
- no UBS source artifacts, table names, D1 migration, transform advancement, or corpus bytes
- no composition-root, MCP tool/schema/prompt/resource, Worker, config, or deployment registration
- no morphology, frequency, gloss-similarity, or TBESH-based sense inference

## Review and verification
- independent final review: GO (P0-P3 zero)
- semantic/guard implementation suite: 118/118
- independent focused review: 112/112
- coordinator focused rerun after rebase onto current main: 40/40
- isolated TypeScript and inertness/diff checks passed