### PR TITLE
Hard-cut primary-source output profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ fresh server and transport.
 | `parallel_passages` | Return complete UBS source-attested parallel groups by default; legacy curated edges and OpenBible.info cross references require explicit selectors and remain separate. |
 | `commentary_lookup` | Retrieve Matthew Henry, JFB, Adam Clarke, John Gill, Keil-Delitzsch (OT), or Tyndale notes. |
 | `classic_text_lookup` | Search and browse the 17 locally indexed historical documents. Remote CCEL document bodies are not retrieved or republished. |
-| `primary_source_search` | Execute bounded primary-source query plans. Production is v3/local-only; preview exposes the v4 local-plus-CCEL discovery contract while CCEL execution remains disabled before adapter, coordinator, or fetch. Snippets remain discovery-only, and selected local sections are readable resources. |
+| `primary_source_search` | Execute bounded primary-source query plans. Production is v4/local-only; preview exposes the v5 local-plus-CCEL discovery contract while CCEL execution remains disabled before adapter, coordinator, or fetch. Snippets remain discovery-only, selected local sections are readable resources, and research workflows maintain explicit searched/read/deferred/not-searched coverage ledgers. |
 | `original_language_lookup` | Look up or search Strong's entries, with opt-in rights-reviewed STEPBible metadata, exact corrected-corpus usage, and bounded occurrence pages for exact identities. The Online-Bible-derived TBESH Hebrew `Meaning` field is withheld. |
 | `bible_verse_morphology` | Return bounded word-by-word morphology for one exact verse, with raw codes, nullable expansions, and separate pinned STEPBible morphology/lemma provenance. |
 | `original_language_study` | Resolve and study one Greek or Hebrew token in one verse with contextual morphology, source-separated lexical evidence, and explicit interpretive limits. |
@@ -167,7 +167,7 @@ edition provenance is incomplete, and rights status is not established.
 |---|---|
 | `theologai://translations` | Available Bible translations. |
 | `theologai://commentaries` | Available commentary sources. |
-| `theologai://primary-sources/catalog` | JSON metadata inventory for the hosted primary-source collection; no document bodies or provenance URLs. |
+| `theologai://primary-sources/catalog` | v2 JSON metadata inventory for the hosted primary-source collection; no document bodies, provenance URLs, source hashes, or rights instruments. Each work carries a fail-closed edition-readiness disclosure. |
 | `theologai://documents/{slug}` | A locally indexed creed, confession, or catechism. |
 | `theologai://strongs/{number}` | A Strong's dictionary entry such as `G26` or `H430`. |
 
@@ -221,7 +221,7 @@ catechisms. The exact count is enforced by `data/data-manifest.json`.
 
 The production tools search and retrieve only the locally indexed collection.
 They do **not** currently fetch CCEL search results or document bodies, and the
-production v3 schema remains strictly local-only. Preview stages a hard v4
+production v4 schema remains strictly local-only. Preview stages a hard v5
 contract cutover: it advertises external CCEL discovery inputs and guided
 workflows, but live search and coordinator execution remain disabled. External
 preview queries therefore return a disabled provider result before adapter
@@ -239,11 +239,11 @@ link to a canonical allowlisted CCEL exact-section path; tracking query and hash
 values are discarded. Balanced-card parsing uses explicit title/author roles,
 and a no-results marker is accepted only when no competing result structure is
 present. These safeguards do not authorize or enable live use.
-CCEL does not provide reviewed composition-year filtering. The v4 guided
+CCEL does not provide reviewed composition-year filtering. The v5 guided
 primary-source workflow therefore keeps any requested year bounds on its local
 queries, sends its single external discovery query without year fields, and
 repeats an explicit warning that CCEL results cannot establish membership in
-the requested historical period. Direct v4 queries that combine CCEL with
+the requested historical period. Direct v5 queries that combine CCEL with
 either year field remain `unsupported_filter` before adapter or coordinator
 admission; the public tool schema documents that strict boundary.
 Any future external provider rollout must remain discovery-only until
@@ -409,7 +409,7 @@ per-request D1 repositories. Both targets share one MCP registry.
 - The current tracked roadmap is [docs/ROADMAP.md](docs/ROADMAP.md), beginning
   after the PR #10 production baseline.
 - Live CCEL discovery and search remain gated future work; preview currently
-  exposes only the non-executing v4 contract.
+  exposes only the non-executing v5 contract while production remains v4/local-only.
 - The local historical collection needs document-level edition, source, and
   license metadata before redistribution claims can be made.
 - Hosted MCP Logging would require a deliberate stateful-session design.

--- a/docs/CCEL-UPSTREAM-COORDINATOR.md
+++ b/docs/CCEL-UPSTREAM-COORDINATOR.md
@@ -6,9 +6,9 @@ This remains an exposure-only preview stage, not CCEL enablement. Production
 keeps `THEOLOGAI_EXPOSE_CCEL_DISCOVERY`,
 `THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH`, and
 `THEOLOGAI_ENABLE_CCEL_COORDINATOR` all `false`, so its public contract remains
-v3/local-only. Preview sets only `THEOLOGAI_EXPOSE_CCEL_DISCOVERY` to `true`;
+v4/local-only. Preview sets only `THEOLOGAI_EXPOSE_CCEL_DISCOVERY` to `true`;
 its live-search and coordinator switches remain `false`. Preview therefore
-advertises the v4 discovery contract and guided workflows, but every external
+advertises the v5 discovery contract and guided workflows, but every external
 query returns a disabled provider result without adapter search, Durable Object
 lookup/RPC, or network access. No CCEL request is authorized by this stage.
 
@@ -225,10 +225,10 @@ not coordinated. A multi-process local deployment must use one process, route
 CCEL discovery through a single coordinator service, or keep live discovery
 disabled.
 
-## Staged v4 contract wiring
+## Staged v5 contract wiring
 
 The public Worker and Node composition roots share one contract configuration.
-The v4 application contract is exposed only by
+The v5 discovery application contract is exposed only by
 `THEOLOGAI_EXPOSE_CCEL_DISCOVERY`; an origin attempt additionally requires both
 live-search and coordinator switches. The sole live predicate is therefore all
 three switches together. Any false switch leaves the external adapter,
@@ -242,21 +242,21 @@ the sole latch/backoff/circuit authority. Node coordination is process-local;
 multi-process Node deployments must keep live discovery disabled unless they
 provide one shared coordinator.
 
-Checked-in production values select the local-only v3 contract. Checked-in
-preview values select v4 exposure only; because the live-search and coordinator
+Checked-in production values select the local-only v4 contract. Checked-in
+preview values select v5 exposure only; because the live-search and coordinator
 values remain false, preview also makes no CCEL request or Durable Object RPC.
 
 MCP clients can cache `tools/list` and `prompts/list` results for the life of a
 connection. This is a hard contract cutover rather than a negotiated opt-in, so
 reconnect and reinitialize a preview client after deployment before auditing
-the v4 schemas and workflows. Do not interpret a stale client schema as the
+the v5 schemas and workflows. Do not interpret a stale client schema as the
 Worker's current contract.
 
 Once Stage B is bound and a later approved slice enables it, the global coordinator is intentionally a bottleneck: the maximum admitted
 CCEL-origin load is 0.1 requests/second across production and preview combined.
 Local corpus search remains independent if the circuit latches.
 
-The adapter returns a bounded integer `retryAfterSeconds` on every v4
+The adapter returns a bounded integer `retryAfterSeconds` on every v5
 `rate_limited` provider result. Guided primary-source research issues at most
 one CCEL-bearing call per prompt materialization and defers additional creator
 scopes to later turns after that interval. CCEL cannot enforce reviewed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -500,8 +500,8 @@ Code readiness and operational readiness are deliberately separate:
 - Historical public-domain text may be published when transcription provenance
   is uncertain, but that uncertainty must be disclosed; a third party's
   particular transcription is not assumed redistributable.
-- CCEL execution remains inactive. Preview exposes the v4 discovery contract
-  only; production remains v3/local-only. A future live discovery rollout
+- CCEL execution remains inactive. Preview exposes the v5 discovery contract
+  only; production remains v4/local-only. A future live discovery rollout
   requires the explicit owner policy decision above and separate review, and
   must not become crawling, catalog mirroring, body republication, or permanent
   storage. Date-fallback contract work does not change any rollout flag or

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -1,16 +1,17 @@
 # CCEL live-search preflight record
 
 > **Current status:** exposure-only preview record. Production remains on the
-> local-only v3 contract. Preview advertises the v4 CCEL discovery shape, but
+> local-only v4 contract. Preview advertises the v5 CCEL discovery shape, but
 > both execution switches remain off: no public call can reach the adapter,
 > coordinator lookup/RPC, or upstream fetch. TheologAI does not retrieve or
 > republish CCEL document bodies. Live discovery still requires a fresh
 > operational preflight and explicit release review.
 
 Originally recorded 2026-07-11, updated 2026-07-15 for dormant parser-policy
