### PR TITLE
Add inactive UBS semantic aggregate contract

### DIFF
--- a/docs/UBS-SEMANTICS-FOUNDATION.md
+++ b/docs/UBS-SEMANTICS-FOUNDATION.md
@@ -127,9 +127,46 @@ candidates per call, with explicit incomplete-coverage metadata when those
 bounds intervene. It never reports evidence as unavailable from an offset,
 partial, or capped window, and its unpaged sense, domain, and exact-reference
 queries must return internally consistent complete first pages. This
-deliberately temporary per-operation choreography is
-not the future aggregate repository query: OL-S2 must replace its bounded N+1
-shape before any runtime composition or public registration.
+deliberately temporary per-operation choreography is not suitable for runtime
+composition or public registration.
+
+OL-S2 adds an inactive `IUbsSemanticEvidenceBundleRepository` contract for one
+bounded aggregate operation. It returns at most eight entry/sense candidate
+rows plus their bounded domain, exact-reference, and two-source provenance
+evidence, together with honest lexical-entry, semantic-sense, nested-evidence,
+and candidate-window totals. Thus a future resolver can distinguish no entry
+from an entry without senses and can fail closed when a returned or whole-query
+window is incomplete without issuing one query per candidate. The operation's
+repository call count is exactly one for an empty, short, or full page.
+
+Every published aggregate object is reconstructed from an explicit allowlist of
+validated fields; adapter-only properties are neither read nor carried into the
+result. Lexical identities, bounded domain references and details, and exact
+reference evidence are canonicalized with stable code-point and ordinal
+ordering, so equivalent Node and D1 rows produce the same result. A candidate's
+`domainTotal` is the authoritative pre-slice count: its returned domain refs
+and details are capped at 16 and may be fewer than that total, in which case
+`domain_evidence` explicitly records incompleteness. This supports real senses
+with more domains than one response can safely include without pretending that
+the capped window is complete.
+
+Aggregate continuation cursors use the candidate's canonical entry/sense
+keyset and bind the exact aggregate operation, order, semantic artifact SHA-256,
+internal H#### identity, normalized reference, and prior result count. The
+decoded cursor remains an untrusted request: the single aggregate repository
+operation must validate that its exact keyset and prior count describe a real
+ordered boundary for that exact artifact/query/order, then return its own
+authoritative boundary attestation. The coordinator rejects missing, stale,
+forged, noncanonical, false-terminal, or mismatched attestations before it
+publishes any result or coverage window. A synthetically constructed cursor is
+acceptable only when it names a genuine boundary; it grants no access beyond
+public source material. No HMAC secret is needed for this read-only continuation
+model.
+
+The contract remains source-free and unregistered: it names no table, index,
+SQL, D1 binding, migration, or source path, and it is absent from both Worker
+and Node composition. Actual storage layout and query-plan work remain deferred
+until the exact approved source artifacts can be inspected rather than inferred.
 
 Repository validation also mirrors compiler identity guarantees: lexical
 identities and source ordinals are unique where their schema defines them, and

