### PR TITLE
Redirect legacy Worker traffic

### DIFF
--- a/docs/CUSTOM-DOMAIN-MIGRATION.md
+++ b/docs/CUSTOM-DOMAIN-MIGRATION.md
@@ -1,10 +1,11 @@
 # Custom-domain migration and rollback
 
-This runbook governs the infrastructure-only migration to `theologai.xyz`.
-It must not be combined with application behavior, database, corpus,
-rate-limit, CCEL, dependency, or feature changes. No existing route, domain,
-deployment, database, or compatibility endpoint may be deleted without
-separate owner approval.
+This runbook governs the infrastructure-only migration to `theologai.xyz` and
+the separately reviewed, post-migration legacy-host redirect window. The
+initial domain migration must not be combined with application behavior,
+database, corpus, rate-limit, CCEL, dependency, or feature changes. No existing
+route, domain, deployment, database, or compatibility endpoint may be deleted
+without separate owner approval.
 
 ## Address and ownership map
 
@@ -15,7 +16,7 @@ separate owner approval.
 | `https://mcp.theologai.xyz/mcp` | Production Worker `theologai` | Canonical production MCP endpoint. |
 | `https://preview-mcp.theologai.xyz/mcp` | Preview Worker `theologai-preview` | Canonical preview MCP endpoint. |
 | `https://theologai.pages.dev/` | Existing Pages project | Website compatibility and rollback alias. |
-| `https://theologai.tjfrederick.workers.dev/mcp` | Production Worker | Production compatibility and rollback alias. |
+| `https://theologai.tjfrederick.workers.dev/mcp` | Production Worker | Temporary 308 migration alias; the confirmed abusive poller is rejected before redirect. |
 | `https://theologai-preview.tjfrederick.workers.dev/mcp` | Preview Worker | Preview compatibility and rollback alias. |
 
 The apex Pages custom domain and Worker custom-domain subdomains do not compete:
@@ -167,15 +168,40 @@ declaration skips the gate.
 After both custom MCP domains pass independent black-box audit, make the custom
 URLs canonical in clients and documentation. Preserve the old URL alongside
 each client entry as a commented or separately named rollback target where the
-client format allows it. Reconnect and reinitialize MCP sessions after changing
-a URL; cached capability inventories are not migration evidence.
+client format allows it until the temporary redirect window begins. Once the
+redirect is active, restoring direct legacy service requires reverting the
+migration gate or restoring the preceding Worker version. Reconnect and
+reinitialize MCP sessions after changing a URL; cached capability inventories
+are not migration evidence.
+
+## Temporary legacy-host redirect window
+
+During the client cutover window, the production Worker handles the legacy
+`workers.dev` hostname before origin validation, rate limiting, request-body
+reads, or MCP construction:
+
+- The exact IP and user-agent tuple of the AWS Frankfurt poller observed on
+  2026-07-17 receives `410 Gone` on the legacy hostname and `403 Forbidden` on
+  any other hostname.
+- Every other method and path on the legacy hostname receives `308 Permanent
+  Redirect` to the same path and query on `https://mcp.theologai.xyz`.
+- Preview hostnames are not redirected.
+
+Monitor status codes and host traffic throughout the window. Once legitimate
+legacy traffic has fallen to an acceptable level, obtain owner approval to set
+`workers_dev = false`, remove the temporary poller rule, and update this runbook.
+The redirect and block reduce application work but still count as legacy Worker
+invocations until the `workers.dev` route is disabled.
 
 ## Rollback
 
 Domain rollback does not require deleting anything:
 
-1. Point affected MCP clients back to the matching `workers.dev` compatibility
-   alias, or the website back to `theologai.pages.dev`.
+1. Before the temporary redirect window, point affected MCP clients back to the
+   matching `workers.dev` compatibility alias. During the redirect window,
+   revert the migration gate or restore the preceding Worker version before
+   using that alias. The website can independently return to
+   `theologai.pages.dev`.
 2. If the new Worker version itself is unhealthy, restore PR #50 production
    Worker version `32520410-d363-4b2b-83d1-cb7613eab2f1` with its unchanged
    production D1, or the recorded preview baseline with its unchanged preview

--- a/docs/CUSTOM-DOMAIN-MIGRATION.md
+++ b/docs/CUSTOM-DOMAIN-MIGRATION.md
@@ -32,26 +32,37 @@ custom-domain attachment, and the optional `www` redirect may require manual
 Cloudflare dashboard action even though Worker routes are declared in
 `wrangler.toml`.
 
-## Known-good pre-migration baseline
+## Release-time known-good baseline
 
-The rollback anchor is PR #50 merge
-`16e633bc70dbbea668caacf87f994a2536441092`, protected production run
-`29527760541`, GitHub deployment `5479150556`, Cloudflare deployment
-`5822242e-d0bf-43a9-bbbc-0ec7d6edd180`, and production Worker version
-`32520410-d363-4b2b-83d1-cb7613eab2f1` at 100%. It uses production D1
+The rollback anchor is deliberately a release-time record, not a stale version
+in this document. Immediately before the temporary redirect is deployed, the
+release coordinator must capture in the protected production approval and
+deployment comment:
+
+- the exact approved production source SHA and the immediately preceding
+  known-good production release (the post-PR #70 release if that is the chosen
+  predecessor);
+- the GitHub Actions run, GitHub deployment, Cloudflare deployment, Worker
+  version, and 100% traffic assignment for that predecessor;
+- production D1 name and ID, rate-limit namespace and policy, CCEL flags, and
+  custom-domain state; and
+- the fresh initialization, CORS, representative-tool, and black-box audit
+  evidence for that predecessor.
+
+Do not substitute an historical deployment identifier for this record. If the
+planned predecessor is not yet released or has not passed its audit, capture
+the actual approved predecessor immediately before release and stop if it is
+not a suitable rollback target. The production D1 remains
 `theologai-production-20260715-a`
 (`c6535a4a-1953-4279-b277-7368445fc61a`), rate namespace `361201` at 120/60,
