### PR TITLE
Harden CCEL preview canary evidence

### DIFF
--- a/docs/CCEL-LIVE-PREVIEW-AUDIT.md
+++ b/docs/CCEL-LIVE-PREVIEW-AUDIT.md
@@ -1,25 +1,50 @@
 # CCEL live preview audit
 
-`npm run audit:ccel-preview` is inert unless all three arguments are exact:
+`npm run audit:ccel-preview` is inert unless both URLs and the authorization
+phrase are exact and the production Worker UUID is syntactically valid:
 
 ```bash
 npm run audit:ccel-preview -- \
   --preview-url https://preview-mcp.theologai.xyz/mcp \
   --production-url https://mcp.theologai.xyz/mcp \
+  --production-worker-version-id '<exact live production Worker UUID>' \
   --authorize-live-ccel 'I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS'
 ```
 
 The command is an operator canary, not a normal CI test. Run it only after the
 owner explicitly authorizes live preview and the current robots/interface
-preflight is recorded. It makes no production tool call: production is a
-`tools/list` v3/000 control only. Preview issues exactly two concurrent,
+preflight is recorded. It makes no production MCP tool call: production is a
+`tools/list` v4 local-only schema control. Before either preview tool call, the canary
+also uses the already-protected production operator route and exact live Worker
+UUID to read a content-free coordinator snapshot. The token is read only from
+`THEOLOGAI_CCEL_OPERATOR_TOKEN`; it is never accepted as a command argument or
+written to the report. Preview's `tools/list` must advertise the v5 CCEL
+discovery schema before the canary proceeds. These schema observations prove
+v4 local-only versus v5 CCEL exposure; they do not attest exact deployed flag
+bits. A successful origin admission separately proves that live execution was
+effective for the canary, which necessarily differs from the checked-in inert
+preview `100` baseline. Preview issues exactly two concurrent,
 CCEL-only contenders and requires one bounded discovery result plus one
 structured globally busy result. A separate local-only search verifies usable
 fallback without touching CCEL. A checked audit-side budget refuses any third
 CCEL-bearing call, so isolate/cache changes or elapsed coordinator intervals
 cannot raise the mechanical maximum above two possible CCEL-origin admissions.
 
-Audit output records only contract versions, provider statuses, counts, retry
-seconds, and pass/fail state. It never retains queries, titles, snippets,
-content, locators, headers, or client identity. Omitting or changing the exact
-authorization phrase or either canonical URL fails before any connection.
+The pre-snapshot must show a clean closed circuit with every prior admission
+retired. The post-snapshot must show the same operator epoch, exactly one
+additional admission, a one-step terminal-retirement watermark advance, and a
+closed circuit. Below the 64-record retained window, the terminal-record count
+also rises by one; at the full window it remains constant because one retired
+record is safely evicted. These checks use the deployed snapshot contract and
+do not require a new coordinator field.
+
+Audit output records only contract versions, provider statuses, bounded counts,
+retry seconds, content-free coordinator snapshots/deltas, and pass/fail state.
+It separately records the hard maximum of two CCEL-bearing preview tool calls
+and the protected-snapshot observation of one upstream origin admission.
+It never retains queries, titles, snippets, content, locators, URLs, headers,
+tokens, nonces, or client identity. Omitting or changing the exact authorization
+phrase or canonical URL, or supplying a malformed production Worker UUID, fails
+before any connection. A different but syntactically valid UUID is rejected by
+the signed operator route after the production and preview `tools/list` checks
+but before any preview `tools/call` invocation.

--- a/scripts/audit-ccel-preview.ts
+++ b/scripts/audit-ccel-preview.ts
@@ -1,15 +1,19 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { normalizeCcelSectionLocator } from '../src/adapters/commentary/CcelSearchAdapter.js';
+import { CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT, type CcelCoordinatorSnapshot } from '../src/services/historical/CcelUpstreamCoordinator.js';
+import { runOperatorRequest } from './ccel-coordinator-operator.js';
 
 export const LIVE_AUDIT_CONFIRMATION = 'I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS';
 const PREVIEW_URL = 'https://preview-mcp.theologai.xyz/mcp';
 const PRODUCTION_URL = 'https://mcp.theologai.xyz/mcp';