--- a/src/kernel/ubsSemanticEvidenceBundle.ts
+++ b/src/kernel/ubsSemanticEvidenceBundle.ts
@@ -1,0 +1,937 @@
+/**
+ * Inactive aggregate-query contract for future UBS Hebrew semantic evidence.
+ *
+ * This contract deliberately names no table, index, SQL statement, D1 binding,
+ * or source artifact path. A future Node or D1 adapter may satisfy the single
+ * repository operation without committing the project to a storage layout.
+ */
+import {
+  UBS_SEMANTIC_CURSOR_MAX_LENGTH,
+  UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS,
+  requireUbsInternalLexicalIdentity,
+  requireUbsSemanticNormalizedReference,
+} from './ubsSemanticDomain.js';
+import type {
+  UbsInternalHebrewLexicalIdentity,
+  UbsSemanticDomain,
+  UbsSemanticDomainRef,
+  UbsSemanticEntry,
+  UbsSemanticReferenceEvidence,
+  UbsSemanticSense,
+  UbsSemanticSource,
+} from './ubsSemanticDomain.js';
+
+export const UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS = Object.freeze({
+  candidatesPerPage: 8,
+  domainsPerSense: 16,
+  matchingReferencesPerSense: 16,
+  provenanceSources: 2,
+  lexicalIdentitiesPerEntry: 16,
+} as const);
+
+export const UBS_SEMANTIC_EVIDENCE_BUNDLE_OPERATION = 'getSemanticEvidenceBundle' as const;
+export const UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER =
+  'entry_source_id_entry_ordinal_entry_id_sense_ordinal_sense_id' as const;
+
+export interface UbsSemanticEvidenceBundleRequest {
+  artifactIdentity: string;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  normalizedReference: string;
+  /** Internal repository continuation only; never a public authorization token. */
+  page?: { cursor?: string };
+}
+
+export interface UbsSemanticEvidenceBundleRepositoryQuery {
+  artifactIdentity: string;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  normalizedReference: string;
+  limit: typeof UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.candidatesPerPage;
+  order: typeof UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER;
+  /**
+   * Decoded from an opaque caller cursor. This is deliberately untrusted until
+   * the repository returns a matching, authoritative boundary attestation.
+   */
+  after?: {
+    keyset: readonly [string, string, string, string, string];
+    priorShowing: number;
+  };
+}
+
+export interface UbsSemanticEvidenceBundleCandidateRow {
+  entry: UbsSemanticEntry;
+  /** `domainRefs` is this bounded aggregate window, not an unbounded source read. */
+  sense: UbsSemanticSense;
+  domains: UbsSemanticDomain[];
+  /** Authoritative source-attested total before bounded domain refs/details are sliced. */
+  domainTotal: number;
+  matchingReferences: UbsSemanticReferenceEvidence[];
+  /** Honest exact-reference total before the bounded representation is sliced. */
+  matchingReferenceTotal: number;
+}
+
+/**
+ * Evidence produced by the one aggregate repository operation. For a
+ * continuation, an adapter must derive `priorShowing` and `after.keyset` from
+ * the actual ordered result set—not echo the cursor request. An adapter must
+ * reject a missing, stale, or non-boundary keyset rather than return a page.
+ */
+export interface UbsSemanticEvidenceBundleRepositoryBoundary {
+  artifactIdentity: string;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  normalizedReference: string;
+  order: typeof UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER;
+  /** Authoritative number of candidates before this returned window. */
+  priorShowing: number;
+  /** Present only after the repository has validated a genuine continuation boundary. */
+  after?: {
+    keyset: readonly [string, string, string, string, string];
+  };
+}
+
+export interface UbsSemanticEvidenceBundleRepositoryPage {
+  items: UbsSemanticEvidenceBundleCandidateRow[];
+  lexicalEntryTotal: number;
+  semanticSenseTotal: number;
+  /** The repository's authoritative attestation of the requested page boundary. */
+  boundary: UbsSemanticEvidenceBundleRepositoryBoundary;
+  sources: UbsSemanticSource[];
+}
+
+export interface IUbsSemanticEvidenceBundleRepository {
+  /** One bounded aggregate operation, independent of the number of returned candidates. */
+  getSemanticEvidenceBundle(
+    query: Readonly<UbsSemanticEvidenceBundleRepositoryQuery>,
+  ): Promise<UbsSemanticEvidenceBundleRepositoryPage>;
+}
+
+export interface UbsSemanticEvidenceBundleCoverage {
+  lexicalEntryTotal: number;
+  semanticSenseTotal: number;
+  candidateWindow: {
+    priorCount: number;
+    returnedCount: number;
+    consumedCount: number;
+    totalCount: number;
+    hasMore: boolean;
+    nextCursor?: string;
+  };
+  completeForReturnedWindow: boolean;
+  completeForWholeQuery: boolean;
+  incompleteReasons: readonly (
+    | 'candidate_window'
+    | 'prior_candidate_window'
+    | 'domain_evidence'
+    | 'reference_evidence'
+  )[];
+}
+
+export interface UbsSemanticEvidenceBundle {
+  operation: typeof UBS_SEMANTIC_EVIDENCE_BUNDLE_OPERATION;
+  order: typeof UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER;
+  query: {
+    artifactIdentity: string;
+    sourceIdentity: UbsInternalHebrewLexicalIdentity;
+    normalizedReference: string;
+  };
+  candidates: readonly UbsSemanticEvidenceBundleCandidateRow[];
+  sources: readonly UbsSemanticSource[];
+  coverage: UbsSemanticEvidenceBundleCoverage;
+}
+
+interface BundleCursorPayload {
+  version: 1;
+  operation: typeof UBS_SEMANTIC_EVIDENCE_BUNDLE_OPERATION;
+  order: typeof UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER;
+  artifactIdentity: string;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  normalizedReference: string;
+  keyset: [string, string, string, string, string];
+  priorShowing: number;
+}
+
+export async function queryUbsSemanticEvidenceBundle(
+  repository: IUbsSemanticEvidenceBundleRepository,
+  request: UbsSemanticEvidenceBundleRequest,
+): Promise<UbsSemanticEvidenceBundle> {
+  const query = snapshotQuery(request);
+  const page = await repository.getSemanticEvidenceBundle(query);
+  return validateAndBuildBundle(page, query);
+}
+
+export function createUbsSemanticEvidenceBundleCursor(
+  query: Pick<UbsSemanticEvidenceBundleRepositoryQuery,
+    'artifactIdentity' | 'sourceIdentity' | 'normalizedReference'>,
+  candidate: UbsSemanticEvidenceBundleCandidateRow,
+  priorShowing: number,
+): string {
+  const binding = snapshotCursorBinding(query);
+  positiveSafeInteger(priorShowing, 'bundle cursor prior showing');
+  const keyset = snapshotCandidateKeyset(candidate);
+  const payload: BundleCursorPayload = {
+    version: 1,
+    operation: UBS_SEMANTIC_EVIDENCE_BUNDLE_OPERATION,
+    order: UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER,
+    artifactIdentity: binding.artifactIdentity,
+    sourceIdentity: binding.sourceIdentity,
+    normalizedReference: binding.normalizedReference,
+    keyset,
+    priorShowing,
+  };
+  const encoded = [...new TextEncoder().encode(JSON.stringify(payload))]
+    .map(byte => byte.toString(16).padStart(2, '0')).join('');
+  const cursor = `ubsa1_${encoded}`;
+  if (cursor.length > UBS_SEMANTIC_CURSOR_MAX_LENGTH) {
+    throw new Error('UBS semantic aggregate cursor exceeds the shared cursor bound');
+  }
+  return cursor;
+}
+
+export function parseUbsSemanticEvidenceBundleCursor(
+  cursor: string,
+  expected: Pick<UbsSemanticEvidenceBundleRepositoryQuery,
+    'artifactIdentity' | 'sourceIdentity' | 'normalizedReference'>,
+): { keyset: [string, string, string, string, string]; priorShowing: number } {
+  const binding = snapshotCursorBinding(expected);
+  if (typeof cursor !== 'string' || cursor.length > UBS_SEMANTIC_CURSOR_MAX_LENGTH
+    || !/^ubsa1_(?:[0-9a-f]{2})+$/.test(cursor)) {
+    throw new Error('UBS semantic aggregate cursor has an invalid bounded encoding');
+  }
+  let value: unknown;
+  try {
+    const bytes = cursor.slice(6).match(/../g)!.map(byte => Number.parseInt(byte, 16));
+    value = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(new Uint8Array(bytes)));
+  } catch {
+    throw new Error('UBS semantic aggregate cursor has an invalid payload');
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('UBS semantic aggregate cursor payload must be an object');
+  }
+  const payload = value as Partial<BundleCursorPayload>;
+  if (Object.keys(payload).join(',') !== [
+    'version', 'operation', 'order', 'artifactIdentity', 'sourceIdentity',
+    'normalizedReference', 'keyset', 'priorShowing',
+  ].join(',')
+    || payload.version !== 1
+    || payload.operation !== UBS_SEMANTIC_EVIDENCE_BUNDLE_OPERATION
+    || payload.order !== UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER
+    || payload.artifactIdentity !== binding.artifactIdentity
+    || payload.sourceIdentity !== binding.sourceIdentity
+    || payload.normalizedReference !== binding.normalizedReference
+    || !Array.isArray(payload.keyset)) {
+    throw new Error('UBS semantic aggregate cursor does not match its exact query and artifact binding');
+  }
+  const keyset = validateCandidateKeyset(payload.keyset);
+  positiveSafeInteger(payload.priorShowing, 'bundle cursor prior showing');
+  const canonical = createCursorFromKeyset(binding, keyset, payload.priorShowing);
+  if (canonical !== cursor) throw new Error('UBS semantic aggregate cursor is not canonical');
+  return { keyset, priorShowing: payload.priorShowing };
+}
+
+function snapshotQuery(request: UbsSemanticEvidenceBundleRequest): Readonly<UbsSemanticEvidenceBundleRepositoryQuery> {
+  if (!request || typeof request !== 'object') throw new Error('UBS semantic aggregate request must be a record');
+  const artifactIdentity = request.artifactIdentity;
+  const sourceIdentity = requireHebrewIdentity(request.sourceIdentity);
+  const normalizedReference = requireUbsSemanticNormalizedReference(request.normalizedReference);
+  const rawPage = request.page;
+  const cursor = rawPage?.cursor;
+  validateArtifactIdentity(artifactIdentity);
+  const base = { artifactIdentity, sourceIdentity, normalizedReference };
+  const after = cursor === undefined
+    ? undefined
+    : parseUbsSemanticEvidenceBundleCursor(cursor, base);
+  return Object.freeze({
+    ...base,
+    limit: UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.candidatesPerPage,
+    order: UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER,
+    ...(after ? { after: Object.freeze({ keyset: Object.freeze(after.keyset), priorShowing: after.priorShowing }) } : {}),
+  });
+}
+
+/**
+ * Cursor payloads bind a request but do not authorize a position. The sole
+ * repository call must therefore return an independently derived boundary
+ * attestation before this coordinator may publish its result window.
+ */
+function validateRepositoryBoundary(
+  raw: UbsSemanticEvidenceBundleRepositoryBoundary,
+  query: Readonly<UbsSemanticEvidenceBundleRepositoryQuery>,
+): number {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('UBS semantic aggregate repository omitted its authoritative page boundary');
+  }
+  const hasContinuation = query.after !== undefined;
+  const expectedKeys = hasContinuation
+    ? ['artifactIdentity', 'sourceIdentity', 'normalizedReference', 'order', 'priorShowing', 'after']
+    : ['artifactIdentity', 'sourceIdentity', 'normalizedReference', 'order', 'priorShowing'];
+  if (!hasExactOwnKeys(raw, expectedKeys)) {
+    throw new Error('UBS semantic aggregate repository returned a malformed authoritative page boundary');
+  }
+  const {
+    artifactIdentity,
+    sourceIdentity: rawSourceIdentity,
+    normalizedReference,
+    order,
+    priorShowing,
+    after: rawAfter,
+  } = raw;
+  validateArtifactIdentity(artifactIdentity);
+  const sourceIdentity = requireHebrewIdentity(rawSourceIdentity);
+  const canonicalReference = requireUbsSemanticNormalizedReference(normalizedReference);
+  nonNegativeSafeInteger(priorShowing, 'bundle authoritative prior showing');
+  if (artifactIdentity !== query.artifactIdentity || sourceIdentity !== query.sourceIdentity
+    || canonicalReference !== query.normalizedReference || order !== query.order) {
+    throw new Error('UBS semantic aggregate repository boundary does not attest the exact query and order');
+  }
+  if (!hasContinuation) {
+    if (priorShowing !== 0 || rawAfter !== undefined) {
+      throw new Error('UBS semantic aggregate first page has a nonzero or continuation boundary');
+    }
+    return priorShowing;
+  }
+  if (!rawAfter || typeof rawAfter !== 'object' || Array.isArray(rawAfter)
+    || !hasExactOwnKeys(rawAfter, ['keyset'])) {
+    throw new Error('UBS semantic aggregate repository did not validate the requested continuation boundary');
+  }
+  const authoritativeKeyset = validateCandidateKeyset(rawAfter.keyset);
+  if (priorShowing !== query.after!.priorShowing
+    || compareKeysets(authoritativeKeyset, query.after!.keyset) !== 0) {
+    throw new Error('UBS semantic aggregate repository boundary does not match the requested cursor position');
+  }
+  return priorShowing;
+}
+
+function validateAndBuildBundle(
+  raw: UbsSemanticEvidenceBundleRepositoryPage,
+  query: Readonly<UbsSemanticEvidenceBundleRepositoryQuery>,
+): UbsSemanticEvidenceBundle {
+  if (!raw || !Array.isArray(raw.items) || !Array.isArray(raw.sources)
+    || raw.items.length > UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.candidatesPerPage) {
+    throw new Error('UBS semantic aggregate repository returned a malformed bounded page');
+  }
+  nonNegativeSafeInteger(raw.lexicalEntryTotal, 'bundle lexical entry total');
+  nonNegativeSafeInteger(raw.semanticSenseTotal, 'bundle semantic sense total');
+  const priorShowing = validateRepositoryBoundary(raw.boundary, query);
+  const consumed = priorShowing + raw.items.length;
+  if (!Number.isSafeInteger(consumed) || consumed > raw.semanticSenseTotal
+    || (consumed < raw.semanticSenseTotal && raw.items.length === 0)) {
+    throw new Error('UBS semantic aggregate page violates its honest candidate window');
+  }
+  if ((raw.semanticSenseTotal > 0 && raw.lexicalEntryTotal === 0)
+    || (raw.semanticSenseTotal === 0 && raw.items.length > 0)) {
+    throw new Error('UBS semantic aggregate entry and sense totals are internally inconsistent');
+  }
+  const sources = cloneAndValidateSources(raw.sources, query.artifactIdentity);
+  const items = raw.items.map(item => cloneAndValidateCandidate(item, query.normalizedReference));
+  validateCandidateOrder(items, query.sourceIdentity, sources, raw.lexicalEntryTotal);
+  if (query.after && items.length > 0 && compareKeysets(candidateKeyset(items[0]!), query.after.keyset) <= 0) {
+    throw new Error('UBS semantic aggregate page did not advance beyond its exact cursor keyset');
+  }
+  const hasMore = consumed < raw.semanticSenseTotal;
+  const nextCursor = hasMore
+    ? createCursorFromKeyset(query, snapshotCandidateKeyset(items.at(-1)!), consumed)
+    : undefined;
+  const incompleteReasons = new Set<UbsSemanticEvidenceBundleCoverage['incompleteReasons'][number]>();
+  if (hasMore) incompleteReasons.add('candidate_window');
+  if (priorShowing > 0) incompleteReasons.add('prior_candidate_window');
+  for (const item of items) {
+    if (item.domains.length !== item.domainTotal) incompleteReasons.add('domain_evidence');
+    if (item.matchingReferences.length !== item.matchingReferenceTotal) incompleteReasons.add('reference_evidence');
+  }
+  const completeForReturnedWindow = !incompleteReasons.has('domain_evidence')
+    && !incompleteReasons.has('reference_evidence');
+  return {
+    operation: UBS_SEMANTIC_EVIDENCE_BUNDLE_OPERATION,
+    order: UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER,
+    query: {
+      artifactIdentity: query.artifactIdentity,
+      sourceIdentity: query.sourceIdentity,
+      normalizedReference: query.normalizedReference,
+    },
+    candidates: items,
+    sources,
+    coverage: {
+      lexicalEntryTotal: raw.lexicalEntryTotal,
+      semanticSenseTotal: raw.semanticSenseTotal,
+      candidateWindow: {
+        priorCount: priorShowing,
+        returnedCount: items.length,
+        consumedCount: consumed,
+        totalCount: raw.semanticSenseTotal,
+        hasMore,
+        ...(nextCursor ? { nextCursor } : {}),
+      },
+      completeForReturnedWindow,
+      completeForWholeQuery: priorShowing === 0 && !hasMore && completeForReturnedWindow,
+      incompleteReasons: [...incompleteReasons],
+    },
+  };
+}
+
+function cloneAndValidateCandidate(
+  raw: UbsSemanticEvidenceBundleCandidateRow,
+  normalizedReference: string,
+): UbsSemanticEvidenceBundleCandidateRow {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('UBS semantic aggregate candidate row is malformed');
+  }
+  const {
+    entry: rawEntry,
+    sense: rawSense,
+    domains: rawDomains,
+    domainTotal,
+    matchingReferences: rawMatchingReferences,
+    matchingReferenceTotal,
+  } = raw;
+  if (!rawEntry || !rawSense || !Array.isArray(rawDomains) || !Array.isArray(rawMatchingReferences)) {
+    throw new Error('UBS semantic aggregate candidate row is malformed');
+  }
+  positiveSafeInteger(domainTotal, 'bundle domain total');
+  nonNegativeSafeInteger(matchingReferenceTotal, 'bundle matching-reference total');
+  if (rawDomains.length > UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.domainsPerSense
+    || rawMatchingReferences.length > UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.matchingReferencesPerSense) {
+    throw new Error('UBS semantic aggregate nested evidence violates deterministic caps or honest totals');
+  }
+  const entry = cloneAndValidateEntry(rawEntry);
+  const sense = cloneAndValidateSense(rawSense);
+  if (sense.sourceId !== entry.sourceId || sense.entryId !== entry.entryId) {
+    throw new Error('UBS semantic aggregate sense does not belong to its bundled entry');
+  }
+  const domains = rawDomains.map(domain => cloneAndValidateDomain(domain)).sort(compareDomains);
+  const matchingReferences = rawMatchingReferences.map(evidence =>
+    cloneAndValidateReferenceEvidence(evidence, normalizedReference, sense.sourceId, sense.senseId),
+  ).sort(compareReferenceEvidence);
+  if (domains.length > domainTotal || sense.domainRefs.length > domainTotal
+    || matchingReferences.length > matchingReferenceTotal) {
+    throw new Error('UBS semantic aggregate nested evidence exceeds its authoritative total');
+  }
+  const expectedDomains = new Set(sense.domainRefs.map(domainReferenceIdentity));
+  if (expectedDomains.size !== sense.domainRefs.length
+    || expectedDomains.size !== domains.length
+    || domains.some(domain => !expectedDomains.has(domainIdentity(domain)))) {
+    throw new Error('UBS semantic aggregate domain evidence does not match its bounded source-attested references');
+  }
+  const domainIdentities = new Set<string>();
+  const domainOrdinals = new Set<number>();
+  for (const domain of domains) {
+    const identity = domainIdentity(domain);
+    if (domainIdentities.has(identity)) throw new Error('UBS semantic aggregate contains a duplicate domain identity');
+    domainIdentities.add(identity);
+    if (domainOrdinals.has(domain.sourceOrdinal)) throw new Error('UBS semantic aggregate contains a duplicate domain ordinal');
+    domainOrdinals.add(domain.sourceOrdinal);
+  }
+  const referenceIdentities = new Set<string>();
+  const referenceOrdinals = new Set<number>();
+  for (const evidence of matchingReferences) {
+    const identity = `${evidence.sourceId}\0${evidence.evidenceId}`;
+    if (referenceIdentities.has(identity)) throw new Error('UBS semantic aggregate contains duplicate reference evidence');
+    referenceIdentities.add(identity);
+    if (referenceOrdinals.has(evidence.sourceOrdinal)) throw new Error('UBS semantic aggregate contains a duplicate reference ordinal');
+    referenceOrdinals.add(evidence.sourceOrdinal);
+  }
+  return {
+    entry,
+    sense,
+    domains,
+    domainTotal,
+    matchingReferences,
+    matchingReferenceTotal,
+  };
+}
+
+function cloneAndValidateEntry(raw: UbsSemanticEntry): UbsSemanticEntry {
+  if (!raw || typeof raw !== 'object') throw new Error('UBS semantic aggregate entry is malformed');
+  const {
+    entryId, sourceId, sourceOrdinal, lemma, transliteration, partOfSpeech,
+    lexicalIdentities: rawLexicalIdentities,
+  } = raw;
+  identifier(sourceId, 'bundle entry source ID');
+  identifier(entryId, 'bundle entry ID');
+  positiveSafeInteger(sourceOrdinal, 'bundle entry ordinal');
+  boundedText(lemma, 2_000, 'bundle entry lemma');
+  if (transliteration !== undefined) boundedText(transliteration, 2_000, 'bundle entry transliteration');
+  if (partOfSpeech !== undefined) boundedText(partOfSpeech, 512, 'bundle entry part of speech');
+  if (!Array.isArray(rawLexicalIdentities)
+    || rawLexicalIdentities.length > UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.lexicalIdentitiesPerEntry) {
+    throw new Error('UBS semantic aggregate entry lexical identities are malformed or unbounded');
+  }
+  const lexicalIdentities = rawLexicalIdentities.map(identity => requireUbsInternalLexicalIdentity(identity))
+    .sort(compareCodePoints);
+  if (new Set(lexicalIdentities).size !== lexicalIdentities.length) {
+    throw new Error('UBS semantic aggregate entry lexical identities are duplicated');
+  }
+  return {
+    entryId,
+    sourceId,
+    sourceOrdinal,
+    lemma,
+    ...(transliteration === undefined ? {} : { transliteration }),
+    ...(partOfSpeech === undefined ? {} : { partOfSpeech }),
+    lexicalIdentities,
+  };
+}
+
+function cloneAndValidateSense(raw: UbsSemanticSense): UbsSemanticSense {
+  if (!raw || typeof raw !== 'object') throw new Error('UBS semantic aggregate sense is malformed');
+  const {
+    senseId, sourceId, entryId, sourceOrdinal, definition, glosses: rawGlosses, domainRefs: rawDomainRefs,
+  } = raw;
+  identifier(sourceId, 'bundle sense source ID');
+  identifier(entryId, 'bundle sense entry ID');
+  identifier(senseId, 'bundle sense ID');
+  positiveSafeInteger(sourceOrdinal, 'bundle sense ordinal');
+  boundedText(definition, UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.definitionCharacters, 'bundle sense definition');
+  if (!Array.isArray(rawGlosses) || rawGlosses.length < 1
+    || rawGlosses.length > UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.glossesPerSense
+    || new Set(rawGlosses).size !== rawGlosses.length) {
+    throw new Error('UBS semantic aggregate sense glosses are malformed, duplicated, or unbounded');
+  }
+  const glosses = rawGlosses.map(gloss => {
+    boundedText(gloss, UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.glossCharacters, 'bundle sense gloss');
+    return gloss;
+  });
+  if (!Array.isArray(rawDomainRefs)
+    || rawDomainRefs.length > UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.domainsPerSense) {
+    throw new Error('UBS semantic aggregate bounded domain references are malformed or unbounded');
+  }
+  const domainRefs = rawDomainRefs.map(domainRef => cloneAndValidateDomainRef(domainRef))
+    .sort(compareDomainRefs);
+  if (new Set(domainRefs.map(domainReferenceIdentity)).size !== domainRefs.length) {
+    throw new Error('UBS semantic aggregate bounded domain references are duplicated');
+  }
+  return { senseId, sourceId, entryId, sourceOrdinal, definition, glosses, domainRefs };
+}
+
+function cloneAndValidateDomainRef(raw: UbsSemanticDomainRef): UbsSemanticDomainRef {
+  if (!raw || typeof raw !== 'object') throw new Error('UBS semantic aggregate domain reference is malformed');
+  const { sourceId, domainId } = raw;
+  identifier(sourceId, 'bundle domain-reference source ID');
+  identifier(domainId, 'bundle domain-reference domain ID');
+  return { sourceId, domainId };
+}
+
+function cloneAndValidateDomain(raw: UbsSemanticDomain): UbsSemanticDomain {
+  if (!raw || typeof raw !== 'object') throw new Error('UBS semantic aggregate domain is malformed');
+  const { domainId, sourceId, sourceOrdinal, parentDomainId, label, description } = raw;
+  identifier(sourceId, 'bundle domain source ID');
+  identifier(domainId, 'bundle domain ID');
+  positiveSafeInteger(sourceOrdinal, 'bundle domain ordinal');
+  boundedText(label, 1_000, 'bundle domain label');
+  if (description !== undefined) boundedText(description, 5_000, 'bundle domain description');
+  if (parentDomainId !== undefined) identifier(parentDomainId, 'bundle parent domain ID');
+  return {
+    domainId,
+    sourceId,
+    sourceOrdinal,
+    ...(parentDomainId === undefined ? {} : { parentDomainId }),
+    label,
+    ...(description === undefined ? {} : { description }),
+  };
+}
+
+function cloneAndValidateReferenceEvidence(
+  raw: UbsSemanticReferenceEvidence,
+  normalizedReference: string,
+  expectedSourceId: string,
+  expectedSenseId: string,
+): UbsSemanticReferenceEvidence {
+  if (!raw || typeof raw !== 'object') throw new Error('UBS semantic aggregate reference evidence is malformed');
+  const {
+    evidenceId, sourceId, senseId, sourceOrdinal, sourceReference,
+    normalizedReference: evidenceNormalizedReference, evidenceKind,
+  } = raw;
+  identifier(sourceId, 'bundle reference source ID');
+  identifier(senseId, 'bundle reference sense ID');
+  identifier(evidenceId, 'bundle reference evidence ID');
+  positiveSafeInteger(sourceOrdinal, 'bundle reference ordinal');
+  requireUbsSemanticNormalizedReference(sourceReference, 'bundle evidence source reference');
+  if (sourceId !== expectedSourceId || senseId !== expectedSenseId
+    || evidenceNormalizedReference !== normalizedReference
+    || evidenceKind !== 'source_attested_sense_reference') {
+    throw new Error('UBS semantic aggregate reference evidence does not belong to its sense or exact query identity');
+  }
+  requireUbsSemanticNormalizedReference(evidenceNormalizedReference, 'bundle evidence normalized reference');
+  return {
+    evidenceId,
+    sourceId,
+    senseId,
+    sourceOrdinal,
+    sourceReference,
+    normalizedReference: evidenceNormalizedReference,
+    evidenceKind,
+  };
+}
+
+function validateCandidateOrder(
+  items: readonly UbsSemanticEvidenceBundleCandidateRow[],
+  identity: UbsInternalHebrewLexicalIdentity,
+  sources: readonly UbsSemanticSource[],
+  lexicalEntryTotal: number,
+): void {
+  const senses = new Set<string>();
+  const evidence = new Set<string>();
+  const entryOrdinals = new Map<string, string>();
+  const entrySignatures = new Map<string, string>();
+  const senseOrdinals = new Set<string>();
+  const domainSignatures = new Map<string, string>();
+  const domainOrdinals = new Map<string, string>();
+  let prior: [string, string, string, string, string] | undefined;
+  for (const item of items) {
+    if (!item.entry.lexicalIdentities.includes(identity)) {
+      throw new Error('UBS semantic aggregate entry is not attached to the exact query identity');
+    }
+    if (item.entry.sourceId !== sources[0]!.sourceId || item.sense.sourceId !== sources[0]!.sourceId
+      || item.sense.domainRefs.some(ref => ref.sourceId !== sources[1]!.sourceId)
+      || item.domains.some(domain => domain.sourceId !== sources[1]!.sourceId)) {
+      throw new Error('UBS semantic aggregate candidate rows do not match their exact provenance source roles');
+    }
+    const entryIdentity = `${item.entry.sourceId}\0${item.entry.entryId}`;
+    const entrySignature = JSON.stringify([
+      item.entry.sourceOrdinal,
+      item.entry.lemma,
+      item.entry.transliteration ?? null,
+      item.entry.partOfSpeech ?? null,
+      item.entry.lexicalIdentities,
+    ]);
+    const existingEntry = entrySignatures.get(entryIdentity);
+    if (existingEntry !== undefined && existingEntry !== entrySignature) {
+      throw new Error('UBS semantic aggregate repeats an entry with inconsistent evidence');
+    }
+    entrySignatures.set(entryIdentity, entrySignature);
+    const entryOrdinal = `${item.entry.sourceId}\0${item.entry.sourceOrdinal}`;
+    const ordinalEntry = entryOrdinals.get(entryOrdinal);
+    if (ordinalEntry !== undefined && ordinalEntry !== item.entry.entryId) {
+      throw new Error('UBS semantic aggregate reuses an entry source ordinal');
+    }
+    entryOrdinals.set(entryOrdinal, item.entry.entryId);
+    const senseIdentity = `${item.sense.sourceId}\0${item.sense.senseId}`;
+    if (senses.has(senseIdentity)) throw new Error('UBS semantic aggregate contains a duplicate sense identity');
+    senses.add(senseIdentity);
+    const senseOrdinal = `${entryIdentity}\0${item.sense.sourceOrdinal}`;
+    if (senseOrdinals.has(senseOrdinal)) throw new Error('UBS semantic aggregate reuses a sense ordinal within an entry');
+    senseOrdinals.add(senseOrdinal);
+    for (const row of item.matchingReferences) {
+      const evidenceIdentity = `${row.sourceId}\0${row.evidenceId}`;
+      if (evidence.has(evidenceIdentity)) throw new Error('UBS semantic aggregate repeats reference evidence across candidates');
+      evidence.add(evidenceIdentity);
+    }
+    for (const domain of item.domains) {
+      const domainIdentity = `${domain.sourceId}\0${domain.domainId}`;
+      const signature = JSON.stringify([
+        domain.sourceOrdinal,
+        domain.parentDomainId ?? null,
+        domain.label,
+        domain.description ?? null,
+      ]);
+      const existingSignature = domainSignatures.get(domainIdentity);
+      if (existingSignature !== undefined && existingSignature !== signature) {
+        throw new Error('UBS semantic aggregate repeats a domain identity with inconsistent evidence');
+      }
+      domainSignatures.set(domainIdentity, signature);
+      const ordinalIdentity = `${domain.sourceId}\0${domain.sourceOrdinal}`;
+      const existingDomainId = domainOrdinals.get(ordinalIdentity);
+      if (existingDomainId !== undefined && existingDomainId !== domain.domainId) {
+        throw new Error('UBS semantic aggregate reuses a domain source ordinal for another domain ID');
+      }
+      domainOrdinals.set(ordinalIdentity, domain.domainId);
+    }
+    const current = candidateKeyset(item);
+    if (prior && compareKeysets(prior, current) >= 0) {
+      throw new Error('UBS semantic aggregate candidates are not in strict canonical order');
+    }
+    prior = current;
+  }
+  if (entrySignatures.size > lexicalEntryTotal) {
+    throw new Error('UBS semantic aggregate exposes more distinct bundled entries than its lexical entry total');
+  }
+}
+
+function cloneAndValidateSources(
+  rawSources: readonly UbsSemanticSource[],
+  artifactIdentity: string,
+): UbsSemanticSource[] {
+  if (rawSources.length !== UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.provenanceSources) {
+    throw new Error('UBS semantic aggregate provenance must contain the exact dictionary/domain artifact pair');
+  }
+  const sources = [
+    cloneAndValidateSource(rawSources[0]!, artifactIdentity, 'dictionary'),
+    cloneAndValidateSource(rawSources[1]!, artifactIdentity, 'lexical_domains'),
+  ];
+  if (sources[0]!.sourceId === sources[1]!.sourceId) {
+    throw new Error('UBS semantic aggregate provenance source IDs must be unique');
+  }
+  return sources;
+}
+
+function cloneAndValidateSource(
+  raw: UbsSemanticSource,
+  artifactIdentity: string,
+  expectedRole: UbsSemanticSource['sourceRole'],
+): UbsSemanticSource {
+  if (!raw || typeof raw !== 'object') throw new Error('UBS semantic aggregate provenance source is malformed');
+  const {
+    sourceId, sourceRole, schemaVersion, artifactIdentity: sourceArtifactIdentity,
+    title, artifactName, artifactVersion, language, publisher, license, licenseUrl,
+    sourceUrl, sourceCommit, sourceBlob, sourceSha256, transformVersion, modified, modificationNote,
+  } = raw;
+  identifier(sourceId, 'bundle provenance source ID');
+  boundedText(title, 1_000, 'bundle provenance title');
+  boundedText(modificationNote, UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.modificationDescriptionCharacters,
+    'bundle provenance modification note');
+  boundedText(sourceUrl, UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.sourceUrlCharacters,
+    'bundle provenance source URL');
+  if (sourceArtifactIdentity !== artifactIdentity || sourceRole !== expectedRole
+    || schemaVersion !== 'ubs-semantics.v1' || artifactVersion !== '0.9.2'
+    || language !== 'Hebrew' || publisher !== 'United Bible Societies'
+    || license !== 'CC BY-SA 4.0'
+    || licenseUrl !== 'https://creativecommons.org/licenses/by-sa/4.0/'
+    || transformVersion !== 7 || modified !== true
+    || (sourceRole === 'dictionary' && artifactName !== 'UBSHebrewDic-v0.9.2-en.JSON')
+    || (sourceRole === 'lexical_domains' && artifactName !== 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON')
+    || !validHttpsUrl(sourceUrl)
+    || !/^[0-9a-f]{40}$/.test(sourceCommit)
+    || !/^[0-9a-f]{40}$/.test(sourceBlob)
+    || !/^[0-9a-f]{64}$/.test(sourceSha256)) {
+    throw new Error('UBS semantic aggregate provenance is malformed or incompatible');
+  }
+  if (sourceRole === 'dictionary') {
+    return {
+      sourceId,
+      sourceRole,
+      schemaVersion,
+      artifactIdentity: sourceArtifactIdentity,
+      title,
+      artifactName,
+      artifactVersion,
+      language,
+      publisher,
+      license,
+      licenseUrl,
+      sourceUrl,
+      sourceCommit,
+      sourceBlob,
+      sourceSha256,
+      transformVersion,
+      modified,
+      modificationNote,
+    };
+  }
+  return {
+    sourceId,
+    sourceRole,
+    schemaVersion,
+    artifactIdentity: sourceArtifactIdentity,
+    title,
+    artifactName,
+    artifactVersion,
+    language,
+    publisher,
+    license,
+    licenseUrl,
+    sourceUrl,
+    sourceCommit,
+    sourceBlob,
+    sourceSha256,
+    transformVersion,
+    modified,
+    modificationNote,
+  };
+}
+
+function domainReferenceIdentity(value: UbsSemanticDomainRef): string {
+  return `${value.sourceId}\0${value.domainId}`;
+}
+
+function domainIdentity(value: UbsSemanticDomain): string {
+  return `${value.sourceId}\0${value.domainId}`;
+}
+
+function compareDomainRefs(left: UbsSemanticDomainRef, right: UbsSemanticDomainRef): number {
+  return compareCodePoints(left.sourceId, right.sourceId)
+    || compareCodePoints(left.domainId, right.domainId);
+}
+
+function compareDomains(left: UbsSemanticDomain, right: UbsSemanticDomain): number {
+  return left.sourceOrdinal - right.sourceOrdinal
+    || compareCodePoints(left.sourceId, right.sourceId)
+    || compareCodePoints(left.domainId, right.domainId);
+}
+
+function compareReferenceEvidence(
+  left: UbsSemanticReferenceEvidence,
+  right: UbsSemanticReferenceEvidence,
+): number {
+  return left.sourceOrdinal - right.sourceOrdinal
+    || compareCodePoints(left.sourceId, right.sourceId)
+    || compareCodePoints(left.senseId, right.senseId)
+    || compareCodePoints(left.evidenceId, right.evidenceId);
+}
+
+function compareCodePoints(left: string, right: string): number {
+  const leftPoints = [...left].map(character => character.codePointAt(0)!);
+  const rightPoints = [...right].map(character => character.codePointAt(0)!);
+  const length = Math.min(leftPoints.length, rightPoints.length);
+  for (let index = 0; index < length; index += 1) {
+    if (leftPoints[index] !== rightPoints[index]) return leftPoints[index]! - rightPoints[index]!;
+  }
+  return leftPoints.length - rightPoints.length;
+}
+
+function candidateKeyset(candidate: UbsSemanticEvidenceBundleCandidateRow): [string, string, string, string, string] {
+  return validateCandidateKeyset([
+    candidate.entry.sourceId,
+    String(candidate.entry.sourceOrdinal),
+    candidate.entry.entryId,
+    String(candidate.sense.sourceOrdinal),
+    candidate.sense.senseId,
+  ]);
+}
+
+function snapshotCandidateKeyset(
+  candidate: UbsSemanticEvidenceBundleCandidateRow,
+): [string, string, string, string, string] {
+  if (!candidate || typeof candidate !== 'object') throw new Error('UBS semantic aggregate cursor candidate must be a record');
+  const entry = candidate.entry;
+  const sense = candidate.sense;
+  if (!entry || typeof entry !== 'object' || !sense || typeof sense !== 'object') {
+    throw new Error('UBS semantic aggregate cursor candidate entry and sense must be records');
+  }
+  const sourceId = entry.sourceId;
+  const entryOrdinal = entry.sourceOrdinal;
+  const entryId = entry.entryId;
+  const senseOrdinal = sense.sourceOrdinal;
+  const senseId = sense.senseId;
+  positiveSafeInteger(entryOrdinal, 'bundle cursor entry ordinal');
+  positiveSafeInteger(senseOrdinal, 'bundle cursor sense ordinal');
+  return validateCandidateKeyset([
+    sourceId, String(entryOrdinal), entryId, String(senseOrdinal), senseId,
+  ]);
+}
+
+function snapshotCursorBinding(
+  query: Pick<UbsSemanticEvidenceBundleRepositoryQuery,
+    'artifactIdentity' | 'sourceIdentity' | 'normalizedReference'>,
+): Readonly<Pick<UbsSemanticEvidenceBundleRepositoryQuery,
+  'artifactIdentity' | 'sourceIdentity' | 'normalizedReference'>> {
+  if (!query || typeof query !== 'object') throw new Error('UBS semantic aggregate cursor binding must be a record');
+  const artifactIdentity = query.artifactIdentity;
+  const rawSourceIdentity = query.sourceIdentity;
+  const rawNormalizedReference = query.normalizedReference;
+  validateArtifactIdentity(artifactIdentity);
+  const sourceIdentity = requireHebrewIdentity(rawSourceIdentity);
+  const normalizedReference = requireUbsSemanticNormalizedReference(rawNormalizedReference);
+  return Object.freeze({ artifactIdentity, sourceIdentity, normalizedReference });
+}
+
+function validateCandidateKeyset(values: readonly unknown[]): [string, string, string, string, string] {
+  if (values.length !== 5 || values.some(value => typeof value !== 'string')) {
+    throw new Error('UBS semantic aggregate cursor keyset must contain exactly five strings');
+  }
+  const [sourceId, entryOrdinal, entryId, senseOrdinal, senseId] = values as string[];
+  identifier(sourceId, 'bundle cursor entry source ID');
+  identifier(entryId, 'bundle cursor entry ID');
+  identifier(senseId, 'bundle cursor sense ID');
+  canonicalPositiveDecimal(entryOrdinal, 'bundle cursor entry ordinal');
+  canonicalPositiveDecimal(senseOrdinal, 'bundle cursor sense ordinal');
+  return [sourceId, entryOrdinal, entryId, senseOrdinal, senseId];
+}
+
+function createCursorFromKeyset(
+  query: Pick<UbsSemanticEvidenceBundleRepositoryQuery,
+    'artifactIdentity' | 'sourceIdentity' | 'normalizedReference'>,
+  keyset: [string, string, string, string, string],
+  priorShowing: number,
+): string {
+  const payload: BundleCursorPayload = {
+    version: 1,
+    operation: UBS_SEMANTIC_EVIDENCE_BUNDLE_OPERATION,
+    order: UBS_SEMANTIC_EVIDENCE_BUNDLE_ORDER,
+    artifactIdentity: query.artifactIdentity,
+    sourceIdentity: query.sourceIdentity,
+    normalizedReference: query.normalizedReference,
+    keyset,
+    priorShowing,
+  };
+  return `ubsa1_${[...new TextEncoder().encode(JSON.stringify(payload))]
+    .map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function requireHebrewIdentity(value: string): UbsInternalHebrewLexicalIdentity {
+  const identity = requireUbsInternalLexicalIdentity(value);
+  if (!identity.startsWith('H')) throw new Error('UBS semantic aggregate resolution accepts only an internal H#### identity');
+  return identity as UbsInternalHebrewLexicalIdentity;
+}
+
+function validateArtifactIdentity(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error('UBS semantic aggregate artifact identity must be a lowercase SHA-256');
+  }
+}
+
+function hasExactOwnKeys(value: object, expected: readonly string[]): boolean {
+  const actual = Object.keys(value);
+  return actual.length === expected.length && expected.every(key => actual.includes(key));
+}
+
+function identifier(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || value.length > 128
+    || !/^[a-z][a-z0-9]*(?:[-_.][a-z0-9]+)*$/.test(value)) {
+    throw new Error(`${label} must be a bounded canonical identifier`);
+  }
+}
+
+function boundedText(value: unknown, maximum: number, label: string): asserts value is string {
+  if (typeof value !== 'string' || !value || value !== value.trim() || value !== value.normalize('NFC')
+    || [...value].length > maximum || /[\p{Cc}\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/u.test(value)
+    || hasUnicodeNoncharacter(value)) {
+    throw new Error(`${label} must be bounded, trimmed, NFC, and permitted Unicode text`);
+  }
+}
+
+function validHttpsUrl(value: unknown): boolean {
+  if (typeof value !== 'string' || [...value].length > UBS_SEMANTIC_DRAFT_OUTPUT_LIMITS.sourceUrlCharacters
+    || hasUnicodeNoncharacter(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function hasUnicodeNoncharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if ((codePoint >= 0xfdd0 && codePoint <= 0xfdef) || (codePoint & 0xffff) >= 0xfffe) return true;
+  }
+  return false;
+}
+
+function canonicalPositiveDecimal(value: string, label: string): void {
+  if (!/^[1-9][0-9]*$/.test(value) || !Number.isSafeInteger(Number(value))) {
+    throw new Error(`${label} must be a canonical positive safe integer`);
+  }
+}
+
+function positiveSafeInteger(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) throw new Error(`${label} must be a positive safe integer`);
+}
+
+function nonNegativeSafeInteger(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative safe integer`);
+}
+
+function compareKeysets(left: readonly string[], right: readonly string[]): number {
+  const numeric = new Set([1, 3]);
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] === right[index]) continue;
+    if (numeric.has(index)) return Number(left[index]) < Number(right[index]) ? -1 : 1;
+    return left[index]! < right[index]! ? -1 : 1;
+  }
+  return 0;
+}
+
+function compareOrdinalId(leftOrdinal: number, leftId: string, rightOrdinal: number, rightId: string): number {
+  if (leftOrdinal !== rightOrdinal) return leftOrdinal < rightOrdinal ? -1 : 1;
+  if (leftId === rightId) return 0;
+  return leftId < rightId ? -1 : 1;
+}