-and CCEL flags `000`. Its post-deployment black-box audit passed 72/72
-assertions with no P0-P3 findings: parallel-text 44/44, protocol/inventory/CCEL
-9/9, and HTTP/CORS/negotiation/under-budget rate behavior 19/19.
+and CCEL flags `000` unless a separately reviewed release changes one of them.
 
-Preview remains Worker version `50bdd564-63da-4461-9a5b-73c61f26f7e6`, D1
+A preview deployment necessarily creates a new Worker version. Record that
+version after each preview deployment; preview must continue to use D1
 `theologai-preview-20260714-a`
 (`0dab804f-8df0-4727-93bd-299612b6e179`), rate namespace `361202`, and CCEL
-flags `100`. A preview deployment necessarily creates a new Worker version;
-record that version after deployment. The preview D1, rate namespace, CCEL
-flags, and environment ownership—not the previous Worker version—must remain
-invariant through domain attachment.
+flags `100`. Those bindings and environment ownership—not a prior Worker
+version—must remain invariant through this migration.
 
 ## Reviewable phase split
 
@@ -181,11 +192,49 @@ During the client cutover window, the production Worker handles the legacy
 reads, or MCP construction:
 
 - The exact IP and user-agent tuple of the AWS Frankfurt poller observed on
-  2026-07-17 receives `410 Gone` on the legacy hostname and `403 Forbidden` on
-  any other hostname.
+  2026-07-17 receives `410 Gone` on the legacy production hostname and `403
+  Forbidden` on the production custom hostname. The tuple is never blocked on
+  preview or arbitrary hostnames.
 - Every other method and path on the legacy hostname receives `308 Permanent
   Redirect` to the same path and query on `https://mcp.theologai.xyz`.
-- Preview hostnames are not redirected.
+- A browser preflight from an exact configured website origin to `/` or `/mcp`
+  receives the existing `204` CORS response instead of a cross-origin redirect.
+  An actual legacy request still receives the redirect with the same exact
+  `Access-Control-Allow-Origin` and `Vary: Origin` behavior. Untrusted origins
+  are never reflected.
+- Preview hostnames are not redirected. This does not make the temporary
+  redirect an authentication migration: browsers and client libraries can strip
+  or decline to forward origin-scoped `Authorization` credentials across a
+  hostname redirect. The current endpoint is anonymous; a future authenticated
+  client must move directly to the canonical URL rather than rely on this
+  redirect.
+- The redirect uses `Cache-Control: no-store` throughout burn-in. Its effective
+  shared/browser cache horizon is zero even though the status is `308`. Do not
+  raise that horizon in this release. A separately reviewed change may use a
+  short cache only after at least seven full days of clean redirect telemetry,
+  no unresolved CORS/client reports, and explicit owner approval.
+
+### Burn-in telemetry
+
+The sampled guard diagnostic is the existing Cloudflare Workers Observability
+Query Builder for Worker `theologai`, using its configured 25% head-sampled
+invocation logs. Save and run this bounded query over 15-minute and 24-hour
+windows:
+
+```text
+$workers.event.response.status = 308 OR $workers.event.response.status = 410
+```
+
+Group by `$workers.event.response.status` and
+`$workers.event.request.path`; use the Worker Metrics request-count chart for
+the unsampled aggregate invocation trend. The routing invariant makes the
+sampled diagnostic host and guard-specific without collecting client identity:
+only the production legacy hostname emits `308`, and only its exact poller
+tuple emits `410`. Production-custom-host poller blocks are `403` and must not
+be counted from the generic `403` population. Never treat this sampled view as
+an exact billing, invocation, or guard-block count, and do not raise log
+sampling merely to observe this migration. Keep `THEOLOGAI_REQUEST_LOGS`
+disabled in production.
 
 Monitor status codes and host traffic throughout the window. Once legitimate
 legacy traffic has fallen to an acceptable level, obtain owner approval to set
@@ -202,10 +251,10 @@ Domain rollback does not require deleting anything:
    revert the migration gate or restore the preceding Worker version before
    using that alias. The website can independently return to
    `theologai.pages.dev`.
-2. If the new Worker version itself is unhealthy, restore PR #50 production
-   Worker version `32520410-d363-4b2b-83d1-cb7613eab2f1` with its unchanged
-   production D1, or the recorded preview baseline with its unchanged preview
-   D1. Re-run readiness before any Worker rollback.
+2. If the new Worker version itself is unhealthy, restore the exact
+   release-time production baseline recorded above with its unchanged production
+   D1, or the recorded preview baseline with its unchanged preview D1. Re-run
+   readiness before any Worker rollback.
 3. Disable or detach a custom hostname only after explicit owner approval; do
    not delete its DNS record, route, certificate, deployment, or legacy alias as
    an automatic rollback step.

--- a/src/http/worker/legacyEndpoint.ts
+++ b/src/http/worker/legacyEndpoint.ts
@@ -1,10 +1,17 @@
-import type { GuardResponse } from './requestPolicy.js';
+import type { Env } from '../../worker-env.js';
+import {
+  getAllowedCorsOrigin,
+  isAllowedMcpPath,
+  responseWithCors,
+  type GuardResponse,
+} from './requestPolicy.js';
 
 export const LEGACY_PRODUCTION_HOST = 'theologai.tjfrederick.workers.dev';
 export const PRIMARY_PRODUCTION_HOST = 'mcp.theologai.xyz';
 
 // Temporary migration guard for the confirmed AWS Frankfurt poller observed
