### PR TITLE
Prepare historical source-first compatibility compiler

### DIFF
--- a/docs/HISTORICAL-SECTION-COMPATIBILITY-EVIDENCE.md
+++ b/docs/HISTORICAL-SECTION-COMPATIBILITY-EVIDENCE.md
@@ -1,5 +1,12 @@
 # Historical section compatibility evidence
 
+The approved source-first decision in this packet is also consumed by the
+migration-free, runtime-inactive compiler described in
+`docs/HISTORICAL-SECTION-SOURCE-FIRST-COMPILER.md`. That compiler freezes all
+17 works and all section/alias identities behind a compact regenerated-output
+attestation; it does not change the current unordered runtime behavior described
+below.
+
 This is an inactive, offline prerequisite for a later historical-section-key
 migration. It changes no historical JSON source, database schema, D1 seed,
 repository query, MCP resource, tool, prompt, Worker configuration, or deployed

--- a/docs/HISTORICAL-SECTION-SOURCE-FIRST-COMPILER.md
+++ b/docs/HISTORICAL-SECTION-SOURCE-FIRST-COMPILER.md
@@ -1,0 +1,77 @@
+# Historical section source-first compatibility compiler
+
+Status: **migration-free preparation; runtime inactive**
+Scope: **the existing 17 checked-in local historical works only**
+Activation gate: **migration `0005`, transform 8, separately reviewed and approved**
+
+## What this freezes
+
+The offline compiler in `scripts/historical-section-compatibility-compiler.ts`
+reconstructs a content-free compatibility map from three authoritative inputs:
+
+1. the current JSON documents in `data/historical-documents/`;
+2. the immutable section-key ledger in
+   `data/historical-section-key-plan.json`; and
+3. the approved source-first decision packet in
+   `test/fixtures/historical-section-compatibility/real-local-evidence.json`.
+
+For every source section, the output binds the existing document ID, one-based
+source ordinal, source signature, old display-number locator, immutable section
+key, and canonical resource locator. For every old locator, it binds exactly one
+future alias target: the first matching section in checked-in source order.
+Canonical section keys are resolved before legacy aliases. An alias that would
+shadow a different canonical key is rejected.
+
+The regenerated output has exactly:
+
+- 17 documents;
+- 3,054 canonical section rows;
+- 2,821 legacy locator aliases; and
+- 23 collision groups, covering 256 sections and making 233 sections newly
+  addressable.
+
+The output intentionally contains no title, body, question, answer, topic, or
+edition-rights fields. Source signatures bind the map to the unchanged current
+content without copying that content into compatibility evidence.
+
+## Compact attestation
+
+`test/fixtures/historical-section-compatibility/source-first-compiler-attestation.json`
+is a compact fail-closed attestation. It pins:
+
+- compiler schema version and the exact inactive policy;
+- canonical hashes of the section-key plan, ordered historical source set, and
+  approved source-first evidence;
+- all six exact count sentinels; and
+- the SHA-256 of the complete canonical compiled output.
+
+The attestation is not a source of section identities or content. Verification
+always regenerates and validates every map row from the authoritative inputs,
+then compares the complete output hash. A future migration may obtain the full
+map only by running the compiler; it must not expand or reinterpret the compact
+attestation as data.
+
+## Verification and future emission
+
+The compiler is intentionally absent from package scripts, builds, runtime
+imports, deployment configuration, manifests, Wrangler configuration, and
+workflows. It makes no database or filesystem writes.
+
+```bash
+npx tsx scripts/historical-section-compatibility-compiler.ts
+npx tsx scripts/historical-section-compatibility-compiler.ts --emit-map
+npx vitest run test/unit/scripts/historicalSectionCompatibilityCompiler.test.ts
+```
+
+The first command regenerates every row and verifies the tracked attestation.
+The second writes the verified full map to standard output for inspection or a
+future separately gated migration compiler. Neither command migrates data or
+changes runtime behavior.
+
+## Explicit non-goals
+
+This preparation does not add migration `0005`, transform historical sources,
+change D1 or SQLite, regenerate seeds or manifests, register MCP resources,
+alter document content or IDs, assign edition rights, or claim production
+observation. It does not include Norton/EEBO-TCP acquisition work or establish
+the separate `sectioned_only` delivery contract.

