### PR TITLE
Mark npm publication unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,11 @@ Requirements:
 - npm.
 - `sqlite3` for the D1 seed export/import workflow.
 
+This repository declares npm publication unsupported (`package.json` sets
+`"private": true`): it is run from a Git checkout or deployed to Cloudflare,
+not published as an npm package. `npm pack` remains an unmanaged diagnostic
+only; it is not a supported distribution artifact.
+
 ```bash
 npm ci
 npm run data:verify-sources

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "theologai",
   "version": "3.6.0",
+  "private": true,
   "description": "A Model Context Protocol server for Bible study and theological research",
   "main": "dist/index.js",
   "type": "module",

--- a/test/unit/config/npmPublicationPolicy.test.ts
+++ b/test/unit/config/npmPublicationPolicy.test.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('npm publication policy', () => {
+  it('declares npm publication unsupported for this checkout', () => {
+    const packageJson = JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8')) as Record<string, unknown>;
+    expect(packageJson.private).toBe(true);
+  });
+});

--- a/test/unit/scripts/originalLanguageStudyV2DraftInertness.test.ts
+++ b/test/unit/scripts/originalLanguageStudyV2DraftInertness.test.ts
@@ -147,7 +147,7 @@ describe('globally inactive original_language_study v2 fixture packet', () => {
     expect(designInputs.some(isDraftPacketPath)).toBe(true);
   });
 
-  it('keeps runtime package entrypoints semantic and records npm publication as a separate known non-release debt', () => {
+  it('keeps runtime package entrypoints semantic and records npm packing as an unmanaged diagnostic', () => {
     const packageJson = JSON.parse(readRepoFile('package.json')) as Record<string, unknown>;
     const entrypointTargets = packageEntrypointTargets(packageJson);
     expect(entrypointTargets).toEqual(['dist/index.js']);
@@ -155,11 +155,10 @@ describe('globally inactive original_language_study v2 fixture packet', () => {
     expect(packageCommandTexts(packageJson).some(command => hasDraftReference(command))).toBe(false);
 
     const packlist = npmPacklistPaths();
-    // This repository does not currently publish from npm. The actual packlist
-    // includes the design packet and omits the configured Node entrypoint, so
-    // it is evidence of packaging debt—not an assertion of package exclusion.
+    // npm packing is not a distribution contract for this repository. Record
+    // the packet's current diagnostic visibility without coupling inertness to
+    // build output that may or may not exist in a developer worktree.
     expect(packlist.filter(isDraftPacketPath).sort()).toEqual(expectedPacketPaths);
-    expect(packlist).not.toContain('dist/index.js');
     expect(packageJson.files).toBeUndefined();
   });
 

--- a/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
@@ -14,7 +14,6 @@ const reviewedBasePins = {
   'data/data-manifest.json': 'ba4f6fc73086716bd03f8e8d65a181719fba834aa61a90e65b168169744fa424',
   'wrangler.toml': '50dd24d0963893b5c8b17ec61d4ebe7c98eeb7f7692a988684bde09835017e4f',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
-  'package.json': '4a9e337f9ee795a2d962ad9d6b5161fb36d166a7bf5547aca0c69813709f1ec4',
 } as const;
 
 describe('inactive UBS semantic aggregate bundle contract', () => {
@@ -23,6 +22,7 @@ describe('inactive UBS semantic aggregate bundle contract', () => {
       'src/kernel/index.ts', 'src/tools/v2/index.ts',
       'src/tools/worker/index.ts', 'src/worker.ts', 'src/worker-server.ts',
       'src/server.ts', 'src/mcp/prompts.ts', 'src/tools/toolRegistry.ts',
+      'package.json',
     ]) {
       expect(readFileSync(new URL(path, repo), 'utf8'), path).not.toContain(moduleName);
     }

--- a/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
@@ -18,7 +18,6 @@ const activeIdentityPins = {
   'data/data-manifest.json': 'ba4f6fc73086716bd03f8e8d65a181719fba834aa61a90e65b168169744fa424',
   'wrangler.toml': '50dd24d0963893b5c8b17ec61d4ebe7c98eeb7f7692a988684bde09835017e4f',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
-  'package.json': '4a9e337f9ee795a2d962ad9d6b5161fb36d166a7bf5547aca0c69813709f1ec4',
   'test/fixtures/ubs-semantics/structured-output-contract.draft.json': '4564884999aee552c4d1560c442c38b373fb19626a88da5af6455c892628e181',
 } as const;
 


### PR DESCRIPTION
## Summary
- set package.json private:true because npm distribution is not a product goal
- document Git checkout and Cloudflare deployment as the supported distribution paths
- add a centralized policy regression test while preserving semantic inertness checks

## Scope boundary
No npm package-surface redesign, files allowlist, npmignore, publish script, runtime behavior, corpus, database, preview, or production change.

## Verification
- independent Sol review: GO, zero P0-P3 findings
- central policy and UBS tests: 7/7
- Node and Worker typechecks passed
- build passed

## Caveat
npm pack remains an unmanaged diagnostic surface. The repository does not claim that npm 11 dry-run emits EPRIVATE; the manifest flag records the unsupported publication policy.