-// on 2026-07-17. Remove this rule when the legacy workers.dev route is retired.
+// on 2026-07-17. Remove this rule only when the legacy workers.dev route is
+// retired with separate owner approval.
 const ABUSIVE_POLLER_IP = '18.192.206.183';
 const ABUSIVE_POLLER_USER_AGENT = 'Go-http-client/2.0';
 
@@ -17,14 +24,19 @@ function isAbusivePoller(request: Request): boolean {
  * Short-circuit the confirmed abusive poller and migrate all other callers of
  * the production workers.dev alias to the canonical custom domain.
  */
-export function getLegacyEndpointResponse(request: Request): GuardResponse | null {
+export function getLegacyEndpointResponse(env: Env, request: Request): GuardResponse | null {
   const url = new URL(request.url);
+  const isLegacyHost = url.hostname === LEGACY_PRODUCTION_HOST;
+  const isPrimaryHost = url.hostname === PRIMARY_PRODUCTION_HOST;
+  const allowedOrigin = getAllowedCorsOrigin(env, request.headers.get('Origin'));
 
-  if (isAbusivePoller(request)) {
-    const isLegacyRequest = url.hostname === LEGACY_PRODUCTION_HOST;
+  // This identity is intentionally scoped to the two production hosts. The
+  // preview alias and arbitrary custom hosts must never inherit a production
+  // traffic block merely because a caller can reproduce its headers.
+  if ((isLegacyHost || isPrimaryHost) && isAbusivePoller(request)) {
     return {
-      response: new Response(isLegacyRequest ? 'Gone' : 'Forbidden', {
-        status: isLegacyRequest ? 410 : 403,
+      response: responseWithCors(allowedOrigin, isLegacyHost ? 'Gone' : 'Forbidden', {
+        status: isLegacyHost ? 410 : 403,
         headers: {
           'Cache-Control': 'private, no-store',
           'Content-Type': 'text/plain; charset=utf-8',
@@ -34,16 +46,32 @@ export function getLegacyEndpointResponse(request: Request): GuardResponse | nul
     };
   }
 
-  if (url.hostname !== LEGACY_PRODUCTION_HOST) return null;
+  if (!isLegacyHost) return null;
+
+  // Redirecting an OPTIONS preflight across origins is not broadly supported
+  // by browsers. Preserve the server's existing CORS contract for its two MCP
+  // paths instead, while keeping native OPTIONS callers on the redirect path.
+  if (request.method === 'OPTIONS' && allowedOrigin && isAllowedMcpPath(url.pathname)) {
+    return {
+      response: responseWithCors(allowedOrigin, null, {
+        status: 204,
+        headers: { 'Cache-Control': 'no-store' },
+      }),
+      reason: 'legacy_host_preflight',
+    };
+  }
 
   url.protocol = 'https:';
   url.host = PRIMARY_PRODUCTION_HOST;
 
   return {
-    response: new Response(null, {
+    response: responseWithCors(allowedOrigin, null, {
       status: 308,
       headers: {
-        'Cache-Control': 'public, max-age=3600',
+        // A 308 has permanent semantics, but the migration is deliberately
+        // reversible during burn-in. Do not let browsers or intermediaries
+        // retain it beyond this individual response.
+        'Cache-Control': 'no-store',
         Location: url.toString(),
       },
     }),

--- a/src/http/worker/legacyEndpoint.ts
+++ b/src/http/worker/legacyEndpoint.ts
@@ -1,0 +1,52 @@
+import type { GuardResponse } from './requestPolicy.js';
+
+export const LEGACY_PRODUCTION_HOST = 'theologai.tjfrederick.workers.dev';
+export const PRIMARY_PRODUCTION_HOST = 'mcp.theologai.xyz';
+
+// Temporary migration guard for the confirmed AWS Frankfurt poller observed
+// on 2026-07-17. Remove this rule when the legacy workers.dev route is retired.
+const ABUSIVE_POLLER_IP = '18.192.206.183';
+const ABUSIVE_POLLER_USER_AGENT = 'Go-http-client/2.0';
+
+function isAbusivePoller(request: Request): boolean {
+  return request.headers.get('CF-Connecting-IP') === ABUSIVE_POLLER_IP
+    && request.headers.get('User-Agent') === ABUSIVE_POLLER_USER_AGENT;
+}
+
+/**
+ * Short-circuit the confirmed abusive poller and migrate all other callers of
+ * the production workers.dev alias to the canonical custom domain.
+ */
+export function getLegacyEndpointResponse(request: Request): GuardResponse | null {
+  const url = new URL(request.url);
+
+  if (isAbusivePoller(request)) {
+    const isLegacyRequest = url.hostname === LEGACY_PRODUCTION_HOST;
+    return {
+      response: new Response(isLegacyRequest ? 'Gone' : 'Forbidden', {
+        status: isLegacyRequest ? 410 : 403,
+        headers: {
+          'Cache-Control': 'private, no-store',
+          'Content-Type': 'text/plain; charset=utf-8',
+        },
+      }),
+      reason: 'blocked_abusive_poller',
+    };
+  }
+
+  if (url.hostname !== LEGACY_PRODUCTION_HOST) return null;
+
+  url.protocol = 'https:';
+  url.host = PRIMARY_PRODUCTION_HOST;
+
+  return {
+    response: new Response(null, {
+      status: 308,
+      headers: {
+        'Cache-Control': 'public, max-age=3600',
+        Location: url.toString(),
+      },
+    }),
+    reason: 'legacy_host_redirect',
+  };
+}

--- a/src/http/worker/requestPolicy.ts
+++ b/src/http/worker/requestPolicy.ts
@@ -31,6 +31,21 @@ function getAllowedOrigins(env: Env): Set<string> {
   return new Set(origins.filter(Boolean));
 }
 
+/**
+ * Return an exact configured browser origin, never a caller-supplied value.
+ *
+ * The legacy-host migration uses this before the normal request guard so a
+ * browser that still has the old endpoint can complete its preflight without
+ * reflecting an untrusted Origin on a redirect response.
+ */
+export function getAllowedCorsOrigin(env: Env, origin: string | null): string | null {
+  return origin && getAllowedOrigins(env).has(origin) ? origin : null;
+}
+
+export function isAllowedMcpPath(pathname: string): boolean {
+  return ALLOWED_PATHS.has(pathname);
+}
+
 function mergeVary(current: string | null, value: string): string {
   const values = new Set((current ?? '').split(',').map(entry => entry.trim()).filter(Boolean));
   values.add(value);
@@ -71,9 +86,7 @@ export function getEarlyResponse(
 ): GuardResponse | null {
   const url = new URL(request.url);
   const origin = request.headers.get('Origin');
-  const allowedOrigin = origin && getAllowedOrigins(env).has(origin)
-    ? origin
-    : null;
+  const allowedOrigin = getAllowedCorsOrigin(env, origin);
 
   if (origin && !allowedOrigin) {
     return {
@@ -85,7 +98,7 @@ export function getEarlyResponse(
     };
   }
 
-  if (!ALLOWED_PATHS.has(url.pathname)) {
+  if (!isAllowedMcpPath(url.pathname)) {
     return {
       response: responseWithCors(allowedOrigin, 'Not found', {
         status: 404,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -28,6 +28,24 @@ import { handleCcelOperatorRequest } from './http/worker/ccelOperator.js';
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     void ctx;
+    // The production legacy-host guard must precede every application route,
+    // including the signed operator path. That keeps migration redirects and
+    // the exact poller block outside body reads, limiters, and Durable Objects.
+    const legacyEndpointResponse = getLegacyEndpointResponse(env, request);
+    if (legacyEndpointResponse) {
+      const startedAt = Date.now();
+      const metadata = getWorkerRequestMetadata(request);
+      logWorkerRequestEvent(env, metadata, { event: 'theologai.worker.request.start' });
+      logWorkerRequestEvent(env, metadata, {
+        event: 'theologai.worker.request.complete',
+        status: legacyEndpointResponse.response.status,
+        guarded: true,
+        guardReason: legacyEndpointResponse.reason,
+        durationMs: Date.now() - startedAt,
+      });
+      return legacyEndpointResponse.response;
+    }
+
     // This signed, fail-closed route is outside public MCP telemetry and its
     // limiter; the handler applies a distinct fail-closed pre-auth budget.
     const operatorResponse = await handleCcelOperatorRequest(request, env);
@@ -54,15 +72,6 @@ export default {
     };
 
     try {
-      const legacyEndpointResponse = getLegacyEndpointResponse(request);
-      if (legacyEndpointResponse) {
-        return complete(
-          legacyEndpointResponse.response,
-          true,
-          legacyEndpointResponse.reason,
-        );
-      }
-
       const earlyResponse = getEarlyResponse(env, request, metadata);
       if (earlyResponse) {
         return complete(earlyResponse.response, true, earlyResponse.reason);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,6 +15,7 @@ import {
   getMaxRequestBytes,
   responseWithCors,
 } from './http/worker/requestPolicy.js';
+import { getLegacyEndpointResponse } from './http/worker/legacyEndpoint.js';
 import { getRateLimitResponse } from './http/worker/rateLimit.js';
 import {
   getWorkerRequestMetadata,
@@ -53,6 +54,15 @@ export default {
     };
 
     try {
+      const legacyEndpointResponse = getLegacyEndpointResponse(request);
+      if (legacyEndpointResponse) {
+        return complete(
+          legacyEndpointResponse.response,
+          true,
+          legacyEndpointResponse.reason,
+        );
+      }
+
       const earlyResponse = getEarlyResponse(env, request, metadata);
       if (earlyResponse) {
         return complete(earlyResponse.response, true, earlyResponse.reason);

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -93,7 +93,7 @@ describe('custom-domain infrastructure contract', () => {
     expect(WORKER_DEFAULT_ALLOWED_ORIGIN).toBe('https://theologai.pages.dev');
   });
 
-  it('documents the baseline, aliases, no-deletion rule, and preview-first merge sequence', async () => {
+  it('documents the release-time baseline, aliases, no-deletion rule, and preview-first merge sequence', async () => {
     const migration = await readProjectFile('docs/CUSTOM-DOMAIN-MIGRATION.md');
     for (const value of [
       'https://theologai.xyz',
@@ -105,10 +105,15 @@ describe('custom-domain infrastructure contract', () => {
     ]) {
       expect(migration).toContain(value);
     }
-    expect(migration).toMatch(/No existing route, domain,\s+deployment, database, or compatibility endpoint may be deleted/);
-    expect(migration).toContain('16e633bc70dbbea668caacf87f994a2536441092');
-    expect(migration).toContain('72/72');
+    expect(migration).toMatch(/No existing\s+route, domain,\s*deployment, database, or compatibility endpoint may be deleted/);
+    expect(migration).toContain('Release-time known-good baseline');
+    expect(migration).not.toContain('PR #50 production');
     expect(migration).toContain('Do not merge it yet');
     expect(migration).toContain('Merge the same reviewed pull request only after preview and the website have');
+    expect(migration).toContain('sampled guard diagnostic');
+    expect(migration).toContain('$workers.event.response.status');
+    expect(migration).toMatch(/Never treat this sampled view as\s+an exact\s+billing, invocation, or guard-block count/);
+    expect(migration).toContain('Cache-Control: no-store');
+    expect(migration).toContain('Authorization');
   });
 });

--- a/test/unit/http/legacyRedirectTransport.test.ts
+++ b/test/unit/http/legacyRedirectTransport.test.ts
@@ -1,0 +1,82 @@
+import { once } from 'node:events';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+interface ListeningServer {
+  server: Server;
+  url: string;
+}
+
+const servers: Server[] = [];
+
+async function listen(
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+): Promise<ListeningServer> {
+  const server = createServer(handler);
+  servers.push(server);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${address.port}` };
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(server => new Promise<void>((resolve, reject) => {
+    server.close(error => error ? reject(error) : resolve());
+  })));
+});
+
+describe('legacy-host redirect transport compatibility', () => {
+  it('lets the official TypeScript Streamable HTTP client follow a cross-origin 308 without changing its POST body', async () => {
+    const targetRequest = vi.fn<(
+      method: string | undefined,
+      url: string | undefined,
+      body: string,
+      headers: IncomingMessage['headers'],
+    ) => void>();
+    const target = await listen(async (request, response) => {
+      targetRequest(request.method, request.url, await readBody(request), request.headers);
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2025-06-18' } }));
+    });
+    const legacy = await listen((request, response) => {
+      response.writeHead(308, { Location: `${target.url}${request.url}` });
+      response.end();
+    });
+
+    const transport = new StreamableHTTPClientTransport(new URL(`${legacy.url}/mcp?source=legacy`));
+    const received = vi.fn();
+    transport.onmessage = received;
+    await transport.start();
+    try {
+      await transport.send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '1.0.0' } },
+      });
+    } finally {
+      await transport.close();
+    }
+
+    expect(targetRequest).toHaveBeenCalledOnce();
+    expect(targetRequest.mock.calls[0]?.[0]).toBe('POST');
+    expect(targetRequest.mock.calls[0]?.[1]).toBe('/mcp?source=legacy');
+    expect(targetRequest.mock.calls[0]?.[2]).toBe(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '1.0.0' } },
+    }));
+    expect(targetRequest.mock.calls[0]?.[3]['content-type']).toBe('application/json');
+    expect(received).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+  });
+});

--- a/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
@@ -9,7 +9,7 @@ const reviewedBasePins = {
   'src/kernel/index.ts': '7df4dc9b32e1a9d4589296d2a32e743eb1e812711e0e4faba8b58066a7b1cde6',
   'src/tools/v2/index.ts': '2bdf52660313eea971ed51253120288488938812c014c7764d6bb85c233251bd',
   'src/tools/worker/index.ts': 'feb1679a520185d11f2b6082b70ea3ef6c2b87652ff49c97c0acedfb76d83b90',
-  'src/worker.ts': '07a439b6f5f20be1e6651ceaad71b4ca189579592c743e5e0f3770d80ba12d44',
+  'src/worker.ts': '619a0a66c30ade7ec8f78f13c59ed0791c67d1ae956eb69e0b126ba20f7dc92d',
   'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
   'data/data-manifest.json': 'ba4f6fc73086716bd03f8e8d65a181719fba834aa61a90e65b168169744fa424',
   'wrangler.toml': '50dd24d0963893b5c8b17ec61d4ebe7c98eeb7f7692a988684bde09835017e4f',

--- a/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
@@ -11,7 +11,7 @@ const activeIdentityPins = {
   'src/tools/worker/index.ts': 'feb1679a520185d11f2b6082b70ea3ef6c2b87652ff49c97c0acedfb76d83b90',
   'src/server.ts': '6b372c049cb7741344bc446b2409524739cc9acba5a3121bc09dbdc8e90acd22',
   'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
-  'src/worker.ts': '07a439b6f5f20be1e6651ceaad71b4ca189579592c743e5e0f3770d80ba12d44',
+  'src/worker.ts': '619a0a66c30ade7ec8f78f13c59ed0791c67d1ae956eb69e0b126ba20f7dc92d',
   'src/mcp/schemas/originalLanguageStudy.ts': 'a98e5966d8a2a850487b4882c49f04c48fc697eee308f6e89c67e06af50fefac',
   'src/presenters/originalLanguageStudyStructured.ts': '49818eb62e89980498669442a4bfc1886944d7751fc675940b17368a030995d9',
   'src/formatters/originalLanguageStudyFormatter.ts': '30a10bf826c6c3174f2e0fb00907f6104735b165fdbfd5915a0ff22bc09b2536',

--- a/test/unit/worker/workerEntryPoint.test.ts
+++ b/test/unit/worker/workerEntryPoint.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
 
 const { mockRoot, mockServer, mockHandleMcp, mockCreateRoot, mockCreateServer } = vi.hoisted(() => {
   const mockRoot = { tools: [], services: {} };
@@ -35,6 +36,10 @@ vi.mock('../../../src/http/worker/mcpHandler.js', () => ({
 import worker from '../../../src/worker.js';
 
 function makeEnv() {
+  const operatorCoordinator = {
+    idFromName: vi.fn().mockReturnValue('operator-coordinator-id'),
+    get: vi.fn().mockReturnValue({ snapshot: vi.fn() }),
+  };
   return {
     THEOLOGAI_DB: {} as D1Database,
     THEOLOGAI_RATE_LIMITER: {
@@ -45,6 +50,12 @@ function makeEnv() {
     THEOLOGAI_REQUEST_LOGS: 'false',
     THEOLOGAI_ALLOWED_ORIGINS: 'https://theologai.xyz,https://theologai.pages.dev',
     THEOLOGAI_MAX_REQUEST_BYTES: String(1024 * 1024),
+    THEOLOGAI_CCEL_OPERATOR_TOKEN: 'operator-test-secret-that-is-at-least-32-characters',
+    CF_VERSION_METADATA: { id: '123e4567-e89b-42d3-a456-426614174000' },
+    THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER: {
+      limit: vi.fn().mockResolvedValue({ success: true }),
+    },
+    THEOLOGAI_CCEL_COORDINATOR: operatorCoordinator,
   };
 }
 
@@ -64,6 +75,32 @@ function makeHostRequest(
   const init: RequestInit & { duplex?: 'half' } = { method, headers, body };
   if (body instanceof ReadableStream) init.duplex = 'half';
   return new Request(`https://${host}${path}`, init);
+}
+
+function makeSignedOperatorRequest(host: string, headers: HeadersInit = {}): Request {
+  const secret = 'operator-test-secret-that-is-at-least-32-characters';
+  const timestamp = String(Date.now());
+  const nonce = 'abcdefghijklmnopqrstuvwxyzABCDEF';
+  const body = JSON.stringify({ action: 'snapshot', workerVersionId: '123e4567-e89b-42d3-a456-426614174000' });
+  const signature = createHmac('sha256', secret)
+    .update(`POST\n/internal/ccel-coordinator\n${timestamp}\n${nonce}\n${body}`)
+    .digest('hex');
+  const bodyBytes = new TextEncoder().encode(body);
+  const streamingBody = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bodyBytes);
+      controller.close();
+    },
+  });
+  return makeHostRequest(host, '/internal/ccel-coordinator', 'POST', {
+    'Content-Type': 'application/json',
+    'X-TheologAI-Timestamp': timestamp,
+    'X-TheologAI-Nonce': nonce,
+    'X-TheologAI-Signature': signature,
+    'CF-Connecting-IP': '192.0.2.44',
+    'User-Agent': 'theologai-operator-test/1.0',
+    ...headers,
+  }, streamingBody);
 }
 
 function makeCtx(): ExecutionContext {
@@ -89,7 +126,7 @@ describe('Worker Entry Point', () => {
       'User-Agent': 'Go-http-client/2.0',
     };
 
-    it.each(['GET', 'POST', 'DELETE', 'OPTIONS'])('redirects legacy %s requests with 308', async (method) => {
+    it.each(['GET', 'POST', 'DELETE', 'OPTIONS'])('redirects native legacy %s requests with 308', async (method) => {
       const response = await worker.fetch(
         makeHostRequest(legacyHost, '/mcp?source=legacy', method),
         env as never,
@@ -100,9 +137,56 @@ describe('Worker Entry Point', () => {
       expect(response.headers.get('Location')).toBe(
         'https://mcp.theologai.xyz/mcp?source=legacy',
       );
-      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
       expect(env.THEOLOGAI_RATE_LIMITER.limit).not.toHaveBeenCalled();
       expect(mockCreateRoot).not.toHaveBeenCalled();
+    });
+
+    it('answers an allowed browser preflight before redirecting the actual request', async () => {
+      const response = await worker.fetch(
+        makeHostRequest(legacyHost, '/mcp', 'OPTIONS', {
+          Origin: 'https://theologai.xyz',
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'Content-Type, Mcp-Protocol-Version',
+        }),
+        env as never,
+        ctx,
+      );
+
+      expect(response.status).toBe(204);
+      expect(response.headers.get('Location')).toBeNull();
+      expect(response.headers.get('Cache-Control')).toBe('no-store');
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://theologai.xyz');
+      expect(response.headers.get('Access-Control-Allow-Methods')).toBe('POST, OPTIONS');
+      expect(response.headers.get('Access-Control-Allow-Headers')).toContain('Mcp-Protocol-Version');
+      expect(env.THEOLOGAI_RATE_LIMITER.limit).not.toHaveBeenCalled();
+      expect(mockCreateRoot).not.toHaveBeenCalled();
+    });
+
+    it('includes exact-origin CORS headers on an allowed browser redirect', async () => {
+      const response = await worker.fetch(
+        makeHostRequest(legacyHost, '/mcp?source=browser', 'POST', {
+          Origin: 'https://theologai.pages.dev',
+        }),
+        env as never,
+        ctx,
+      );
+
+      expect(response.status).toBe(308);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://theologai.pages.dev');
+      expect(response.headers.get('Vary')).toContain('Origin');
+    });
+
+    it('does not reflect an untrusted browser origin on a legacy redirect', async () => {
+      const response = await worker.fetch(
+        makeHostRequest(legacyHost, '/mcp', 'POST', { Origin: 'https://evil.example' }),
+        env as never,
+        ctx,
+      );
+
+      expect(response.status).toBe(308);
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+      expect(response.headers.get('Vary')).toContain('Origin');
     });
 
     it('redirects before consuming a streaming request body', async () => {
@@ -118,6 +202,25 @@ describe('Worker Entry Point', () => {
 
       expect(response.status).toBe(308);
       expect(request.bodyUsed).toBe(false);
+      expect(mockHandleMcp).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { name: 'redirects', headers: {}, status: 308 },
+      { name: 'blocks the exact poller before', headers: pollerHeaders, status: 410 },
+    ])('$name the legacy operator path without invoking any application dependency', async ({ headers, status }) => {
+      const request = makeSignedOperatorRequest(legacyHost, headers);
+
+      const response = await worker.fetch(request, env as never, ctx);
+
+      expect(response.status).toBe(status);
+      expect(request.bodyUsed).toBe(false);
+      expect(env.THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER.limit).not.toHaveBeenCalled();
+      expect(env.THEOLOGAI_CCEL_COORDINATOR.idFromName).not.toHaveBeenCalled();
+      expect(env.THEOLOGAI_CCEL_COORDINATOR.get).not.toHaveBeenCalled();
+      expect(env.THEOLOGAI_RATE_LIMITER.limit).not.toHaveBeenCalled();
+      expect(mockCreateRoot).not.toHaveBeenCalled();
+      expect(mockCreateServer).not.toHaveBeenCalled();
       expect(mockHandleMcp).not.toHaveBeenCalled();
     });
 
@@ -148,6 +251,18 @@ describe('Worker Entry Point', () => {
       expect(response.headers.get('Location')).toBeNull();
       expect(env.THEOLOGAI_RATE_LIMITER.limit).not.toHaveBeenCalled();
       expect(mockCreateRoot).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'theologai-preview.tjfrederick.workers.dev',
+      'preview-mcp.theologai.xyz',
+      'unrelated.example',
+    ])('never applies the production poller block to %s', async (host) => {
+      const request = makeHostRequest(host, '/mcp', 'POST', pollerHeaders);
+      const response = await worker.fetch(request, env as never, ctx);
+
+      expect(response.status).toBe(200);
+      expect(mockHandleMcp).toHaveBeenCalledWith(mockServer, request);
     });
 
     it.each([

--- a/test/unit/worker/workerEntryPoint.test.ts
+++ b/test/unit/worker/workerEntryPoint.test.ts
@@ -54,6 +54,18 @@ function makeRequest(path = '/mcp', method = 'POST', headers?: HeadersInit, body
   return new Request(`https://example.com${path}`, init);
 }
 
+function makeHostRequest(
+  host: string,
+  path = '/mcp',
+  method = 'POST',
+  headers?: HeadersInit,
+  body?: BodyInit,
+) {
+  const init: RequestInit & { duplex?: 'half' } = { method, headers, body };
+  if (body instanceof ReadableStream) init.duplex = 'half';
+  return new Request(`https://${host}${path}`, init);
+}
+
 function makeCtx(): ExecutionContext {
   return { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as unknown as ExecutionContext;
 }
@@ -67,6 +79,97 @@ describe('Worker Entry Point', () => {
     mockHandleMcp.mockResolvedValue({ response: new Response('ok') });
     env = makeEnv();
     ctx = makeCtx();
+  });
+
+  describe('legacy production endpoint migration', () => {
+    const legacyHost = 'theologai.tjfrederick.workers.dev';
+    const primaryHost = 'mcp.theologai.xyz';
+    const pollerHeaders = {
+      'CF-Connecting-IP': '18.192.206.183',
+      'User-Agent': 'Go-http-client/2.0',
+    };
+
+    it.each(['GET', 'POST', 'DELETE', 'OPTIONS'])('redirects legacy %s requests with 308', async (method) => {
+      const response = await worker.fetch(
+        makeHostRequest(legacyHost, '/mcp?source=legacy', method),
+        env as never,
+        ctx,
+      );
+
+      expect(response.status).toBe(308);
+      expect(response.headers.get('Location')).toBe(
+        'https://mcp.theologai.xyz/mcp?source=legacy',
+      );
+      expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+      expect(env.THEOLOGAI_RATE_LIMITER.limit).not.toHaveBeenCalled();
+      expect(mockCreateRoot).not.toHaveBeenCalled();
+    });
+
+    it('redirects before consuming a streaming request body', async () => {
+      const request = makeHostRequest(
+        legacyHost,
+        '/mcp',
+        'POST',
+        undefined,
+        new ReadableStream<Uint8Array>(),
+      );
+
+      const response = await worker.fetch(request, env as never, ctx);
+
+      expect(response.status).toBe(308);
+      expect(request.bodyUsed).toBe(false);
+      expect(mockHandleMcp).not.toHaveBeenCalled();
+    });
+
+    it('returns 410 for the confirmed poller on the legacy hostname', async () => {
+      const response = await worker.fetch(
+        makeHostRequest(legacyHost, '/mcp', 'POST', pollerHeaders),
+        env as never,
+        ctx,
+      );
+
+      expect(response.status).toBe(410);
+      await expect(response.text()).resolves.toBe('Gone');
+      expect(response.headers.get('Location')).toBeNull();
+      expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+      expect(env.THEOLOGAI_RATE_LIMITER.limit).not.toHaveBeenCalled();
+      expect(mockCreateRoot).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 if the confirmed poller reaches the primary hostname', async () => {
+      const response = await worker.fetch(
+        makeHostRequest(primaryHost, '/mcp', 'POST', pollerHeaders),
+        env as never,
+        ctx,
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.text()).resolves.toBe('Forbidden');
+      expect(response.headers.get('Location')).toBeNull();
+      expect(env.THEOLOGAI_RATE_LIMITER.limit).not.toHaveBeenCalled();
+      expect(mockCreateRoot).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { 'CF-Connecting-IP': '18.192.206.183', 'User-Agent': 'another-client/1.0' },
+      { 'CF-Connecting-IP': '203.0.113.10', 'User-Agent': 'Go-http-client/2.0' },
+    ])('does not block partial poller identity matches', async (headers) => {
+      const response = await worker.fetch(
+        makeHostRequest(legacyHost, '/mcp', 'POST', headers),
+        env as never,
+        ctx,
+      );
+
+      expect(response.status).toBe(308);
+    });
+
+    it('continues serving ordinary requests on the primary hostname', async () => {
+      const request = makeHostRequest(primaryHost);
+      const response = await worker.fetch(request, env as never, ctx);
+
+      expect(response.status).toBe(200);
+      expect(mockHandleMcp).toHaveBeenCalledWith(mockServer, request);
+    });
   });
 
   it('creates a fresh composition root and MCP server for an accepted request', async () => {

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -7,6 +7,11 @@ import { parseSourceAttestedLookupReference } from '../../src/kernel/sourceAttes
 
 const MCP_URL = 'https://worker.test/mcp';
 const ALLOWED_ORIGIN = 'https://allowed.example';
+const LEGACY_PRODUCTION_MCP_URL = 'https://theologai.tjfrederick.workers.dev/mcp';
+const PRIMARY_PRODUCTION_MCP_URL = 'https://mcp.theologai.xyz/mcp';
+const PREVIEW_MCP_URL = 'https://preview-mcp.theologai.xyz/mcp';
+const LEGACY_PRODUCTION_OPERATOR_URL = 'https://theologai.tjfrederick.workers.dev/internal/ccel-coordinator';
+const PRIMARY_PRODUCTION_OPERATOR_URL = 'https://mcp.theologai.xyz/internal/ccel-coordinator';
 
 interface JsonRpcResponse {
   jsonrpc: '2.0';
@@ -79,6 +84,64 @@ async function rateLimitKey(ip: string, userAgent: string): Promise<string> {
 }
 
 describe('Worker MCP endpoint in workerd', () => {
+  it('keeps the legacy production migration browser-safe and scopes the poller guard to production hosts', async () => {
+    const browserPreflight = await SELF.fetch(LEGACY_PRODUCTION_MCP_URL, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Content-Type, Mcp-Protocol-Version',
+      },
+    });
+    expect(browserPreflight.status).toBe(204);
+    expect(browserPreflight.headers.get('Location')).toBeNull();
+    expect(browserPreflight.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN);
+
+    const browserRequest = await SELF.fetch(LEGACY_PRODUCTION_MCP_URL, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { Origin: ALLOWED_ORIGIN },
+      body: '{}',
+    });
+    expect(browserRequest.status).toBe(308);
+    expect(browserRequest.headers.get('Location')).toBe(PRIMARY_PRODUCTION_MCP_URL);
+    expect(browserRequest.headers.get('Cache-Control')).toBe('no-store');
+    expect(browserRequest.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN);
+
+    const legacyOperator = await SELF.fetch(LEGACY_PRODUCTION_OPERATOR_URL, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    expect(legacyOperator.status).toBe(308);
+    expect(legacyOperator.headers.get('Location')).toBe(PRIMARY_PRODUCTION_OPERATOR_URL);
+
+    const pollerHeaders = {
+      'CF-Connecting-IP': '18.192.206.183',
+      'User-Agent': 'Go-http-client/2.0',
+    };
+    await expect(SELF.fetch(LEGACY_PRODUCTION_MCP_URL, { method: 'POST', headers: pollerHeaders }))
+      .resolves.toMatchObject({ status: 410 });
+    await expect(SELF.fetch(PRIMARY_PRODUCTION_MCP_URL, { method: 'POST', headers: pollerHeaders }))
+      .resolves.toMatchObject({ status: 403 });
+    await expect(SELF.fetch(LEGACY_PRODUCTION_OPERATOR_URL, {
+      method: 'POST', headers: { ...pollerHeaders, 'Content-Type': 'application/json' }, body: '{}',
+    })).resolves.toMatchObject({ status: 410 });
+
+    const previewRequest = await SELF.fetch(PREVIEW_MCP_URL, {
+      method: 'POST',
+      headers: {
+        ...pollerHeaders,
+        Accept: 'application/json, text/event-stream',
+        'Content-Type': 'application/json',
+        'Mcp-Protocol-Version': '2025-11-25',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 70, method: 'tools/list' }),
+    });
+    expect(previewRequest.status).toBe(200);
+  });
+
   it('executes the checked-in preview v5 contract without enabling live CCEL', async () => {
     expect(env.THEOLOGAI_EXPOSE_CCEL_DISCOVERY).toBe('true');
     expect(env.THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH).toBe('false');


### PR DESCRIPTION
## Summary

- short-circuit the confirmed AWS Frankfurt MCP poller before every application route, including the signed CCEL operator path, body reads, limiters, Durable Objects, D1, or MCP construction
- return a method-preserving `308` from the production `workers.dev` hostname to `https://mcp.theologai.xyz`, retaining the original path and query
- keep browser migration CORS-safe with a trusted-origin `204` preflight and exact-origin headers on the redirect
- use `Cache-Control: no-store` during burn-in, leave preview and arbitrary hostnames unchanged, and document a release-time rollback baseline plus sampled diagnostics

## Root cause

The public `workers.dev` compatibility alias still served the full MCP application. A protocol-aware client from one AWS Frankfurt address repeatedly performed an MCP lifecycle, accounting for roughly 120,000 daily requests while remaining below the existing per-minute limiter.

## Impact and limits

Legitimate callers using the old production hostname are directed to the canonical custom domain. The exact observed poller tuple receives `410 Gone` on the legacy production hostname and `403 Forbidden` on the canonical production hostname only. Preview hostnames are unchanged.

This is a temporary, evadable application-cost mitigation. Redirects and blocks still count as Worker invocations until a separately owner-approved `workers_dev = false` cutover, and a followed redirect can create a second invocation. Cross-host clients may strip `Authorization`; the current endpoint is anonymous. The 25%-sampled Workers Logs view is diagnostic, not an exact billing or guard count.

## Release dependency

This PR remains draft and undeployed. PR #70 must first complete its production release and audit. Then this branch must be rebased onto that exact `main`, independently re-reviewed, pass fresh CI, prove preview isolation, and capture the exact post-#70 production Worker as the rollback anchor before production approval.

## Validation

- independent Sol review: GO, P0-P3 zero
- focused corrective tests: 53/53
- Worker runtime/workerd: 25/25
- Node, Worker, Worker-runtime, and fixture typechecks
- generated Worker binding type check
- production and preview Wrangler dry runs
- official TypeScript MCP transport preserves the POST method and body across the `308`
- fresh GitHub CI for corrected head `2f1b1d6` is running