--- a/scripts/historical-section-compatibility-compiler.ts
+++ b/scripts/historical-section-compatibility-compiler.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env tsx
+
+/**
+ * Compile the reviewed source-first compatibility map for the 17 current local
+ * historical works without changing a database, seed, manifest, or runtime.
+ *
+ * The checked-in attestation is evidence about a reproducible output, never an
+ * input from which section data may be reconstructed. A future reviewed
+ * migration must call the compiler against the then-current sources and key
+ * ledger, verify the attestation, and consume the emitted map.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildLocalDocumentResourceUri } from '../src/kernel/documentResource.js';
+import {
+  HISTORICAL_SECTION_KEY_PLAN_PATH,
+  historicalLegacySectionId,
+  parseHistoricalSectionKeyPlan,
+  readHistoricalSectionSources,
+  sha256Canonical,
+  verifyHistoricalSectionKeyPlan,
+  type HistoricalSectionKeyPlan,
+  type HistoricalSectionSourceDocument,
+} from './historical-section-key-plan.js';
+import {
+  parseHistoricalSectionCompatibilityEvidence,
+  verifyHistoricalSectionCompatibilityEvidenceFromSources,
+  type HistoricalSectionCompatibilityEvidence,
+} from './historical-section-compatibility-evidence.js';
+import {
+  HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_KIND,
+  HISTORICAL_SECTION_COMPATIBILITY_COMPILER_SCHEMA_VERSION,
+  HISTORICAL_SECTION_COMPATIBILITY_MAP_KIND,
+  HISTORICAL_SECTION_COMPATIBILITY_POLICY,
+  countHistoricalSectionCompatibilityMap,
+  parseHistoricalSectionCompatibilityAttestation,
+  parseHistoricalSectionCompatibilityMap,
+  sameHistoricalSectionCompatibilityCounts,
+  type HistoricalSectionCompatibilityAttestation,
+  type HistoricalSectionCompatibilityCounts,
+  type HistoricalSectionCompatibilityMap,
+  type HistoricalSectionCompatibilityMapAlias,
+  type HistoricalSectionCompatibilityMapDocument,
+  type HistoricalSectionCompatibilityMapSection,
+} from './historical-section-compatibility-schema.js';
+
+export {
+  HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_KIND,
+  HISTORICAL_SECTION_COMPATIBILITY_COMPILER_SCHEMA_VERSION,
+  HISTORICAL_SECTION_COMPATIBILITY_MAP_KIND,
+  HISTORICAL_SECTION_COMPATIBILITY_POLICY,
+  countHistoricalSectionCompatibilityMap,
+  parseHistoricalSectionCompatibilityAttestation,
+  parseHistoricalSectionCompatibilityMap,
+  resolveHistoricalSectionCompatibility,
+  type HistoricalSectionCompatibilityAttestation,
+  type HistoricalSectionCompatibilityCounts,
+  type HistoricalSectionCompatibilityMap,
+  type HistoricalSectionCompatibilityMapAlias,
+  type HistoricalSectionCompatibilityMapDocument,
+  type HistoricalSectionCompatibilityMapSection,
+  type HistoricalSectionCompatibilityResolution,
+} from './historical-section-compatibility-schema.js';
+
+export const HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_PATH =
+  'test/fixtures/historical-section-compatibility/source-first-compiler-attestation.json';
+export const HISTORICAL_SECTION_COMPATIBILITY_EVIDENCE_PATH =
+  'test/fixtures/historical-section-compatibility/real-local-evidence.json';
+
+export interface HistoricalSectionCompatibilityCompilation {
+  map: HistoricalSectionCompatibilityMap;
+  attestation: HistoricalSectionCompatibilityAttestation;
+  counts: HistoricalSectionCompatibilityCounts;
+}
+
+/** Compile only from source documents, the immutable key plan, and the approved evidence. */
+export function compileHistoricalSectionCompatibility(
+  plan: HistoricalSectionKeyPlan,
+  sources: HistoricalSectionSourceDocument[],
+  approvedEvidence: HistoricalSectionCompatibilityEvidence,
+): HistoricalSectionCompatibilityCompilation {
+  const planReport = verifyHistoricalSectionKeyPlan(plan, sources);
+  const sourceById = new Map(sources.map(source => [source.documentId, source]));
+
+  const documents = plan.documents.map((document): HistoricalSectionCompatibilityMapDocument => {
+    const source = sourceById.get(document.documentId);
+    if (!source) throw new Error(`Compatibility compiler has no source document for ${document.documentId}`);
+    const keyBySignature = new Map(document.sections.map(section => [section.sourceSignature, section.sectionKey]));
+    const sections = source.value.sections.map((section, sourceIndex): HistoricalSectionCompatibilityMapSection => {
+      const sourceSignature = sha256Canonical(section);
+      const sectionKey = keyBySignature.get(sourceSignature);
+      if (!sectionKey) throw new Error(`Compatibility compiler has no immutable key for ${document.documentId} source row ${sourceIndex + 1}`);
+      const canonicalLocator = buildLocalDocumentResourceUri(document.documentId, sectionKey);
+      if (!canonicalLocator) throw new Error(`Compatibility compiler cannot form a canonical locator for ${document.documentId}#${sectionKey}`);
+      return {
+        sourceOrdinal: sourceIndex + 1,
+        sourceSignature,
+        legacySectionId: historicalLegacySectionId(section, sourceIndex),
+        sectionKey,
+        canonicalLocator,
+      };
+    });
+    const sectionByKey = new Map(sections.map(section => [section.sectionKey, section]));
+    const legacyAliases = document.legacyLocators.map((alias): HistoricalSectionCompatibilityMapAlias => {
+      const target = sectionByKey.get(alias.sectionKey);
+      if (!target) throw new Error(`Compatibility compiler alias targets an unknown key: ${document.documentId}#${alias.sectionKey}`);
+      return {
+        legacySectionId: alias.legacySectionId,
+        targetSectionKey: target.sectionKey,
+        targetSourceOrdinal: target.sourceOrdinal,
+        targetCanonicalLocator: target.canonicalLocator,
+      };
+    });
+    return { documentId: document.documentId, sections, legacyAliases };
+  });
+
+  const map = parseHistoricalSectionCompatibilityMap({
+    schemaVersion: HISTORICAL_SECTION_COMPATIBILITY_COMPILER_SCHEMA_VERSION,
+    kind: HISTORICAL_SECTION_COMPATIBILITY_MAP_KIND,
+    policy: HISTORICAL_SECTION_COMPATIBILITY_POLICY,
+    documents,
+  });
+  verifyApprovedEvidenceAgainstCompiledMap(plan, approvedEvidence, map);
+  const counts = countHistoricalSectionCompatibilityMap(map);
+  if (!sameHistoricalSectionCompatibilityCounts(counts, planReport)) {
+    throw new Error('Compatibility compiler output counts contradict the verified section-key plan');
+  }
+  const attestation: HistoricalSectionCompatibilityAttestation = {
+    schemaVersion: HISTORICAL_SECTION_COMPATIBILITY_COMPILER_SCHEMA_VERSION,
+    kind: HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_KIND,
+    policy: HISTORICAL_SECTION_COMPATIBILITY_POLICY,
+    inputs: {
+      historicalSectionKeyPlanCanonicalSha256: sha256Canonical(plan),
+      historicalSourcesCanonicalSha256: sha256Canonical(sources.map(source => ({
+        documentId: source.documentId,
+        sourceCanonicalSha256: sha256Canonical(source.value),
+      }))),
+      approvedSourceFirstEvidenceCanonicalSha256: sha256Canonical(approvedEvidence),
+    },
+    exactCounts: counts,
+    canonicalOutputSha256: sha256Canonical(map),
+  };
+  return { map, attestation: parseHistoricalSectionCompatibilityAttestation(attestation), counts };
+}
+
+function verifyApprovedEvidenceAgainstCompiledMap(
+  plan: HistoricalSectionKeyPlan,
+  evidence: HistoricalSectionCompatibilityEvidence,
+  map: HistoricalSectionCompatibilityMap,
+): void {
+  if (evidence.historicalSectionKeyPlanSha256 !== sha256Canonical(plan)) {
+    throw new Error('Approved source-first evidence does not bind the compiled section-key plan');
+  }
+  const compiledGroups = map.documents.flatMap(document => {
+    const byLegacy = new Map<string, HistoricalSectionCompatibilityMapSection[]>();
+    for (const section of document.sections) {
+      const group = byLegacy.get(section.legacySectionId) ?? [];
+      group.push(section);
+      byLegacy.set(section.legacySectionId, group);
+    }
+    return [...byLegacy.entries()]
+      .filter(([, sections]) => sections.length > 1)
+      .map(([legacySectionId, sections]) => ({
+        documentId: document.documentId,
+        legacySectionId,
+        members: sections.map(section => ({
+          sourceOrdinal: section.sourceOrdinal,
+          sourceSignature: section.sourceSignature,
+          plannedSectionKey: section.sectionKey,
+        })),
+      }));
+  }).sort((left, right) => {
+    const leftId = `${left.documentId}\u0000${left.legacySectionId}`;
+    const rightId = `${right.documentId}\u0000${right.legacySectionId}`;
+    return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+  });
+  const approvedGroups = evidence.collisionGroups.map(group => ({
+    documentId: group.documentId,
+    legacySectionId: group.legacySectionId,
+    members: group.members.map(member => ({
+      sourceOrdinal: member.sourceOrdinal,
+      sourceSignature: member.sourceSignature,
+      plannedSectionKey: member.plannedSectionKey,
+    })),
+  }));
+  if (sha256Canonical(compiledGroups) !== sha256Canonical(approvedGroups)) {
+    throw new Error('Approved source-first evidence does not exactly cover compiled collision members and keys');
+  }
+}
+
+/** Read and verify all three authoritative inputs before compiling. */
+export function compileHistoricalSectionCompatibilityFromDisk(root: string): HistoricalSectionCompatibilityCompilation {
+  const plan = parseHistoricalSectionKeyPlan(JSON.parse(readFileSync(join(root, HISTORICAL_SECTION_KEY_PLAN_PATH), 'utf8')));
+  const sources = readHistoricalSectionSources(root);
+  const evidence = parseHistoricalSectionCompatibilityEvidence(JSON.parse(readFileSync(
+    join(root, HISTORICAL_SECTION_COMPATIBILITY_EVIDENCE_PATH),
+    'utf8',
+  )));
+  verifyHistoricalSectionCompatibilityEvidenceFromSources(root, evidence);
+  return compileHistoricalSectionCompatibility(plan, sources, evidence);
+}
+
+/** Verify the compact packet by regenerating every output row from authority. */
+export function verifyHistoricalSectionCompatibilityAttestationFromDisk(
+  root: string,
+): HistoricalSectionCompatibilityCompilation {
+  const tracked = parseHistoricalSectionCompatibilityAttestation(JSON.parse(readFileSync(
+    join(root, HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_PATH),
+    'utf8',
+  )));
+  const compilation = compileHistoricalSectionCompatibilityFromDisk(root);
+  if (sha256Canonical(tracked) !== sha256Canonical(compilation.attestation)) {
+    throw new Error('Historical section compatibility attestation does not match regenerated authoritative inputs and output');
+  }
+  return compilation;
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  if (process.argv.length === 2) {
+    const compilation = verifyHistoricalSectionCompatibilityAttestationFromDisk(root);
+    process.stdout.write(`${JSON.stringify({ ...compilation.counts, canonicalOutputSha256: compilation.attestation.canonicalOutputSha256 })}\n`);
+  } else if (process.argv.length === 3 && process.argv[2] === '--emit-map') {
+    const compilation = verifyHistoricalSectionCompatibilityAttestationFromDisk(root);
+    process.stdout.write(`${JSON.stringify(compilation.map)}\n`);
+  } else {
+    throw new Error('Usage: historical-section-compatibility-compiler.ts [--emit-map]');
+  }
+}