+const PRODUCTION_OPERATOR_ENDPOINT = 'https://mcp.theologai.xyz/internal/ccel-coordinator';
 
 export interface CcelAuditOptions {
   previewUrl: string;
   productionUrl: string;
   authorization: string;
+  productionWorkerVersionId: string;
 }
 
 export function parseCcelAuditArgs(argv: string[]): CcelAuditOptions {
@@ -19,17 +23,20 @@ export function parseCcelAuditArgs(argv: string[]): CcelAuditOptions {
     if (!key?.startsWith('--') || value === undefined || values.has(key)) throw new Error('Invalid audit arguments.');
     values.set(key, value);
   }
-  if ([...values.keys()].some(key => !['--preview-url', '--production-url', '--authorize-live-ccel'].includes(key))) {
+  if ([...values.keys()].some(key => ![
+    '--preview-url', '--production-url', '--authorize-live-ccel', '--production-worker-version-id',
+  ].includes(key))) {
     throw new Error('Unknown audit argument.');
   }
   const options = {
     previewUrl: values.get('--preview-url') ?? '',
     productionUrl: values.get('--production-url') ?? '',
     authorization: values.get('--authorize-live-ccel') ?? '',
+    productionWorkerVersionId: values.get('--production-worker-version-id') ?? '',
   };
   if (options.previewUrl !== PREVIEW_URL || options.productionUrl !== PRODUCTION_URL
-    || options.authorization !== LIVE_AUDIT_CONFIRMATION) {
-    throw new Error('Live audit remains inert without the exact canonical URLs and authorization phrase.');
+    || options.authorization !== LIVE_AUDIT_CONFIRMATION || !isUuid(options.productionWorkerVersionId)) {
+    throw new Error('Live audit remains inert without canonical URLs, the exact authorization phrase, and a valid production Worker UUID.');
   }
   return options;
 }
@@ -94,6 +101,9 @@ export interface CcelAuditClient {
 
 export interface CcelAuditDependencies {
   connect?: (url: string, name: string) => Promise<CcelAuditClient>;
+  /** Existing protected operator route; never receives or returns provider content. */
+  snapshotCoordinator?: () => Promise<CcelCoordinatorSnapshot>;
+  now?: () => number;
 }
 
 class CcelCallBudget {
@@ -113,6 +123,9 @@ class CcelCallBudget {
 
 export async function runCcelPreviewAudit(options: CcelAuditOptions, dependencies: CcelAuditDependencies = {}) {
   const connectClient = dependencies.connect ?? connect;
+  const snapshotCoordinator = dependencies.snapshotCoordinator
+    ?? (() => readProtectedCoordinatorSnapshot(options.productionWorkerVersionId));
+  const now = dependencies.now ?? Date.now;
   const production = await connectClient(options.productionUrl, 'theologai-ccel-production-control');
   const preview = await connectClient(options.previewUrl, 'theologai-ccel-preview-audit');
   const ccelBudget = new CcelCallBudget(2);
@@ -128,6 +141,12 @@ export async function runCcelPreviewAudit(options: CcelAuditOptions, dependencie
       && schemaContainsConst(previewSchema, 'ccel_live')
       && schemaContainsProperty(previewSchema, 'retryAfterSeconds'), 'preview v5 CCEL contract');
 
+    // These are public-contract proofs before any tool call. The protected
+    // snapshot adds only content-free coordinator evidence; it never reserves
+    // an origin slot or changes the circuit.
+    const preSnapshot = await readAuditSnapshot(snapshotCoordinator, 'pre');
+    assertCanaryReady(preSnapshot, now());
+
     // Exactly two concurrent CCEL-only calls exercise the one global Durable
     // Object budget without relying on process-local cache affinity or elapsed
     // wall time. One may be admitted; the other must receive structured busy.
@@ -142,6 +161,8 @@ export async function runCcelPreviewAudit(options: CcelAuditOptions, dependencie
     for (const output of contenders) assertValidV5Envelope(output);
     assertValidExternalDiscovery(provider(cold[0]!, 'ccel_live')!);
     assertValidRateLimited(provider(busy[0]!, 'ccel_live')!);
+    const postSnapshot = await readAuditSnapshot(snapshotCoordinator, 'post');
+    const coordinator = assertCanaryDelta(preSnapshot, postSnapshot);
 
     // Local search is deliberately separate and cannot consume an origin slot.
     const local = await search(preview, ccelBudget, 'audit-local-fallback', 'justification', ['local']);
@@ -151,17 +172,112 @@ export async function runCcelPreviewAudit(options: CcelAuditOptions, dependencie
 
     return {
       schemaVersion: '1', audit: 'ccel-live-preview', passed: true,
-      productionControl: { contractVersion: '4', liveCallMade: false },
+      productionControl: {
+        contractVersionObserved: '4', discoverySchemaObserved: 'local_only', toolsListCalls: 1,
+        protectedSnapshotReads: 2, toolCallInvocations: 0,
+      },
       preview: {
-        contractVersion: '5', ccelBearingToolCallMaximum: 2, upstreamOriginAdmissionMaximum: 2,
+        contractVersionObserved: '5', discoverySchemaObserved: 'ccel_exposed', ccelBearingToolCallMaximum: 2,
+        upstreamOriginAdmissionObserved: coordinator.delta.admissionCount,
         statuses: [...contenders, local].map(summarize),
       },
-      privacy: 'No query, title, snippet, content, URL, header, or client identity is retained.',
+      coordinator,
+      privacy: 'No query, title, snippet, content, URL, header, token, nonce, or client identity is retained.',
     };
   } finally {
     await production.close().catch(() => undefined);
     await preview.close().catch(() => undefined);
   }
+}
+
+async function readAuditSnapshot(
+  snapshotCoordinator: () => Promise<CcelCoordinatorSnapshot>,
+  phase: 'pre' | 'post',
+): Promise<CcelCoordinatorSnapshot> {
+  try {
+    return await snapshotCoordinator();
+  } catch {
+    throw new Error(`Audit failed: protected coordinator ${phase}-snapshot unavailable.`);
+  }
+}
+
+async function readProtectedCoordinatorSnapshot(workerVersionId: string): Promise<CcelCoordinatorSnapshot> {
+  const secret = process.env.THEOLOGAI_CCEL_OPERATOR_TOKEN ?? '';
+  const response = await runOperatorRequest({
+    endpoint: PRODUCTION_OPERATOR_ENDPOINT,
+    action: 'snapshot',
+    workerVersionId,
+  }, secret);
+  const snapshot = (response as { snapshot?: unknown }).snapshot;
+  if (!isCoordinatorSnapshot(snapshot)) throw new Error('Audit failed: protected coordinator snapshot was malformed.');
+  return snapshot;
+}
+
+function assertCanaryReady(snapshot: CcelCoordinatorSnapshot, observedAtMs: number): void {
+  assert(isCoordinatorSnapshot(snapshot), 'protected coordinator pre-snapshot shape');
+  assert(Number.isSafeInteger(observedAtMs) && observedAtMs >= 0, 'safe audit clock');
+  assert(snapshot.state === 'closed'
+    && snapshot.transientFailures === 0
+    && snapshot.backoffUntilMs === 0
+    && snapshot.probeInFlight === false
+    && snapshot.probeLeaseUntilMs === 0
+    && snapshot.nextAllowedAtMs <= observedAtMs
+    && snapshot.terminalAttemptCount <= CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT
+    && snapshot.terminalRetiredThroughAttemptId === snapshot.attemptSequence,
+  'clean coordinator precondition');
+}
+
+function assertCanaryDelta(pre: CcelCoordinatorSnapshot, post: CcelCoordinatorSnapshot) {
+  assert(isCoordinatorSnapshot(post), 'protected coordinator post-snapshot shape');
+  const admissionCount = post.attemptSequence - pre.attemptSequence;
+  const terminalOutcomeCount = post.terminalAttemptCount - pre.terminalAttemptCount;
+  const terminalRetirementCount = post.terminalRetiredThroughAttemptId - pre.terminalRetiredThroughAttemptId;
+  const expectedTerminalOutcomeCount = pre.terminalAttemptCount === CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT ? 0 : 1;
+  assert(post.operatorEpoch === pre.operatorEpoch
+    && admissionCount === 1
+    && terminalOutcomeCount === expectedTerminalOutcomeCount
+    && terminalRetirementCount === 1
+    && post.state === 'closed'
+    && post.transientFailures === 0
+    && post.backoffUntilMs === 0
+    && post.probeInFlight === false
+    && post.probeLeaseUntilMs === 0,
+  'one admitted and finalized contender with a closed terminal circuit');
+  return {
+    pre: summarizeCoordinatorSnapshot(pre),
+    post: summarizeCoordinatorSnapshot(post),
+    delta: {
+      admissionCount,
+      terminalOutcomeCount,
+      terminalRetirementCount,
+      operatorEpochChanged: false,
+    },
+    terminalCircuitState: 'closed',
+  };
+}
+
+function summarizeCoordinatorSnapshot(snapshot: CcelCoordinatorSnapshot) {
+  return {
+    state: snapshot.state,
+    attemptSequence: snapshot.attemptSequence,
+    terminalAttemptCount: snapshot.terminalAttemptCount,
+    terminalRetiredThroughAttemptId: snapshot.terminalRetiredThroughAttemptId,
+    probeInFlight: snapshot.probeInFlight,
+    transientFailures: snapshot.transientFailures,
+    backoffActive: snapshot.backoffUntilMs > 0,
+  };
+}
+
+function isCoordinatorSnapshot(value: unknown): value is CcelCoordinatorSnapshot {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (!['closed', 'transient_backoff', 'rate_limited', 'latched_policy', 'latched_interface'].includes(String(record.state))
+    || typeof record.probeInFlight !== 'boolean') return false;
+  return [
+    record.nextAllowedAtMs, record.backoffUntilMs, record.lastObservedAtMs, record.attemptSequence,
+    record.operatorEpoch, record.transientFailures, record.probeLeaseUntilMs,
+    record.terminalAttemptCount, record.terminalRetiredThroughAttemptId,
+  ].every(item => Number.isSafeInteger(item) && (item as number) >= 0);
 }
 
 export function boundedAuditSleepMs(retryAfterSeconds: number): number {
@@ -346,6 +462,10 @@ function schemaContainsProperty(value: unknown, expected: string): boolean {
   const properties = (value as { properties?: unknown }).properties;
   if (properties && typeof properties === 'object' && expected in properties) return true;
   return Object.values(value).some(item => schemaContainsProperty(item, expected));
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }
 
 function assert(condition: boolean, label: string): asserts condition {

--- a/test/unit/scripts/ccelCoordinatorOperator.test.ts
+++ b/test/unit/scripts/ccelCoordinatorOperator.test.ts
@@ -5,6 +5,10 @@ import {
   runCcelPreviewAudit,
   type CcelAuditClient,
 } from '../../../scripts/audit-ccel-preview.js';
+import {
+  CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT,
+  type CcelCoordinatorSnapshot,
+} from '../../../src/services/historical/CcelUpstreamCoordinator.js';
 import { parseOperatorCli, runOperatorRequest } from '../../../scripts/ccel-coordinator-operator.js';
 import { assertRetiredCcelScriptIsNetworkInert } from '../../adapters/ccel-test.js';
 import { assertRetiredCcelToolContractGuard } from '../../integration/ccel-tool-test.js';
@@ -14,6 +18,7 @@ const auditOptions = {
   previewUrl: 'https://preview-mcp.theologai.xyz/mcp',
   productionUrl: 'https://mcp.theologai.xyz/mcp',
   authorization: 'I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS',
+  productionWorkerVersionId: version,
 };
 
 const localEditionReadiness = {
@@ -79,9 +84,9 @@ function provider(
   };
 }
 
-function externalHit() {
+function externalHit(snippet = 'A short authorized discovery snippet.') {
   return {
-    provider: 'ccel_live', snippet: 'A short authorized discovery snippet.',
+    provider: 'ccel_live', snippet,
     metadataStatus: 'provider_search_result_unreviewed', editionReadiness: externalEditionReadiness,
     locator: { kind: 'external_url', url: 'https://ccel.org/ccel/calvin/institutes/iv.xvii.html' },
   };
@@ -91,6 +96,35 @@ function localHit() {
   return {
     provider: 'local', snippet: 'A local discovery snippet.', editionReadiness: localEditionReadiness,
     locator: { kind: 'mcp_resource', uri: 'theologai://documents/example' },
+  };
+}
+
+function coordinatorSnapshot(overrides: Partial<CcelCoordinatorSnapshot> = {}): CcelCoordinatorSnapshot {
+  return {
+    state: 'closed', nextAllowedAtMs: 0, backoffUntilMs: 0, lastObservedAtMs: 0,
+    attemptSequence: 0, operatorEpoch: 0, transientFailures: 0, probeInFlight: false,
+    probeLeaseUntilMs: 0, terminalAttemptCount: 0, terminalRetiredThroughAttemptId: 0,
+    ...overrides,
+  };
+}
+
+function auditDependencies(
+  production: CcelAuditClient,
+  preview: CcelAuditClient,
+  snapshots: CcelCoordinatorSnapshot[] = [
+    coordinatorSnapshot(),
+    coordinatorSnapshot({ attemptSequence: 1, terminalAttemptCount: 1, terminalRetiredThroughAttemptId: 1 }),
+  ],
+) {
+  let index = 0;
+  return {
+    connect: async (url: string) => url === auditOptions.productionUrl ? production : preview,
+    snapshotCoordinator: vi.fn(async () => {
+      const snapshot = snapshots[index++];
+      if (!snapshot) throw new Error('Unexpected coordinator snapshot.');
+      return snapshot;
+    }),
+    now: () => 100_000,
   };
 }
 
@@ -107,6 +141,11 @@ describe('CCEL operational scripts', () => {
       '--production-url', 'https://mcp.theologai.xyz/mcp',
       '--authorize-live-ccel', 'wrong',
     ])).toThrow(/remains inert/);
+    expect(() => parseCcelAuditArgs([
+      '--preview-url', 'https://preview-mcp.theologai.xyz/mcp',
+      '--production-url', 'https://mcp.theologai.xyz/mcp',
+      '--authorize-live-ccel', 'I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS',
+    ])).toThrow(/Worker UUID/);
   });
 
   it('caps the expected immediate coordinator wait and refuses anomalous values', () => {
@@ -124,32 +163,47 @@ describe('CCEL operational scripts', () => {
     };
     const preview: CcelAuditClient = {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
-      callTool: vi.fn(async request => {
-        const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
-        if (providers.includes('ccel')) {
-          ccelCalls++;
-          if (ccelCalls === 1) {
-            possibleOriginAdmissions++;
-            return { structuredContent: envelope(provider('ccel_live', 'ok', undefined, [externalHit()])) };
-          }
-          return { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
-        }
-        return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
-      }),
+      callTool: vi.fn(),
       close: vi.fn().mockResolvedValue(undefined),
     };
-    const report = await runCcelPreviewAudit(auditOptions, {
-      connect: async url => url === auditOptions.productionUrl ? production : preview,
+    const privateMarker = 'never-report-this-private-snippet';
+    preview.callTool.mockImplementation(async request => {
+      const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
+      if (providers.includes('ccel')) {
+        ccelCalls++;
+        if (ccelCalls === 1) {
+          possibleOriginAdmissions++;
+          return { structuredContent: envelope(provider('ccel_live', 'ok', undefined, [externalHit(privateMarker)])) };
+        }
+        return { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+      }
+      return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
     });
+    const dependencies = auditDependencies(production, preview);
+    const report = await runCcelPreviewAudit(auditOptions, dependencies);
     expect(report).toMatchObject({
       passed: true,
-      productionControl: { contractVersion: '4', liveCallMade: false },
-      preview: { contractVersion: '5', ccelBearingToolCallMaximum: 2, upstreamOriginAdmissionMaximum: 2 },
+      productionControl: {
+        contractVersionObserved: '4', discoverySchemaObserved: 'local_only', toolsListCalls: 1,
+        protectedSnapshotReads: 2, toolCallInvocations: 0,
+      },
+      preview: {
+        contractVersionObserved: '5', discoverySchemaObserved: 'ccel_exposed', ccelBearingToolCallMaximum: 2,
+        upstreamOriginAdmissionObserved: 1,
+      },
+      coordinator: {
+        delta: { admissionCount: 1, terminalOutcomeCount: 1, terminalRetirementCount: 1, operatorEpochChanged: false },
+        terminalCircuitState: 'closed',
+      },
     });
     expect(ccelCalls).toBe(2);
     expect(possibleOriginAdmissions).toBeLessThanOrEqual(2);
     expect(production.callTool).not.toHaveBeenCalled();
     expect(preview.callTool).toHaveBeenCalledTimes(3);
+    expect(dependencies.snapshotCoordinator).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(report)).not.toContain(privateMarker);
+    expect(report.productionControl).not.toHaveProperty('rolloutContract');
+    expect(report.preview).not.toHaveProperty('rolloutContract');
   });
 
   it('fails closed before any tool call when preview still advertises v4', async () => {
@@ -163,11 +217,11 @@ describe('CCEL operational scripts', () => {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: stalePreviewSchema }] }),
       callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
     };
-    await expect(runCcelPreviewAudit(auditOptions, {
-      connect: async url => url === auditOptions.productionUrl ? production : preview,
-    })).rejects.toThrow(/preview v5 CCEL contract/);
+    const dependencies = auditDependencies(production, preview);
+    await expect(runCcelPreviewAudit(auditOptions, dependencies)).rejects.toThrow(/preview v5 CCEL contract/);
     expect(production.callTool).not.toHaveBeenCalled();
     expect(preview.callTool).not.toHaveBeenCalled();
+    expect(dependencies.snapshotCoordinator).not.toHaveBeenCalled();
   });
 
   it('fails closed before any tool call when production still advertises v3', async () => {
@@ -181,11 +235,48 @@ describe('CCEL operational scripts', () => {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
       callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
     };
-    await expect(runCcelPreviewAudit(auditOptions, {
-      connect: async url => url === auditOptions.productionUrl ? production : preview,
-    })).rejects.toThrow(/production v4 local-only control/);
+    const dependencies = auditDependencies(production, preview);
+    await expect(runCcelPreviewAudit(auditOptions, dependencies)).rejects.toThrow(/production v4 local-only control/);
     expect(production.callTool).not.toHaveBeenCalled();
     expect(preview.callTool).not.toHaveBeenCalled();
+    expect(dependencies.snapshotCoordinator).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on a dirty pre-snapshot before any preview tool call', async () => {
+    const production: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const preview: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const dependencies = auditDependencies(production, preview, [
+      coordinatorSnapshot({ attemptSequence: 2, terminalRetiredThroughAttemptId: 1 }),
+    ]);
+    await expect(runCcelPreviewAudit(auditOptions, dependencies))
+      .rejects.toThrow(/clean coordinator precondition/);
+    expect(production.callTool).not.toHaveBeenCalled();
+    expect(preview.callTool).not.toHaveBeenCalled();
+    expect(dependencies.snapshotCoordinator).toHaveBeenCalledOnce();
+  });
+
+  it('sanitizes a failed protected pre-snapshot and makes no preview tool call', async () => {
+    const production: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const preview: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const dependencies = auditDependencies(production, preview);
+    dependencies.snapshotCoordinator.mockRejectedValueOnce(new Error('private-operator-material'));
+    await expect(runCcelPreviewAudit(auditOptions, dependencies))
+      .rejects.toThrow('Audit failed: protected coordinator pre-snapshot unavailable.');
+    expect(production.callTool).not.toHaveBeenCalled();
+    expect(preview.callTool).not.toHaveBeenCalled();
+    expect(dependencies.snapshotCoordinator).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -216,9 +307,7 @@ describe('CCEL operational scripts', () => {
       }),
       close: vi.fn().mockResolvedValue(undefined),
     };
-    await expect(runCcelPreviewAudit(auditOptions, {
-      connect: async url => url === auditOptions.productionUrl ? production : preview,
-    })).rejects.toThrow(/coverage|execution state/);
+    await expect(runCcelPreviewAudit(auditOptions, auditDependencies(production, preview))).rejects.toThrow(/coverage|execution state/);
     expect(production.callTool).not.toHaveBeenCalled();
     expect(preview.callTool).toHaveBeenCalledTimes(2);
   });
@@ -237,9 +326,8 @@ describe('CCEL operational scripts', () => {
       }),
       close: vi.fn().mockResolvedValue(undefined),
     };
-    await expect(runCcelPreviewAudit(auditOptions, {
-      connect: async url => url === auditOptions.productionUrl ? production : preview,
-    })).rejects.toThrow(/one admitted discovery and one globally rate-limited contender/);
+    await expect(runCcelPreviewAudit(auditOptions, auditDependencies(production, preview)))
+      .rejects.toThrow(/one admitted discovery and one globally rate-limited contender/);
     expect(possibleOriginAdmissions).toBe(2);
     expect(preview.callTool).toHaveBeenCalledTimes(2);
   });
@@ -254,9 +342,74 @@ describe('CCEL operational scripts', () => {
       callTool: vi.fn().mockResolvedValue({ isError: true, structuredContent: envelope(provider('local', 'rate_limited', 3), 'unavailable') }),
       close: vi.fn().mockResolvedValue(undefined),
     };
-    await expect(runCcelPreviewAudit(auditOptions, {
-      connect: async url => url === auditOptions.productionUrl ? production : preview,
-    })).rejects.toThrow(/unexpected tool error form/);
+    await expect(runCcelPreviewAudit(auditOptions, auditDependencies(production, preview)))
+      .rejects.toThrow(/unexpected tool error form/);
+  });
+
+  it('keeps the full retained terminal window usable and records its bounded eviction', async () => {
+    let ccelCalls = 0;
+    const production: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const preview: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
+      callTool: vi.fn(async request => {
+        const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
+        if (providers.includes('ccel')) {
+          ccelCalls++;
+          return ccelCalls === 1
+            ? { structuredContent: envelope(provider('ccel_live', 'no_results')) }
+            : { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+        }
+        return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
+      }), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const report = await runCcelPreviewAudit(auditOptions, auditDependencies(production, preview, [
+      coordinatorSnapshot({
+        attemptSequence: CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT,
+        terminalAttemptCount: CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT,
+        terminalRetiredThroughAttemptId: CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT,
+      }),
+      coordinatorSnapshot({
+        attemptSequence: CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT + 1,
+        terminalAttemptCount: CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT,
+        terminalRetiredThroughAttemptId: CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT + 1,
+      }),
+    ]));
+    expect(production.callTool).not.toHaveBeenCalled();
+    expect(preview.callTool).toHaveBeenCalledTimes(3);
+    expect(report).toMatchObject({
+      coordinator: { delta: { admissionCount: 1, terminalOutcomeCount: 0, terminalRetirementCount: 1 } },
+    });
+  });
+
+  it('requires the protected post-snapshot to prove the terminal retirement watermark advanced', async () => {
+    let ccelCalls = 0;
+    const production: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('4', false) }] }),
+      callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
+    };
+    const preview: CcelAuditClient = {
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('5', true, true) }] }),
+      callTool: vi.fn(async request => {
+        const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
+        if (providers.includes('ccel')) {
+          ccelCalls++;
+          return ccelCalls === 1
+            ? { structuredContent: envelope(provider('ccel_live', 'no_results')) }
+            : { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+        }
+        return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    await expect(runCcelPreviewAudit(auditOptions, auditDependencies(production, preview, [
+      coordinatorSnapshot(),
+      coordinatorSnapshot({ attemptSequence: 1, terminalAttemptCount: 1 }),
+    ]))).rejects.toThrow(/one admitted and finalized contender/);
+    expect(production.callTool).not.toHaveBeenCalled();
+    expect(preview.callTool).toHaveBeenCalledTimes(2);
   });
 
   it('requires exact operator reset preconditions', () => {


### PR DESCRIPTION
## Summary

- require exact production Worker version evidence for the live CCEL preview canary
- prove one shared-coordinator admission and terminal retirement with protected before/after snapshots
- preserve the hard two-call budget, content-free reporting, and full-window eviction semantics
- document exact authorization and UUID verification timing

## Scope

Audit tooling, tests, and documentation only. No runtime, Worker configuration, workflow, database, preview, production, secret, or live CCEL change.

## Verification

- 130/130 CCEL tests
- Node and Worker typechecks
- independent Sol review: GO, zero P0-P3 findings
- git diff check

No preview deployment is requested.