--- a/test/unit/kernel/ubsSemanticEvidenceBundle.test.ts
+++ b/test/unit/kernel/ubsSemanticEvidenceBundle.test.ts
@@ -1,0 +1,649 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS,
+  createUbsSemanticEvidenceBundleCursor,
+  parseUbsSemanticEvidenceBundleCursor,
+  queryUbsSemanticEvidenceBundle,
+  type IUbsSemanticEvidenceBundleRepository,
+  type UbsSemanticEvidenceBundleCandidateRow,
+  type UbsSemanticEvidenceBundleRepositoryPage,
+  type UbsSemanticEvidenceBundleRepositoryQuery,
+} from '../../../src/kernel/ubsSemanticEvidenceBundle.js';
+import { requireUbsInternalLexicalIdentity } from '../../../src/kernel/ubsSemanticDomain.js';
+import type {
+  UbsInternalHebrewLexicalIdentity,
+  UbsSemanticDomain,
+  UbsSemanticEntry,
+  UbsSemanticReferenceEvidence,
+  UbsSemanticSense,
+  UbsSemanticSource,
+} from '../../../src/kernel/ubsSemanticDomain.js';
+
+const ARTIFACT = '7'.repeat(64);
+const OTHER_ARTIFACT = '8'.repeat(64);
+const H0001 = requireUbsInternalLexicalIdentity('H0001') as UbsInternalHebrewLexicalIdentity;
+const H0002 = requireUbsInternalLexicalIdentity('H0002') as UbsInternalHebrewLexicalIdentity;
+
+function source(role: 'dictionary' | 'lexical_domains'): UbsSemanticSource {
+  return {
+    sourceId: role === 'dictionary' ? 'synthetic-dictionary' : 'synthetic-domains',
+    sourceRole: role,
+    schemaVersion: 'ubs-semantics.v1', artifactIdentity: ARTIFACT,
+    title: `SYNTHETIC ${role.toUpperCase()}`,
+    artifactName: role === 'dictionary'
+      ? 'UBSHebrewDic-v0.9.2-en.JSON' : 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON',
+    artifactVersion: '0.9.2', language: 'Hebrew', publisher: 'United Bible Societies',
+    license: 'CC BY-SA 4.0', licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
+    sourceUrl: `https://example.invalid/synthetic/${role}`,
+    sourceCommit: (role === 'dictionary' ? '1' : '2').repeat(40),
+    sourceBlob: (role === 'dictionary' ? '3' : '4').repeat(40),
+    sourceSha256: (role === 'dictionary' ? '5' : '6').repeat(64),
+    transformVersion: 7, modified: true, modificationNote: 'Synthetic only.',
+  } as UbsSemanticSource;
+}
+
+function candidate(index: number, normalizedReference = 'Synthetic 1:1'): UbsSemanticEvidenceBundleCandidateRow {
+  const suffix = String(index).padStart(2, '0');
+  const entry: UbsSemanticEntry = {
+    sourceId: 'synthetic-dictionary', entryId: 'entry-one', sourceOrdinal: 1,
+    lemma: 'SYNTHETIC LEMMA', lexicalIdentities: [H0001],
+  };
+  const domain: UbsSemanticDomain = {
+    sourceId: 'synthetic-domains', domainId: `domain-${suffix}`,
+    sourceOrdinal: index, label: `SYNTHETIC DOMAIN ${suffix}`,
+  };
+  const sense: UbsSemanticSense = {
+    sourceId: 'synthetic-dictionary', entryId: entry.entryId,
+    senseId: `sense-${suffix}`, sourceOrdinal: index,
+    definition: `SYNTHETIC DEFINITION ${suffix}`, glosses: [`GLOSS ${suffix}`],
+    domainRefs: [{ sourceId: domain.sourceId, domainId: domain.domainId }],
+  };
+  const evidence: UbsSemanticReferenceEvidence = {
+    sourceId: sense.sourceId, senseId: sense.senseId,
+    evidenceId: `reference-${suffix}`, sourceOrdinal: 1,
+    sourceReference: 'SYN 1:1', normalizedReference,
+    evidenceKind: 'source_attested_sense_reference',
+  };
+  return {
+    entry, sense, domains: [domain], domainTotal: 1,
+    matchingReferences: [evidence], matchingReferenceTotal: 1,
+  };
+}
+
+function candidateKeyset(candidateRow: UbsSemanticEvidenceBundleCandidateRow): [string, string, string, string, string] {
+  return [
+    candidateRow.entry.sourceId,
+    String(candidateRow.entry.sourceOrdinal),
+    candidateRow.entry.entryId,
+    String(candidateRow.sense.sourceOrdinal),
+    candidateRow.sense.senseId,
+  ];
+}
+
+function sameKeyset(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function hostileEnumerableProxy<T extends object>(value: T, label: string): T {
+  return new Proxy(value, {
+    ownKeys(target) {
+      return [...Reflect.ownKeys(target), label];
+    },
+    getOwnPropertyDescriptor(target, property) {
+      if (property === label) return { configurable: true, enumerable: true };
+      return Reflect.getOwnPropertyDescriptor(target, property);
+    },
+    get(target, property, receiver) {
+      if (property === label) throw new Error(`unvalidated ${label} must never be read`);
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}
+
+function candidateWithCappedDomains(total = 17): UbsSemanticEvidenceBundleCandidateRow {
+  const value = candidate(1);
+  const domains = Array.from({ length: UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.domainsPerSense }, (_, index) => {
+    const suffix = String(index + 1).padStart(2, '0');
+    return {
+      sourceId: 'synthetic-domains',
+      domainId: `domain-cap-${suffix}`,
+      sourceOrdinal: index + 1,
+      label: `SYNTHETIC CAPPED DOMAIN ${suffix}`,
+    } as UbsSemanticDomain;
+  });
+  value.domains = [...domains].reverse();
+  value.sense.domainRefs = domains.map(domain => ({
+    sourceId: domain.sourceId,
+    domainId: domain.domainId,
+  })).reverse();
+  value.domainTotal = total;
+  return value;
+}
+
+class SyntheticAggregateRepository implements IUbsSemanticEvidenceBundleRepository {
+  queryCount = 0;
+  readonly queries: UbsSemanticEvidenceBundleRepositoryQuery[] = [];
+
+  constructor(
+    private readonly allCandidates: UbsSemanticEvidenceBundleCandidateRow[],
+    private readonly shape: 'node' | 'd1' = 'node',
+    private readonly lexicalEntryTotal = allCandidates.length > 0 ? 1 : 0,
+  ) {}
+
+  async getSemanticEvidenceBundle(query: Readonly<UbsSemanticEvidenceBundleRepositoryQuery>) {
+    this.queryCount += 1;
+    this.queries.push(structuredClone(query));
+    if (query.artifactIdentity !== ARTIFACT) {
+      throw new Error('synthetic aggregate artifact is unavailable');
+    }
+    const exactCandidates = this.allCandidates.filter(candidateRow =>
+      candidateRow.entry.lexicalIdentities.includes(query.sourceIdentity)
+      && candidateRow.matchingReferences.some(evidence =>
+        evidence.normalizedReference === query.normalizedReference,
+      ));
+    let start = 0;
+    if (query.after) {
+      const boundaryIndex = exactCandidates.findIndex(candidateRow =>
+        sameKeyset(candidateKeyset(candidateRow), query.after!.keyset));
+      if (boundaryIndex < 0 || boundaryIndex + 1 !== query.after.priorShowing) {
+        throw new Error('synthetic aggregate cursor is not a genuine current page boundary');
+      }
+      start = boundaryIndex + 1;
+    }
+    const items = exactCandidates.slice(start, start + query.limit);
+    const page: UbsSemanticEvidenceBundleRepositoryPage = {
+      items,
+      lexicalEntryTotal: this.lexicalEntryTotal,
+      semanticSenseTotal: exactCandidates.length,
+      boundary: {
+        artifactIdentity: query.artifactIdentity,
+        sourceIdentity: query.sourceIdentity,
+        normalizedReference: query.normalizedReference,
+        order: query.order,
+        priorShowing: start,
+        ...(query.after ? { after: { keyset: [...query.after.keyset] as [string, string, string, string, string] } } : {}),
+      },
+      sources: [source('dictionary'), source('lexical_domains')],
+    };
+    return clone(page, this.shape);
+  }
+}
+
+function clone<T>(value: T, shape: 'node' | 'd1'): T {
+  const copy = structuredClone(value);
+  return shape === 'node' ? copy : JSON.parse(JSON.stringify(copy)) as T;
+}
+
+function request(overrides: Partial<{
+  artifactIdentity: string;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  normalizedReference: string;
+  cursor: string;
+}> = {}) {
+  return {
+    artifactIdentity: overrides.artifactIdentity ?? ARTIFACT,
+    sourceIdentity: overrides.sourceIdentity ?? H0001,
+    normalizedReference: overrides.normalizedReference ?? 'Synthetic 1:1',
+    ...(overrides.cursor ? { page: { cursor: overrides.cursor } } : {}),
+  };
+}
+
+function mutateCursor(cursor: string, mutate: (payload: Record<string, unknown>) => void): string {
+  const bytes = cursor.slice(6).match(/../g)!.map(byte => Number.parseInt(byte, 16));
+  const payload = JSON.parse(new TextDecoder().decode(new Uint8Array(bytes))) as Record<string, unknown>;
+  mutate(payload);
+  return encodeRawCursorJson(JSON.stringify(payload));
+}
+
+function encodeRawCursorJson(json: string): string {
+  return `ubsa1_${[...new TextEncoder().encode(json)]
+    .map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+describe('inactive UBS semantic aggregate evidence bundle', () => {
+  it('produces byte-equivalent synthetic Node/D1-shaped bundles with one query', async () => {
+    const values = [candidate(1), candidate(2), candidate(3)];
+    const node = new SyntheticAggregateRepository(values, 'node');
+    const d1 = new SyntheticAggregateRepository(values, 'd1');
+    const [nodeResult, d1Result] = await Promise.all([
+      queryUbsSemanticEvidenceBundle(node, request()),
+      queryUbsSemanticEvidenceBundle(d1, request()),
+    ]);
+    expect(d1Result).toEqual(nodeResult);
+    expect(node.queryCount).toBe(1);
+    expect(d1.queryCount).toBe(1);
+    expect(nodeResult.coverage).toMatchObject({
+      completeForReturnedWindow: true,
+      completeForWholeQuery: true,
+      incompleteReasons: [],
+      candidateWindow: { returnedCount: 3, totalCount: 3, hasMore: false },
+    });
+  });
+
+  it('canonicalizes explicit undefined optionals identically across Node and D1 shapes', async () => {
+    const value = candidate(1);
+    value.entry.transliteration = undefined;
+    value.entry.partOfSpeech = undefined;
+    value.domains[0].parentDomainId = undefined;
+    value.domains[0].description = undefined;
+    const node = await queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([value], 'node'), request(),
+    );
+    const d1 = await queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([value], 'd1'), request(),
+    );
+    expect(node).toEqual(d1);
+    expect('transliteration' in node.candidates[0].entry).toBe(false);
+    expect('partOfSpeech' in node.candidates[0].entry).toBe(false);
+    expect('parentDomainId' in node.candidates[0].domains[0]).toBe(false);
+    expect('description' in node.candidates[0].domains[0]).toBe(false);
+  });
+
+  it('allowlists validated fields without enumerating hostile adapter extras', async () => {
+    const repository = new SyntheticAggregateRepository([candidate(1)]);
+    const original = repository.getSemanticEvidenceBundle.bind(repository);
+    repository.getSemanticEvidenceBundle = async query => {
+      const page = await original(query);
+      page.items[0].sense.domainRefs[0] = hostileEnumerableProxy(
+        page.items[0].sense.domainRefs[0], 'hostileDomainReference',
+      );
+      page.items[0].matchingReferences[0] = hostileEnumerableProxy(
+        page.items[0].matchingReferences[0], 'hostileReferenceEvidence',
+      );
+      page.items[0].sense = hostileEnumerableProxy(page.items[0].sense, 'hostileSense');
+      page.sources[0] = hostileEnumerableProxy(page.sources[0], 'hostileProvenance');
+      return page;
+    };
+    const result = await queryUbsSemanticEvidenceBundle(repository, request());
+    expect(result.candidates[0]!.sense).not.toHaveProperty('hostileSense');
+    expect(result.candidates[0]!.sense.domainRefs[0]).not.toHaveProperty('hostileDomainReference');
+    expect(result.candidates[0]!.matchingReferences[0]).not.toHaveProperty('hostileReferenceEvidence');
+    expect(result.sources[0]).not.toHaveProperty('hostileProvenance');
+    expect(repository.queryCount).toBe(1);
+  });
+
+  it('canonicalizes lexical identities and nested domain/reference evidence across shuffled Node/D1 shapes', async () => {
+    const shuffled = candidateWithCappedDomains(16);
+    shuffled.entry.lexicalIdentities = [H0002, H0001];
+    shuffled.matchingReferences = [
+      {
+        ...shuffled.matchingReferences[0],
+        evidenceId: 'reference-z',
+        sourceOrdinal: 2,
+      },
+      {
+        ...shuffled.matchingReferences[0],
+        evidenceId: 'reference-a',
+        sourceOrdinal: 1,
+      },
+    ];
+    shuffled.matchingReferenceTotal = 2;
+    const ordered = structuredClone(shuffled);
+    ordered.entry.lexicalIdentities.reverse();
+    ordered.sense.domainRefs.reverse();
+    ordered.domains.reverse();
+    ordered.matchingReferences.reverse();
+    const [node, d1] = await Promise.all([
+      queryUbsSemanticEvidenceBundle(new SyntheticAggregateRepository([shuffled], 'node'), request()),
+      queryUbsSemanticEvidenceBundle(new SyntheticAggregateRepository([ordered], 'd1'), request()),
+    ]);
+    expect(node).toEqual(d1);
+    expect(node.candidates[0]!.entry.lexicalIdentities).toEqual([H0001, H0002]);
+    expect(node.candidates[0]!.sense.domainRefs.map(ref => ref.domainId)).toEqual([
+      ...node.candidates[0]!.sense.domainRefs.map(ref => ref.domainId),
+    ].sort());
+    expect(node.candidates[0]!.matchingReferences.map(evidence => evidence.evidenceId))
+      .toEqual(['reference-a', 'reference-z']);
+  });
+
+  it('rejects adversarial nested ordering ties that cannot have a deterministic source identity', async () => {
+    const value = candidate(1);
+    value.matchingReferences = [
+      value.matchingReferences[0],
+      { ...value.matchingReferences[0], evidenceId: 'reference-tie', sourceOrdinal: 1 },
+    ];
+    value.matchingReferenceTotal = 2;
+    await expect(queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([value]), request(),
+    )).rejects.toThrow('duplicate reference ordinal');
+  });
+
+  it('uses a fixed one-query count independent of zero, one, or many candidates', async () => {
+    for (const count of [0, 1, 20]) {
+      const repository = new SyntheticAggregateRepository(
+        Array.from({ length: count }, (_, index) => candidate(index + 1)),
+      );
+      const result = await queryUbsSemanticEvidenceBundle(repository, request());
+      expect(repository.queryCount).toBe(1);
+      expect(result.candidates).toHaveLength(Math.min(
+        count, UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.candidatesPerPage,
+      ));
+    }
+  });
+
+  it('paginates deterministic candidate windows and marks both pages honestly incomplete', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => candidate(index + 1));
+    const firstRepository = new SyntheticAggregateRepository(values);
+    const first = await queryUbsSemanticEvidenceBundle(firstRepository, request());
+    expect(firstRepository.queryCount).toBe(1);
+    expect(first.coverage).toMatchObject({
+      completeForReturnedWindow: true, completeForWholeQuery: false,
+      incompleteReasons: ['candidate_window'],
+      candidateWindow: { priorCount: 0, returnedCount: 8, consumedCount: 8, totalCount: 10, hasMore: true },
+    });
+    const cursor = first.coverage.candidateWindow.nextCursor!;
+    const secondRepository = new SyntheticAggregateRepository(values);
+    const second = await queryUbsSemanticEvidenceBundle(secondRepository, request({ cursor }));
+    expect(secondRepository.queryCount).toBe(1);
+    expect(second.candidates.map(item => item.sense.senseId)).toEqual(['sense-09', 'sense-10']);
+    expect(second.coverage).toMatchObject({
+      completeForReturnedWindow: true, completeForWholeQuery: false,
+      incompleteReasons: ['prior_candidate_window'],
+      candidateWindow: { priorCount: 8, returnedCount: 2, consumedCount: 10, totalCount: 10, hasMore: false },
+    });
+  });
+
+  it('binds cursors to the exact operation, artifact, H identity, and normalized reference', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => candidate(index + 1));
+    const first = await queryUbsSemanticEvidenceBundle(new SyntheticAggregateRepository(values), request());
+    const cursor = first.coverage.candidateWindow.nextCursor!;
+    for (const changed of [
+      request({ cursor, artifactIdentity: OTHER_ARTIFACT }),
+      request({ cursor, sourceIdentity: H0002 }),
+      request({ cursor, normalizedReference: 'Synthetic 1:2' }),
+    ]) {
+      const repository = new SyntheticAggregateRepository(values);
+      await expect(queryUbsSemanticEvidenceBundle(repository, changed))
+        .rejects.toThrow('exact query and artifact binding');
+      expect(repository.queryCount).toBe(0);
+    }
+    for (const tampered of [
+      mutateCursor(cursor, payload => { payload.operation = 'different-operation'; }),
+      mutateCursor(cursor, payload => { payload.order = 'different-order'; }),
+    ]) {
+      const repository = new SyntheticAggregateRepository(values);
+      await expect(queryUbsSemanticEvidenceBundle(repository, request({ cursor: tampered })))
+        .rejects.toThrow('exact query and artifact binding');
+      expect(repository.queryCount).toBe(0);
+    }
+  });
+
+  it('reports nested evidence incompleteness without changing the one-query bound', async () => {
+    const value = candidate(1);
+    value.matchingReferenceTotal = 2;
+    const repository = new SyntheticAggregateRepository([value]);
+    const result = await queryUbsSemanticEvidenceBundle(repository, request());
+    expect(repository.queryCount).toBe(1);
+    expect(result.coverage).toMatchObject({
+      completeForReturnedWindow: false,
+      completeForWholeQuery: false,
+      incompleteReasons: ['reference_evidence'],
+    });
+
+    const partialDomain = candidate(1);
+    partialDomain.domains = [];
+    partialDomain.sense.domainRefs = [];
+    const domainResult = await queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([partialDomain]), request(),
+    );
+    expect(domainResult.coverage).toMatchObject({
+      completeForReturnedWindow: false,
+      completeForWholeQuery: false,
+      incompleteReasons: ['domain_evidence'],
+    });
+  });
+
+  it('reports an authoritative domain total beyond the returned cap without overstating completeness', async () => {
+    const value = candidateWithCappedDomains();
+    const result = await queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([value]), request(),
+    );
+    expect(result.candidates[0]).toMatchObject({
+      domainTotal: 17,
+      domains: { length: UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.domainsPerSense },
+      sense: { domainRefs: { length: UBS_SEMANTIC_EVIDENCE_BUNDLE_LIMITS.domainsPerSense } },
+    });
+    expect(result.coverage).toMatchObject({
+      completeForReturnedWindow: false,
+      completeForWholeQuery: false,
+      incompleteReasons: ['domain_evidence'],
+    });
+    expect(result.candidates[0]!.domains.map(domain => domain.domainId)).toEqual([
+      ...result.candidates[0]!.domains.map(domain => domain.domainId),
+    ].sort());
+  });
+
+  it('rejects a claimed domain total smaller than the bounded evidence actually returned', async () => {
+    const value = candidateWithCappedDomains(15);
+    await expect(queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([value]), request(),
+    )).rejects.toThrow('nested evidence exceeds its authoritative total');
+  });
+
+  it('distinguishes no lexical entry from an entry with no semantic senses using aggregate totals', async () => {
+    const missing = await queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([], 'node', 0), request(),
+    );
+    const entryWithoutSenses = await queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository([], 'node', 1), request(),
+    );
+    expect(missing.coverage).toMatchObject({ lexicalEntryTotal: 0, semanticSenseTotal: 0, completeForWholeQuery: true });
+    expect(entryWithoutSenses.coverage).toMatchObject({ lexicalEntryTotal: 1, semanticSenseTotal: 0, completeForWholeQuery: true });
+  });
+
+  it('rejects more visible distinct entries than the honest lexical-entry total', async () => {
+    const values = [candidate(1), candidate(2)];
+    values[1].entry.entryId = 'entry-two';
+    values[1].entry.sourceOrdinal = 2;
+    values[1].sense.entryId = 'entry-two';
+    values[1].sense.sourceOrdinal = 1;
+    await expect(queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository(values, 'node', 1), request(),
+    )).rejects.toThrow('more distinct bundled entries');
+  });
+
+  it('allows identical shared domains but rejects inconsistent identity or ordinal reuse page-wide', async () => {
+    const shared = [candidate(1), candidate(2)];
+    shared[1].domains = [structuredClone(shared[0].domains[0])];
+    shared[1].sense.domainRefs = [structuredClone(shared[0].sense.domainRefs[0])];
+    const accepted = await queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository(shared), request(),
+    );
+    expect(accepted.candidates).toHaveLength(2);
+
+    const inconsistent = structuredClone(shared);
+    inconsistent[1].domains[0].label = 'INCONSISTENT SHARED DOMAIN';
+    await expect(queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository(inconsistent), request(),
+    )).rejects.toThrow('domain identity with inconsistent evidence');
+
+    const ordinalReuse = [candidate(1), candidate(2)];
+    ordinalReuse[1].domains[0].sourceOrdinal = 1;
+    await expect(queryUbsSemanticEvidenceBundle(
+      new SyntheticAggregateRepository(ordinalReuse), request(),
+    )).rejects.toThrow('domain source ordinal for another domain ID');
+  });
+
+  it('snapshots cursor helper bindings and candidate keyset primitives exactly once', () => {
+    const baselineBinding = request();
+    const value = candidate(1);
+    const baseline = createUbsSemanticEvidenceBundleCursor(baselineBinding, value, 1);
+    const bindingReads = new Map<PropertyKey, number>();
+    const proxiedBinding = new Proxy(baselineBinding, {
+      get(target, property, receiver) {
+        const count = (bindingReads.get(property) ?? 0) + 1;
+        bindingReads.set(property, count);
+        if (count > 1) {
+          if (property === 'artifactIdentity') return OTHER_ARTIFACT;
+          if (property === 'sourceIdentity') return H0002;
+          if (property === 'normalizedReference') return 'Mutated 9:9';
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    let sourceIdReads = 0;
+    const accessorEntry = {
+      ...value.entry,
+      get sourceId() {
+        sourceIdReads += 1;
+        return sourceIdReads === 1 ? 'synthetic-dictionary' : 'swapped-source';
+      },
+    };
+    const candidateReads = new Map<PropertyKey, number>();
+    const proxiedCandidate = new Proxy({ ...value, entry: accessorEntry }, {
+      get(target, property, receiver) {
+        candidateReads.set(property, (candidateReads.get(property) ?? 0) + 1);
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const actual = createUbsSemanticEvidenceBundleCursor(proxiedBinding, proxiedCandidate, 1);
+    expect(actual).toBe(baseline);
+    expect([...bindingReads.values()]).toEqual([1, 1, 1]);
+    expect(candidateReads.get('entry')).toBe(1);
+    expect(candidateReads.get('sense')).toBe(1);
+    expect(sourceIdReads).toBe(1);
+
+    const parseReads = new Map<PropertyKey, number>();
+    const parseBinding = new Proxy(baselineBinding, {
+      get(target, property, receiver) {
+        const count = (parseReads.get(property) ?? 0) + 1;
+        parseReads.set(property, count);
+        return count === 1 ? Reflect.get(target, property, receiver) : 'mutated';
+      },
+    });
+    expect(parseUbsSemanticEvidenceBundleCursor(actual, parseBinding)).toMatchObject({ priorShowing: 1 });
+    expect([...parseReads.values()]).toEqual([1, 1, 1]);
+  });
+
+  it('server-validates a genuine synthesized boundary once and preserves Node/D1 parity', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => candidate(index + 1));
+    const synthesizedCursor = createUbsSemanticEvidenceBundleCursor(request(), values[0]!, 1);
+    const nodeRepository = new SyntheticAggregateRepository(values, 'node');
+    const d1Repository = new SyntheticAggregateRepository(values, 'd1');
+    const [node, d1] = await Promise.all([
+      queryUbsSemanticEvidenceBundle(nodeRepository, request({ cursor: synthesizedCursor })),
+      queryUbsSemanticEvidenceBundle(d1Repository, request({ cursor: synthesizedCursor })),
+    ]);
+    expect(node).toEqual(d1);
+    expect(node.candidates[0]?.sense.senseId).toBe('sense-02');
+    expect(node.coverage.candidateWindow).toMatchObject({ priorCount: 1, returnedCount: 8, hasMore: true });
+    expect(nodeRepository.queryCount).toBe(1);
+    expect(d1Repository.queryCount).toBe(1);
+  });
+
+  it('rejects tampered, false-terminal, huge, and stale continuation positions through one authoritative call', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => candidate(index + 1));
+    const first = await queryUbsSemanticEvidenceBundle(new SyntheticAggregateRepository(values), request());
+    const cursor = first.coverage.candidateWindow.nextCursor!;
+    const tamperedPositions = [
+      {
+        name: 'keyset',
+        cursor: mutateCursor(cursor, payload => {
+          payload.keyset = candidateKeyset(values[1]!);
+        }),
+      },
+      {
+        name: 'prior count',
+        cursor: mutateCursor(cursor, payload => { payload.priorShowing = 7; }),
+      },
+      {
+        name: 'false terminal',
+        cursor: mutateCursor(cursor, payload => { payload.priorShowing = 10; }),
+      },
+      {
+        name: 'huge terminal',
+        cursor: mutateCursor(cursor, payload => { payload.priorShowing = Number.MAX_SAFE_INTEGER; }),
+      },
+    ];
+    for (const tampered of tamperedPositions) {
+      const repository = new SyntheticAggregateRepository(values);
+      await expect(queryUbsSemanticEvidenceBundle(repository, request({ cursor: tampered.cursor })), tampered.name)
+        .rejects.toThrow('genuine current page boundary');
+      expect(repository.queryCount, tampered.name).toBe(1);
+    }
+
+    const staleValues = [...values.slice(0, 7), ...values.slice(8)];
+    const staleRepository = new SyntheticAggregateRepository(staleValues);
+    await expect(queryUbsSemanticEvidenceBundle(staleRepository, request({ cursor })))
+      .rejects.toThrow('genuine current page boundary');
+    expect(staleRepository.queryCount).toBe(1);
+  });
+
+  it('rejects noncanonical cursor aliases before querying and mismatched repository attestations before publishing', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => candidate(index + 1));
+    const first = await queryUbsSemanticEvidenceBundle(new SyntheticAggregateRepository(values), request());
+    const cursor = first.coverage.candidateWindow.nextCursor!;
+    const bytes = cursor.slice(6).match(/../g)!.map(byte => Number.parseInt(byte, 16));
+    const json = new TextDecoder().decode(new Uint8Array(bytes));
+    const decimalAlias = encodeRawCursorJson(json.replace('"priorShowing":8', '"priorShowing":8.0'));
+    for (const alias of [decimalAlias, cursor.toUpperCase()]) {
+      const repository = new SyntheticAggregateRepository(values);
+      await expect(queryUbsSemanticEvidenceBundle(repository, request({ cursor: alias })))
+        .rejects.toThrow(/canonical|bounded encoding/);
+      expect(repository.queryCount).toBe(0);
+    }
+
+    const repository = new SyntheticAggregateRepository(values);
+    const original = repository.getSemanticEvidenceBundle.bind(repository);
+    repository.getSemanticEvidenceBundle = async query => {
+      const page = await original(query);
+      page.boundary.after!.keyset = candidateKeyset(values[6]!);
+      return page;
+    };
+    await expect(queryUbsSemanticEvidenceBundle(repository, request({ cursor })))
+      .rejects.toThrow('does not match the requested cursor position');
+    expect(repository.queryCount).toBe(1);
+  });
+
+  it('fails closed on adversarial malformed aggregate rows and honest-window metadata', async () => {
+    const mutations: Array<{ message: string; mutate(page: UbsSemanticEvidenceBundleRepositoryPage): void }> = [
+      { message: 'exact query identity', mutate: page => { page.items[0].entry.lexicalIdentities = [H0002]; } },
+      { message: 'strict canonical order', mutate: page => { page.items.reverse(); } },
+      { message: 'duplicate sense identity', mutate: page => { page.items[1] = structuredClone(page.items[0]); } },
+      { message: 'exact query identity', mutate: page => { page.items[0].matchingReferences[0].normalizedReference = 'Synthetic 1:2'; } },
+      { message: 'domain total', mutate: page => { page.items[0].domainTotal = 0; } },
+      { message: 'provenance is malformed', mutate: page => { page.sources[0].artifactIdentity = OTHER_ARTIFACT; } },
+      { message: 'honest candidate window', mutate: page => { page.semanticSenseTotal = 1; } },
+      { message: 'inconsistent evidence', mutate: page => { page.items[1].entry.lemma = 'INCONSISTENT LEMMA'; } },
+      { message: 'reuses a sense ordinal', mutate: page => { page.items[1].sense.sourceOrdinal = 1; } },
+      {
+        message: 'repeats reference evidence',
+        mutate: page => { page.items[1].matchingReferences[0].evidenceId = 'reference-01'; },
+      },
+      {
+        message: 'exact provenance source roles',
+        mutate: page => {
+          page.items[0].domains[0].sourceId = 'synthetic-dictionary';
+          page.items[0].sense.domainRefs[0].sourceId = 'synthetic-dictionary';
+        },
+      },
+    ];
+    for (const testCase of mutations) {
+      const values = [candidate(1), candidate(2)];
+      const repository = new SyntheticAggregateRepository(values);
+      const original = repository.getSemanticEvidenceBundle.bind(repository);
+      repository.getSemanticEvidenceBundle = async query => {
+        const page = await original(query);
+        testCase.mutate(page);
+        return page;
+      };
+      await expect(queryUbsSemanticEvidenceBundle(repository, request())).rejects.toThrow(testCase.message);
+      expect(repository.queryCount).toBe(1);
+    }
+  });
+
+  it('rejects stale cursor position metadata and pages that do not advance', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => candidate(index + 1));
+    const first = await queryUbsSemanticEvidenceBundle(new SyntheticAggregateRepository(values), request());
+    const cursor = first.coverage.candidateWindow.nextCursor!;
+    const stale = new SyntheticAggregateRepository(values);
+    const original = stale.getSemanticEvidenceBundle.bind(stale);
+    stale.getSemanticEvidenceBundle = async query => {
+      const page = await original(query);
+      page.boundary.priorShowing = 0;
+      return page;
+    };
+    await expect(queryUbsSemanticEvidenceBundle(stale, request({ cursor })))
+      .rejects.toThrow('cursor position');
+  });
+});

--- a/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const repo = new URL('../../../', import.meta.url);
+const moduleName = 'ubsSemanticEvidenceBundle';
+
+const reviewedBasePins = {
+  'src/kernel/index.ts': 'e7c00224d935dba7bc6e22cc7bfeb79c9ffab58656715688d58f7302cdec5d20',
+  'src/tools/v2/index.ts': '2bdf52660313eea971ed51253120288488938812c014c7764d6bb85c233251bd',
+  'src/tools/worker/index.ts': 'feb1679a520185d11f2b6082b70ea3ef6c2b87652ff49c97c0acedfb76d83b90',
+  'src/worker.ts': '07a439b6f5f20be1e6651ceaad71b4ca189579592c743e5e0f3770d80ba12d44',
+  'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
+  'data/data-manifest.json': 'ba4f6fc73086716bd03f8e8d65a181719fba834aa61a90e65b168169744fa424',
+  'wrangler.toml': '512128beeb51f9134381f06cebd822b3402a3f99c6622410989bd3d188f711bc',
+  'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
+  'package.json': '4a9e337f9ee795a2d962ad9d6b5161fb36d166a7bf5547aca0c69813709f1ec4',
+} as const;
+
+describe('inactive UBS semantic aggregate bundle contract', () => {
+  it('is absent from Node, Worker, MCP, service, prompt, resource, and tool composition', () => {
+    for (const path of [
+      'src/kernel/index.ts', 'src/tools/v2/index.ts',
+      'src/tools/worker/index.ts', 'src/worker.ts', 'src/worker-server.ts',
+      'src/server.ts', 'src/mcp/prompts.ts', 'src/tools/toolRegistry.ts',
+    ]) {
+      expect(readFileSync(new URL(path, repo), 'utf8'), path).not.toContain(moduleName);
+    }
+  });
+
+  it('preserves reviewed Worker inputs, configuration, inventory, and active data identity', () => {
+    for (const [path, expected] of Object.entries(reviewedBasePins)) {
+      const actual = createHash('sha256').update(readFileSync(new URL(path, repo))).digest('hex');
+      expect(actual, path).toBe(expected);
+    }
+  });
+
+  it('contains no storage layout, source bytes, migration, D1 adapter, or runtime binding', () => {
+    const source = readFileSync(new URL('src/kernel/ubsSemanticEvidenceBundle.ts', repo), 'utf8');
+    expect(source).not.toMatch(/from ['"][^'"]*(?:data\/|migrations\/|adapters\/d1|adapters\/data)/);
+    expect(source).not.toMatch(/\b(?:SELECT|INSERT|CREATE TABLE|D1Database|better-sqlite3)\b/i);
+    const manifest = JSON.parse(readFileSync(new URL('data/data-manifest.json', repo), 'utf8')) as {
+      schemaVersion: string;
+      materializations: { d1: { transformVersion: number } };
+    };
+    expect(manifest).toMatchObject({
+      schemaVersion: '0003_original_language_usage',
+      materializations: { d1: { transformVersion: 6 } },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add an inactive, source-free one-call aggregate contract for future UBS semantic evidence
- use server-validated canonical continuation boundaries without a signing secret
- enforce bounded evidence, honest incomplete coverage, exact field allowlists, and deterministic Node/D1 ordering
- document the deferred storage/runtime boundary

## Safety
- no runtime export or composition registration
- no storage schema, migration, D1 binding, source artifact, secret, or deployment change
- remains an inactive foundation slice

## Verification
- 1,879 unit tests passed; 1 skipped
- 284 kernel tests passed
- focused/inertness tests: 23 passed
- Node and fixture type checks passed
- independent Sol re-review: GO, zero P0-P3 findings