--- a/scripts/historical-section-compatibility-schema.ts
+++ b/scripts/historical-section-compatibility-schema.ts
@@ -1,0 +1,296 @@
+import { buildLocalDocumentResourceUri } from '../src/kernel/documentResource.js';
+import { sha256Canonical } from './historical-section-key-plan.js';
+
+export const HISTORICAL_SECTION_COMPATIBILITY_MAP_KIND =
+  'historical_section_source_first_compatibility_map' as const;
+export const HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_KIND =
+  'historical_section_source_first_compiler_attestation' as const;
+export const HISTORICAL_SECTION_COMPATIBILITY_COMPILER_SCHEMA_VERSION = 1 as const;
+
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/;
+const DOCUMENT_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$/;
+const SHA256 = /^[a-f0-9]{64}$/;
+
+export const HISTORICAL_SECTION_COMPATIBILITY_POLICY = {
+  scope: 'existing_17_local_works_only',
+  sourceAuthority: 'current_checked_in_historical_documents',
+  keyAuthority: 'checked_in_immutable_section_key_plan',
+  legacyAliasTarget: 'approved_source_first',
+  resolutionOrder: 'canonical_before_legacy_alias',
+  contentPolicy: 'excluded_source_signatures_only',
+  runtimeStatus: 'inactive_until_0005_transform_8',
+  productionObservedTarget: null,
+} as const;
+
+export interface HistoricalSectionCompatibilityMapSection {
+  sourceOrdinal: number;
+  sourceSignature: string;
+  legacySectionId: string;
+  sectionKey: string;
+  canonicalLocator: string;
+}
+
+export interface HistoricalSectionCompatibilityMapAlias {
+  legacySectionId: string;
+  targetSectionKey: string;
+  targetSourceOrdinal: number;
+  targetCanonicalLocator: string;
+}
+
+export interface HistoricalSectionCompatibilityMapDocument {
+  documentId: string;
+  sections: HistoricalSectionCompatibilityMapSection[];
+  legacyAliases: HistoricalSectionCompatibilityMapAlias[];
+}
+
+export interface HistoricalSectionCompatibilityMap {
+  schemaVersion: 1;
+  kind: typeof HISTORICAL_SECTION_COMPATIBILITY_MAP_KIND;
+  policy: typeof HISTORICAL_SECTION_COMPATIBILITY_POLICY;
+  documents: HistoricalSectionCompatibilityMapDocument[];
+}
+
+export interface HistoricalSectionCompatibilityCounts {
+  documentCount: number;
+  sectionCount: number;
+  legacyLocatorCount: number;
+  collisionGroups: number;
+  affectedSections: number;
+  newlyAddressableSections: number;
+}
+
+export interface HistoricalSectionCompatibilityAttestation {
+  schemaVersion: 1;
+  kind: typeof HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_KIND;
+  policy: typeof HISTORICAL_SECTION_COMPATIBILITY_POLICY;
+  inputs: {
+    historicalSectionKeyPlanCanonicalSha256: string;
+    historicalSourcesCanonicalSha256: string;
+    approvedSourceFirstEvidenceCanonicalSha256: string;
+  };
+  exactCounts: HistoricalSectionCompatibilityCounts;
+  canonicalOutputSha256: string;
+}
+
+export interface HistoricalSectionCompatibilityResolution {
+  kind: 'canonical' | 'legacy_alias';
+  documentId: string;
+  sectionKey: string;
+  sourceOrdinal: number;
+  canonicalLocator: string;
+}
+
+/** Parse a future migration input with a closed schema and source-first semantics. */
+export function parseHistoricalSectionCompatibilityMap(value: unknown): HistoricalSectionCompatibilityMap {
+  const root = record(value, 'Historical section compatibility map');
+  exactKeys(root, ['schemaVersion', 'kind', 'policy', 'documents'], 'Historical section compatibility map');
+  if (root.schemaVersion !== HISTORICAL_SECTION_COMPATIBILITY_COMPILER_SCHEMA_VERSION
+    || root.kind !== HISTORICAL_SECTION_COMPATIBILITY_MAP_KIND) {
+    throw new Error('Historical section compatibility map has an unsupported identity or schema version');
+  }
+  parsePolicy(root.policy);
+  if (!Array.isArray(root.documents) || root.documents.length < 1 || root.documents.length > 100) {
+    throw new Error('Historical section compatibility map must contain 1..100 documents');
+  }
+  const documentIds = new Set<string>();
+  const documents = root.documents.map((rawDocument, documentIndex): HistoricalSectionCompatibilityMapDocument => {
+    const document = record(rawDocument, `Compatibility document ${documentIndex + 1}`);
+    exactKeys(document, ['documentId', 'sections', 'legacyAliases'], `Compatibility document ${documentIndex + 1}`);
+    const documentId = safeText(document.documentId, DOCUMENT_ID, `Compatibility document ${documentIndex + 1} id`);
+    if (documentIds.has(documentId)) throw new Error(`Duplicate compatibility document: ${documentId}`);
+    documentIds.add(documentId);
+    if (!Array.isArray(document.sections) || document.sections.length < 1 || document.sections.length > 2000) {
+      throw new Error(`Compatibility document ${documentId} must contain 1..2000 sections`);
+    }
+    const sectionKeys = new Set<string>();
+    const signatures = new Set<string>();
+    const sections = document.sections.map((rawSection, sectionIndex): HistoricalSectionCompatibilityMapSection => {
+      const section = record(rawSection, `${documentId} compatibility section ${sectionIndex + 1}`);
+      exactKeys(section, ['sourceOrdinal', 'sourceSignature', 'legacySectionId', 'sectionKey', 'canonicalLocator'], `${documentId} compatibility section ${sectionIndex + 1}`);
+      const sourceOrdinal = positiveInteger(section.sourceOrdinal, `${documentId} compatibility source ordinal`);
+      if (sourceOrdinal !== sectionIndex + 1) throw new Error(`${documentId} compatibility source ordinals must be dense and source-ordered`);
+      const sourceSignature = hash(section.sourceSignature, `${documentId} compatibility source signature`);
+      const legacySectionId = safeText(section.legacySectionId, SAFE_ID, `${documentId} compatibility legacy locator`);
+      const sectionKey = safeText(section.sectionKey, SAFE_ID, `${documentId} compatibility section key`);
+      const canonicalLocator = exactLocator(section.canonicalLocator, documentId, sectionKey, `${documentId} compatibility canonical locator`);
+      if (signatures.has(sourceSignature)) throw new Error(`${documentId} compatibility source signatures must be unique`);
+      if (sectionKeys.has(sectionKey)) throw new Error(`${documentId} compatibility section keys must be unique`);
+      signatures.add(sourceSignature);
+      sectionKeys.add(sectionKey);
+      return { sourceOrdinal, sourceSignature, legacySectionId, sectionKey, canonicalLocator };
+    });
+    if (!Array.isArray(document.legacyAliases) || document.legacyAliases.length < 1 || document.legacyAliases.length > 2000) {
+      throw new Error(`Compatibility document ${documentId} must contain 1..2000 legacy aliases`);
+    }
+    const sectionByKey = new Map(sections.map(section => [section.sectionKey, section]));
+    const firstByLegacy = new Map<string, HistoricalSectionCompatibilityMapSection>();
+    for (const section of sections) if (!firstByLegacy.has(section.legacySectionId)) firstByLegacy.set(section.legacySectionId, section);
+    const aliasIds = new Set<string>();
+    const legacyAliases = document.legacyAliases.map((rawAlias, aliasIndex): HistoricalSectionCompatibilityMapAlias => {
+      const alias = record(rawAlias, `${documentId} compatibility alias ${aliasIndex + 1}`);
+      exactKeys(alias, ['legacySectionId', 'targetSectionKey', 'targetSourceOrdinal', 'targetCanonicalLocator'], `${documentId} compatibility alias ${aliasIndex + 1}`);
+      const legacySectionId = safeText(alias.legacySectionId, SAFE_ID, `${documentId} compatibility alias id`);
+      const targetSectionKey = safeText(alias.targetSectionKey, SAFE_ID, `${documentId} compatibility alias target`);
+      const targetSourceOrdinal = positiveInteger(alias.targetSourceOrdinal, `${documentId} compatibility alias target ordinal`);
+      const targetCanonicalLocator = exactLocator(alias.targetCanonicalLocator, documentId, targetSectionKey, `${documentId} compatibility alias locator`);
+      if (aliasIds.has(legacySectionId)) throw new Error(`${documentId} compatibility aliases must be unique`);
+      aliasIds.add(legacySectionId);
+      const target = sectionByKey.get(targetSectionKey);
+      const first = firstByLegacy.get(legacySectionId);
+      if (!target || target.sourceOrdinal !== targetSourceOrdinal || target.canonicalLocator !== targetCanonicalLocator) {
+        throw new Error(`${documentId} compatibility alias target does not match a canonical section`);
+      }
+      if (!first || target.sectionKey !== first.sectionKey) {
+        throw new Error(`${documentId} compatibility alias ${legacySectionId} is not the sole source-first target`);
+      }
+      const canonicalShadow = sectionByKey.get(legacySectionId);
+      if (canonicalShadow && canonicalShadow.sectionKey !== target.sectionKey) {
+        throw new Error(`${documentId} compatibility alias conflicts with canonical-before-alias resolution`);
+      }
+      return { legacySectionId, targetSectionKey, targetSourceOrdinal, targetCanonicalLocator };
+    });
+    if (aliasIds.size !== firstByLegacy.size || [...firstByLegacy.keys()].some(id => !aliasIds.has(id))) {
+      throw new Error(`${documentId} compatibility aliases must exactly cover legacy locator groups`);
+    }
+    assertSorted(legacyAliases.map(alias => alias.legacySectionId), `${documentId} compatibility aliases`);
+    return { documentId, sections, legacyAliases };
+  });
+  assertSorted(documents.map(document => document.documentId), 'Compatibility documents');
+  return { schemaVersion: 1, kind: HISTORICAL_SECTION_COMPATIBILITY_MAP_KIND, policy: HISTORICAL_SECTION_COMPATIBILITY_POLICY, documents };
+}
+
+/** Canonical identifiers always win; aliases are consulted only on a miss. */
+export function resolveHistoricalSectionCompatibility(
+  map: HistoricalSectionCompatibilityMap,
+  documentId: string,
+  locator: string,
+): HistoricalSectionCompatibilityResolution | undefined {
+  const document = map.documents.find(candidate => candidate.documentId === documentId);
+  if (!document) return undefined;
+  const canonical = document.sections.find(section => section.sectionKey === locator);
+  if (canonical) return {
+    kind: 'canonical', documentId, sectionKey: canonical.sectionKey,
+    sourceOrdinal: canonical.sourceOrdinal, canonicalLocator: canonical.canonicalLocator,
+  };
+  const alias = document.legacyAliases.find(candidate => candidate.legacySectionId === locator);
+  if (!alias) return undefined;
+  return {
+    kind: 'legacy_alias', documentId, sectionKey: alias.targetSectionKey,
+    sourceOrdinal: alias.targetSourceOrdinal, canonicalLocator: alias.targetCanonicalLocator,
+  };
+}
+
+export function countHistoricalSectionCompatibilityMap(map: HistoricalSectionCompatibilityMap): HistoricalSectionCompatibilityCounts {
+  let sectionCount = 0;
+  let legacyLocatorCount = 0;
+  let collisionGroups = 0;
+  let affectedSections = 0;
+  let newlyAddressableSections = 0;
+  for (const document of map.documents) {
+    sectionCount += document.sections.length;
+    legacyLocatorCount += document.legacyAliases.length;
+    const groupSizes = new Map<string, number>();
+    for (const section of document.sections) groupSizes.set(section.legacySectionId, (groupSizes.get(section.legacySectionId) ?? 0) + 1);
+    for (const size of groupSizes.values()) if (size > 1) {
+      collisionGroups++;
+      affectedSections += size;
+      newlyAddressableSections += size - 1;
+    }
+  }
+  return { documentCount: map.documents.length, sectionCount, legacyLocatorCount, collisionGroups, affectedSections, newlyAddressableSections };
+}
+
+export function parseHistoricalSectionCompatibilityAttestation(value: unknown): HistoricalSectionCompatibilityAttestation {
+  const root = record(value, 'Historical section compatibility attestation');
+  exactKeys(root, ['schemaVersion', 'kind', 'policy', 'inputs', 'exactCounts', 'canonicalOutputSha256'], 'Historical section compatibility attestation');
+  if (root.schemaVersion !== HISTORICAL_SECTION_COMPATIBILITY_COMPILER_SCHEMA_VERSION
+    || root.kind !== HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_KIND) {
+    throw new Error('Historical section compatibility attestation has an unsupported identity or schema version');
+  }
+  parsePolicy(root.policy);
+  const inputs = record(root.inputs, 'Historical section compatibility attestation inputs');
+  exactKeys(inputs, ['historicalSectionKeyPlanCanonicalSha256', 'historicalSourcesCanonicalSha256', 'approvedSourceFirstEvidenceCanonicalSha256'], 'Historical section compatibility attestation inputs');
+  const exactCounts = parseCounts(root.exactCounts);
+  const reviewed = { documentCount: 17, sectionCount: 3054, legacyLocatorCount: 2821, collisionGroups: 23, affectedSections: 256, newlyAddressableSections: 233 };
+  if (!sameCounts(exactCounts, reviewed)) throw new Error('Historical section compatibility attestation must retain exact 17/3054/2821 and 23/256/233 sentinels');
+  return {
+    schemaVersion: 1,
+    kind: HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_KIND,
+    policy: HISTORICAL_SECTION_COMPATIBILITY_POLICY,
+    inputs: {
+      historicalSectionKeyPlanCanonicalSha256: hash(inputs.historicalSectionKeyPlanCanonicalSha256, 'Historical section-key plan input hash'),
+      historicalSourcesCanonicalSha256: hash(inputs.historicalSourcesCanonicalSha256, 'Historical sources input hash'),
+      approvedSourceFirstEvidenceCanonicalSha256: hash(inputs.approvedSourceFirstEvidenceCanonicalSha256, 'Approved source-first evidence input hash'),
+    },
+    exactCounts,
+    canonicalOutputSha256: hash(root.canonicalOutputSha256, 'Historical section compatibility output hash'),
+  };
+}
+
+export function sameHistoricalSectionCompatibilityCounts(
+  actual: HistoricalSectionCompatibilityCounts,
+  expected: HistoricalSectionCompatibilityCounts,
+): boolean {
+  return sameCounts(actual, expected);
+}
+
+function parsePolicy(value: unknown): typeof HISTORICAL_SECTION_COMPATIBILITY_POLICY {
+  const policy = record(value, 'Historical section compatibility policy');
+  exactKeys(policy, Object.keys(HISTORICAL_SECTION_COMPATIBILITY_POLICY), 'Historical section compatibility policy');
+  if (sha256Canonical(policy) !== sha256Canonical(HISTORICAL_SECTION_COMPATIBILITY_POLICY)) {
+    throw new Error('Historical section compatibility policy must remain source-first, canonical-before-alias, content-free, and runtime-inactive');
+  }
+  return HISTORICAL_SECTION_COMPATIBILITY_POLICY;
+}
+
+function parseCounts(value: unknown): HistoricalSectionCompatibilityCounts {
+  const counts = record(value, 'Historical section compatibility counts');
+  const keys = ['documentCount', 'sectionCount', 'legacyLocatorCount', 'collisionGroups', 'affectedSections', 'newlyAddressableSections'];
+  exactKeys(counts, keys, 'Historical section compatibility counts');
+  for (const key of keys) if (!Number.isSafeInteger(counts[key]) || (counts[key] as number) < 0) throw new Error(`Historical section compatibility count ${key} must be a non-negative safe integer`);
+  return counts as unknown as HistoricalSectionCompatibilityCounts;
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${field} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: string[], field: string): void {
+  if (JSON.stringify(Object.keys(value).sort(compareText)) !== JSON.stringify([...keys].sort(compareText))) throw new Error(`${field} must have exact keys: ${keys.join(', ')}`);
+}
+
+function safeText(value: unknown, pattern: RegExp, field: string): string {
+  if (typeof value !== 'string' || !pattern.test(value) || value === '.' || value === '..') throw new Error(`${field} is outside the safe identity alphabet or length bound`);
+  return value;
+}
+
+function hash(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !SHA256.test(value)) throw new Error(`${field} must be a lowercase SHA-256`);
+  return value;
+}
+
+function positiveInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 1) throw new Error(`${field} must be a positive safe integer`);
+  return value as number;
+}
+
+function exactLocator(value: unknown, documentId: string, sectionKey: string, field: string): string {
+  const expected = buildLocalDocumentResourceUri(documentId, sectionKey);
+  if (typeof value !== 'string' || value !== expected) throw new Error(`${field} must be the exact canonical section locator`);
+  return value;
+}
+
+function sameCounts(actual: HistoricalSectionCompatibilityCounts, expected: HistoricalSectionCompatibilityCounts): boolean {
+  return actual.documentCount === expected.documentCount && actual.sectionCount === expected.sectionCount
+    && actual.legacyLocatorCount === expected.legacyLocatorCount && actual.collisionGroups === expected.collisionGroups
+    && actual.affectedSections === expected.affectedSections && actual.newlyAddressableSections === expected.newlyAddressableSections;
+}
+
+function assertSorted(values: string[], field: string): void {
+  if (JSON.stringify(values) !== JSON.stringify([...values].sort(compareText))) throw new Error(`${field} must be sorted`);
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/test/fixtures/historical-section-compatibility/source-first-compiler-attestation.json
+++ b/test/fixtures/historical-section-compatibility/source-first-compiler-attestation.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "kind": "historical_section_source_first_compiler_attestation",
+  "policy": {
+    "scope": "existing_17_local_works_only",
+    "sourceAuthority": "current_checked_in_historical_documents",
+    "keyAuthority": "checked_in_immutable_section_key_plan",
+    "legacyAliasTarget": "approved_source_first",
+    "resolutionOrder": "canonical_before_legacy_alias",
+    "contentPolicy": "excluded_source_signatures_only",
+    "runtimeStatus": "inactive_until_0005_transform_8",
+    "productionObservedTarget": null
+  },
+  "inputs": {
+    "historicalSectionKeyPlanCanonicalSha256": "27d82c139aeb8521fab535a0988c0e7f0902e6b3aedf1970bb8a5c0b26702fbf",
+    "historicalSourcesCanonicalSha256": "9c987dc30ed3a9dfe29c83a25693c55797cef367deeb4f764386fa07fb3b61c4",
+    "approvedSourceFirstEvidenceCanonicalSha256": "158082ee3e42bcc211b955970ed13a2f0e1758df9cf1ae8b2bac6fc961f4a085"
+  },
+  "exactCounts": {
+    "documentCount": 17,
+    "sectionCount": 3054,
+    "legacyLocatorCount": 2821,
+    "collisionGroups": 23,
+    "affectedSections": 256,
+    "newlyAddressableSections": 233
+  },
+  "canonicalOutputSha256": "3a8734e7f5ee4974f7b88811e7507021cfaddd5cfdbc0ab6f801b1e7d43a5bc5"
+}