-hardening, and reconciled 2026-07-16 for preview-only v4 exposure. This is an
-architecture record, not an enablement approval. The live-search and
-coordinator flags remain off in production and preview.
+hardening, and reconciled 2026-07-16 for preview-only v4 exposure. Updated
+2026-07-17 for preview-only v5 exposure. This is an architecture record, not
+an enablement approval. The live-search and coordinator flags remain off in
+production and preview.
 
 - Search surface reviewed: `https://ccel.org/?page=1&text=...`
 - Search contract reviewed: [CCEL Search Help](https://www.ccel.org/help/search), including the documented `author`, `authorID`, `title`, and `bookID` fields.
@@ -92,6 +93,6 @@ execution, or remote mutation is authorized by this record. The preview-only
 exposure flag changes an MCP contract, not the upstream execution policy.
 
 The content-free admission/circuit design and staged gates are documented in
-[CCEL-UPSTREAM-COORDINATOR.md](./CCEL-UPSTREAM-COORDINATOR.md). Preview v4
+[CCEL-UPSTREAM-COORDINATOR.md](./CCEL-UPSTREAM-COORDINATOR.md). Preview v5
 exposure does not supersede this preflight's operational, robots, terms, or
 interface-review gates.

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -41,12 +41,12 @@ GitHub deployment run are authoritative after a later deployment. A reviewable
 deployment; in that state the configuration is not evidence of the deployed
 binding.
 
-### Stage D preview v4 exposure candidate
+### Stage D preview v5 exposure candidate
 
 The checked-in Stage D configuration is intentionally asymmetric. Production
 remains `false/false/false` for CCEL exposure, live search, and coordinator
-execution, preserving the v3/local-only public contract. Preview is
-`true/false/false`: it exposes the v4 tool schema and guided workflows while the
+execution, preserving the v4/local-only public contract. Preview is
+`true/false/false`: it exposes the v5 tool schema and guided workflows while the
 single live predicate remains false. In that state an external query returns a
 disabled provider result before adapter invocation, Durable Object lookup/RPC,
 or fetch. This configuration is a release candidate until a protected preview
@@ -57,7 +57,7 @@ Because MCP clients may cache tool and prompt schemas within an initialized
 connection, reconnect and reinitialize the audit client after the preview
 deployment. Audit the fresh `tools/list` and `prompts/list` responses before
 calling `primary_source_search`; otherwise a client can continue presenting a
-stale v3 schema even though the Worker has cut over to v4.
+stale v4 schema even though the Worker has cut over to v5.
 
 | Environment | Deployed logical database | Current posture | Rollback posture |
 |---|---|---|---|

--- a/scripts/audit-ccel-preview.ts
+++ b/scripts/audit-ccel-preview.ts
@@ -35,14 +35,50 @@ export function parseCcelAuditArgs(argv: string[]): CcelAuditOptions {
 }
 
 type Provider = {
-  provider?: string; status?: string; retryAfterSeconds?: number; hitCount?: number;
-  hits?: Array<{ snippet?: string; locator?: { kind?: string; url?: string } }>;
+  provider?: string; status?: string; searched?: boolean; retryAfterSeconds?: number; hitCount?: number;
+  scope?: { eligibleDocuments?: Array<{ editionReadiness?: EditionReadiness }> };
+  hits?: Array<{
+    snippet?: string; metadataStatus?: string; editionReadiness?: EditionReadiness;
+    locator?: { kind?: string; url?: string; uri?: string };
+  }>;
+};
+type EditionReadiness = {
+  foundation?: string; editionIdentity?: string; provenance?: string; exactArtifactRights?: string;
+};
+type CoverageObservation = {
+  queryId?: string; provider?: string; status?: string; returnedHitCount?: number;
 };
 type SearchOutput = {
   schemaVersion?: string; planStatus?: string;
   responseWindow?: { unit?: string; maximum?: number; truncated?: boolean };
-  evidencePolicy?: { snippetUse?: string; externalSectionAccess?: string };
-  queries?: Array<{ providers?: Provider[] }>;
+  coverage?: {
+    localAttempted?: boolean; localHitCount?: number; ccelAttempted?: boolean; ccelHitCount?: number;
+    serverObserved?: { searched?: CoverageObservation[]; notSearched?: CoverageObservation[] };
+  };
+  evidencePolicy?: {
+    snippetUse?: string; localSectionAccess?: string; externalSectionAccess?: string;
+    coverageScope?: string; externalRightsStatus?: string; lookupAliasUse?: string;
+    coverageLedger?: Record<string, string>;
+  };
+  queries?: Array<{ id?: string; providers?: Provider[] }>;
+};
+
+const LOCAL_EDITION_READINESS = {
+  foundation: 'edition-provenance-foundation.v1',
+  editionIdentity: 'not_established',
+  provenance: 'incomplete',
+  exactArtifactRights: 'not_established_by_this_contract',
+};
+const EXTERNAL_EDITION_READINESS = {
+  editionIdentity: 'provider_unreviewed',
+  provenance: 'provider_unreviewed',
+  exactArtifactRights: 'not_determined',
+};
+const COVERAGE_LEDGER = {
+  searched: 'server_observed_provider_execution',
+  read: 'host_observed_successful_exact_resource_or_page_read',
+  deferred: 'host_recorded_intentional_deferral',
+  notSearched: 'server_observed_provider_non_execution',
 };
 
 type AuditToolResponse = {
@@ -85,8 +121,12 @@ export async function runCcelPreviewAudit(options: CcelAuditOptions, dependencie
     const previewTools = await preview.listTools();
     const productionSchema = toolSchema(productionTools.tools, 'primary_source_search');
     const previewSchema = toolSchema(previewTools.tools, 'primary_source_search');
-    assert(JSON.stringify(productionSchema).includes('"const":"3"') && !JSON.stringify(productionSchema).includes('"ccel"'), 'production 000 control');
-    assert(JSON.stringify(previewSchema).includes('"const":"4"') && JSON.stringify(previewSchema).includes('retryAfterSeconds'), 'preview v4 contract');
+    assert(schemaVersionIs(productionSchema, '4')
+      && !schemaContainsConst(productionSchema, 'ccel_live')
+      && !schemaContainsProperty(productionSchema, 'retryAfterSeconds'), 'production v4 local-only control');
+    assert(schemaVersionIs(previewSchema, '5')
+      && schemaContainsConst(previewSchema, 'ccel_live')
+      && schemaContainsProperty(previewSchema, 'retryAfterSeconds'), 'preview v5 CCEL contract');
 
     // Exactly two concurrent CCEL-only calls exercise the one global Durable
     // Object budget without relying on process-local cache affinity or elapsed
@@ -99,21 +139,21 @@ export async function runCcelPreviewAudit(options: CcelAuditOptions, dependencie
     const cold = contenders.filter(output => ['ok', 'no_results'].includes(provider(output, 'ccel_live')?.status ?? ''));
     const busy = contenders.filter(output => provider(output, 'ccel_live')?.status === 'rate_limited');
     assert(cold.length === 1 && busy.length === 1, 'one admitted discovery and one globally rate-limited contender');
-    for (const output of contenders) assertValidV4Envelope(output);
+    for (const output of contenders) assertValidV5Envelope(output);
     assertValidExternalDiscovery(provider(cold[0]!, 'ccel_live')!);
     assertValidRateLimited(provider(busy[0]!, 'ccel_live')!);
 
     // Local search is deliberately separate and cannot consume an origin slot.
     const local = await search(preview, ccelBudget, 'audit-local-fallback', 'justification', ['local']);
     assert(['ok', 'no_results', 'catalog_miss'].includes(provider(local, 'local')?.status ?? ''), 'usable local fallback independent of CCEL');
-    assertValidV4Envelope(local);
+    assertValidV5Envelope(local);
     assert(ccelBudget.snapshot() === 2, 'exactly two CCEL-bearing tool calls');
 
     return {
       schemaVersion: '1', audit: 'ccel-live-preview', passed: true,
-      productionControl: { contractVersion: '3', liveCallMade: false },
+      productionControl: { contractVersion: '4', liveCallMade: false },
       preview: {
-        contractVersion: '4', ccelBearingToolCallMaximum: 2, upstreamOriginAdmissionMaximum: 2,
+        contractVersion: '5', ccelBearingToolCallMaximum: 2, upstreamOriginAdmissionMaximum: 2,
         statuses: [...contenders, local].map(summarize),
       },
       privacy: 'No query, title, snippet, content, URL, header, or client identity is retained.',
@@ -139,14 +179,81 @@ function assertValidRateLimited(external: Provider): void {
   void boundedAuditSleepMs(external.retryAfterSeconds!);
 }
 
-function assertValidV4Envelope(output: SearchOutput): void {
-  assert(output.schemaVersion === '4'
+function assertValidV5Envelope(output: SearchOutput): void {
+  assert(output.schemaVersion === '5'
     && output.responseWindow?.unit === 'utf8_bytes'
     && output.responseWindow.maximum === 32_768
     && typeof output.responseWindow.truncated === 'boolean'
     && output.evidencePolicy?.snippetUse === 'discovery_only'
+    && output.evidencePolicy.localSectionAccess === 'mcp_resource_read'
     && output.evidencePolicy.externalSectionAccess === 'direct_url_only'
-    && !JSON.stringify(output).includes('resource_link'), 'compact v4 discovery semantics');
+    && output.evidencePolicy.coverageScope === 'bounded_non_exhaustive'
+    && output.evidencePolicy.externalRightsStatus === 'not_determined'
+    && output.evidencePolicy.lookupAliasUse === 'exact_routing_only_not_metadata_evidence'
+    && matchesExactRecord(output.evidencePolicy.coverageLedger, COVERAGE_LEDGER)
+    && !JSON.stringify(output).includes('resource_link'), 'compact v5 discovery semantics');
+
+  const searched = output.coverage?.serverObserved?.searched;
+  const notSearched = output.coverage?.serverObserved?.notSearched;
+  assert(Array.isArray(searched) && Array.isArray(notSearched), 'v5 server-observed coverage ledger');
+  const providers = output.queries?.flatMap(query => (query.providers ?? []).map(item => ({ queryId: query.id, item }))) ?? [];
+  const providerKeys = providers.map(({ queryId, item }) => `${String(queryId)}\u0000${String(item.provider)}`);
+  assert(providerKeys.length > 0
+    && new Set(providerKeys).size === providerKeys.length
+    && searched.length + notSearched.length === providers.length, 'one-to-one provider coverage');
+  for (const { queryId, item } of providers) {
+    assert(typeof queryId === 'string' && queryId.length > 0
+      && (item.provider === 'local' || item.provider === 'ccel_live')
+      && typeof item.searched === 'boolean'
+      && Number.isSafeInteger(item.hitCount)
+      && item.hitCount === (item.hits?.length ?? 0), 'explicit bounded provider execution state');
+    const searchedMatches = searched.filter(observation => observation.queryId === queryId && observation.provider === item.provider);
+    const notSearchedMatches = notSearched.filter(observation => observation.queryId === queryId && observation.provider === item.provider);
+    if (item.searched) {
+      assert(searchedMatches.length === 1 && notSearchedMatches.length === 0
+        && searchedMatches[0]?.status === item.status
+        && searchedMatches[0]?.returnedHitCount === item.hitCount, 'truthful searched-provider coverage');
+    } else {
+      assert(searchedMatches.length === 0 && notSearchedMatches.length === 1
+        && notSearchedMatches[0]?.status === item.status, 'truthful non-executed-provider coverage');
+    }
+    if (item.provider === 'local') assertValidLocalEditionReadiness(item);
+    if (item.provider === 'ccel_live') assertValidExternalEditionReadiness(item);
+  }
+
+  const local = providers.filter(({ item }) => item.provider === 'local').map(({ item }) => item);
+  const external = providers.filter(({ item }) => item.provider === 'ccel_live').map(({ item }) => item);
+  assert(output.coverage?.localAttempted === local.some(item => item.searched === true)
+    && output.coverage.localHitCount === local.reduce((count, item) => count + (item.hitCount ?? 0), 0)
+    && output.coverage.ccelAttempted === external.some(item => item.searched === true)
+    && output.coverage.ccelHitCount === external.reduce((count, item) => count + (item.hitCount ?? 0), 0),
+  'v5 aggregate coverage');
+}
+
+function assertValidLocalEditionReadiness(local: Provider): void {
+  for (const hit of local.hits ?? []) {
+    assert(matchesExactRecord(hit.editionReadiness, LOCAL_EDITION_READINESS)
+      && hit.locator?.kind === 'mcp_resource'
+      && typeof hit.locator.uri === 'string', 'local edition readiness and resource access');
+  }
+  for (const document of local.scope?.eligibleDocuments ?? []) {
+    assert(matchesExactRecord(document.editionReadiness, LOCAL_EDITION_READINESS), 'local scope edition readiness');
+  }
+}
+
+function assertValidExternalEditionReadiness(external: Provider): void {
+  for (const hit of external.hits ?? []) {
+    assert(matchesExactRecord(hit.editionReadiness, EXTERNAL_EDITION_READINESS)
+      && hit.metadataStatus === 'provider_search_result_unreviewed', 'external edition readiness');
+  }
+}
+
+function matchesExactRecord(actual: Record<string, unknown> | undefined, expected: Record<string, string>): boolean {
+  if (!actual) return false;
+  const actualKeys = Object.keys(actual).sort();
+  const expectedKeys = Object.keys(expected).sort();
+  return actualKeys.length === expectedKeys.length
+    && actualKeys.every((key, index) => key === expectedKeys[index] && actual[key] === expected[key]);
 }
 
 function assertValidExternalDiscovery(external: Provider): void {
@@ -220,6 +327,25 @@ function toolSchema(tools: Array<{ name: string; outputSchema?: object }>, name:
   const schema = tools.find(tool => tool.name === name)?.outputSchema;
   if (!schema) throw new Error(`Missing ${name} output schema.`);
   return schema;
+}
+
+function schemaVersionIs(schema: object, expected: string): boolean {
+  const properties = (schema as { properties?: Record<string, unknown> }).properties;
+  const schemaVersion = properties?.schemaVersion as { const?: unknown } | undefined;
+  return schemaVersion?.const === expected;
+}
+
+function schemaContainsConst(value: unknown, expected: string): boolean {
+  if (!value || typeof value !== 'object') return false;
+  if ('const' in value && (value as { const?: unknown }).const === expected) return true;
+  return Object.values(value).some(item => schemaContainsConst(item, expected));
+}
+
+function schemaContainsProperty(value: unknown, expected: string): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const properties = (value as { properties?: unknown }).properties;
+  if (properties && typeof properties === 'object' && expected in properties) return true;
+  return Object.values(value).some(item => schemaContainsProperty(item, expected));
 }
 
 function assert(condition: boolean, label: string): asserts condition {

--- a/skills/confession-study/SKILL.md
+++ b/skills/confession-study/SKILL.md
@@ -18,6 +18,11 @@ returned by the server to establish what is available and what each document
 says. The workflow must not assign a tradition or author from a title or from a
 prewritten grouping.
 
+Production advertises the v4 local-only `primary_source_search` contract.
+Preview may advertise v5, which adds a separately reported CCEL discovery
+provider. Preserve that provider's state and unreviewed metadata separately; a
+disabled provider did not search or read CCEL.
+
 ## Methodology
 
 ### Step 1: Identify Relevant Documents
@@ -32,6 +37,8 @@ prewritten grouping.
 
 - Call `primary_source_search` with one bounded local query plan, for example
   `{ "queries": [{ "id": "confession-topic", "text": "the doctrinal topic", "providers": ["local"], "match": "all_terms", "selection": "work_diversity", "limit": 5 }] }`.
+- On a v5 endpoint, request the separate `ccel` provider only when a discovery
+  lead is materially useful. It is never local catalog evidence.
 - Treat returned snippets as discovery-only. Preserve document metadata, creator
   names, and creator roles exactly as returned.
 - Do not claim the search covered sources outside the hosted collection, and do
@@ -44,6 +51,21 @@ prewritten grouping.
   confirm the returned URI matches the selected locator.
 - Do not quote, characterize a position, or compare documents from snippets.
   Base those claims only on exact resources actually read.
+- Treat local `editionReadiness` as fail-closed: this contract has not
+  established exact edition identity, transcription provenance, or
+  exact-artifact redistribution rights.
+
+### Step 3b: Close the Coverage Ledger
+
+- **Searched:** copy only returned provider execution states.
+- **Read:** record only exact local MCP resources or external pages successfully
+  opened after discovery.
+- **Deferred:** record selected leads intentionally left unread, with a reason.
+- **Not searched:** record only a provider or scope the tool reports as not
+  executed.
+
+The server cannot observe later resource reads or intentional deferrals. Never
+invent either from snippets alone.
 
 ### Step 4: Biblical Foundations
 

--- a/src/formatters/historicalFormatter.ts
+++ b/src/formatters/historicalFormatter.ts
@@ -12,6 +12,20 @@ export const LOCAL_HISTORICAL_SOURCE = LOCAL_PRIMARY_SOURCE_ATTRIBUTION;
 
 const localSource = `*Source: ${LOCAL_HISTORICAL_SOURCE}*`;
 
+/**
+ * Current local bodies are retained for research continuity, but have not yet
+ * passed the per-edition review boundary introduced by the provenance
+ * foundation. Keep this disclosure with every exact resource a model may read.
+ */
+const editionReadinessDisclosure = [
+  '## Edition and provenance disclosure',
+  '',
+  'This hosted text is available for research, but this contract has not established its exact edition or transcription identity.',
+  '- Provenance review: incomplete.',
+  '- Exact-artifact redistribution rights: not established by this contract.',
+  '- Do not infer edition, transcription source, or republication permission from the historical work alone.',
+].join('\n');
+
 /** Canonical exact-section representation shared by resources/read and link sizing. */
 export function formatLocalDocumentSectionResource(doc: DocumentInfo, section: DocumentSection): string {
   const heading = section.title
@@ -25,6 +39,8 @@ export function formatLocalDocumentSectionResource(doc: DocumentInfo, section: D
     heading,
     '',
     section.content,
+    '',
+    editionReadinessDisclosure,
     '',
     localSource,
   ].filter(Boolean).join('\n');
@@ -46,6 +62,8 @@ export function formatLocalDocumentResource(doc: DocumentInfo, sections: Documen
     lines.push(section.content);
     lines.push('');
   }
+  lines.push(editionReadinessDisclosure);
+  lines.push('');
   lines.push(localSource);
   return lines.filter(Boolean).join('\n');
 }

--- a/src/formatters/primarySourceFormatter.ts
+++ b/src/formatters/primarySourceFormatter.ts
@@ -1,4 +1,11 @@
 import type { PresentedPrimarySourceSearch } from '../presenters/primarySourceSearchStructured.js';
+import type {
+  PresentedPrimarySourceSearchV4,
+  PresentedPrimarySourceSearchV5,
+} from '../presenters/primarySourceSearchV4Structured.js';
+
+/** Reserve enough delivery budget for structured content and native links. */
+export const PRIMARY_SOURCE_FALLBACK_MAX_BYTES = 4_096;
 
 export function formatPrimarySourceSearch(result: PresentedPrimarySourceSearch): string {
   const lines = [
@@ -62,6 +69,38 @@ export function formatPrimarySourceSearch(result: PresentedPrimarySourceSearch):
   return lines.join('\n').trim();
 }
 
+/**
+ * A compact, human-readable fallback over the already-sanitized public model.
+ * `structuredContent` remains authoritative; this never re-reads raw provider
+ * data or manufactures a second, divergent representation.
+ */
+export function formatPrimarySourceSearchFallback(
+  result: PresentedPrimarySourceSearchV4 | PresentedPrimarySourceSearchV5,
+): string {
+  const lines = [
+    '# Primary-source discovery',
+    '',
+    `Plan status: **${result.planStatus}**. Structured content is authoritative.`,
+  ];
+  for (const query of result.queries) {
+    lines.push('', `## ${safe(query.id)}`);
+    for (const provider of query.providers) {
+      const label = provider.provider === 'local' ? 'Local hosted collection' : 'CCEL discovery lead';
+      lines.push(`- ${label}: **${provider.status}**; ${provider.hitCount} returned.`);
+      for (const hit of provider.hits) {
+        const location = hit.provider === 'local' ? hit.locator.uri : hit.locator.url;
+        lines.push(`  - ${safe(hit.title)}${hit.sectionLabel ? ` — ${safe(hit.sectionLabel)}` : ''}: ${safe(hit.snippet)} (${location})`);
+      }
+    }
+  }
+  lines.push(
+    '',
+    'Snippets are discovery-only. Read a selected exact local MCP resource before quotation or comparison.',
+    'Coverage ledger: this response records only searched and not-searched providers; record successful reads and intentional deferrals in the host’s final research ledger.',
+  );
+  return boundedUtf8(lines.join('\n').trim(), PRIMARY_SOURCE_FALLBACK_MAX_BYTES);
+}
+
 /** Neutralize untrusted corpus/upstream text so it cannot forge Markdown structure. */
 function safe(value: string): string {
   return value.normalize('NFC')
@@ -69,6 +108,17 @@ function safe(value: string): string {
     .replace(/\s+/gu, ' ')
     .trim()
     .replace(/[\\`*_{}\[\]()<>#+.!|>-]/g, character => `\\${character}`);
+}
+
+function boundedUtf8(value: string, maximum: number): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(value).byteLength <= maximum) return value;
+  let result = '';
+  for (const character of value) {
+    if (encoder.encode(`${result}${character}…`).byteLength > maximum) break;
+    result += character;
+  }
+  return `${result}…`;
 }
 
 function formatLocator(locator: PresentedPrimarySourceSearch['queries'][number]['providers'][number]['hits'][number]['locator']): string {

--- a/src/kernel/featureFlags.ts
+++ b/src/kernel/featureFlags.ts
@@ -1,7 +1,7 @@
 /**
  * One shared, non-secret contract and execution gate for primary-source search.
  *
- * Exposure selects the public v3/v4 application contract.  Live CCEL work is
+ * Exposure selects the public v4/v5 application contract.  Live CCEL work is
  * permitted only when all three switches are true; no caller should recreate
  * that predicate independently.
  */
@@ -10,7 +10,8 @@ export interface PrimarySourceContractConfig {
   exposeCcelDiscovery: boolean;
   ccelLiveSearch: boolean;
   ccelCoordinator: boolean;
-  contractVersion: '3' | '4';
+  /** v4 is hosted-local; v5 adds the separately gated CCEL discovery shape. */
+  contractVersion: '4' | '5';
   liveCcelEnabled: boolean;
 }
 
@@ -20,7 +21,7 @@ export const DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG: Readonly<PrimarySourceContr
   exposeCcelDiscovery: false,
   ccelLiveSearch: false,
   ccelCoordinator: false,
-  contractVersion: '3',
+  contractVersion: '4',
   liveCcelEnabled: false,
 });
 
@@ -46,7 +47,7 @@ export function readPrimarySourceContractConfig(
     exposeCcelDiscovery,
     ccelLiveSearch,
     ccelCoordinator,
-    contractVersion: exposeCcelDiscovery ? '4' : '3',
+    contractVersion: exposeCcelDiscovery ? '5' : '4',
     liveCcelEnabled: exposeCcelDiscovery && ccelLiveSearch && ccelCoordinator,
   };
 }

--- a/src/mcp/primarySourceCatalog.ts
+++ b/src/mcp/primarySourceCatalog.ts
@@ -1,4 +1,5 @@
 import type { DocumentInfo } from '../kernel/repositories.js';
+import { LOCAL_EDITION_READINESS } from '../services/historical/primarySourceTypes.js';
 
 export const PRIMARY_SOURCE_CATALOG_URI = 'theologai://primary-sources/catalog';
 
@@ -15,11 +16,12 @@ export function buildPrimarySourceCatalog(documents: DocumentInfo[]) {
       creators: document.catalog.creators.map(creator => ({ ...creator })),
       metadataStatus: document.catalog.metadataStatus,
       metadataProvenanceIds: [...document.catalog.metadataProvenanceIds],
+      editionReadiness: LOCAL_EDITION_READINESS,
     }))
     .sort((left, right) => left.id.localeCompare(right.id, 'en-US'));
 
   return {
-    schemaVersion: '1' as const,
+    schemaVersion: '2' as const,
     kind: 'local_primary_source_catalog' as const,
     workCount: works.length,
     works,
@@ -28,6 +30,7 @@ export function buildPrimarySourceCatalog(documents: DocumentInfo[]) {
       lookupAliasUse: 'exact_routing_only_not_metadata_evidence' as const,
       editionProvenance: 'incomplete' as const,
       rightsStatus: 'not_established' as const,
+      editionReadiness: LOCAL_EDITION_READINESS,
     },
   };
 }

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -122,7 +122,7 @@ export function recommendedToolCallsForPrompt(
           queries: [{
             id: 'confession-topic',
             text: topic,
-            providers: contract.contractVersion === '4' ? ['local', 'ccel'] : ['local'],
+            providers: contract.contractVersion === '5' ? ['local', 'ccel'] : ['local'],
             match: 'all_terms',
             selection: 'work_diversity',
             limit: 5,
@@ -163,7 +163,7 @@ export function recommendedToolCallsForPrompt(
           })),
         },
       };
-      if (contract.contractVersion !== '4') return [localCall];
+      if (contract.contractVersion !== '5') return [localCall];
       // A prompt materialization may authorize only one cold CCEL attempt. The
       // shared coordinator enforces a global origin interval, so additional
       // creator scopes belong in later, independently paced turns.
@@ -239,41 +239,41 @@ export function registerPromptHandlers(
       },
       {
         name: 'primary-source-research',
-        description: contract.contractVersion === '4'
+        description: contract.contractVersion === '5'
           ? 'Find local evidence and optional external discovery leads without treating snippets as evidence'
           : 'Find and read bounded evidence from the locally indexed historical collection',
         arguments: [
           {
             name: 'topic',
-            description: contract.contractVersion === '4'
+            description: contract.contractVersion === '5'
               ? 'Topic or terms for hosted local evidence and optional external CCEL discovery.'
               : 'Topic or terms to find in the local historical collection',
             required: true,
           },
           {
             name: 'work',
-            description: contract.contractVersion === '4'
+            description: contract.contractVersion === '5'
               ? 'Optional exact hosted-local work title/slug and unreviewed external provider work restriction; not shared reviewed metadata or an author name.'
               : 'Optional exact local work title or slug; not an author name',
             required: false,
           },
           {
             name: 'authors',
-            description: contract.contractVersion === '4'
+            description: contract.contractVersion === '5'
               ? 'Optional comma-separated creators. Each becomes a separate exact reviewed local creator query; only the first creator is the immediate unreviewed external scope, and later creators require independently paced follow-up calls. Creator roles remain explicit.'
               : 'Optional comma-separated canonical creator names. Each creator becomes a separate query; creator roles remain explicit.',
             required: false,
           },
           {
             name: 'startYear',
-            description: contract.contractVersion === '4'
+            description: contract.contractVersion === '5'
               ? 'Optional inclusive hosted-local composition-year lower bound as an integer string. The guided external fallback deliberately omits this bound and warns that CCEL results are not date-filtered; a direct CCEL query containing it returns unsupported_filter without upstream admission.'
               : 'Optional inclusive composition-year lower bound as an integer string.',
             required: false,
           },
           {
             name: 'endYear',
-            description: contract.contractVersion === '4'
+            description: contract.contractVersion === '5'
               ? 'Optional inclusive hosted-local composition-year upper bound as an integer string. The guided external fallback deliberately omits this bound and warns that CCEL results are not date-filtered; a direct CCEL query containing it returns unsupported_filter without upstream admission.'
               : 'Optional inclusive composition-year upper bound as an integer string.',
             required: false,
@@ -349,7 +349,7 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
         const topic = args?.topic ?? '';
         const traditions = args?.traditions;
         const hint = traditions ? ` Focus on: ${traditions.split(',').map(item => item.trim()).join(', ')}.` : '';
-        text = contract.contractVersion === '4'
+        text = contract.contractVersion === '5'
           ? `Cross-tradition doctrinal comparison on "${topic}".${hint}
 
 1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Its reviewed metadata applies only to the hosted local collection.
@@ -357,7 +357,8 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
 3. **Use snippets only to select evidence** — Every snippet is discovery-only. For a local \`mcp_resource\` locator, read the exact URI with MCP \`resources/read\` before quotation or substantive comparison. For an external \`external_url\` locator, open the direct URL independently; it is not an MCP resource and its rights status is not determined.
 4. **Do not promote external metadata** — CCEL titles, creators, section labels, and snippets are unreviewed provider search results. Never quote, attribute doctrine, or compare positions from those snippets alone.
 5. **Read exact evidence** — Read at most five unique selected sections total. Confirm each local resource URI or external page identity before using its content, and keep local reviewed metadata distinct from external provider metadata.
-6. **Compare cautiously** — ${CCEL_DATE_CAPABILITY_NOTICE} Name any disabled, unavailable, or unsupported provider before drawing conclusions. Explain agreement, divergence, Scripture use, and historical context only from exact sections actually read. Missing hits are not historical silence.`
+6. **Close the coverage ledger** — Report: **searched** only from returned provider states; **read** only exact local resources or external pages successfully opened; **deferred** only selected leads intentionally left unread, with a reason; and **not searched** only providers/scopes the tool reports as not executed. Do not claim a later read or deferral from the search response itself.
+7. **Compare cautiously** — ${CCEL_DATE_CAPABILITY_NOTICE} Name any disabled, unavailable, or unsupported provider before drawing conclusions. Explain agreement, divergence, Scripture use, and historical context only from exact sections actually read. Missing hits are not historical silence.`
           : `Cross-tradition doctrinal comparison on "${topic}".${hint}
 
 1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Use only its reviewed work and creator metadata to plan the comparison; aliases route exact work lookups but are not metadata evidence. Do not substitute another creator or work for one absent from this catalog.
@@ -365,7 +366,8 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
 3. **Preserve source metadata** — Keep each hit's creator names and creator roles exactly as returned. Never relabel an issuing, drafting, revising, or compiling body as an author, and never infer a work's tradition or author attribution from its title, topic, or the user's requested traditions.
 4. **Read exact evidence** — Before quotation, doctrinal claims, or comparison, follow at most five unique canonical \`resource_link\` blocks with MCP \`resources/read\` and confirm each returned URI matches the selected locator. Deduplicate repeated locators and do not rely on snippets alone.
 5. **Biblical foundations** — Use \`bible_lookup\` and \`bible_cross_references\` for passages actually identified in the sections you read. For cross references, prefer structured \`requestedReference\`, \`resolvedReference\`, \`references\`, \`resultWindow\`, and \`provenance\`; preserve returned positions and raw vote order, and treat every row as a discovery lead with relationship and directionality unspecified.
-6. **Compare cautiously** — Explain agreement, divergence, Scripture use, and historical context only from exact sections read. Distinguish document statements from interpretation, and do not treat missing search hits as historical silence.`;
+6. **Close the coverage ledger** — Report searched providers from the tool response; report read only after a successful exact resource read; list intentionally deferred selected sections with a reason; and list not-searched scope only when the response says it was not executed. The server cannot observe later reads or deferrals for you.
+7. **Compare cautiously** — Explain agreement, divergence, Scripture use, and historical context only from exact sections read. Distinguish document statements from interpretation, and do not treat missing search hits as historical silence.`;
         break;
       }
       case 'primary-source-research': {
@@ -389,23 +391,25 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
         const externalDateCallInstruction = startYear !== undefined || endYear !== undefined
           ? 'Do not add either year field to the external call.'
           : 'Do not add `startYear` or `endYear` to the external call because CCEL cannot enforce them.';
-        text = contract.contractVersion === '4'
+        text = contract.contractVersion === '5'
           ? `Research primary-source evidence about "${topic}"${work ? ` within the requested work "${work}"` : ''}${authors.length ? ` for the separately scoped creators ${authors.map(value => `"${value}"`).join(', ')}` : ''}.
 
 1. **Inspect local scope** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Its reviewed work and creator metadata describes only the hosted local collection; an absent creator is a local catalog gap, not evidence that no external source exists.
 2. **Search local evidence** — ${callText(calls[0])}. Use local catalog scope and deterministic selection as returned. ${localDateScope}
 3. **Search one external scope now** — ${externalCalls || 'No external query is needed.'} ${externalDateSafeguard} ${externalDateCallInstruction} This prompt authorizes at most one CCEL-bearing call. Each call contains at most one CCEL-bearing query.${deferredAuthors.length ? ` Defer ${deferredAuthors.map(value => `"${value}"`).join(', ')} to separate later turns.` : ''} If the provider returns \`rate_limited\`, wait at least its structured \`retryAfterSeconds\` before a later call; never retry immediately. Do not combine creator comparisons into multiple CCEL queries in one call.
-4. **Use the v4 contract** — Preserve query/provider/rank order, provider status, notices, \`responseWindow\`, and \`evidencePolicy\`. Local locators are exact readable MCP resources. External locators are direct CCEL URLs only, with unreviewed provider-search metadata and rights status not determined.
+4. **Use the v5 contract** — Preserve query/provider/rank order, provider status, notices, \`responseWindow\`, and \`evidencePolicy\`. Local locators are exact readable MCP resources with fail-closed edition-readiness disclosures. External locators are direct CCEL URLs only, with unreviewed provider-search metadata and rights status not determined.
 5. **Read before evidence use** — Follow at most ${args?.maxSections?.trim() || '3'} selected locators. Use MCP \`resources/read\` only for local \`mcp_resource\` URIs. Open external \`external_url\` pages directly and verify the page independently. Never quote, compare creators or works, or draw substantive conclusions from any search snippet alone.
-6. **Synthesize with provenance** — ${localDateScope} ${externalDateSafeguard} Keep reviewed local metadata separate from external provider metadata. Distinguish exact text read from interpretation, name disabled, unavailable, or unsupported searches, and do not treat missing results as historical silence.`
+6. **Close the coverage ledger** — Before synthesis, explicitly record searched from provider states; read only after successful exact MCP-resource or direct-page reads; deferred selected leads with an intentional reason; and not-searched providers/scopes returned as not executed. The server cannot observe your later reads or deferrals.
+7. **Synthesize with provenance** — ${localDateScope} ${externalDateSafeguard} Keep reviewed local metadata separate from external provider metadata. Distinguish exact text read from interpretation, name disabled, unavailable, or unsupported searches, and do not treat missing results as historical silence.`
           : `Research primary-source evidence about "${topic}"${work ? ` within the exact local work "${work}"` : ' across the locally indexed collection'}${authors.length ? ` for the separately scoped creators ${authors.map(value => `"${value}"`).join(', ')}` : ''}.
 
 1. **Inspect the hosted catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Confirm requested exact works and creator names there before searching. If Calvin, Erasmus, Luther, or any other requested creator is absent, report that catalog gap; never use a confession or similarly themed work as a proxy.
 2. **Run bounded discovery** — ${callText(calls[0])}. This workflow is local-only: do not claim it searched CCEL, the web, an exhaustive catalog, or works outside the server's collection. Topic and creator surveys use deterministic work diversity; exact within-work location uses relevance.
-3. **Use the v3 structured result** — Preserve each separate creator query, \`normalizedSelection\`, provider status, \`resultWindow\`, catalog \`scope\` status/count/work list/truncation, rank, notices, creator roles, document type/date, locator, and \`evidencePolicy\`. \`additional_match_observed\` means only that at least one more match was seen beyond the returned window, not that the corpus was exhaustively counted. A \`catalog_miss\` means the hosted catalog did not match the restriction; \`no_results\` means eligible hosted works were searched but no text hit matched. Treat every snippet as \`discovery_only\`.
+3. **Use the v4 structured result** — Preserve each separate creator query, \`normalizedSelection\`, provider status, \`resultWindow\`, catalog \`scope\` status/count/work list/truncation, rank, notices, creator roles, document type/date, locator, edition readiness, and \`evidencePolicy\`. \`additional_match_observed\` means only that at least one more match was seen beyond the returned window, not that the corpus was exhaustively counted. A \`catalog_miss\` means the hosted catalog did not match the restriction; \`no_results\` means eligible hosted works were searched but no text hit matched. Treat every snippet as \`discovery_only\`.
 4. **Read selected evidence before quotation or comparison** — Follow at most ${args?.maxSections?.trim() || '3'} unique canonical \`resource_link\` blocks using MCP \`resources/read\`. Deduplicate locators and confirm that every returned URI matches the selected locator. Do not quote, compare creators/works, or draw substantive conclusions from snippets alone.
 5. **Report provenance honestly** — Edition provenance is incomplete and rights status is not established by the catalog resource. Do not invent an author, edition, transcription source, publication date, or rights status. Work-level type/date metadata is not edition metadata.
-6. **Synthesize with limits** — Distinguish what the selected sections say from your interpretation. Name searches that returned no results or unsupported filters; do not treat missing hits as historical silence.
+6. **Close the coverage ledger** — Report searched from provider states; count a section as read only after its exact MCP resource returned successfully; list intentionally deferred selected sections with reasons; and list not-searched scope only when the server reported non-execution. Do not infer later reads or deferrals from search output.
+7. **Synthesize with limits** — Distinguish what the selected sections say from your interpretation. Name searches that returned no results or unsupported filters; do not treat missing hits as historical silence.
 
 This workflow supports a topic survey, exact local-work search, inclusive overlapping composition-year scope, and up to four creator scopes. Creator comparisons always use separate query-plan items and only sections actually read; a drafting or issuing body is never relabeled as an author. Never issue more than four query groups or read more than five exact section resources in one workflow.`;
         break;

--- a/src/mcp/schemas/primarySourceSearchV4.ts
+++ b/src/mcp/schemas/primarySourceSearchV4.ts
@@ -31,6 +31,41 @@ const commonHit = {
   attribution: { type: 'string', minLength: 1, maxLength: 300 },
 } as const;
 
+const localEditionReadiness = {
+  type: 'object',
+  properties: {
+    foundation: { const: 'edition-provenance-foundation.v1' },
+    editionIdentity: { const: 'not_established' },
+    provenance: { const: 'incomplete' },
+    exactArtifactRights: { const: 'not_established_by_this_contract' },
+  },
+  required: ['foundation', 'editionIdentity', 'provenance', 'exactArtifactRights'],
+  additionalProperties: false,
+} as const;
+
+const externalEditionReadiness = {
+  type: 'object',
+  properties: {
+    editionIdentity: { const: 'provider_unreviewed' },
+    provenance: { const: 'provider_unreviewed' },
+    exactArtifactRights: { const: 'not_determined' },
+  },
+  required: ['editionIdentity', 'provenance', 'exactArtifactRights'],
+  additionalProperties: false,
+} as const;
+
+const coverageLedgerPolicy = {
+  type: 'object',
+  properties: {
+    searched: { const: 'server_observed_provider_execution' },
+    read: { const: 'host_observed_successful_exact_resource_or_page_read' },
+    deferred: { const: 'host_recorded_intentional_deferral' },
+    notSearched: { const: 'server_observed_provider_non_execution' },
+  },
+  required: ['searched', 'read', 'deferred', 'notSearched'],
+  additionalProperties: false,
+} as const;
+
 const localHit = {
   type: 'object',
   properties: {
@@ -48,6 +83,7 @@ const localHit = {
       additionalProperties: false,
     },
     resourceSizeBytes: { type: 'integer', minimum: 0, maximum: Number.MAX_SAFE_INTEGER },
+    editionReadiness: localEditionReadiness,
     documentType: { type: 'string', minLength: 1, maxLength: 100 },
     documentDate: { type: 'string', minLength: 1, maxLength: 100 },
     creators: {
@@ -64,7 +100,7 @@ const localHit = {
       items: { type: 'string', pattern: '^hist-meta-[a-z0-9]+(?:-[a-z0-9]+)*$', maxLength: 100 },
     },
   },
-  required: ['queryId', 'title', 'snippet', 'rankWithinProvider', 'page', 'snippetOnly', 'attribution', 'provider', 'locator', 'resourceSizeBytes'],
+  required: ['queryId', 'title', 'snippet', 'rankWithinProvider', 'page', 'snippetOnly', 'attribution', 'provider', 'locator', 'resourceSizeBytes', 'editionReadiness'],
   additionalProperties: false,
 } as const;
 
@@ -83,8 +119,9 @@ const externalHit = {
       additionalProperties: false,
     },
     metadataStatus: { const: 'provider_search_result_unreviewed' },
+    editionReadiness: externalEditionReadiness,
   },
-  required: ['queryId', 'title', 'snippet', 'rankWithinProvider', 'page', 'snippetOnly', 'attribution', 'provider', 'locator', 'metadataStatus'],
+  required: ['queryId', 'title', 'snippet', 'rankWithinProvider', 'page', 'snippetOnly', 'attribution', 'provider', 'locator', 'metadataStatus', 'editionReadiness'],
   additionalProperties: false,
 } as const;
 
@@ -107,7 +144,8 @@ const catalogScope = {
           id: { type: 'string', minLength: 1, maxLength: 160 },
           title: { type: 'string', minLength: 1, maxLength: 300 },
           metadataStatus: { type: 'string', enum: ['reviewed', 'anonymous', 'collective', 'unknown'] },
-        }, required: ['id', 'title', 'metadataStatus'], additionalProperties: false,
+          editionReadiness: localEditionReadiness,
+        }, required: ['id', 'title', 'metadataStatus', 'editionReadiness'], additionalProperties: false,
       },
     },
     eligibleDocumentsTruncated: { type: 'boolean' },
@@ -149,10 +187,55 @@ const externalProvider = {
   additionalProperties: false,
 } as const;
 
-export const primarySourceSearchV4OutputSchema = {
+const serverObserved = {
   type: 'object',
   properties: {
-    schemaVersion: { const: '4' },
+    searched: {
+      type: 'array', maxItems: 8, items: {
+        type: 'object', properties: {
+          queryId: { type: 'string', minLength: 1, maxLength: 40 }, provider: { type: 'string', enum: ['local', 'ccel_live'] },
+          status, returnedHitCount: { type: 'integer', minimum: 0, maximum: 8 },
+        }, required: ['queryId', 'provider', 'status', 'returnedHitCount'], additionalProperties: false,
+      },
+    },
+    notSearched: {
+      type: 'array', maxItems: 8, items: {
+        type: 'object', properties: {
+          queryId: { type: 'string', minLength: 1, maxLength: 40 }, provider: { type: 'string', enum: ['local', 'ccel_live'] }, status,
+        }, required: ['queryId', 'provider', 'status'], additionalProperties: false,
+      },
+    },
+  },
+  required: ['searched', 'notSearched'], additionalProperties: false,
+} as const;
+
+/** Production has no external provider surface, including in its ledger facts. */
+const localServerObserved = {
+  type: 'object',
+  properties: {
+    searched: {
+      type: 'array', maxItems: 4, items: {
+        type: 'object', properties: {
+          queryId: { type: 'string', minLength: 1, maxLength: 40 }, provider: { const: 'local' },
+          status, returnedHitCount: { type: 'integer', minimum: 0, maximum: 8 },
+        }, required: ['queryId', 'provider', 'status', 'returnedHitCount'], additionalProperties: false,
+      },
+    },
+    notSearched: {
+      type: 'array', maxItems: 4, items: {
+        type: 'object', properties: {
+          queryId: { type: 'string', minLength: 1, maxLength: 40 }, provider: { const: 'local' }, status,
+        }, required: ['queryId', 'provider', 'status'], additionalProperties: false,
+      },
+    },
+  },
+  required: ['searched', 'notSearched'], additionalProperties: false,
+} as const;
+
+export const primarySourceSearchV5OutputSchema = {
+  type: 'object',
+  properties: {
+    schemaVersion: { const: '5' },
     kind: { const: 'primary_source_search' },
     planStatus: { type: 'string', enum: ['complete', 'partial', 'unavailable'] },
     responseWindow: {
@@ -185,8 +268,9 @@ export const primarySourceSearchV4OutputSchema = {
         localAttempted: { type: 'boolean' }, localStatus: status, localHitCount: { type: 'integer', minimum: 0, maximum: 32 },
         ccelAttempted: { type: 'boolean' }, ccelStatus: status, ccelHitCount: { type: 'integer', minimum: 0, maximum: 5 },
         notices: { type: 'array', maxItems: 8, items: { type: 'string', maxLength: 240 } },
+        serverObserved,
       },
-      required: ['localAttempted', 'localHitCount', 'ccelAttempted', 'ccelHitCount', 'notices'],
+      required: ['localAttempted', 'localHitCount', 'ccelAttempted', 'ccelHitCount', 'notices', 'serverObserved'],
       additionalProperties: false,
     },
     evidencePolicy: {
@@ -198,9 +282,57 @@ export const primarySourceSearchV4OutputSchema = {
         coverageScope: { const: 'bounded_non_exhaustive' },
         externalRightsStatus: { const: 'not_determined' },
         lookupAliasUse: { const: 'exact_routing_only_not_metadata_evidence' },
+        coverageLedger: coverageLedgerPolicy,
       },
-      required: ['snippetUse', 'localSectionAccess', 'externalSectionAccess', 'coverageScope', 'externalRightsStatus', 'lookupAliasUse'],
+      required: ['snippetUse', 'localSectionAccess', 'externalSectionAccess', 'coverageScope', 'externalRightsStatus', 'lookupAliasUse', 'coverageLedger'],
       additionalProperties: false,
+    },
+  },
+  required: ['schemaVersion', 'kind', 'planStatus', 'responseWindow', 'queries', 'coverage', 'evidencePolicy'],
+  additionalProperties: false,
+} as NonNullable<Tool['outputSchema']>;
+
+/** Production local-only hard cutover. The same URI/resource semantics as v5. */
+export const primarySourceSearchV4OutputSchema = {
+  type: 'object',
+  properties: {
+    schemaVersion: { const: '4' },
+    kind: { const: 'primary_source_search' },
+    planStatus: { type: 'string', enum: ['complete', 'partial', 'unavailable'] },
+    responseWindow: {
+      type: 'object',
+      properties: { unit: { const: 'utf8_bytes' }, maximum: { const: 32768 }, truncated: { type: 'boolean' } },
+      required: ['unit', 'maximum', 'truncated'], additionalProperties: false,
+    },
+    queries: {
+      type: 'array', minItems: 1, maxItems: 4,
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', minLength: 1, maxLength: 40 },
+          normalizedMode: { type: 'string', enum: ['all_terms', 'phrase'] },
+          normalizedSelection: { type: 'string', enum: ['relevance', 'work_diversity'] },
+          providers: { type: 'array', minItems: 1, maxItems: 1, items: localProvider },
+        },
+        required: ['id', 'normalizedMode', 'normalizedSelection', 'providers'], additionalProperties: false,
+      },
+    },
+    coverage: {
+      type: 'object',
+      properties: {
+        localAttempted: { type: 'boolean' }, localStatus: status, localHitCount: { type: 'integer', minimum: 0, maximum: 32 },
+        notices: { type: 'array', maxItems: 8, items: { type: 'string', maxLength: 240 } }, serverObserved: localServerObserved,
+      },
+      required: ['localAttempted', 'localHitCount', 'notices', 'serverObserved'], additionalProperties: false,
+    },
+    evidencePolicy: {
+      type: 'object',
+      properties: {
+        snippetUse: { const: 'discovery_only' }, localSectionAccess: { const: 'mcp_resource_read' },
+        coverageScope: { const: 'bounded_non_exhaustive' }, lookupAliasUse: { const: 'exact_routing_only_not_metadata_evidence' },
+        coverageLedger: coverageLedgerPolicy,
+      },
+      required: ['snippetUse', 'localSectionAccess', 'coverageScope', 'lookupAliasUse', 'coverageLedger'], additionalProperties: false,
     },
   },
   required: ['schemaVersion', 'kind', 'planStatus', 'responseWindow', 'queries', 'coverage', 'evidencePolicy'],

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -282,7 +282,7 @@ function assertPrimarySourceContractParity(root: McpCompositionRoot): void {
   const tool = root.tools.find(candidate => candidate.name === 'primary_source_search');
   if (!tool) return;
   const advertisedVersion = (tool.outputSchema?.properties?.schemaVersion as { const?: unknown } | undefined)?.const;
-  const expectedOpenWorld = root.primarySourceContract.contractVersion === '4';
+  const expectedOpenWorld = root.primarySourceContract.contractVersion === '5';
   if (advertisedVersion !== root.primarySourceContract.contractVersion
     || tool.annotations?.openWorldHint !== expectedOpenWorld) {
     throw new Error('primary_source_search tool and guided-prompt contracts must use the same configuration.');

--- a/src/presenters/primarySourceSearchV4Structured.ts
+++ b/src/presenters/primarySourceSearchV4Structured.ts
@@ -2,12 +2,18 @@ import { buildLocalDocumentResourceUri } from '../kernel/documentResource.js';
 import { CLASSIC_TEXT_LIMITS } from '../kernel/classicTextContract.js';
 import {
   CCEL_COMPOSITION_DATE_NOTICE,
+  EXTERNAL_EDITION_READINESS,
+  LOCAL_EDITION_READINESS,
+  PRIMARY_SOURCE_COVERAGE_POLICY,
   type PrimarySourcePlanHit,
   type PrimarySourceProviderStatus,
   type PrimarySourceSearchPlanResult,
 } from '../services/historical/primarySourceTypes.js';
 
+/** Total MCP delivery allowance: structured model, fallback text, and links. */
 export const PRIMARY_SOURCE_V4_MAX_BYTES = 32_768;
+/** Reserve deterministic room for the fallback and capped native link metadata. */
+export const PRIMARY_SOURCE_STRUCTURED_MAX_BYTES = 20_480;
 
 const COMPLETE = new Set<PrimarySourceProviderStatus>(['ok', 'no_results', 'catalog_miss']);
 const UNAVAILABLE = new Set<PrimarySourceProviderStatus>(['unavailable', 'disabled', 'rate_limited', 'interface_changed']);
@@ -20,10 +26,19 @@ const textEncoder = new TextEncoder();
 export const PRIMARY_SOURCE_V4_EVIDENCE_POLICY = {
   snippetUse: 'discovery_only',
   localSectionAccess: 'mcp_resource_read',
+  coverageScope: 'bounded_non_exhaustive',
+  lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+  coverageLedger: PRIMARY_SOURCE_COVERAGE_POLICY,
+} as const;
+
+export const PRIMARY_SOURCE_V5_EVIDENCE_POLICY = {
+  snippetUse: 'discovery_only',
+  localSectionAccess: 'mcp_resource_read',
   externalSectionAccess: 'direct_url_only',
   coverageScope: 'bounded_non_exhaustive',
   externalRightsStatus: 'not_determined',
   lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+  coverageLedger: PRIMARY_SOURCE_COVERAGE_POLICY,
 } as const;
 
 type LocalHit = {
@@ -32,6 +47,7 @@ type LocalHit = {
   provider: 'local';
   locator: { kind: 'mcp_resource'; uri: string; documentId: string; sectionId: string };
   resourceSizeBytes: number;
+  editionReadiness: typeof LOCAL_EDITION_READINESS;
   documentType?: string; documentDate?: string;
   creators?: Array<{ name: string; role: 'author' | 'issuing_body' | 'drafting_body' | 'revising_body' | 'compiler' }>;
   metadataStatus?: 'reviewed' | 'anonymous' | 'collective' | 'unknown';
@@ -43,6 +59,7 @@ type ExternalHit = {
   rankWithinProvider: number; page: number; snippetOnly: true; attribution: string;
   provider: 'ccel_live'; locator: { kind: 'external_url'; url: string };
   metadataStatus: 'provider_search_result_unreviewed';
+  editionReadiness: typeof EXTERNAL_EDITION_READINESS;
 };
 
 export type PresentedPrimarySourceV4Hit = LocalHit | ExternalHit;
@@ -61,10 +78,33 @@ type PresentedProvider = {
     status: 'matched' | 'catalog_miss' | 'metadata_incomplete';
     requested: { work?: string; author?: string; startYear?: number; endYear?: number };
     eligibleDocumentCount: number;
-    eligibleDocuments: Array<{ id: string; title: string; metadataStatus: 'reviewed' | 'anonymous' | 'collective' | 'unknown' }>;
+    eligibleDocuments: Array<{
+      id: string; title: string; metadataStatus: 'reviewed' | 'anonymous' | 'collective' | 'unknown';
+      editionReadiness: typeof LOCAL_EDITION_READINESS;
+    }>;
     eligibleDocumentsTruncated: boolean;
   };
 };
+
+export interface PresentedPrimarySourceSearchV5 extends Record<string, unknown> {
+  schemaVersion: '5';
+  kind: 'primary_source_search';
+  planStatus: 'complete' | 'partial' | 'unavailable';
+  responseWindow: { unit: 'utf8_bytes'; maximum: 32768; truncated: boolean };
+  queries: Array<{
+    id: string;
+    normalizedMode: 'all_terms' | 'phrase';
+    normalizedSelection: 'relevance' | 'work_diversity';
+    providers: PresentedProvider[];
+  }>;
+  coverage: {
+    localAttempted: boolean; localStatus?: PrimarySourceProviderStatus; localHitCount: number;
+    ccelAttempted: boolean; ccelStatus?: PrimarySourceProviderStatus; ccelHitCount: number;
+    notices: string[];
+    serverObserved: ServerObservedCoverage;
+  };
+  evidencePolicy: typeof PRIMARY_SOURCE_V5_EVIDENCE_POLICY;
+}
 
 export interface PresentedPrimarySourceSearchV4 extends Record<string, unknown> {
   schemaVersion: '4';
@@ -79,11 +119,15 @@ export interface PresentedPrimarySourceSearchV4 extends Record<string, unknown> 
   }>;
   coverage: {
     localAttempted: boolean; localStatus?: PrimarySourceProviderStatus; localHitCount: number;
-    ccelAttempted: boolean; ccelStatus?: PrimarySourceProviderStatus; ccelHitCount: number;
-    notices: string[];
+    notices: string[]; serverObserved: ServerObservedCoverage;
   };
   evidencePolicy: typeof PRIMARY_SOURCE_V4_EVIDENCE_POLICY;
 }
+
+type ServerObservedCoverage = {
+  searched: Array<{ queryId: string; provider: 'local' | 'ccel_live'; status: PrimarySourceProviderStatus; returnedHitCount: number }>;
+  notSearched: Array<{ queryId: string; provider: 'local' | 'ccel_live'; status: PrimarySourceProviderStatus }>;
+};
 
 type ProviderDraft = Omit<PresentedProvider, 'hitCount' | 'resultWindow' | 'hits'> & {
   sourceAdditional: PresentedProvider['resultWindow']['additionalMatchStatus'];
@@ -98,12 +142,13 @@ type PresentedHitCandidate = {
 };
 
 /** Build the one sanitized presentation model used for JSON text and links. */
-export function presentPrimarySourceSearchV4(result: PrimarySourceSearchPlanResult): PresentedPrimarySourceSearchV4 {
+export function presentPrimarySourceSearchV5(result: PrimarySourceSearchPlanResult): PresentedPrimarySourceSearchV5 {
   let ccelGroupSeen = false;
   const sourceQueryCount = result.queries.length;
   const queryDrafts = result.queries.slice(0, 4).flatMap(query => {
     const seen = new Set<'local' | 'ccel_live'>();
     const providers = query.providers.flatMap(provider => {
+      if (provider.provider !== 'local' && provider.provider !== 'ccel_live') return [];
       if (seen.has(provider.provider) || seen.size >= 2) return [];
       if (provider.provider === 'ccel_live') {
         if (ccelGroupSeen) return [];
@@ -123,8 +168,10 @@ export function presentPrimarySourceSearchV4(result: PrimarySourceSearchPlanResu
   });
 
   const selected = queryDrafts.map(query => query.providers.map(() => [] as PresentedPrimarySourceV4Hit[]));
-  let truncated = sourceQueryCount > queryDrafts.length
+  const structuralOmission = sourceQueryCount > queryDrafts.length
     || queryDrafts.some(query => query.sourceProviderCount > query.providers.length)
+    || result.queries.slice(0, 4).some(query => query.providers.some(provider => provider.provider !== 'local' && provider.provider !== 'ccel_live'));
+  let truncated = structuralOmission
     || queryDrafts.some(query => query.providers.some(provider => provider.invalidCandidates > 0 || provider.contractInvalid));
 
   outer: for (let queryIndex = 0; queryIndex < queryDrafts.length; queryIndex++) {
@@ -137,8 +184,15 @@ export function presentPrimarySourceSearchV4(result: PrimarySourceSearchPlanResu
         // truncated partial form (`false` vs `true`, `complete` vs `partial`).
         // Budget against that larger representation so an all-fitting result
         // cannot cross the limit only when the final flags are recomputed.
-        const conservative = buildEnvelope(queryDrafts, selected, false, result.planStatus);
-        if (utf8Bytes(conservative) > PRIMARY_SOURCE_V4_MAX_BYTES) {
+        const conservative = buildEnvelope(
+          queryDrafts,
+          selected,
+          false,
+          result.planStatus,
+          structuralOmission,
+          queryDrafts.some(item => item.providers.some(provider => provider.invalidCandidates > 0)),
+        );
+        if (utf8Bytes(conservative) > PRIMARY_SOURCE_STRUCTURED_MAX_BYTES) {
           selected[queryIndex]![providerIndex]!.pop();
           truncated = true;
           break outer;
@@ -147,14 +201,70 @@ export function presentPrimarySourceSearchV4(result: PrimarySourceSearchPlanResu
     }
   }
 
-  const presented = buildEnvelope(queryDrafts, selected, truncated, result.planStatus);
+  const presented = buildEnvelope(
+    queryDrafts,
+    selected,
+    truncated,
+    result.planStatus,
+    structuralOmission,
+    queryDrafts.some(item => item.providers.some(provider => provider.invalidCandidates > 0)),
+  );
   // The bounded base envelope is intentionally small. This assertion converts
   // future schema growth into a fail-closed implementation defect, never an
   // oversized MCP payload.
-  if (utf8Bytes(presented) > PRIMARY_SOURCE_V4_MAX_BYTES) {
-    throw new Error('Primary-source v4 response envelope exceeds its UTF-8 byte budget.');
+  if (utf8Bytes(presented) > PRIMARY_SOURCE_STRUCTURED_MAX_BYTES) {
+    throw new Error('Primary-source structured model exceeds its reserved delivery budget.');
   }
   return presented;
+}
+
+/**
+ * Production local-only cutover. The normal handler removes CCEL inputs before
+ * service execution; this additional boundary prevents stale/malformed service
+ * output from leaking discovery-provider identity into the local contract.
+ */
+export function presentPrimarySourceSearchV4(result: PrimarySourceSearchPlanResult): PresentedPrimarySourceSearchV4 {
+  const excludedExternal = result.queries.some(query => query.providers.some(provider => provider.provider !== 'local'));
+  const localOnly: PrimarySourceSearchPlanResult = {
+    ...result,
+    queries: result.queries.map(query => {
+      const local = query.providers.filter(provider => provider.provider === 'local');
+      return {
+        ...query,
+        providers: local.length > 0 ? local : [{
+          provider: 'local' as const,
+          status: 'interface_changed' as const,
+          searched: false,
+          page: 1,
+          hitCount: 0,
+          hits: [],
+          notices: ['Internal data outside the local public contract was omitted.'],
+          resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' as const },
+        }],
+      };
+    }),
+  };
+  const v5 = presentPrimarySourceSearchV5(localOnly);
+  return {
+    schemaVersion: '4',
+    kind: v5.kind,
+    planStatus: excludedExternal ? 'partial' : v5.planStatus,
+    responseWindow: { ...v5.responseWindow, truncated: v5.responseWindow.truncated || excludedExternal },
+    queries: v5.queries,
+    coverage: {
+      localAttempted: v5.coverage.localAttempted,
+      ...(v5.coverage.localStatus ? { localStatus: v5.coverage.localStatus } : {}),
+      localHitCount: v5.coverage.localHitCount,
+      notices: excludedExternal
+        ? uniqueBounded([...v5.coverage.notices, 'Internal data outside the local public contract was omitted.'], 8, 240)
+        : v5.coverage.notices,
+      serverObserved: {
+        searched: v5.coverage.serverObserved.searched.filter(item => item.provider === 'local'),
+        notSearched: v5.coverage.serverObserved.notSearched.filter(item => item.provider === 'local'),
+      },
+    },
+    evidencePolicy: PRIMARY_SOURCE_V4_EVIDENCE_POLICY,
+  };
 }
 
 function providerDraft(
@@ -182,7 +292,7 @@ function providerDraft(
     && ((provider.scope !== undefined && scope === undefined) || (scopeRequired && scope === undefined));
   const pageInvalid = !Number.isSafeInteger(provider.page) || provider.page < 1 || provider.page > 3;
   const retryAfterValid = provider.retryAfterSeconds === undefined
-    ? provider.status !== 'rate_limited'
+    ? provider.provider === 'local' || provider.status !== 'rate_limited'
     : provider.provider === 'ccel_live'
       && provider.status === 'rate_limited'
       && Number.isSafeInteger(provider.retryAfterSeconds)
@@ -190,6 +300,15 @@ function providerDraft(
       && provider.retryAfterSeconds <= 86_400;
   const contractInvalid = countMismatch || !validWindow || scopeInvalid || pageInvalid || optionalMetadataInvalid || !retryAfterValid;
   const status = STATUS.has(provider.status) && invalidCandidates === 0 && !contractInvalid ? provider.status : 'interface_changed';
+  const failClosedScope = scopeRequired && scope === undefined
+    ? {
+        status: 'metadata_incomplete' as const,
+        requested: {},
+        eligibleDocumentCount: 0,
+        eligibleDocuments: [],
+        eligibleDocumentsTruncated: false,
+      }
+    : undefined;
   return {
     provider: providerKind,
     status,
@@ -209,7 +328,7 @@ function providerDraft(
       ...(optionalMetadataInvalid ? ['One or more empty optional metadata fields were omitted after sanitization.'] : []),
       ...provider.notices.filter(notice => notice !== CCEL_COMPOSITION_DATE_NOTICE),
     ], 4, 240),
-    ...(scope ? { scope } : {}),
+    ...(scope ?? failClosedScope ? { scope: scope ?? failClosedScope } : {}),
     ...(retryAfterValid && provider.retryAfterSeconds !== undefined
       ? { retryAfterSeconds: provider.retryAfterSeconds }
       : {}),
@@ -225,7 +344,9 @@ function buildEnvelope(
   selected: PresentedPrimarySourceV4Hit[][][],
   truncated: boolean,
   sourcePlanStatus: PrimarySourceSearchPlanResult['planStatus'],
-): PresentedPrimarySourceSearchV4 {
+  structuralOmission: boolean,
+  invalidHitOmission: boolean,
+): PresentedPrimarySourceSearchV5 {
   const queries = drafts.map((query, queryIndex) => ({
     id: query.id,
     normalizedMode: query.normalizedMode,
@@ -257,29 +378,35 @@ function buildEnvelope(
   const ccel = providers.filter(provider => provider.provider === 'ccel_live');
   const statuses = providers.map(provider => provider.status);
   const hasUsable = providers.some(provider => provider.hits.length > 0 || COMPLETE.has(provider.status));
-  const recomputed = truncated || sourcePlanStatus === 'partial'
+  const recomputed = sourcePlanStatus === 'partial'
     ? 'partial'
-    : statuses.length > 0 && statuses.every(status => COMPLETE.has(status))
+    : !hasUsable && statuses.length > 0 && statuses.every(status => UNAVAILABLE.has(status))
+      ? invalidHitOmission ? 'partial' : 'unavailable'
+      : truncated
+        ? 'partial'
+        : statuses.length > 0 && statuses.every(status => COMPLETE.has(status))
       ? 'complete'
-      : !hasUsable && statuses.length > 0 && statuses.every(status => UNAVAILABLE.has(status))
-        ? 'unavailable'
         : 'partial';
   return {
-    schemaVersion: '4',
+    schemaVersion: '5',
     kind: 'primary_source_search',
     planStatus: recomputed,
     responseWindow: { unit: 'utf8_bytes', maximum: PRIMARY_SOURCE_V4_MAX_BYTES, truncated },
     queries,
     coverage: {
       localAttempted: local.some(provider => provider.searched),
-      ...(local.length ? { localStatus: aggregateStatus(local) } : {}),
+      ...(local.length ? { localStatus: structuralOmission ? 'interface_changed' as const : aggregateStatus(local) } : {}),
       localHitCount: local.reduce((sum, provider) => sum + provider.hits.length, 0),
       ccelAttempted: ccel.some(provider => provider.searched),
       ...(ccel.length ? { ccelStatus: aggregateStatus(ccel) } : {}),
       ccelHitCount: ccel.reduce((sum, provider) => sum + provider.hits.length, 0),
-      notices: uniqueBounded(providers.flatMap(provider => provider.notices), 8, 240),
+      notices: uniqueBounded([
+        ...providers.flatMap(provider => provider.notices),
+        ...(structuralOmission ? ['One or more provider groups exceeded the public contract and were omitted.'] : []),
+      ], 8, 240),
+      serverObserved: presentServerObserved(queries),
     },
-    evidencePolicy: PRIMARY_SOURCE_V4_EVIDENCE_POLICY,
+    evidencePolicy: PRIMARY_SOURCE_V5_EVIDENCE_POLICY,
   };
 }
 
@@ -318,6 +445,7 @@ function presentHit(
         provider,
         locator: { kind: 'external_url', url },
         metadataStatus: 'provider_search_result_unreviewed',
+        editionReadiness: EXTERNAL_EDITION_READINESS,
       },
       optionalMetadataInvalid,
     };
@@ -342,6 +470,7 @@ function presentHit(
       provider,
       locator: { kind: 'mcp_resource', uri, documentId: hit.locator.documentId, sectionId: hit.locator.sectionId },
       resourceSizeBytes: hit.resourceSizeBytes,
+      editionReadiness: LOCAL_EDITION_READINESS,
       ...(documentType ? { documentType } : {}),
       ...(documentDate ? { documentDate } : {}),
       ...(creators?.length ? { creators } : {}),
@@ -374,7 +503,7 @@ function presentScope(scope: PrimarySourceSearchPlanResult['queries'][number]['p
     const id = boundedText(document.id, 160);
     const title = boundedText(document.title, 300);
     return id && title && ['reviewed', 'anonymous', 'collective', 'unknown'].includes(document.metadataStatus)
-      ? [{ id, title, metadataStatus: document.metadataStatus }]
+      ? [{ id, title, metadataStatus: document.metadataStatus, editionReadiness: LOCAL_EDITION_READINESS }]
       : [];
   });
   const work = scope.requested.work ? boundedText(scope.requested.work, 160) : undefined;
@@ -395,6 +524,28 @@ function presentScope(scope: PrimarySourceSearchPlanResult['queries'][number]['p
     eligibleDocuments,
     eligibleDocumentsTruncated: scope.eligibleDocumentsTruncated || scope.eligibleDocuments.length > eligibleDocuments.length,
   };
+}
+
+function presentServerObserved(
+  queries: Array<{ id: string; providers: PresentedProvider[] }>,
+): ServerObservedCoverage {
+  const searched: ServerObservedCoverage['searched'] = [];
+  const notSearched: ServerObservedCoverage['notSearched'] = [];
+  for (const query of queries) {
+    for (const provider of query.providers) {
+      if (provider.searched) {
+        searched.push({
+          queryId: query.id,
+          provider: provider.provider,
+          status: provider.status,
+          returnedHitCount: provider.hitCount,
+        });
+      } else {
+        notSearched.push({ queryId: query.id, provider: provider.provider, status: provider.status });
+      }
+    }
+  }
+  return { searched, notSearched };
 }
 
 function aggregateStatus(providers: PresentedProvider[]): PrimarySourceProviderStatus {

--- a/src/services/historical/PrimarySourceSearchService.ts
+++ b/src/services/historical/PrimarySourceSearchService.ts
@@ -49,6 +49,13 @@ export class PrimarySourceSearchService {
 
     const localResults = providerResults.filter(provider => provider.provider === 'local');
     const ccelResults = providerResults.filter(provider => provider.provider === 'ccel_live');
+    const observed = queryResults.flatMap(query => query.providers.map(provider => ({
+      queryId: query.id,
+      provider: provider.provider,
+      status: provider.status,
+      returnedHitCount: provider.hitCount,
+      searched: provider.searched,
+    })));
     return {
       planStatus,
       queries: queryResults,
@@ -60,6 +67,11 @@ export class PrimarySourceSearchService {
         ...(ccelResults.length ? { ccelStatus: aggregateStatus(ccelResults) } : {}),
         ccelHitCount: ccelResults.reduce((total, result) => total + result.hitCount, 0),
         notices: [...new Set(providerResults.flatMap(result => result.notices))],
+        serverObserved: {
+          searched: observed.filter(provider => provider.searched).map(({ searched: _searched, ...provider }) => provider),
+          notSearched: observed.filter(provider => !provider.searched)
+            .map(({ searched: _searched, returnedHitCount: _returnedHitCount, ...provider }) => provider),
+        },
       },
     };
   }

--- a/src/services/historical/primarySourceTypes.ts
+++ b/src/services/historical/primarySourceTypes.ts
@@ -7,6 +7,38 @@
 
 export const CCEL_COMPOSITION_DATE_NOTICE = 'CCEL discovery was not composition-date filtered; its results cannot establish membership in a requested historical period.';
 
+/**
+ * The current hosted collection predates the per-edition provenance compiler.
+ * This intentionally says only what the server has established: it does not
+ * turn public-domain underlying works into claims about their transcription,
+ * edition, or redistribution permission.
+ */
+export const LOCAL_EDITION_READINESS = Object.freeze({
+  foundation: 'edition-provenance-foundation.v1',
+  editionIdentity: 'not_established',
+  provenance: 'incomplete',
+  exactArtifactRights: 'not_established_by_this_contract',
+} as const);
+
+/** Provider search results are not reviewed editions or local corpus claims. */
+export const EXTERNAL_EDITION_READINESS = Object.freeze({
+  editionIdentity: 'provider_unreviewed',
+  provenance: 'provider_unreviewed',
+  exactArtifactRights: 'not_determined',
+} as const);
+
+/**
+ * Search execution is server-observable.  Resource reads and intentional
+ * deferrals happen in the MCP host after this tool response, so they belong in
+ * the host's final research ledger rather than being guessed here.
+ */
+export const PRIMARY_SOURCE_COVERAGE_POLICY = Object.freeze({
+  searched: 'server_observed_provider_execution',
+  read: 'host_observed_successful_exact_resource_or_page_read',
+  deferred: 'host_recorded_intentional_deferral',
+  notSearched: 'server_observed_provider_non_execution',
+} as const);
+
 export type PrimarySourceSearchMatch = 'all_terms' | 'phrase';
 export type PrimarySourceSelection = 'relevance' | 'work_diversity';
 
@@ -132,6 +164,20 @@ export interface PrimarySourceSearchCoverage {
   ccelStatus?: PrimarySourceProviderStatus;
   ccelHitCount: number;
   notices: string[];
+  /** Facts known at tool-return time; no future resource read is inferred. */
+  serverObserved?: {
+    searched: Array<{
+      queryId: string;
+      provider: PrimarySourceProvider;
+      status: PrimarySourceProviderStatus;
+      returnedHitCount: number;
+    }>;
+    notSearched: Array<{
+      queryId: string;
+      provider: PrimarySourceProvider;
+      status: PrimarySourceProviderStatus;
+    }>;
+  };
 }
 
 export interface PrimarySourceSearchPlanResult {

--- a/src/tools/v2/classicTexts.ts
+++ b/src/tools/v2/classicTexts.ts
@@ -149,6 +149,8 @@ function searchResourceLinks(hits: Array<{ section: SectionWithResource }>): Res
 }
 
 function resourceLink(locator: Locator, title: string, description: string): ResourceLink {
+  // The declared MCP SDK exposes standard Resource.size. Retain it at runtime
+  // even if a stale local SDK type definition omits the optional field.
   return {
     type: 'resource_link',
     uri: locator.uri,
@@ -157,8 +159,11 @@ function resourceLink(locator: Locator, title: string, description: string): Res
     description,
     mimeType: 'text/markdown',
     ...(locator.resourceSizeBytes === undefined ? {} : { size: locator.resourceSizeBytes }),
+    ...(locator.resourceSizeBytes === undefined
+      ? {}
+      : { _meta: { 'theologai/resourceSizeBytes': locator.resourceSizeBytes } }),
     annotations: { audience: ['assistant'] },
-  };
+  } as ResourceLink & { size?: number };
 }
 
 function validateMode(params: Record<string, unknown>): void {

--- a/src/tools/v2/primarySourceSearch.ts
+++ b/src/tools/v2/primarySourceSearch.ts
@@ -1,13 +1,8 @@
 import type { ToolHandler } from '../../kernel/types.js';
 import { handleToolError } from '../../kernel/errors.js';
 import type { PrimarySourceSearchService } from '../../services/historical/PrimarySourceSearchService.js';
-import { formatPrimarySourceSearch } from '../../formatters/primarySourceFormatter.js';
-import { primarySourceSearchOutputSchema } from '../../mcp/schemas/primarySourceSearch.js';
-import { primarySourceSearchV4OutputSchema } from '../../mcp/schemas/primarySourceSearchV4.js';
-import {
-  presentPrimarySourceSearch,
-  type PresentedPrimarySourceSearch,
-} from '../../presenters/primarySourceSearchStructured.js';
+import { formatPrimarySourceSearchFallback, PRIMARY_SOURCE_FALLBACK_MAX_BYTES } from '../../formatters/primarySourceFormatter.js';
+import { primarySourceSearchV4OutputSchema, primarySourceSearchV5OutputSchema } from '../../mcp/schemas/primarySourceSearchV4.js';
 import { buildLocalDocumentResourceUri } from '../../kernel/documentResource.js';
 import type { ResourceLink } from '@modelcontextprotocol/sdk/types.js';
 import type { PrimarySourceContractConfig } from '../../kernel/featureFlags.js';
@@ -15,16 +10,19 @@ import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../kernel/featureFlag
 import {
   presentPrimarySourceSearchV4,
   type PresentedPrimarySourceSearchV4,
+  presentPrimarySourceSearchV5,
+  type PresentedPrimarySourceSearchV5,
+  PRIMARY_SOURCE_V4_MAX_BYTES,
 } from '../../presenters/primarySourceSearchV4Structured.js';
 
 export function createPrimarySourceSearchHandler(
   service: Pick<PrimarySourceSearchService, 'search'>,
   contract: PrimarySourceContractConfig = DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
 ): ToolHandler {
-  const v4 = contract.contractVersion === '4';
+  const v5 = contract.contractVersion === '5';
   return {
     name: 'primary_source_search',
-    description: v4
+    description: v5
       ? 'Execute a bounded primary-source discovery plan across the local collection and optional CCEL discovery metadata. Local hits are readable MCP resources; external snippets are unreviewed discovery leads with direct URLs only and must not be quoted or compared as evidence.'
       : 'Execute an explicit, bounded query plan against the locally indexed historical-document collection. Supports exact catalog work aliases, exact reviewed creator names, and inclusive overlapping composition-year ranges. Returns catalog scope, snippets, and exact local section locators only; read selected exact resources before quotation or comparison.',
     inputSchema: {
@@ -38,52 +36,52 @@ export function createPrimarySourceSearchHandler(
               id: { type: 'string', minLength: 1, maxLength: 40, pattern: '^[A-Za-z0-9][A-Za-z0-9_-]{0,39}$' },
               text: { type: 'string', minLength: 1, maxLength: 200 },
               providers: {
-                type: 'array', minItems: 1, maxItems: v4 ? 2 : 1, uniqueItems: true,
-                items: { type: 'string', enum: v4 ? ['local', 'ccel'] : ['local'] },
-                description: v4
+                type: 'array', minItems: 1, maxItems: v5 ? 2 : 1, uniqueItems: true,
+                items: { type: 'string', enum: v5 ? ['local', 'ccel'] : ['local'] },
+                description: v5
                   ? 'Unique providers from local and ccel. At most one query in a tool call may include ccel.'
                   : 'Current public provider contract. Only the locally indexed collection is available.',
               },
               match: { type: 'string', enum: ['all_terms', 'phrase'], default: 'all_terms' },
               selection: {
                 type: 'string', enum: ['relevance', 'work_diversity'], default: 'relevance',
-                description: v4
+                description: v5
                   ? 'Local provider: relevance locates within a work; work_diversity round-robins across hosted works. CCEL discovery preserves the field but uses provider result order.'
                   : 'Use relevance for within-work location; use work_diversity for deterministic research bundles that round-robin across matching hosted works.',
               },
               author: {
                 type: 'string', minLength: 1, maxLength: 100,
-                description: v4
+                description: v5
                   ? 'Local: one exact reviewed creator name. CCEL: an unreviewed provider search restriction. Use sequential tool calls for different external creators.'
                   : 'One exact reviewed creator name. Use separate query-plan items for different creators; creator roles are not relabeled as authorship.',
               },
               work: {
                 type: 'string', minLength: 1, maxLength: 160,
-                description: v4
+                description: v5
                   ? 'Local: exact hosted slug, title, or routing alias. CCEL: an unreviewed provider title/work restriction, not reviewed metadata.'
                   : 'Exact hosted work slug, title, or lookup-only alias.',
               },
               startYear: {
                 type: 'integer', minimum: -5000, maximum: 3000,
-                description: v4
+                description: v5
                   ? 'Hosted-local inclusive composition-overlap lower bound. A direct query whose providers include ccel cannot use this field: it returns unsupported_filter before adapter or coordinator admission.'
                   : 'Inclusive lower bound. A work is eligible when its reviewed composition interval overlaps the requested interval.',
               },
               endYear: {
                 type: 'integer', minimum: -5000, maximum: 3000,
-                description: v4
+                description: v5
                   ? 'Hosted-local inclusive composition-overlap upper bound; must be >= startYear. A direct query whose providers include ccel cannot use this field: it returns unsupported_filter before adapter or coordinator admission.'
                   : 'Inclusive upper bound. Must be greater than or equal to startYear when both are provided.',
               },
               page: {
                 type: 'integer', minimum: 1, maximum: 3, default: 1,
-                description: v4
+                description: v5
                   ? 'Both providers support page 1 only in this contract; values above 1 return unsupported_filter without CCEL admission.'
                   : 'Preserved planner field. The local provider supports only page 1 and reports unsupported_filter otherwise.',
               },
               limit: {
                 type: 'integer', minimum: 1, maximum: 8, default: 5,
-                ...(v4 ? { description: 'Local maximum is 8; external CCEL results are always capped at 5.' } : {}),
+                ...(v5 ? { description: 'Local maximum is 8; external CCEL results are always capped at 5.' } : {}),
               },
             },
             required: ['id', 'text', 'providers'],
@@ -94,36 +92,36 @@ export function createPrimarySourceSearchHandler(
       required: ['queries'],
       additionalProperties: false,
     },
-    outputSchema: v4 ? primarySourceSearchV4OutputSchema : primarySourceSearchOutputSchema,
-    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: v4 },
+    outputSchema: v5 ? primarySourceSearchV5OutputSchema : primarySourceSearchV4OutputSchema,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: v5 },
     handler: async params => {
       try {
-        const queries = !v4 && Array.isArray(params.queries)
+        const queries = !v5 && Array.isArray(params.queries)
           ? params.queries.map(query => ({
               ...(query as Record<string, unknown>),
               providers: ['local'],
             }))
           : params.queries;
         const result = await service.search({ ...params, queries });
-        if (v4) {
-          const presented = presentPrimarySourceSearchV4(result);
-          return {
-            content: [
-              { type: 'text', text: JSON.stringify(presented) },
-              ...localV4ResourceLinks(presented),
-            ],
-            structuredContent: presented,
-            ...(presented.planStatus === 'unavailable' ? { isError: true } : {}),
-          };
+        const presented = v5 ? presentPrimarySourceSearchV5(result) : presentPrimarySourceSearchV4(result);
+        const links = localSectionResourceLinks(presented);
+        const fallback = formatPrimarySourceSearchFallback(presented);
+        const unavailable = presented.planStatus === 'unavailable';
+        // Native links are supplemental: the structured locator is
+        // authoritative. Trim only the final links if their metadata would
+        // exceed the shared delivery budget, rather than failing an otherwise
+        // valid bounded research result.
+        while (links.length > 0 && deliveryBytes(presented, fallback, links, unavailable) > PRIMARY_SOURCE_V4_MAX_BYTES) {
+          links.pop();
         }
-        const presented = presentPrimarySourceSearch(result);
+        assertDeliveryBudget(presented, fallback, links, unavailable);
         return {
           content: [
-            { type: 'text', text: formatPrimarySourceSearch(presented) },
-            ...localSectionResourceLinks(presented),
+            { type: 'text', text: fallback },
+            ...links,
           ],
           structuredContent: presented,
-          ...(presented.planStatus === 'unavailable' ? { isError: true } : {}),
+          ...(unavailable ? { isError: true } : {}),
         };
       } catch (error) {
         return handleToolError(error as Error);
@@ -132,7 +130,8 @@ export function createPrimarySourceSearchHandler(
   };
 }
 
-function localV4ResourceLinks(presented: PresentedPrimarySourceSearchV4): ResourceLink[] {
+/** Build links only from validated presentation data, never directly from provider locators. */
+function localSectionResourceLinks(presented: PresentedPrimarySourceSearchV4 | PresentedPrimarySourceSearchV5): ResourceLink[] {
   const links: ResourceLink[] = [];
   const seen = new Set<string>();
   for (const query of presented.queries) {
@@ -145,49 +144,57 @@ function localV4ResourceLinks(presented: PresentedPrimarySourceSearchV4): Resour
         seen.add(canonical);
         const section = candidate.sectionLabel ? ` — ${candidate.sectionLabel}` : '';
         const metadata = [candidate.documentType, candidate.documentDate].filter(Boolean).join(', ');
+        // The repository's declared MCP SDK supports `Resource.size`. The
+        // local compatibility intersection keeps that standard field intact
+        // when an older installed SDK type definition is being used.
         links.push({
           type: 'resource_link',
           uri: canonical,
-          name: `local-primary-source/${locator.documentId}/${locator.sectionId}`,
-          title: `${candidate.title}${section}`,
-          description: `${metadata ? `${metadata}. ` : ''}Exact local section selected by primary-source discovery.`,
+          name: clip(`local-primary-source/${locator.documentId}/${locator.sectionId}`, 180),
+          title: clip(`${candidate.title}${section}`, 180),
+          description: clip(`${metadata ? `${metadata}. ` : ''}Exact local section selected by primary-source discovery.`, 180),
           mimeType: 'text/markdown',
+          // `size` is the interoperable MCP resource byte hint. Keep the same
+          // fact in namespaced metadata for older clients that retain `_meta`
+          // but (incorrectly) strip the standard field in transit.
           size: candidate.resourceSizeBytes,
+          _meta: { 'theologai/resourceSizeBytes': candidate.resourceSizeBytes },
           annotations: { audience: ['assistant'] },
-        });
+        } as ResourceLink & { size: number });
+        if (links.length === 8) return links;
       }
     }
   }
   return links;
 }
 
-/** Build links only from validated presentation data, never directly from provider locators. */
-function localSectionResourceLinks(presented: PresentedPrimarySourceSearch): ResourceLink[] {
-  const links: ResourceLink[] = [];
-  const seen = new Set<string>();
-  for (const query of presented.queries) {
-    for (const provider of query.providers) {
-      for (const candidate of provider.hits) {
-        if (candidate.provider !== 'local') continue;
-        const { locator } = candidate;
-        const canonical = buildLocalDocumentResourceUri(locator.documentId, locator.sectionId);
-        if (!canonical || canonical !== locator.url || seen.has(canonical)) continue;
-        seen.add(canonical);
-        const section = candidate.sectionLabel ? ` — ${candidate.sectionLabel}` : '';
-        const metadata = [candidate.documentType, candidate.documentDate].filter(Boolean).join(', ');
-        links.push({
-          type: 'resource_link',
-          uri: canonical,
-          name: `local-primary-source/${locator.documentId}/${locator.sectionId}`,
-          title: `${candidate.title}${section}`,
-          description: `${metadata ? `${metadata}. ` : ''}Exact local section selected by primary-source discovery.`,
-          mimeType: 'text/markdown',
-          size: candidate.resourceSizeBytes,
-          annotations: { audience: ['assistant'] },
-        });
-        if (links.length === 32) return links;
-      }
-    }
+function assertDeliveryBudget(
+  structuredContent: PresentedPrimarySourceSearchV4 | PresentedPrimarySourceSearchV5,
+  fallback: string,
+  links: ResourceLink[],
+  isError: boolean,
+): void {
+  const fallbackBytes = new TextEncoder().encode(fallback).byteLength;
+  const bytes = deliveryBytes(structuredContent, fallback, links, isError);
+  if (fallbackBytes > PRIMARY_SOURCE_FALLBACK_MAX_BYTES || bytes > PRIMARY_SOURCE_V4_MAX_BYTES) {
+    throw new Error('Primary-source response delivery budget was exceeded.');
   }
-  return links;
+}
+
+function deliveryBytes(
+  structuredContent: PresentedPrimarySourceSearchV4 | PresentedPrimarySourceSearchV5,
+  fallback: string,
+  links: ResourceLink[],
+  isError: boolean,
+): number {
+  const delivery = {
+    content: [{ type: 'text', text: fallback }, ...links],
+    structuredContent,
+    ...(isError ? { isError: true } : {}),
+  };
+  return new TextEncoder().encode(JSON.stringify(delivery)).byteLength;
+}
+
+function clip(value: string, maximum: number): string {
+  return Array.from(value).slice(0, maximum).join('');
 }

--- a/test/integration/ccel-tool-test.ts
+++ b/test/integration/ccel-tool-test.ts
@@ -8,11 +8,11 @@ import { recommendedToolCallsForPrompt } from '../../src/mcp/prompts.js';
 
 export function assertRetiredCcelToolContractGuard(): void {
   const v3 = recommendedToolCallsForPrompt('primary-source-research', { topic: 'guard' });
-  const v4 = recommendedToolCallsForPrompt('primary-source-research', { topic: 'guard', authors: 'One,Two' }, {
+  const v5 = recommendedToolCallsForPrompt('primary-source-research', { topic: 'guard', authors: 'One,Two' }, {
     exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
-    contractVersion: '4', liveCcelEnabled: false,
+    contractVersion: '5', liveCcelEnabled: false,
   });
-  if (JSON.stringify(v3).includes('"ccel"') || v4.slice(1).length !== 1) {
+  if (JSON.stringify(v3).includes('"ccel"') || v5.slice(1).length !== 1) {
     throw new Error('Primary-source CCEL contract guard failed.');
   }
 }

--- a/test/integration/current/mcp-protocol.test.ts
+++ b/test/integration/current/mcp-protocol.test.ts
@@ -137,7 +137,7 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
         },
       });
       expect(listed.tools.find(tool => tool.name === 'primary_source_search')?.outputSchema).toMatchObject({
-        properties: { schemaVersion: { const: '3' } },
+        properties: { schemaVersion: { const: '4' } },
       });
       const primarySourceTool = listed.tools.find(tool => tool.name === 'primary_source_search')!;
       expect(JSON.stringify(primarySourceTool.inputSchema).toLowerCase()).not.toContain('ccel');
@@ -151,7 +151,7 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
       });
       expect(primarySource.isError).not.toBe(true);
       expect(primarySource.structuredContent).toMatchObject({
-        schemaVersion: '3', kind: 'primary_source_search',
+        schemaVersion: '4', kind: 'primary_source_search',
         queries: [{ providers: [{ provider: 'local' }] }],
         coverage: { localAttempted: false, localHitCount: 0 },
       });
@@ -194,7 +194,7 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
       }));
       const catalog = await client.readResource({ uri: 'theologai://primary-sources/catalog' });
       expect(JSON.parse(String(catalog.contents[0].text))).toMatchObject({
-        schemaVersion: '1', kind: 'local_primary_source_catalog', workCount: 0,
+        schemaVersion: '2', kind: 'local_primary_source_catalog', workCount: 0,
         policies: { scope: 'hosted_collection_only', rightsStatus: 'not_established' },
       });
       expect(listed.tools).toEqual(expect.arrayContaining([
@@ -269,7 +269,7 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
           text: expect.stringContaining('Plan status: **complete**'),
         })],
         structuredContent: {
-          schemaVersion: '3',
+          schemaVersion: '4',
           kind: 'primary_source_search',
           planStatus: 'complete',
           queries: [expect.objectContaining({
@@ -281,9 +281,8 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
           coverage: expect.any(Object),
           evidencePolicy: {
             snippetUse: 'discovery_only',
-            selectedSectionAccess: 'mcp_resource_read',
+            localSectionAccess: 'mcp_resource_read',
             coverageScope: 'bounded_non_exhaustive',
-            editionProvenance: 'incomplete',
             lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
           },
         },

--- a/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
+++ b/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
@@ -267,7 +267,7 @@ describe('primary-source feature flags', () => {
   it('defaults all three rollout gates off and derives one live predicate', () => {
     expect(DEFAULT_PRIMARY_SOURCE_FEATURE_FLAGS).toEqual({
       exposeCcelDiscovery: false, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '3', liveCcelEnabled: false,
+      contractVersion: '4', liveCcelEnabled: false,
     });
     expect(readPrimarySourceFeatureFlags()).toEqual(DEFAULT_PRIMARY_SOURCE_FEATURE_FLAGS);
     expect(readPrimarySourceFeatureFlags({
@@ -276,7 +276,7 @@ describe('primary-source feature flags', () => {
       THEOLOGAI_ENABLE_CCEL_COORDINATOR: 'TRUE',
     })).toEqual({
       exposeCcelDiscovery: true, ccelLiveSearch: true, ccelCoordinator: true,
-      contractVersion: '4', liveCcelEnabled: true,
+      contractVersion: '5', liveCcelEnabled: true,
     });
   });
 });

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -183,23 +183,23 @@ describe('published project contract', () => {
     expect(readme).not.toMatch(/eighteen locally indexed|18 locally indexed/i);
     expect(readme).not.toMatch(/six public-domain commentar/i);
     expect(readme).toContain('do **not** currently fetch CCEL search results or document bodies');
-    expect(readme).toContain('production v3 schema remains strictly local-only');
-    expect(readme).toContain('Preview stages a hard v4');
+    expect(readme).toContain('production v4 schema remains strictly local-only');
+    expect(readme).toContain('Preview stages a hard v5');
     expect(readme).toContain('live search and coordinator execution remain disabled');
     expect(readme).toContain('before adapter');
     expect(readme).toContain('Durable Object lookup/RPC, or fetch');
     expect(readme).toContain('reconnect');
     expect(readme).toContain('reinitialize');
     expect(readme).toMatch(/keeps any requested year bounds on its local\s+queries/);
-    expect(readme).toMatch(/Direct v4 queries that combine CCEL with\s+either year field/);
+    expect(readme).toMatch(/Direct v5 queries that combine CCEL with\s+either year field/);
     expect(coordinatorGuide).toContain('Every executable unbounded CCEL provider result begins');
     expect(coordinatorGuide).toContain('A direct CCEL-bearing query with either');
     expect(roadmap).toContain('guided broad topical fallback');
     expect(roadmap).toContain('Direct CCEL-plus-year tool input remains fail-closed');
     const primarySourceToolRow = readme.split('\n')
       .find(line => line.startsWith('| `primary_source_search` |'));
-    expect(primarySourceToolRow).toContain('Production is v3/local-only');
-    expect(primarySourceToolRow).toContain('preview exposes the v4 local-plus-CCEL discovery contract');
+    expect(primarySourceToolRow).toContain('Production is v4/local-only');
+    expect(primarySourceToolRow).toContain('preview exposes the v5 local-plus-CCEL discovery contract');
     expect(primarySourceToolRow).toContain('execution remains disabled before adapter, coordinator, or fetch');
     const previewStart = workerConfig.indexOf('[env.preview]');
     expect(previewStart).toBeGreaterThan(0);

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -17,8 +17,7 @@ import { createDeterministicMcpFixture } from '../../fixtures/mcpCompositionRoot
 import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../../src/kernel/featureFlags.js';
 import { classicTextsOutputSchema } from '../../../src/mcp/schemas/classicTexts.js';
 import { validateClassicTextsOutputSemantics } from '../../../src/presenters/classicTextsStructured.js';
-import { primarySourceSearchOutputSchema } from '../../../src/mcp/schemas/primarySourceSearch.js';
-import { primarySourceSearchV4OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
+import { primarySourceSearchV4OutputSchema, primarySourceSearchV5OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
 
 const connected: Array<{ client: Client; server: Server }> = [];
 type LogMessage = { level: string; logger?: string; data: unknown };
@@ -68,14 +67,14 @@ describe('MCP structured output validation', () => {
   });
 
   it.each([
-    ['v3', primarySourceSearchOutputSchema],
     ['v4', primarySourceSearchV4OutputSchema],
+    ['v5', primarySourceSearchV5OutputSchema],
   ] as const)('accepts 100 eligible works and rejects 101 at the %s output-schema boundary', async (version, outputSchema) => {
     const structuredContent = (eligibleDocumentCount: number) => ({
-      schemaVersion: version === 'v3' ? '3' : '4',
+      schemaVersion: version === 'v4' ? '4' : '5',
       kind: 'primary_source_search',
       planStatus: 'complete',
-      ...(version === 'v4' ? { responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false } } : {}),
+      responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
       queries: [{
         id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance',
         providers: [{
@@ -90,18 +89,27 @@ describe('MCP structured output validation', () => {
       }],
       coverage: {
         localAttempted: true, localStatus: 'no_results', localHitCount: 0,
-        ...(version === 'v4' ? { ccelAttempted: false, ccelHitCount: 0 } : {}),
+        ...(version === 'v5' ? { ccelAttempted: false, ccelHitCount: 0 } : {}),
         notices: [],
+        serverObserved: { searched: [{ queryId: 'q', provider: 'local', status: 'no_results', returnedHitCount: 0 }], notSearched: [] },
       },
-      evidencePolicy: version === 'v4'
+      evidencePolicy: version === 'v5'
         ? {
           snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', externalSectionAccess: 'direct_url_only',
           coverageScope: 'bounded_non_exhaustive', externalRightsStatus: 'not_determined',
           lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+          coverageLedger: {
+            searched: 'server_observed_provider_execution', read: 'host_observed_successful_exact_resource_or_page_read',
+            deferred: 'host_recorded_intentional_deferral', notSearched: 'server_observed_provider_non_execution',
+          },
         }
         : {
-          snippetUse: 'discovery_only', selectedSectionAccess: 'mcp_resource_read', coverageScope: 'bounded_non_exhaustive',
-          editionProvenance: 'incomplete', lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+          snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', coverageScope: 'bounded_non_exhaustive',
+          lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+          coverageLedger: {
+            searched: 'server_observed_provider_execution', read: 'host_observed_successful_exact_resource_or_page_read',
+            deferred: 'host_recorded_intentional_deferral', notSearched: 'server_observed_provider_non_execution',
+          },
         },
     });
     let count = 100;
@@ -145,7 +153,8 @@ describe('MCP structured output validation', () => {
       const schema = listed.tools.find(tool => tool.name === toolName)?.outputSchema;
       expect(schema).toMatchObject({ type: 'object', additionalProperties: false });
       expect(schema).not.toHaveProperty('$ref');
-      const expectedVersion = toolName === 'primary_source_search' || toolName === 'parallel_passages' ? '3' : '1';
+      const expectedVersion = toolName === 'primary_source_search' ? '4'
+        : toolName === 'parallel_passages' ? '3' : '1';
       expect(schema?.properties?.schemaVersion).toMatchObject({ const: expectedVersion });
     }
   });
@@ -449,7 +458,7 @@ describe('MCP structured output validation', () => {
   it('accepts a v4 primary-source result after control-only optional metadata is omitted', async () => {
     const contract = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '4' as const, liveCcelEnabled: false,
+      contractVersion: '5' as const, liveCcelEnabled: false,
     };
     const handler = createPrimarySourceSearchHandler({
       search: async () => ({

--- a/test/unit/mcp/promptContracts.test.ts
+++ b/test/unit/mcp/promptContracts.test.ts
@@ -195,15 +195,15 @@ describe('prompt-recommended tool-call contracts', () => {
     ['lower bound only', { startYear: '500' }, { startYear: 500 }],
     ['upper bound only', { endYear: '1500' }, { endYear: 1500 }],
     ['both bounds', { startYear: '500', endYear: '1500' }, { startYear: 500, endYear: 1500 }],
-  ])('keeps %s on local calls while making one unbounded, sequential v4 external discovery call', (_label, dateArgs, expectedLocalDates) => {
-    const v4 = {
+  ])('keeps %s on local calls while making one unbounded, sequential v5 external discovery call', (_label, dateArgs, expectedLocalDates) => {
+    const v5 = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '4' as const, liveCcelEnabled: false,
+      contractVersion: '5' as const, liveCcelEnabled: false,
     };
     const calls = recommendedToolCallsForPrompt('primary-source-research', {
       topic: 'eucharist', authors: 'Erasmus of Rotterdam, Martin Luther',
       ...dateArgs,
-    }, v4);
+    }, v5);
     const localQueries = calls[0]!.arguments.queries as Array<Record<string, unknown>>;
     expect(localQueries.every(query => (query.providers as string[])[0] === 'local')).toBe(true);
     expect(localQueries).toHaveLength(2);
@@ -214,24 +214,24 @@ describe('prompt-recommended tool-call contracts', () => {
     expect(externalQueries[0]).toMatchObject({ providers: ['ccel'], author: 'Erasmus of Rotterdam' });
     expect(externalQueries[0]).not.toHaveProperty('startYear');
     expect(externalQueries[0]).not.toHaveProperty('endYear');
-    const validateV4 = validatorFor(createPrimarySourceSearchHandler(unused, v4).inputSchema);
-    for (const call of calls) expect(validateV4(call.arguments).valid).toBe(true);
+    const validateV5 = validatorFor(createPrimarySourceSearchHandler(unused, v5).inputSchema);
+    for (const call of calls) expect(validateV5(call.arguments).valid).toBe(true);
   });
 
   it('retains the optional work restriction in both guided scopes without copying date bounds to CCEL', () => {
-    const v4 = {
+    const v5 = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '4' as const, liveCcelEnabled: false,
+      contractVersion: '5' as const, liveCcelEnabled: false,
     };
     const calls = recommendedToolCallsForPrompt('primary-source-research', {
       topic: 'sacraments', work: 'Institutes', startYear: '1536', endYear: '1559',
-    }, v4);
+    }, v5);
     expect(calls[0]!.arguments).toMatchObject({ queries: [{ work: 'Institutes', startYear: 1536, endYear: 1559 }] });
     expect(calls[1]!.arguments).toEqual({ queries: [{
       id: 'external-topic', text: 'sacraments', providers: ['ccel'], match: 'all_terms',
       selection: 'relevance', work: 'Institutes', limit: 3,
     }] });
-    expect(recommendedToolCallsForPrompt('confession-study', { topic: 'justification' }, v4)[0]!.arguments)
+    expect(recommendedToolCallsForPrompt('confession-study', { topic: 'justification' }, v5)[0]!.arguments)
       .toMatchObject({ queries: [{ providers: ['local', 'ccel'] }] });
   });
 });

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -15,7 +15,7 @@ import { createPrimarySourceSearchHandler } from '../../../src/tools/v2/primaryS
 import { createClassicTextsHandler } from '../../../src/tools/v2/classicTexts.js';
 import { formatLocalDocumentResource, formatLocalDocumentSectionResource } from '../../../src/formatters/historicalFormatter.js';
 import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../../src/kernel/featureFlags.js';
-import { primarySourceSearchOutputSchema } from '../../../src/mcp/schemas/primarySourceSearch.js';
+import { primarySourceSearchV4OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
 
 const TOOL_NAMES = [
   'bible_lookup',
@@ -41,7 +41,7 @@ function makeMockTool(name: string): ToolHandler {
       required: ['reference'],
       additionalProperties: false,
     },
-    ...(name === 'primary_source_search' ? { outputSchema: primarySourceSearchOutputSchema } : {}),
+    ...(name === 'primary_source_search' ? { outputSchema: primarySourceSearchV4OutputSchema } : {}),
     annotations: {
       readOnlyHint: true, destructiveHint: false, idempotentHint: true,
       ...(name === 'primary_source_search' ? { openWorldHint: false } : {}),
@@ -355,16 +355,24 @@ describe('shared MCP registration', () => {
     const catalog = await client.readResource({ uri: 'theologai://primary-sources/catalog' });
     expect(catalog.contents[0]).toMatchObject({ mimeType: 'application/json' });
     expect(JSON.parse(String(catalog.contents[0].text))).toEqual({
-      schemaVersion: '1', kind: 'local_primary_source_catalog', workCount: 1,
+      schemaVersion: '2', kind: 'local_primary_source_catalog', workCount: 1,
       works: [{
         id: 'nicene-creed', title: 'Nicene Creed', documentType: 'creed',
         lookupAliases: ['The Nicene Creed'], composition: { startYear: 381, endYear: 381, label: '381 AD' },
         creators: [{ name: 'First Council of Constantinople', role: 'revising_body' }],
         metadataStatus: 'collective', metadataProvenanceIds: ['hist-meta-test-nicene'],
+        editionReadiness: {
+          foundation: 'edition-provenance-foundation.v1', editionIdentity: 'not_established',
+          provenance: 'incomplete', exactArtifactRights: 'not_established_by_this_contract',
+        },
       }],
       policies: {
         scope: 'hosted_collection_only', lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
         editionProvenance: 'incomplete', rightsStatus: 'not_established',
+        editionReadiness: {
+          foundation: 'edition-provenance-foundation.v1', editionIdentity: 'not_established',
+          provenance: 'incomplete', exactArtifactRights: 'not_established_by_this_contract',
+        },
       },
     });
   });
@@ -556,13 +564,13 @@ describe('shared MCP registration', () => {
     const link = result.content.find(block => block.type === 'resource_link');
     expect(link).toMatchObject({
       type: 'resource_link', uri: 'theologai://documents/nicene-creed#section-1',
-      mimeType: 'text/markdown', size: resourceSizeBytes,
+      mimeType: 'text/markdown', _meta: { 'theologai/resourceSizeBytes': resourceSizeBytes },
       annotations: { audience: ['assistant'] },
     });
     if (!link || link.type !== 'resource_link') throw new Error('Expected resource link');
     const read = await client.readResource({ uri: link.uri });
     const readText = String(read.contents[0].text);
-    expect(new TextEncoder().encode(readText).byteLength).toBe(link.size);
+    expect(new TextEncoder().encode(readText).byteLength).toBe((link._meta as any)?.['theologai/resourceSizeBytes']);
     expect(readText).toBe(resourceText);
   });
 
@@ -591,7 +599,7 @@ describe('shared MCP registration', () => {
     const workRead = await client.readResource({ uri: workLink.uri });
     const workText = String(workRead.contents[0].text);
     expect(workText).toBe(formatLocalDocumentResource(document!, sections));
-    expect(new TextEncoder().encode(workText).byteLength).toBe(workLink.size);
+    expect(new TextEncoder().encode(workText).byteLength).toBe((workLink._meta as any)?.['theologai/resourceSizeBytes']);
     expect(JSON.stringify(workResult.structuredContent)).not.toContain('We believe...');
 
     const searchResult = await client.callTool({
@@ -602,7 +610,7 @@ describe('shared MCP registration', () => {
     const sectionRead = await client.readResource({ uri: sectionLink.uri });
     const sectionText = String(sectionRead.contents[0].text);
     expect(sectionText).toBe(formatLocalDocumentSectionResource(document!, sections[0]));
-    expect(new TextEncoder().encode(sectionText).byteLength).toBe(sectionLink.size);
+    expect(new TextEncoder().encode(sectionText).byteLength).toBe((sectionLink._meta as any)?.['theologai/resourceSizeBytes']);
   });
 
   it('canonicalizes classical and extended Strong\'s resources and rejects invalid domain numbers', async () => {
@@ -875,16 +883,16 @@ describe('shared MCP registration', () => {
     expect(donateText).toContain('provider gaps fail closed');
   });
 
-  it('renders v4 primary-source prompts with separate local and external evidence access', async () => {
+  it('renders v5 primary-source prompts with separate local and external evidence access', async () => {
     const root = makeMockRoot();
     root.primarySourceContract = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '4', liveCcelEnabled: false,
+      contractVersion: '5', liveCcelEnabled: false,
     };
     root.tools = root.tools.map(tool => tool.name === 'primary_source_search'
       ? createPrimarySourceSearchHandler({ search: vi.fn() } as any, root.primarySourceContract)
       : tool);
-    const client = await connect(createTheologAiMcpServer(root, '1.0.0-v4-test').server);
+    const client = await connect(createTheologAiMcpServer(root, '1.0.0-v5-test').server);
     const listed = await client.listPrompts();
     const primaryDefinition = listed.prompts.find(prompt => prompt.name === 'primary-source-research')!;
     const argumentDescription = (name: string) => primaryDefinition.arguments?.find(argument => argument.name === name)?.description ?? '';
@@ -947,16 +955,16 @@ describe('shared MCP registration', () => {
     const root = makeMockRoot();
     root.primarySourceContract = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '4', liveCcelEnabled: false,
+      contractVersion: '5', liveCcelEnabled: false,
     };
     expect(() => createTheologAiMcpServer(root, 'mismatched-contract-test'))
       .toThrow('tool and guided-prompt contracts must use the same configuration');
   });
 
-  it('advertises and executes the exact v4 tool contract through MCP', async () => {
+  it('advertises and executes the exact v5 tool contract through MCP', async () => {
     const contract = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '4' as const, liveCcelEnabled: false,
+      contractVersion: '5' as const, liveCcelEnabled: false,
     };
     const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue({
       planStatus: 'unavailable',
@@ -972,11 +980,11 @@ describe('shared MCP registration', () => {
     const root = makeMockRoot();
     root.primarySourceContract = contract;
     root.tools = root.tools.map(tool => tool.name === 'primary_source_search' ? handler : tool);
-    const client = await connect(createTheologAiMcpServer(root, '1.0.0-v4-tool-test').server);
+    const client = await connect(createTheologAiMcpServer(root, '1.0.0-v5-tool-test').server);
 
     const listed = await client.listTools();
     const advertised = listed.tools.find(tool => tool.name === 'primary_source_search')!;
-    expect(advertised.outputSchema?.properties?.schemaVersion).toEqual({ const: '4' });
+    expect(advertised.outputSchema?.properties?.schemaVersion).toEqual({ const: '5' });
     expect(advertised.annotations).toMatchObject({ openWorldHint: true });
     expect((advertised.inputSchema.properties?.queries as any).items.properties.providers.items.enum).toEqual(['local', 'ccel']);
 
@@ -984,8 +992,8 @@ describe('shared MCP registration', () => {
       name: 'primary_source_search',
       arguments: { queries: [{ id: 'external', text: 'grace', providers: ['ccel'] }] },
     });
-    expect(called).toMatchObject({ isError: true, structuredContent: { schemaVersion: '4', planStatus: 'unavailable' } });
-    expect(called.content[0]).toEqual({ type: 'text', text: JSON.stringify(called.structuredContent) });
+    expect(called).toMatchObject({ isError: true, structuredContent: { schemaVersion: '5', planStatus: 'unavailable' } });
+    expect(called.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('# Primary-source discovery') });
   });
 
   it('uses InvalidParams for unknown prompts and missing prompt arguments', async () => {

--- a/test/unit/presenters/primarySourceSearchV4Structured.test.ts
+++ b/test/unit/presenters/primarySourceSearchV4Structured.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { presentPrimarySourceSearchV4 } from '../../../src/presenters/primarySourceSearchV4Structured.js';
+import { presentPrimarySourceSearchV5 } from '../../../src/presenters/primarySourceSearchV4Structured.js';
 import type { PrimarySourceSearchPlanResult } from '../../../src/services/historical/primarySourceTypes.js';
 import { CCEL_COMPOSITION_DATE_NOTICE } from '../../../src/services/historical/primarySourceTypes.js';
 
@@ -86,7 +86,7 @@ function largePlan(): PrimarySourceSearchPlanResult {
   };
 }
 
-describe('primary-source v4 structured presentation', () => {
+describe('primary-source v5 structured presentation', () => {
   it('defensively prepends the date invariant to every executable external provider result', () => {
     const plan = largePlan();
     const external = externalProvider('external', 1);
@@ -94,7 +94,7 @@ describe('primary-source v4 structured presentation', () => {
     plan.queries = [{ id: 'external', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [external] }];
     plan.coverage = { localAttempted: false, localHitCount: 0, ccelAttempted: true, ccelStatus: 'ok', ccelHitCount: 1, notices: [] };
 
-    const presented = presentPrimarySourceSearchV4(plan);
+    const presented = presentPrimarySourceSearchV5(plan);
 
     expect(presented.queries[0]!.providers[0]!.notices).toEqual([
       CCEL_COMPOSITION_DATE_NOTICE,
@@ -111,7 +111,7 @@ describe('primary-source v4 structured presentation', () => {
     external.notices = ['Live CCEL discovery does not expose reviewed composition-date bounds.'];
     plan.queries = [{ id: 'external', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [external] }];
 
-    const provider = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    const provider = presentPrimarySourceSearchV5(plan).queries[0]!.providers[0]!;
     expect(provider.notices).not.toContain(CCEL_COMPOSITION_DATE_NOTICE);
   });
 
@@ -123,7 +123,7 @@ describe('primary-source v4 structured presentation', () => {
     external.notices = ['Live CCEL search is disabled. No remote request was made.'];
     plan.queries = [{ id: 'external', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [external] }];
 
-    const provider = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    const provider = presentPrimarySourceSearchV5(plan).queries[0]!.providers[0]!;
     expect(provider.notices).not.toContain(CCEL_COMPOSITION_DATE_NOTICE);
   });
 
@@ -139,11 +139,11 @@ describe('primary-source v4 structured presentation', () => {
     provider.scope!.eligibleDocuments = [];
     provider.scope!.eligibleDocumentsTruncated = true;
 
-    expect(presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!.scope?.eligibleDocumentCount).toBe(100);
+    expect(presentPrimarySourceSearchV5(plan).queries[0]!.providers[0]!.scope?.eligibleDocumentCount).toBe(100);
     provider.scope!.eligibleDocumentCount = 101;
-    const rejected = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    const rejected = presentPrimarySourceSearchV5(plan).queries[0]!.providers[0]!;
     expect(rejected.status).toBe('interface_changed');
-    expect(rejected).not.toHaveProperty('scope');
+    expect(rejected).toMatchObject({ scope: { status: 'metadata_incomplete', eligibleDocumentCount: 0 } });
   });
 
   it('publishes bounded retry guidance only for a rate-limited external provider', () => {
@@ -153,19 +153,19 @@ describe('primary-source v4 structured presentation', () => {
     external.searched = false;
     external.retryAfterSeconds = 11;
     plan.queries = [{ id: 'external', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [external] }];
-    const provider = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    const provider = presentPrimarySourceSearchV5(plan).queries[0]!.providers[0]!;
     expect(provider).toMatchObject({ status: 'rate_limited', retryAfterSeconds: 11 });
 
     external.retryAfterSeconds = 0;
-    const invalid = presentPrimarySourceSearchV4(plan).queries[0]!.providers[0]!;
+    const invalid = presentPrimarySourceSearchV5(plan).queries[0]!.providers[0]!;
     expect(invalid.status).toBe('interface_changed');
     expect(invalid).not.toHaveProperty('retryAfterSeconds');
   });
 
-  it('stops at the first non-fitting hit and recomputes every public count within 32 KiB', () => {
-    const presented = presentPrimarySourceSearchV4(largePlan());
+  it('stops at the first non-fitting hit and recomputes every public count within the structured delivery reserve', () => {
+    const presented = presentPrimarySourceSearchV5(largePlan());
     const json = JSON.stringify(presented);
-    expect(new TextEncoder().encode(json).byteLength).toBeLessThanOrEqual(32768);
+    expect(new TextEncoder().encode(json).byteLength).toBeLessThanOrEqual(20480);
     expect(presented).toMatchObject({ planStatus: 'partial', responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: true } });
     expect(json).not.toContain('FINAL_MARKER');
     const providers = presented.queries.flatMap(query => query.providers);
@@ -181,7 +181,7 @@ describe('primary-source v4 structured presentation', () => {
     expect(providers[0]?.scope?.eligibleDocumentsTruncated).toBe(true);
   });
 
-  it('budgets against the larger complete, non-truncated envelope at the exact byte boundary', () => {
+  it('reserves delivery space while preserving a truthful structured response window', () => {
     const boundaryPlan = (twoByteCharacters: number) => {
       const plan = largePlan();
       plan.queries = [plan.queries[0]!];
@@ -194,20 +194,16 @@ describe('primary-source v4 structured presentation', () => {
       return plan;
     };
 
-    const exact = presentPrimarySourceSearchV4(boundaryPlan(118));
-    expect(exact.responseWindow.truncated).toBe(false);
-    expect(exact.planStatus).toBe('complete');
-    expect(exact.queries[0]!.providers[0]!.hits).toHaveLength(8);
-    expect(new TextEncoder().encode(JSON.stringify(exact)).byteLength).toBe(32768);
-
-    // One additional UTF-8 byte makes the non-truncated all-eight-hit envelope
-    // exactly 32,769 bytes. The truncated/partial tentative form is two bytes
-    // smaller, so probing against that form would admit the hit and then throw.
-    const overflow = presentPrimarySourceSearchV4(boundaryPlan(119));
-    expect(overflow.responseWindow.truncated).toBe(true);
-    expect(overflow.planStatus).toBe('partial');
-    expect(overflow.queries[0]!.providers[0]!.hits).toHaveLength(7);
-    expect(new TextEncoder().encode(JSON.stringify(overflow)).byteLength).toBeLessThanOrEqual(32768);
+    const first = presentPrimarySourceSearchV5(boundaryPlan(118));
+    const second = presentPrimarySourceSearchV5(boundaryPlan(119));
+    for (const presented of [first, second]) {
+      expect(presented.responseWindow.maximum).toBe(32768);
+      expect(new TextEncoder().encode(JSON.stringify(presented)).byteLength).toBeLessThanOrEqual(20480);
+      for (const provider of presented.queries.flatMap(query => query.providers)) {
+        expect(provider.hitCount).toBe(provider.hits.length);
+        expect(provider.resultWindow.returnedHitCount).toBe(provider.hits.length);
+      }
+    }
   });
 
   it('uses stable query/provider order and rank order without leaking external routing fields', () => {
@@ -216,7 +212,7 @@ describe('primary-source v4 structured presentation', () => {
     plan.queries[0]!.providers[0]!.hits = [localHit('q2', 2), localHit('q2', 1)];
     plan.queries[0]!.providers[0]!.hitCount = 2;
     plan.queries[0]!.providers[0]!.resultWindow.returnedHitCount = 2;
-    const presented = presentPrimarySourceSearchV4(plan);
+    const presented = presentPrimarySourceSearchV5(plan);
     expect(presented.queries.map(query => query.id)).toEqual(['q2', 'q1']);
     expect(presented.queries[0]!.providers[0]!.hits.map(hit => hit.rankWithinProvider)).toEqual([1, 2]);
     expect(JSON.stringify(presented)).not.toContain('ccel_section');
@@ -237,7 +233,7 @@ describe('primary-source v4 structured presentation', () => {
     plan.queries = [query];
     plan.coverage.localHitCount = 1;
 
-    const presented = presentPrimarySourceSearchV4(plan);
+    const presented = presentPrimarySourceSearchV5(plan);
     const sanitized = presented.queries[0]!.providers[0]!.hits[0]!;
     expect(sanitized).not.toHaveProperty('author');
     expect(sanitized).not.toHaveProperty('sectionLabel');
@@ -258,7 +254,7 @@ describe('primary-source v4 structured presentation', () => {
     ];
     plan.coverage = { localAttempted: false, localHitCount: 0, ccelAttempted: true, ccelStatus: 'ok', ccelHitCount: 13, notices: [] };
 
-    const presented = presentPrimarySourceSearchV4(plan);
+    const presented = presentPrimarySourceSearchV5(plan);
     const externalProviders = presented.queries.flatMap(query => query.providers)
       .filter(provider => provider.provider === 'ccel_live');
     expect(externalProviders).toHaveLength(1);

--- a/test/unit/scripts/ccelCoordinatorOperator.test.ts
+++ b/test/unit/scripts/ccelCoordinatorOperator.test.ts
@@ -16,21 +16,81 @@ const auditOptions = {
   authorization: 'I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS',
 };
 
-function envelope(provider: Record<string, unknown>, planStatus = 'complete') {
+const localEditionReadiness = {
+  foundation: 'edition-provenance-foundation.v1', editionIdentity: 'not_established',
+  provenance: 'incomplete', exactArtifactRights: 'not_established_by_this_contract',
+};
+const externalEditionReadiness = {
+  editionIdentity: 'provider_unreviewed', provenance: 'provider_unreviewed',
+  exactArtifactRights: 'not_determined',
+};
+
+function toolSchema(version: '3' | '4' | '5', includeCcel: boolean, retryAfterSeconds = false): { properties: Record<string, unknown> } {
+  const local = { properties: { provider: { const: 'local' } } };
+  const external = { properties: {
+    provider: { const: 'ccel_live' }, ...(retryAfterSeconds ? { retryAfterSeconds: { type: 'integer' } } : {}),
+  } };
+  return { properties: {
+    schemaVersion: { const: version },
+    queries: { items: { properties: { providers: { items: includeCcel ? { oneOf: [local, external] } : local } } } },
+  } };
+}
+
+function envelope(searchProvider: ReturnType<typeof provider>, planStatus = 'complete') {
+  const searched = searchProvider.searched;
+  const kind = searchProvider.provider;
+  const observation = { queryId: 'audit', provider: kind, status: searchProvider.status };
   return {
-    schemaVersion: '4', kind: 'primary_source_search', planStatus,
+    schemaVersion: '5', kind: 'primary_source_search', planStatus,
     responseWindow: { unit: 'utf8_bytes', maximum: 32_768, truncated: false },
-    queries: [{ id: 'audit', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [provider] }],
-    coverage: { localAttempted: false, localHitCount: 0, ccelAttempted: true, ccelHitCount: 0, notices: [] },
-    evidencePolicy: { snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', externalSectionAccess: 'direct_url_only', coverageScope: 'bounded_non_exhaustive', externalRightsStatus: 'not_determined', lookupAliasUse: 'exact_routing_only_not_metadata_evidence' },
+    queries: [{ id: 'audit', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [searchProvider] }],
+    coverage: {
+      localAttempted: kind === 'local' && searched, localHitCount: kind === 'local' ? searchProvider.hitCount : 0,
+      ccelAttempted: kind === 'ccel_live' && searched, ccelHitCount: kind === 'ccel_live' ? searchProvider.hitCount : 0,
+      notices: [], serverObserved: {
+        searched: searched ? [{ ...observation, returnedHitCount: searchProvider.hitCount }] : [],
+        notSearched: searched ? [] : [observation],
+      },
+    },
+    evidencePolicy: {
+      snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', externalSectionAccess: 'direct_url_only',
+      coverageScope: 'bounded_non_exhaustive', externalRightsStatus: 'not_determined', lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+      coverageLedger: {
+        searched: 'server_observed_provider_execution', read: 'host_observed_successful_exact_resource_or_page_read',
+        deferred: 'host_recorded_intentional_deferral', notSearched: 'server_observed_provider_non_execution',
+      },
+    },
   };
 }
 
-function provider(kind: 'local' | 'ccel_live', status: string, retryAfterSeconds?: number) {
+function provider(
+  kind: 'local' | 'ccel_live',
+  status: string,
+  retryAfterSeconds?: number,
+  hits: Array<Record<string, unknown>> = [],
+) {
+  const searched = status !== 'rate_limited';
   return {
-    provider: kind, status, searched: status !== 'rate_limited', page: 1, hitCount: 0,
-    resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'no_additional_match_observed' },
-    hits: [], notices: [], ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
+    provider: kind, status, searched, page: 1, hitCount: hits.length,
+    resultWindow: { returnedHitCount: hits.length, additionalMatchStatus: 'no_additional_match_observed' },
+    hits, notices: [],
+    ...(kind === 'local' && searched ? { scope: { eligibleDocuments: [{ editionReadiness: localEditionReadiness }] } } : {}),
+    ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
+  };
+}
+
+function externalHit() {
+  return {
+    provider: 'ccel_live', snippet: 'A short authorized discovery snippet.',
+    metadataStatus: 'provider_search_result_unreviewed', editionReadiness: externalEditionReadiness,
+    locator: { kind: 'external_url', url: 'https://ccel.org/ccel/calvin/institutes/iv.xvii.html' },
+  };
+}
+
+function localHit() {
+  return {
+    provider: 'local', snippet: 'A local discovery snippet.', editionReadiness: localEditionReadiness,
+    locator: { kind: 'mcp_resource', uri: 'theologai://documents/example' },
   };
 }
 
@@ -59,22 +119,22 @@ describe('CCEL operational scripts', () => {
     let ccelCalls = 0;
     let possibleOriginAdmissions = 0;
     const production: CcelAuditClient = {
-      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: { properties: { schemaVersion: { const: '3' } } } }] }),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
       callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
     };
     const preview: CcelAuditClient = {
-      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: { properties: { schemaVersion: { const: '4' }, retryAfterSeconds: {} } } }] }),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
       callTool: vi.fn(async request => {
         const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
         if (providers.includes('ccel')) {
           ccelCalls++;
           if (ccelCalls === 1) {
             possibleOriginAdmissions++;
-            return { structuredContent: envelope(provider('ccel_live', 'no_results')) };
+            return { structuredContent: envelope(provider('ccel_live', 'ok', undefined, [externalHit()])) };
           }
           return { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
         }
-        return { structuredContent: envelope(provider('local', 'no_results')) };
+        return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
       }),
       close: vi.fn().mockResolvedValue(undefined),
     };
@@ -83,8 +143,8 @@ describe('CCEL operational scripts', () => {
     });
     expect(report).toMatchObject({
       passed: true,
-      productionControl: { liveCallMade: false },
-      preview: { ccelBearingToolCallMaximum: 2, upstreamOriginAdmissionMaximum: 2 },
+      productionControl: { contractVersion: '4', liveCallMade: false },
+      preview: { contractVersion: '5', ccelBearingToolCallMaximum: 2, upstreamOriginAdmissionMaximum: 2 },
     });
     expect(ccelCalls).toBe(2);
     expect(possibleOriginAdmissions).toBeLessThanOrEqual(2);
@@ -92,14 +152,85 @@ describe('CCEL operational scripts', () => {
     expect(preview.callTool).toHaveBeenCalledTimes(3);
   });
 
-  it('stops after two possible origin admissions even when the mocked coordinator violates busy policy', async () => {
-    let possibleOriginAdmissions = 0;
+  it('fails closed before any tool call when preview still advertises v4', async () => {
+    const stalePreviewSchema = toolSchema('4', true, true);
+    stalePreviewSchema.properties.unrelatedVersion = { const: '5' };
     const production: CcelAuditClient = {
-      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: { properties: { schemaVersion: { const: '3' } } } }] }),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
       callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
     };
     const preview: CcelAuditClient = {
-      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: { properties: { schemaVersion: { const: '4' }, retryAfterSeconds: {} } } }] }),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: stalePreviewSchema }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    await expect(runCcelPreviewAudit(auditOptions, {
+      connect: async url => url === auditOptions.productionUrl ? production : preview,
+    })).rejects.toThrow(/preview v5 CCEL contract/);
+    expect(production.callTool).not.toHaveBeenCalled();
+    expect(preview.callTool).not.toHaveBeenCalled();
+  });
+
+  it('fails closed before any tool call when production still advertises v3', async () => {
+    const staleProductionSchema = toolSchema('3', false);
+    staleProductionSchema.properties.unrelatedVersion = { const: '4' };
+    const production: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: staleProductionSchema }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const preview: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    await expect(runCcelPreviewAudit(auditOptions, {
+      connect: async url => url === auditOptions.productionUrl ? production : preview,
+    })).rejects.toThrow(/production v4 local-only control/);
+    expect(production.callTool).not.toHaveBeenCalled();
+    expect(preview.callTool).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an extra unreported search observation', (output: ReturnType<typeof envelope>) => {
+      output.coverage.serverObserved.searched.push({
+        queryId: 'unknown', provider: 'ccel_live', status: 'ok', returnedHitCount: 0,
+      });
+    }],
+    ['a missing provider execution flag', (output: ReturnType<typeof envelope>) => {
+      Reflect.deleteProperty(output.queries[0]!.providers[0]!, 'searched');
+    }],
+  ])('fails closed on %s in the v5 coverage ledger', async (_label, corrupt) => {
+    let ccelCalls = 0;
+    const production: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const preview: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
+      callTool: vi.fn(async () => {
+        ccelCalls++;
+        if (ccelCalls === 1) {
+          const output = envelope(provider('ccel_live', 'no_results'));
+          corrupt(output);
+          return { structuredContent: output };
+        }
+        return { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    await expect(runCcelPreviewAudit(auditOptions, {
+      connect: async url => url === auditOptions.productionUrl ? production : preview,
+    })).rejects.toThrow(/coverage|execution state/);
+    expect(production.callTool).not.toHaveBeenCalled();
+    expect(preview.callTool).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after two possible origin admissions even when the mocked coordinator violates busy policy', async () => {
+    let possibleOriginAdmissions = 0;
+    const production: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const preview: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
       callTool: vi.fn(async () => {
         possibleOriginAdmissions++;
         return { structuredContent: envelope(provider('ccel_live', 'no_results')) };
@@ -115,11 +246,11 @@ describe('CCEL operational scripts', () => {
 
   it('rejects an isError response unless it is the exact CCEL-only rate-limit form', async () => {
     const production: CcelAuditClient = {
-      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: { properties: { schemaVersion: { const: '3' } } } }] }),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
       callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
     };
     const preview: CcelAuditClient = {
-      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: { properties: { schemaVersion: { const: '4' }, retryAfterSeconds: {} } } }] }),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
       callTool: vi.fn().mockResolvedValue({ isError: true, structuredContent: envelope(provider('local', 'rate_limited', 3), 'unavailable') }),
       close: vi.fn().mockResolvedValue(undefined),
     };

--- a/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
@@ -12,7 +12,7 @@ const reviewedBasePins = {
   'src/worker.ts': '07a439b6f5f20be1e6651ceaad71b4ca189579592c743e5e0f3770d80ba12d44',
   'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
   'data/data-manifest.json': 'ba4f6fc73086716bd03f8e8d65a181719fba834aa61a90e65b168169744fa424',
-  'wrangler.toml': '512128beeb51f9134381f06cebd822b3402a3f99c6622410989bd3d188f711bc',
+  'wrangler.toml': '50dd24d0963893b5c8b17ec61d4ebe7c98eeb7f7692a988684bde09835017e4f',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
   'package.json': '4a9e337f9ee795a2d962ad9d6b5161fb36d166a7bf5547aca0c69813709f1ec4',
 } as const;

--- a/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
@@ -16,7 +16,7 @@ const activeIdentityPins = {
   'src/presenters/originalLanguageStudyStructured.ts': '49818eb62e89980498669442a4bfc1886944d7751fc675940b17368a030995d9',
   'src/formatters/originalLanguageStudyFormatter.ts': '30a10bf826c6c3174f2e0fb00907f6104735b165fdbfd5915a0ff22bc09b2536',
   'data/data-manifest.json': 'ba4f6fc73086716bd03f8e8d65a181719fba834aa61a90e65b168169744fa424',
-  'wrangler.toml': '512128beeb51f9134381f06cebd822b3402a3f99c6622410989bd3d188f711bc',
+  'wrangler.toml': '50dd24d0963893b5c8b17ec61d4ebe7c98eeb7f7692a988684bde09835017e4f',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
   'package.json': '4a9e337f9ee795a2d962ad9d6b5161fb36d166a7bf5547aca0c69813709f1ec4',
   'test/fixtures/ubs-semantics/structured-output-contract.draft.json': '4564884999aee552c4d1560c442c38b373fb19626a88da5af6455c892628e181',

--- a/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
@@ -12,7 +12,6 @@ const activeIdentityPins = {
   'src/server.ts': '6b372c049cb7741344bc446b2409524739cc9acba5a3121bc09dbdc8e90acd22',
   'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
   'src/worker.ts': '07a439b6f5f20be1e6651ceaad71b4ca189579592c743e5e0f3770d80ba12d44',
-  'src/mcp/prompts.ts': '6122a305d1a6025f1c980e1f105f78c02b4eb156061d12c44942d163c40002da',
   'src/mcp/schemas/originalLanguageStudy.ts': 'a98e5966d8a2a850487b4882c49f04c48fc697eee308f6e89c67e06af50fefac',
   'src/presenters/originalLanguageStudyStructured.ts': '49818eb62e89980498669442a4bfc1886944d7751fc675940b17368a030995d9',
   'src/formatters/originalLanguageStudyFormatter.ts': '30a10bf826c6c3174f2e0fb00907f6104735b165fdbfd5915a0ff22bc09b2536',

--- a/test/unit/services/historical/PrimarySourceSearchService.test.ts
+++ b/test/unit/services/historical/PrimarySourceSearchService.test.ts
@@ -23,8 +23,8 @@ function providerResult(provider: 'local' | 'ccel_live', status: PrimarySourcePr
 
 const plan = (queries: unknown[]) => ({ queries });
 const query = (overrides: Record<string, unknown> = {}) => ({ id: 'q1', text: 'union with Christ', providers: ['local'], ...overrides });
-const dormant = { exposeCcelDiscovery: false, ccelLiveSearch: false, ccelCoordinator: false, contractVersion: '3' as const, liveCcelEnabled: false };
-const live = { exposeCcelDiscovery: true, ccelLiveSearch: true, ccelCoordinator: true, contractVersion: '4' as const, liveCcelEnabled: true };
+const dormant = { exposeCcelDiscovery: false, ccelLiveSearch: false, ccelCoordinator: false, contractVersion: '4' as const, liveCcelEnabled: false };
+const live = { exposeCcelDiscovery: true, ccelLiveSearch: true, ccelCoordinator: true, contractVersion: '5' as const, liveCcelEnabled: true };
 const coordinator = { admit: vi.fn(), recordOutcome: vi.fn(), snapshot: vi.fn() } as any;
 
 describe('PrimarySourceSearchService', () => {

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -782,6 +782,11 @@ describe('classic_text_lookup handler', () => {
       mode: 'work',
       document: { sectionCount: 1, bodyDelivery: 'markdown_only' },
     });
+    const resourceSizeBytes = (result.structuredContent as any).document.work.resource.resourceSizeBytes;
+    expect(result.content.find(block => block.type === 'resource_link')).toMatchObject({
+      type: 'resource_link', size: resourceSizeBytes,
+      _meta: { 'theologai/resourceSizeBytes': resourceSizeBytes },
+    });
     expect(JSON.stringify(result.structuredContent)).not.toContain('We believe in one God.');
   });
 

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -25,7 +25,7 @@ describe('primary_source_search handler', () => {
     expect(handler.outputSchema).toMatchObject({
       type: 'object', additionalProperties: false,
       properties: {
-        schemaVersion: { const: '3' },
+        schemaVersion: { const: '4' },
         kind: { const: 'primary_source_search' },
       },
     });
@@ -270,13 +270,14 @@ describe('primary_source_search handler', () => {
       description: 'treatise, 1559. Exact local section selected by primary-source discovery.',
       mimeType: 'text/markdown',
       size: 321,
+      _meta: { 'theologai/resourceSizeBytes': 321 },
       annotations: { audience: ['assistant'] },
     }]);
     expect(result.structuredContent).toMatchObject({
-      schemaVersion: '3', kind: 'primary_source_search',
+      schemaVersion: '4', kind: 'primary_source_search',
       evidencePolicy: {
-        snippetUse: 'discovery_only', selectedSectionAccess: 'mcp_resource_read',
-        coverageScope: 'bounded_non_exhaustive', editionProvenance: 'incomplete',
+        snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read',
+        coverageScope: 'bounded_non_exhaustive',
         lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
       },
     });
@@ -310,11 +311,11 @@ describe('primary_source_search handler', () => {
     expect(result.content[0].text).not.toContain('Oversized');
     expect(JSON.stringify(result.structuredContent)).not.toContain('evil.test');
     expect(result.structuredContent).toMatchObject({
-      planStatus: 'unavailable',
-      queries: [{ providers: [{ status: 'interface_changed', hitCount: 0, hits: [], notices: [expect.stringContaining('2 local hits omitted')] }] }],
+      planStatus: 'partial',
+      queries: [{ providers: [{ status: 'interface_changed', hitCount: 0, hits: [] }] }],
       coverage: { localStatus: 'interface_changed', localHitCount: 0 },
     });
-    expect(result.isError).toBe(true);
+    expect(result.isError).toBeUndefined();
     expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
   });
 
@@ -355,7 +356,9 @@ describe('primary_source_search handler', () => {
 
     expect(result.content).toHaveLength(2);
     expect(result.content[1]).toMatchObject({
-      type: 'resource_link', uri: 'theologai://documents/doc#section-1', size: 10,
+      type: 'resource_link', uri: 'theologai://documents/doc#section-1',
+      size: 10,
+      _meta: { 'theologai/resourceSizeBytes': 10 },
     });
     expect(JSON.stringify(result)).not.toContain('Foreign query evidence');
     expect(JSON.stringify(result)).not.toContain('Foreign provider evidence');
@@ -365,7 +368,7 @@ describe('primary_source_search handler', () => {
       queries: [{ providers: [{
         provider: 'local', status: 'interface_changed', hitCount: 1,
         hits: [{ provider: 'local', queryId: 'q1' }],
-        notices: [expect.stringContaining('3 local hits omitted')],
+        notices: [expect.stringContaining('unsafe or mismatched provider hits')],
       }] }],
       coverage: { localStatus: 'interface_changed', localHitCount: 1 },
     });
@@ -409,7 +412,7 @@ describe('primary_source_search handler', () => {
       queries: [{ id: 'q1' }, { id: 'q2' }, { id: 'q3' }, { id: 'q4' }],
       coverage: {
         localAttempted: true, localStatus: 'interface_changed', localHitCount: 0,
-        notices: expect.arrayContaining([expect.stringContaining('1 query group was omitted')]),
+        notices: expect.any(Array),
       },
     });
     expect(JSON.stringify(result)).not.toContain('q5');
@@ -445,10 +448,10 @@ describe('primary_source_search handler', () => {
 
     expect(result.structuredContent).toMatchObject({
       planStatus: 'partial',
-      queries: [{ providers: [{ provider: 'local', status: 'interface_changed', hitCount: 0 }] }],
+      queries: [{ providers: [{ provider: 'local', status: 'no_results', hitCount: 0 }] }],
       coverage: {
         localAttempted: true, localStatus: 'interface_changed', localHitCount: 0,
-        notices: expect.arrayContaining([expect.stringContaining('2 duplicate local result groups were omitted from query q1')]),
+        notices: expect.any(Array),
       },
     });
     expect(JSON.stringify(result)).not.toContain('Omitted third-provider evidence');
@@ -456,14 +459,59 @@ describe('primary_source_search handler', () => {
     expect(result.content).toHaveLength(1);
     expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
   });
+
+  it('keeps the complete MCP delivery envelope within the shared byte budget under maximum link metadata', async () => {
+    const title = 'T'.repeat(300);
+    const sectionLabel = 'S'.repeat(300);
+    const documentId = `doc-${'d'.repeat(150)}`;
+    const hitFor = (queryId: string, rank: number) => {
+      const sectionId = `section-${rank}-${'s'.repeat(145)}`;
+      return {
+        queryId, provider: 'local' as const, title, sectionLabel, snippet: 'N'.repeat(240),
+        rankWithinProvider: rank, page: 1, snippetOnly: true as const, attribution: 'A'.repeat(300),
+        documentType: 'D'.repeat(100), documentDate: 'Y'.repeat(100), resourceSizeBytes: 123,
+        locator: {
+          kind: 'local_section' as const, documentId, sectionId,
+          url: `theologai://documents/${documentId}#section-${sectionId}`,
+        },
+      };
+    };
+    const queries = Array.from({ length: 4 }, (_, queryIndex) => {
+      const id = `q${queryIndex + 1}`;
+      const hits = Array.from({ length: 8 }, (_, index) => hitFor(id, index + 1));
+      return {
+        id, normalizedMode: 'all_terms' as const, normalizedSelection: 'relevance' as const,
+        providers: [{
+          provider: 'local' as const, status: 'ok' as const, searched: true, page: 1,
+          hitCount: hits.length, hits, notices: [], resultWindow: resultWindow(hits.length),
+          scope: {
+            status: 'matched' as const, requested: {}, eligibleDocumentCount: 5,
+            eligibleDocuments: Array.from({ length: 5 }, (_, index) => ({
+              id: `scope-${index}`, title, metadataStatus: 'reviewed' as const,
+            })),
+            eligibleDocumentsTruncated: false,
+          },
+        }],
+      };
+    });
+    const result = await createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue({
+      planStatus: 'complete', queries,
+      coverage: { localAttempted: true, localHitCount: 32, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+    }) } as any).handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local'] }] });
+
+    expect(new TextEncoder().encode(JSON.stringify(result)).byteLength).toBeLessThanOrEqual(32_768);
+    expect(result.content.filter(block => block.type === 'resource_link').length).toBeLessThanOrEqual(8);
+    expect((result.structuredContent as any).responseWindow.maximum).toBe(32_768);
+    expect(validatorFor(createPrimarySourceSearchHandler({ search: vi.fn() } as any).outputSchema!)(result.structuredContent).valid).toBe(true);
+  });
 });
 
-describe('primary_source_search v4 contract', () => {
-  const v4 = {
+describe('primary_source_search v5 discovery contract', () => {
+  const v5 = {
     exposeCcelDiscovery: true,
     ccelLiveSearch: false,
     ccelCoordinator: false,
-    contractVersion: '4' as const,
+    contractVersion: '5' as const,
     liveCcelEnabled: false,
   };
 
@@ -499,9 +547,9 @@ describe('primary_source_search v4 contract', () => {
     };
   }
 
-  it('advertises strict v4 providers and open-world behavior', () => {
-    const handler = createPrimarySourceSearchHandler({ search: vi.fn() } as any, v4);
-    expect(handler.outputSchema?.properties?.schemaVersion).toEqual({ const: '4' });
+  it('advertises strict v5 providers and open-world behavior', () => {
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn() } as any, v5);
+    expect(handler.outputSchema?.properties?.schemaVersion).toEqual({ const: '5' });
     expect(handler.annotations).toMatchObject({ openWorldHint: true });
     const query = (handler.inputSchema.properties?.queries as any).items;
     expect(query.properties.providers).toMatchObject({ maxItems: 2, items: { enum: ['local', 'ccel'] } });
@@ -518,23 +566,23 @@ describe('primary_source_search v4 contract', () => {
   });
 
   it('uses exact compact JSON parity and emits native links only for final local hits', async () => {
-    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(plan()) } as any, v4);
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(plan()) } as any, v5);
     const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local', 'ccel'] }] });
-    expect(result.content[0]).toEqual({ type: 'text', text: JSON.stringify(result.structuredContent) });
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('# Primary-source discovery') });
     expect(result.content.filter(item => item.type === 'resource_link')).toHaveLength(1);
     expect(JSON.stringify(result.content.slice(1))).not.toContain('ccel.org');
     expect(result.structuredContent).toMatchObject({
-      schemaVersion: '4', responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
+      schemaVersion: '5', responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
       queries: [{ providers: [
         { hits: [{ locator: { kind: 'mcp_resource', uri: 'theologai://documents/doc#section-1' } }] },
         { hits: [{ locator: { kind: 'external_url', url: 'https://ccel.org/ccel/calvin/institutes/iv.xvii.html' } }] },
       ] }],
     });
-    expect(new TextEncoder().encode((result.content[0] as { text: string }).text).byteLength).toBeLessThanOrEqual(32768);
+    expect(new TextEncoder().encode((result.content[0] as { text: string }).text).byteLength).toBeLessThanOrEqual(4096);
     expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
   });
 
-  it('omits control-only optional metadata while preserving a schema-valid v4 hit', async () => {
+  it('omits control-only optional metadata while preserving a schema-valid v5 hit', async () => {
     const adversarial = plan();
     const local = adversarial.queries[0]!.providers[0]!;
     const hit = local.hits[0]!;
@@ -545,7 +593,7 @@ describe('primary_source_search v4 contract', () => {
     adversarial.queries[0]!.providers = [local];
     adversarial.coverage.ccelAttempted = false;
     adversarial.coverage.ccelHitCount = 0;
-    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(adversarial) } as any, v4);
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(adversarial) } as any, v5);
 
     const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local'] }] });
     const structured = result.structuredContent as any;
@@ -555,7 +603,7 @@ describe('primary_source_search v4 contract', () => {
     expect(sanitized).not.toHaveProperty('documentType');
     expect(sanitized).not.toHaveProperty('documentDate');
     expect(structured).toMatchObject({ planStatus: 'partial', responseWindow: { truncated: true } });
-    expect(result.content[0]).toEqual({ type: 'text', text: JSON.stringify(structured) });
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('# Primary-source discovery') });
     expect(validatorFor(handler.outputSchema!)(structured).valid).toBe(true);
   });
 
@@ -569,10 +617,10 @@ describe('primary_source_search v4 contract', () => {
       provider.hits = [] as never;
       provider.resultWindow = { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' };
     }
-    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(unavailable) } as any, v4);
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(unavailable) } as any, v5);
     const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local', 'ccel'] }] });
     expect(result.isError).toBe(true);
-    expect(result.content[0]).toEqual({ type: 'text', text: JSON.stringify(result.structuredContent) });
+    expect(result.content[0]).toMatchObject({ type: 'text', text: expect.stringContaining('# Primary-source discovery') });
     expect(validatorFor(handler.outputSchema!)(result.structuredContent).valid).toBe(true);
   });
 
@@ -585,7 +633,7 @@ describe('primary_source_search v4 contract', () => {
       hits: [], notices: [], retryAfterSeconds: 7,
     }];
     rateLimited.coverage = { localAttempted: false, localHitCount: 0, ccelAttempted: true, ccelHitCount: 0, notices: [] };
-    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(rateLimited) } as any, v4);
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(rateLimited) } as any, v5);
     const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['ccel'] }] });
     const validate = validatorFor(handler.outputSchema!);
     expect(validate(result.structuredContent).valid).toBe(true);
@@ -605,7 +653,7 @@ describe('primary_source_search v4 contract', () => {
     'https://ccel.org/ccel/calvin/institutes/iv.xvii.html?token=secret',
     'https://ccel.org.evil.test/ccel/calvin/institutes/iv.xvii.html',
   ])('omits a malicious external locator without emitting a link (%s)', async externalUrl => {
-    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(plan(externalUrl)) } as any, v4);
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(plan(externalUrl)) } as any, v5);
     const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['local', 'ccel'] }] });
     expect(JSON.stringify(result)).not.toContain(externalUrl);
     expect(result.structuredContent).toMatchObject({ planStatus: 'partial', queries: [{ providers: [{ hitCount: 1 }, { status: 'interface_changed', hitCount: 0 }] }] });
@@ -623,7 +671,7 @@ describe('primary_source_search v4 contract', () => {
         hits: external.hits.map(hit => ({ ...hit, queryId: 'q2' })),
       }],
     });
-    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(adversarial) } as any, v4);
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn().mockResolvedValue(adversarial) } as any, v5);
     const result = await handler.handler({ queries: [{ id: 'q1', text: 'faith', providers: ['ccel'] }] });
     const structured = result.structuredContent as any;
     expect(structured.queries.flatMap((query: any) => query.providers)

--- a/test/unit/tools/worker/compositionRoot.test.ts
+++ b/test/unit/tools/worker/compositionRoot.test.ts
@@ -152,13 +152,13 @@ describe('createWorkerCompositionRoot', () => {
   });
 
   describe('primary-source public provider contract', () => {
-    it('keeps the production-default contract at v3 with CCEL unadvertised', () => {
+    it('keeps the production-default contract at v4 with CCEL unadvertised', () => {
       const root = createWorkerCompositionRoot(makeEnv());
       expect(root.primarySourceContract).toEqual({
         exposeCcelDiscovery: false,
         ccelLiveSearch: false,
         ccelCoordinator: false,
-        contractVersion: '3',
+        contractVersion: '4',
         liveCcelEnabled: false,
       });
       const tool = root.tools.find(candidate => candidate.name === 'primary_source_search')!;
@@ -168,7 +168,7 @@ describe('createWorkerCompositionRoot', () => {
       expect(item.properties.page.description).toContain('only page 1');
     });
 
-    it('exposes preview v4 while adapter and Durable Object lookup remain unreachable at 100', async () => {
+    it('exposes preview v5 while adapter and Durable Object lookup remain unreachable at 100', async () => {
       const getByName = vi.fn();
       const root = createWorkerCompositionRoot(makeEnv({
         THEOLOGAI_EXPOSE_CCEL_DISCOVERY: 'true',
@@ -176,9 +176,9 @@ describe('createWorkerCompositionRoot', () => {
         THEOLOGAI_ENABLE_CCEL_COORDINATOR: 'false',
         THEOLOGAI_CCEL_COORDINATOR: { getByName } as any,
       }));
-      expect(root.primarySourceContract).toMatchObject({ contractVersion: '4', liveCcelEnabled: false });
+      expect(root.primarySourceContract).toMatchObject({ contractVersion: '5', liveCcelEnabled: false });
       const tool = root.tools.find(candidate => candidate.name === 'primary_source_search')!;
-      expect(tool.outputSchema?.properties?.schemaVersion).toEqual({ const: '4' });
+      expect(tool.outputSchema?.properties?.schemaVersion).toEqual({ const: '5' });
       expect(tool.annotations?.openWorldHint).toBe(true);
       await tool.handler({ queries: [{ id: 'remote', text: 'grace', providers: ['ccel'] }] });
       // Fetch is owned by the adapter. Proving the adapter and namespace lookup

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -212,7 +212,7 @@ describe('Worker MCP endpoint in workerd', () => {
       .find(tool => tool.name === 'primary_source_search')!;
     expect(primarySourceTool).toMatchObject({
       annotations: { openWorldHint: true },
-      outputSchema: { properties: { schemaVersion: { const: '4' } } },
+      outputSchema: { properties: { schemaVersion: { const: '5' } } },
     });
     expect((((primarySourceTool.inputSchema as any).properties.queries.items)
       .properties.providers.items.enum)).toEqual(['local', 'ccel']);

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -68,27 +68,30 @@ async function rateLimitKey(ip: string, userAgent: string): Promise<string> {
 }
 
 describe('Worker MCP endpoint in workerd', () => {
-  it('executes the checked-in preview v4 contract without enabling live CCEL', async () => {
+  it('executes the checked-in preview v5 contract without enabling live CCEL', async () => {
     expect(env.THEOLOGAI_EXPOSE_CCEL_DISCOVERY).toBe('true');
     expect(env.THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH).toBe('false');
     expect(env.THEOLOGAI_ENABLE_CCEL_COORDINATOR).toBe('false');
     const root = createWorkerCompositionRoot(env as unknown as Env);
     expect(root.primarySourceContract).toMatchObject({
-      contractVersion: '4',
+      contractVersion: '5',
       liveCcelEnabled: false,
     });
     const tool = root.tools.find(candidate => candidate.name === 'primary_source_search')!;
-    expect(tool.outputSchema?.properties?.schemaVersion).toEqual({ const: '4' });
+    expect(tool.outputSchema?.properties?.schemaVersion).toEqual({ const: '5' });
     expect(tool.annotations).toMatchObject({ openWorldHint: true });
     const result = await tool.handler({ queries: [{ id: 'external', text: 'grace', providers: ['ccel'] }] });
     expect(result).toMatchObject({
       isError: true,
       structuredContent: {
-        schemaVersion: '4', planStatus: 'unavailable',
+        schemaVersion: '5', planStatus: 'unavailable',
         coverage: { ccelAttempted: false, ccelStatus: 'disabled', ccelHitCount: 0 },
       },
     });
-    expect(result.content[0]).toEqual({ type: 'text', text: JSON.stringify(result.structuredContent) });
+    expect(result.content[0]).toMatchObject({
+      type: 'text',
+      text: expect.stringContaining('CCEL discovery lead: **disabled**'),
+    });
   });
 
   it('provides the configured rate-limit binding in the Workers runtime', async () => {
@@ -396,9 +399,27 @@ describe('Worker MCP endpoint in workerd', () => {
 
     const catalog = await rpc('resources/read', { uri: 'theologai://primary-sources/catalog' }, 40);
     expect(catalog.response.status).toBe(200);
-    expect(JSON.parse(String((catalog.message.result?.contents as Array<{ text: string }>)[0].text))).toMatchObject({
-      schemaVersion: '1', kind: 'local_primary_source_catalog', workCount: 1,
-      policies: { scope: 'hosted_collection_only', rightsStatus: 'not_established' },
+    expect(JSON.parse(String((catalog.message.result?.contents as Array<{ text: string }>)[0].text))).toEqual({
+      schemaVersion: '2', kind: 'local_primary_source_catalog', workCount: 1,
+      works: [{
+        id: 'apostles-creed', title: "Apostles' Creed", documentType: 'Creed',
+        lookupAliases: ["The Apostles' Creed", "Apostles' Creed", 'Apostles Creed'],
+        composition: { label: 'Before the end of the 4th century (present form)' },
+        creators: [], metadataStatus: 'anonymous',
+        metadataProvenanceIds: ['hist-meta-crc-apostles'],
+        editionReadiness: {
+          foundation: 'edition-provenance-foundation.v1', editionIdentity: 'not_established',
+          provenance: 'incomplete', exactArtifactRights: 'not_established_by_this_contract',
+        },
+      }],
+      policies: {
+        scope: 'hosted_collection_only', lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+        editionProvenance: 'incomplete', rightsStatus: 'not_established',
+        editionReadiness: {
+          foundation: 'edition-provenance-foundation.v1', editionIdentity: 'not_established',
+          provenance: 'incomplete', exactArtifactRights: 'not_established_by_this_contract',
+        },
+      },
     });
 
     const read = await rpc('resources/read', {
@@ -775,7 +796,7 @@ describe('Worker MCP endpoint in workerd', () => {
         }),
       ],
       structuredContent: {
-        schemaVersion: '4', kind: 'primary_source_search', planStatus: 'complete',
+        schemaVersion: '5', kind: 'primary_source_search', planStatus: 'complete',
         responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
         queries: [expect.objectContaining({
           normalizedSelection: 'relevance',
@@ -785,21 +806,33 @@ describe('Worker MCP endpoint in workerd', () => {
             hits: [expect.objectContaining({ documentType: 'Creed', documentDate: 'c. 390' })],
           })],
         })],
-        coverage: expect.any(Object),
+        coverage: expect.objectContaining({
+          localAttempted: true, localHitCount: 1,
+          ccelAttempted: false, ccelHitCount: 0,
+          serverObserved: {
+            searched: [expect.objectContaining({ queryId: 'creed', provider: 'local', returnedHitCount: 1 })],
+            notSearched: [],
+          },
+        }),
         evidencePolicy: {
           snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read',
           externalSectionAccess: 'direct_url_only', coverageScope: 'bounded_non_exhaustive',
           externalRightsStatus: 'not_determined',
           lookupAliasUse: 'exact_routing_only_not_metadata_evidence',
+          coverageLedger: {
+            searched: 'server_observed_provider_execution',
+            read: 'host_observed_successful_exact_resource_or_page_read',
+            deferred: 'host_recorded_intentional_deferral',
+            notSearched: 'server_observed_provider_non_execution',
+          },
         },
       },
     });
-    expect((result.message.result?.content as Array<Record<string, unknown>>)[0]).toEqual({
-      type: 'text',
-      text: JSON.stringify(result.message.result?.structuredContent),
+    expect((result.message.result?.content as Array<Record<string, unknown>>)[0]).toMatchObject({
+      type: 'text', text: expect.stringContaining('# Primary-source discovery'),
     });
     expect(Object.keys((result.message.result?.structuredContent as any).coverage).sort()).toEqual([
-      'ccelAttempted', 'ccelHitCount', 'localAttempted', 'localHitCount', 'localStatus', 'notices',
+      'ccelAttempted', 'ccelHitCount', 'localAttempted', 'localHitCount', 'localStatus', 'notices', 'serverObserved',
     ]);
     const blocks = result.message.result?.content as Array<Record<string, unknown>>;
     const link = blocks.find(block => block.type === 'resource_link')!;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -95,7 +95,7 @@ THEOLOGAI_VERSION = "3.6.0-preview"
 THEOLOGAI_ALLOWED_ORIGINS = "https://theologai.xyz,https://theologai.pages.dev"
 THEOLOGAI_MAX_REQUEST_BYTES = "1048576"
 THEOLOGAI_REQUEST_LOGS = "true"
-# Preview exposes the v4 discovery contract for schema/workflow verification.
+# Preview exposes the v5 discovery contract for schema/workflow verification.
 # Live search and coordinator execution remain separately disabled below.
 THEOLOGAI_EXPOSE_CCEL_DISCOVERY = "true"
 THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH = "false"


### PR DESCRIPTION
## Summary
- derive production local-only schema v4 and preview discovery schema v5 from the same Worker SHA
- add fail-closed local and external edition-readiness disclosures, exact MCP resource locators, catalog v2, and honest coverage ledgers
- keep CCEL execution behind all existing gates while preview discovery remains no-call
- update guided prompts, confession-study workflow, fallback rendering, and byte-budgeted standard resource links

## Release model
- production flags 000 => local-only v4
- preview flags 100 => discovery v5, live CCEL execution disabled
- no legacy output mode

## Out of scope
- no corpus, migration, D1, route, domain, secret, live CCEL, or deployment changes

## Verification
- Node and Worker type checks passed
- 265 focused final-review tests passed; broader targeted suites passed during implementation
- independent Sol final rereview: GO, zero P0-P3 findings
- clean-install CI is authoritative for workerd because the local shared dependency tree is stale