--- a/test/unit/scripts/historicalSectionCompatibilityCompiler.test.ts
+++ b/test/unit/scripts/historicalSectionCompatibilityCompiler.test.ts
@@ -1,0 +1,270 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_PATH,
+  HISTORICAL_SECTION_COMPATIBILITY_POLICY,
+  compileHistoricalSectionCompatibility,
+  compileHistoricalSectionCompatibilityFromDisk,
+  countHistoricalSectionCompatibilityMap,
+  parseHistoricalSectionCompatibilityAttestation,
+  parseHistoricalSectionCompatibilityMap,
+  resolveHistoricalSectionCompatibility,
+  verifyHistoricalSectionCompatibilityAttestationFromDisk,
+  type HistoricalSectionCompatibilityMap,
+} from '../../../scripts/historical-section-compatibility-compiler.js';
+import {
+  parseHistoricalSectionKeyPlan,
+  readHistoricalSectionSources,
+} from '../../../scripts/historical-section-key-plan.js';
+import { parseHistoricalSectionCompatibilityEvidence } from '../../../scripts/historical-section-compatibility-evidence.js';
+import { buildLocalDocumentResourceUri } from '../../../src/kernel/documentResource.js';
+
+const ROOT = process.cwd();
+
+function trackedAttestation(): unknown {
+  return JSON.parse(readFileSync(HISTORICAL_SECTION_COMPATIBILITY_ATTESTATION_PATH, 'utf8'));
+}
+
+describe('historical section source-first compatibility compiler', () => {
+  it('regenerates and attests every row for exactly the approved 17-work scope', () => {
+    const compilation = verifyHistoricalSectionCompatibilityAttestationFromDisk(ROOT);
+
+    expect(compilation.counts).toEqual({
+      documentCount: 17,
+      sectionCount: 3054,
+      legacyLocatorCount: 2821,
+      collisionGroups: 23,
+      affectedSections: 256,
+      newlyAddressableSections: 233,
+    });
+    expect(countHistoricalSectionCompatibilityMap(compilation.map)).toEqual(compilation.counts);
+    expect(compilation.attestation.policy).toEqual(HISTORICAL_SECTION_COMPATIBILITY_POLICY);
+    expect(compilation.map.documents.map(document => document.documentId)).toEqual(
+      [...compilation.map.documents.map(document => document.documentId)].sort(),
+    );
+
+    let visitedSections = 0;
+    let visitedAliases = 0;
+    for (const document of compilation.map.documents) {
+      const sectionByKey = new Map(document.sections.map(section => [section.sectionKey, section]));
+      for (const [index, section] of document.sections.entries()) {
+        visitedSections++;
+        expect(section.sourceOrdinal).toBe(index + 1);
+        expect(section.canonicalLocator).toBe(buildLocalDocumentResourceUri(document.documentId, section.sectionKey));
+        expect(Object.keys(section).sort()).toEqual([
+          'canonicalLocator',
+          'legacySectionId',
+          'sectionKey',
+          'sourceOrdinal',
+          'sourceSignature',
+        ]);
+      }
+      for (const alias of document.legacyAliases) {
+        visitedAliases++;
+        const target = sectionByKey.get(alias.targetSectionKey);
+        expect(target).toMatchObject({
+          sourceOrdinal: alias.targetSourceOrdinal,
+          canonicalLocator: alias.targetCanonicalLocator,
+        });
+        expect(target!.legacySectionId).toBe(alias.legacySectionId);
+      }
+    }
+    expect(visitedSections).toBe(3054);
+    expect(visitedAliases).toBe(2821);
+    expect(JSON.stringify(compilation.map)).not.toMatch(/"(?:title|content|question|answer|chapter|topics)"\s*:/);
+  });
+
+  it('is byte-stable in ordering and canonical identity across repeated regeneration', () => {
+    const first = compileHistoricalSectionCompatibilityFromDisk(ROOT);
+    const second = compileHistoricalSectionCompatibilityFromDisk(ROOT);
+    expect(JSON.stringify(first.map)).toBe(JSON.stringify(second.map));
+    expect(first.attestation).toEqual(second.attestation);
+    expect(first.attestation.canonicalOutputSha256).toBe('3a8734e7f5ee4974f7b88811e7507021cfaddd5cfdbc0ab6f801b1e7d43a5bc5');
+  });
+
+  it('resolves canonical keys before aliases and keeps aliases as a fallback only', () => {
+    const real = verifyHistoricalSectionCompatibilityAttestationFromDisk(ROOT).map;
+    const realDocument = real.documents.find(document => document.documentId === 'baltimore-catechism')!;
+    const overlap = realDocument.legacyAliases.find(alias => alias.legacySectionId === alias.targetSectionKey)!;
+    expect(resolveHistoricalSectionCompatibility(real, realDocument.documentId, overlap.legacySectionId)).toMatchObject({
+      kind: 'canonical',
+      sectionKey: overlap.targetSectionKey,
+      sourceOrdinal: overlap.targetSourceOrdinal,
+    });
+
+    const fallback = parseHistoricalSectionCompatibilityMap(syntheticMap());
+    expect(resolveHistoricalSectionCompatibility(fallback, 'synthetic', 'legacy-1')).toEqual({
+      kind: 'legacy_alias',
+      documentId: 'synthetic',
+      sectionKey: 'canonical-1',
+      sourceOrdinal: 1,
+      canonicalLocator: 'theologai://documents/synthetic#section-canonical-1',
+    });
+    expect(resolveHistoricalSectionCompatibility(fallback, 'synthetic', 'canonical-1')?.kind).toBe('canonical');
+    expect(resolveHistoricalSectionCompatibility(fallback, 'synthetic', 'unknown')).toBeUndefined();
+  });
+
+  it.each([
+    ['policy drift', (raw: any) => { raw.policy.runtimeStatus = 'active'; }, 'policy must remain'],
+    ['input drift', (raw: any) => { raw.inputs.historicalSourcesCanonicalSha256 = '0'.repeat(64); }, 'does not match regenerated'],
+    ['count drift', (raw: any) => { raw.exactCounts.sectionCount = 3053; }, 'exact 17/3054/2821'],
+    ['output drift', (raw: any) => { raw.canonicalOutputSha256 = '0'.repeat(64); }, 'does not match regenerated'],
+    ['extra field', (raw: any) => { raw.content = 'forbidden'; }, 'exact keys'],
+  ])('fails closed on attestation %s', (_label, mutate, message) => {
+    const raw = trackedAttestation() as any;
+    mutate(raw);
+    if (_label === 'policy drift' || _label === 'count drift' || _label === 'extra field') {
+      expect(() => parseHistoricalSectionCompatibilityAttestation(raw)).toThrow(message);
+      return;
+    }
+    const parsed = parseHistoricalSectionCompatibilityAttestation(raw);
+    const regenerated = compileHistoricalSectionCompatibilityFromDisk(ROOT).attestation;
+    expect(parsed).not.toEqual(regenerated);
+    expect(() => {
+      if (JSON.stringify(parsed) !== JSON.stringify(regenerated)) throw new Error('does not match regenerated');
+    }).toThrow(message);
+  });
+
+  it.each([
+    ['body content', (raw: any) => { raw.documents[0].sections[0].content = 'forbidden'; }, 'exact keys'],
+    ['source ordinal drift', (raw: any) => { raw.documents[0].sections[0].sourceOrdinal = 2; }, 'dense and source-ordered'],
+    ['canonical locator drift', (raw: any) => { raw.documents[0].sections[0].canonicalLocator += '-wrong'; }, 'exact canonical section locator'],
+    ['alias target drift', (raw: any) => { raw.documents[0].legacyAliases[0].targetSourceOrdinal = 2; }, 'does not match a canonical section'],
+    ['missing alias', (raw: any) => { raw.documents[0].legacyAliases = []; }, 'must contain 1..2000 legacy aliases'],
+  ])('rejects compiled-map %s', (_label, mutate, message) => {
+    const raw = structuredClone(compileHistoricalSectionCompatibilityFromDisk(ROOT).map) as any;
+    mutate(raw);
+    expect(() => parseHistoricalSectionCompatibilityMap(raw)).toThrow(message);
+  });
+
+  it('rejects an alias that would shadow a different canonical section', () => {
+    const raw = syntheticMap() as any;
+    raw.documents[0].sections.push({
+      sourceOrdinal: 2,
+      sourceSignature: 'b'.repeat(64),
+      legacySectionId: 'legacy-2',
+      sectionKey: 'legacy-1',
+      canonicalLocator: 'theologai://documents/synthetic#section-legacy-1',
+    });
+    raw.documents[0].legacyAliases.push({
+      legacySectionId: 'legacy-2',
+      targetSectionKey: 'legacy-1',
+      targetSourceOrdinal: 2,
+      targetCanonicalLocator: 'theologai://documents/synthetic#section-legacy-1',
+    });
+    expect(() => parseHistoricalSectionCompatibilityMap(raw)).toThrow('conflicts with canonical-before-alias resolution');
+  });
+
+  it('refuses source drift and a decision packet that no longer matches collision members', () => {
+    const plan = parseHistoricalSectionKeyPlan(JSON.parse(readFileSync('data/historical-section-key-plan.json', 'utf8')));
+    const evidence = parseHistoricalSectionCompatibilityEvidence(JSON.parse(readFileSync(
+      'test/fixtures/historical-section-compatibility/real-local-evidence.json',
+      'utf8',
+    )));
+    const changedSources = structuredClone(readHistoricalSectionSources(ROOT));
+    (changedSources[0]!.value.sections[0] as Record<string, unknown>).content = 'changed';
+    expect(() => compileHistoricalSectionCompatibility(plan, changedSources, evidence)).toThrow('source snapshot changed');
+
+    const changedEvidence = structuredClone(evidence);
+    changedEvidence.collisionGroups[0]!.members[0]!.plannedSectionKey = 'wrong-but-safe';
+    expect(() => compileHistoricalSectionCompatibility(plan, readHistoricalSectionSources(ROOT), changedEvidence))
+      .toThrow('does not exactly cover compiled collision members and keys');
+  });
+
+  it('remains unreferenced by every bounded operational build, data, deployment, and runtime surface', () => {
+    const forbiddenReferences = [
+      'historical-section-compatibility-compiler',
+      'historical-section-compatibility-schema',
+      'source-first-compiler-attestation',
+      'historical_section_source_first_compatibility_map',
+    ];
+    const allowedPreparationScripts = new Set([
+      'scripts/historical-section-compatibility-compiler.ts',
+      'scripts/historical-section-compatibility-schema.ts',
+    ]);
+    const operationalScripts = walkFiles('scripts')
+      .filter(path => /\.(?:[cm]?[jt]s|sh)$/.test(path))
+      .filter(path => !allowedPreparationScripts.has(path));
+    const manifestsAndSeeds = [
+      ...walkFiles('data'),
+      ...walkFiles('test/fixtures'),
+    ].filter(path => /(?:^|\/)[^/]*(?:manifest|seed)[^/]*(?:\/|$)/i.test(path));
+    const wranglerConfigs = [
+      ...readdirSync('.').filter(path => /^wrangler.*\.toml$/.test(path)),
+      ...walkFiles('test').filter(path => /(?:^|\/)wrangler[^/]*\.toml$/.test(path)),
+    ];
+    const surfaces = [...new Set([
+      ...walkFiles('src'),
+      ...walkFiles('migrations'),
+      ...walkFiles('.github/workflows'),
+      ...operationalScripts,
+      ...manifestsAndSeeds,
+      ...wranglerConfigs,
+      'package.json',
+      'package-lock.json',
+    ])].sort();
+
+    expect(surfaces).toEqual(expect.arrayContaining([
+      'src/index.ts',
+      'migrations/0001_initial_schema.sql',
+      '.github/workflows/pr.yml',
+      'scripts/build-database.ts',
+      'scripts/export-for-d1.ts',
+      'scripts/export-for-d1.sh',
+      'scripts/d1-seed-manifest.ts',
+      'scripts/d1-seed-utils.ts',
+      'scripts/verify-d1-seed.ts',
+      'scripts/verify-d1-seed-import.ts',
+      'scripts/verify-d1-seed-workerd.ts',
+      'scripts/verify-data-manifest.ts',
+      'scripts/historical-section-compatibility-evidence.ts',
+      'scripts/historical-section-key-plan.ts',
+      'data/data-manifest.json',
+      'package.json',
+      'package-lock.json',
+      'wrangler.toml',
+      'wrangler.release.toml',
+      'wrangler.ccel-coordinator.toml',
+      'test/worker-runtime/wrangler.test.toml',
+      'test/ccel-coordinator-runtime/wrangler.test.toml',
+    ]));
+    for (const allowed of allowedPreparationScripts) expect(surfaces).not.toContain(allowed);
+    for (const path of surfaces) {
+      const source = readFileSync(path, 'utf8');
+      for (const reference of forbiddenReferences) expect(source, path).not.toContain(reference);
+    }
+    expect(readdirSync('migrations').some(path => path.startsWith('0005'))).toBe(false);
+  });
+});
+
+function syntheticMap(): HistoricalSectionCompatibilityMap {
+  return {
+    schemaVersion: 1,
+    kind: 'historical_section_source_first_compatibility_map',
+    policy: HISTORICAL_SECTION_COMPATIBILITY_POLICY,
+    documents: [{
+      documentId: 'synthetic',
+      sections: [{
+        sourceOrdinal: 1,
+        sourceSignature: 'a'.repeat(64),
+        legacySectionId: 'legacy-1',
+        sectionKey: 'canonical-1',
+        canonicalLocator: 'theologai://documents/synthetic#section-canonical-1',
+      }],
+      legacyAliases: [{
+        legacySectionId: 'legacy-1',
+        targetSectionKey: 'canonical-1',
+        targetSourceOrdinal: 1,
+        targetCanonicalLocator: 'theologai://documents/synthetic#section-canonical-1',
+      }],
+    }],
+  };
+}
+
+function walkFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? walkFiles(path) : [path];
+  });
+}


### PR DESCRIPTION
## Summary

- add a deterministic, content-free compiler for the approved source-first compatibility map across the existing 17 local works
- freeze 3,054 canonical sections, 2,821 legacy aliases, and the reviewed 23/256/233 collision accounting
- add a compact attestation binding exact source, key-plan, decision-evidence, policy, count, and complete-output hashes
- enforce canonical-before-alias resolution and migration/runtime inertness

## Scope

Migration-free preparation only. No migration 0005, transform, source-content, SQLite/D1, seed, manifest, runtime, MCP, Wrangler, workflow, preview, or production change.

## Verification

- 51 focused and neighboring tests
- exact CLI reproduction with output SHA-256 3a8734e7f5ee4974f7b88811e7507021cfaddd5cfdbc0ab6f801b1e7d43a5bc5
- Node and Worker typechecks and build
- independent Sol review: GO, zero P0-P3 findings
- git diff check

No preview deployment is requested.