### PR TITLE
Prepare sectioned-only Norton delivery contract

### DIFF
--- a/docs/HISTORICAL-SECTIONED-DELIVERY-NORTON-PREPARATION.md
+++ b/docs/HISTORICAL-SECTIONED-DELIVERY-NORTON-PREPARATION.md
@@ -1,0 +1,65 @@
+# Historical `sectioned_only` delivery and Norton preparation
+
+Status: migration-free and inactive. This document records a future delivery
+contract and prepares one already-vendored edition for a later transform 9. It
+does not add a migration, change the data manifest or D1 seed, register a
+runtime service/resource/tool, alter a Worker, or authorize preview or
+production deployment.
+
+## Delivery boundary
+
+Large historical works use `sectioned_only` delivery. A future whole-document
+resource is only a bounded landing representation (at most 16,384 UTF-8 bytes)
+with work and edition metadata plus a browse contract. It must not contain a
+full body or a complete section directory.
+
+`classic_text_lookup` will later provide browse pages of at most 32 entries.
+Each entry is limited to source ordinal, frozen key, display label, heading,
+and a native exact-section resource link. It contains no body. Its cursor is
+bound to the delivery-contract version, document ID, edition ID, Gate 1 package
+SHA-256, and last source ordinal. This makes cursors invalid if the corpus
+identity or edition changes.
+
+Only an exact-section resource may deliver body text. This design prevents a
+1,250-entry directory or the approximately 4 MB Norton body from entering a
+single MCP response.
+
+## Norton transform-9 preparation
+
+The checked-in plan at
+`test/fixtures/historical-sectioned-delivery/norton-transform9-preparation.draft.json`
+references, but does not copy, the existing Gate 1 package:
+
+- work ID: `calvin-institutes-of-the-christian-religion`;
+- edition/document ID: `calvin-institutes-norton-1561-eebo-tcp-a17662`;
+- package SHA-256: `3054f4446b2e92af87c1713ee1c44d6745bca42a32aed7c67890d25fedbdff33`;
+- 1,250 frozen keys from `a17662-source-ordinal-0001` through
+  `a17662-source-ordinal-1250`;
+- work chronology: 1536–1559, successive Latin editions with final Latin
+  edition in 1559; and
+- exact Norton edition publication: London, Reinolde Wolfe and Richarde
+  Harison, 1561.
+
+The work chronology names the Bibliothèque nationale de France canonical work
+record as metadata provenance. The exact edition/transcription provenance,
+rights boundary, and unresolved-transcription disclosure remain the existing
+local EEBO-TCP A17662 Gate 1 record. This preparation neither re-acquires nor
+duplicates those bytes. It does not state an unqualified 6 May publication
+date, does not claim Norton translated the French edition, and does not make a
+generic Calvin alias active.
+
+Run the local, read-only audit with:
+
+```bash
+node --import tsx scripts/historical-sectioned-delivery.ts --verify
+```
+
+## Transform ordering and activation gate
+
+Transform 8 remains a separate compatibility release for the existing 17
+historical documents. The plan records transform 9 as a future successor and
+does not make transform 8 depend on Norton. A later activation must first have
+an implemented, transform-8-compatible `sectioned_only` Worker path, then
+separately approve migration, deterministic materialization, catalogue/routing,
+preview, and production. Generic aliases remain dormant until that later
+activation decision.

--- a/scripts/historical-sectioned-delivery.ts
+++ b/scripts/historical-sectioned-delivery.ts
@@ -1,0 +1,478 @@
+/**
+ * Inert compiler/auditor for the future large historical-work delivery
+ * contract. It deliberately has no runtime registration, database writes,
+ * network access, or source acquisition behavior.
+ *
+ * The only currently prepared target is the already-vendored EEBO-TCP A17662
+ * Norton package. A later, separately approved transform 9 may consume this
+ * reviewed plan only after transform 8 compatibility support is available.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  compileEditionPackage,
+  type EditionCompilationPackage,
+} from '../src/kernel/editionProvenanceFoundation.js';
+
+export const HISTORICAL_SECTIONED_DELIVERY_SCHEMA_VERSION = 1 as const;
+export const HISTORICAL_SECTIONED_DELIVERY_KIND = 'historical_sectioned_delivery_norton_transform9_preparation' as const;
+export const HISTORICAL_SECTIONED_DELIVERY_CURSOR_VERSION = 'historical-sectioned-only-cursor-v1' as const;
+export const NORTON_TRANSFORM9_PLAN_PATH = 'test/fixtures/historical-sectioned-delivery/norton-transform9-preparation.draft.json' as const;
+export const NORTON_GATE1_PACKAGE_PATH = 'data/historical-sources/eebo-tcp/A17662/norton-1561.edition.json' as const;
+export const NORTON_GATE1_PACKAGE_SHA256 = '3054f4446b2e92af87c1713ee1c44d6745bca42a32aed7c67890d25fedbdff33' as const;
+export const NORTON_GATE1_PACKAGE_BYTES = 4_058_506 as const;
+export const NORTON_WORK_ID = 'calvin-institutes-of-the-christian-religion' as const;
+export const NORTON_EDITION_ID = 'calvin-institutes-norton-1561-eebo-tcp-a17662' as const;
+export const NORTON_DOCUMENT_ID = NORTON_EDITION_ID;
+export const NORTON_SECTION_COUNT = 1_250 as const;
+export const NORTON_SECTION_KEY_PREFIX = 'a17662-source-ordinal-' as const;
+
+const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const CURSOR_BINDINGS = [
+  'contractVersion',
+  'documentId',
+  'editionId',
+  'packageSha256',
+  'lastSourceOrdinal',
+] as const;
+const BROWSE_ENTRY_FIELDS = [
+  'sourceOrdinal',
+  'sectionKey',
+  'displayLabel',
+  'heading',
+  'resourceUri',
+] as const;
+const LANDING_FIELDS = [
+  'workId',
+  'editionId',
+  'title',
+  'language',
+  'sectionCount',
+  'browseContract',
+] as const;
+
+export interface HistoricalSectionedDeliveryPlan {
+  schemaVersion: 1;
+  kind: typeof HISTORICAL_SECTIONED_DELIVERY_KIND;
+  runtimeStatus: 'inactive_until_transform_9';
+  delivery: {
+    mode: 'sectioned_only';
+    wholeDocumentResource: {
+      representation: 'bounded_landing_metadata_only';
+      maxUtf8Bytes: 16_384;
+      fields: typeof LANDING_FIELDS[number][];
+      sectionDirectory: 'not_included';
+      body: 'not_included';
+    };
+    browse: {
+      maxSectionEntries: 32;
+      entryFields: typeof BROWSE_ENTRY_FIELDS[number][];
+      body: 'not_included';
+      nativeResourceLinks: 'exact_section_only';
+      cursor: {
+        version: typeof HISTORICAL_SECTIONED_DELIVERY_CURSOR_VERSION;
+        bindings: typeof CURSOR_BINDINGS[number][];
+      };
+    };
+    exactSectionResource: {
+      body: 'only_body_delivery_route';
+    };
+  };
+  transform: {
+    targetTransformVersion: 9;
+    predecessor: {
+      transformVersion: 8;
+      scope: 'existing_17_historical_documents_only';
+    };
+    migrationStatus: 'not_authorized';
+    dataManifestStatus: 'unchanged';
+  };
+  work: {
+    workId: typeof NORTON_WORK_ID;
+    title: 'Institutes of the Christian Religion';
+    composition: {
+      startYear: 1536;
+      endYear: 1559;
+      statement: 'successive Latin editions; final Latin edition 1559';
+    };
+    metadataProvenance: {
+      authority: 'Bibliotheque nationale de France canonical work record';
+      locator: 'https://catalogue.bnf.fr/ark:/12148/cb11963198n';
+      reviewedAt: string;
+    };
+  };
+  edition: {
+    documentId: typeof NORTON_DOCUMENT_ID;
+    editionId: typeof NORTON_EDITION_ID;
+    workId: typeof NORTON_WORK_ID;
+    language: 'en';
+    publication: {
+      year: 1561;
+      statement: 'London: Reinolde Wolfe and Richarde Harison, 1561';
+    };
+    editionProvenance: {
+      sourceId: 'eebo-tcp-a17662-norton-1561';
+      sourceCommit: '32191150ad4a919dfd2c28c89b1dbc1c2396252a';
+      reviewedAt: string;
+      exactArtifactStatus: 'verified_with_uncertainty';
+    };
+  };
+  gate1Package: {
+    path: typeof NORTON_GATE1_PACKAGE_PATH;
+    sha256: typeof NORTON_GATE1_PACKAGE_SHA256;
+    bytes: typeof NORTON_GATE1_PACKAGE_BYTES;
+    sectionCount: typeof NORTON_SECTION_COUNT;
+    sectionKeys: {
+      prefix: typeof NORTON_SECTION_KEY_PREFIX;
+      first: 'a17662-source-ordinal-0001';
+      last: 'a17662-source-ordinal-1250';
+    };
+  };
+  genericAliasStatus: 'dormant_until_future_activation';
+}
+
+export interface NortonTransform9PreparationAudit {
+  documentId: string;
+  workId: string;
+  editionId: string;
+  sectionCount: number;
+  packageSha256: string;
+  packageBytes: number;
+  firstSectionKey: string;
+  lastSectionKey: string;
+  browseMaxSectionEntries: number;
+}
+
+export class HistoricalSectionedDeliveryValidationError extends Error {
+  constructor(public readonly path: string, message: string) {
+    super(`${path}: ${message}`);
+    this.name = 'HistoricalSectionedDeliveryValidationError';
+  }
+}
+
+/**
+ * Strictly parse the checked-in, inert contract. This deliberately accepts no
+ * generic large-work configuration: its sole purpose is to freeze the reviewed
+ * Norton transform-9 preparation before a later activation decision.
+ */
+export function parseHistoricalSectionedDeliveryPlan(input: unknown): HistoricalSectionedDeliveryPlan {
+  const root = objectAt(input, '$', [
+    'schemaVersion', 'kind', 'runtimeStatus', 'delivery', 'transform', 'work',
+    'edition', 'gate1Package', 'genericAliasStatus',
+  ]);
+  literalAt(root.schemaVersion, '$.schemaVersion', HISTORICAL_SECTIONED_DELIVERY_SCHEMA_VERSION);
+  literalAt(root.kind, '$.kind', HISTORICAL_SECTIONED_DELIVERY_KIND);
+  literalAt(root.runtimeStatus, '$.runtimeStatus', 'inactive_until_transform_9');
+  literalAt(root.genericAliasStatus, '$.genericAliasStatus', 'dormant_until_future_activation');
+
+  const delivery = parseDelivery(root.delivery);
+  const transform = parseTransform(root.transform);
+  const work = parseWork(root.work);
+  const edition = parseEdition(root.edition);
+  const gate1Package = parseGate1Package(root.gate1Package);
+
+  if (edition.workId !== work.workId) fail('$.edition.workId', 'must exactly match $.work.workId');
+  if (edition.editionId !== edition.documentId) {
+    fail('$.edition.editionId', 'must be the edition-specific document identity while generic aliases remain dormant');
+  }
+  return {
+    schemaVersion: HISTORICAL_SECTIONED_DELIVERY_SCHEMA_VERSION,
+    kind: HISTORICAL_SECTIONED_DELIVERY_KIND,
+    runtimeStatus: 'inactive_until_transform_9',
+    delivery,
+    transform,
+    work,
+    edition,
+    gate1Package,
+    genericAliasStatus: 'dormant_until_future_activation',
+  };
+}
+
+/**
+ * Audit the existing Gate 1 package against the inert plan. It reads only
+ * local, already-vendored bytes and has no write, network, database, or
+ * runtime-registration side effect.
+ */
+export function verifyNortonTransform9Preparation(
+  rootDirectory = fileURLToPath(new URL('../', import.meta.url)),
+  rawPlan: unknown = readJsonAt(rootDirectory, NORTON_TRANSFORM9_PLAN_PATH),
+): NortonTransform9PreparationAudit {
+  const plan = parseHistoricalSectionedDeliveryPlan(rawPlan);
+  const bytes = readFileSync(resolve(rootDirectory, plan.gate1Package.path));
+  if (bytes.byteLength !== plan.gate1Package.bytes) {
+    fail('$.gate1Package.bytes', `does not match local Gate 1 byte count ${bytes.byteLength}`);
+  }
+  const rawSha256 = sha256(bytes);
+  if (rawSha256 !== plan.gate1Package.sha256) {
+    fail('$.gate1Package.sha256', 'does not match the local Gate 1 package bytes');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    fail('$.gate1Package.path', 'does not contain JSON');
+  }
+  const compiled = compileEditionPackage(parsed);
+  if (compiled.sha256 !== plan.gate1Package.sha256) {
+    fail('$.gate1Package.sha256', 'does not match the canonical Gate 1 package identity');
+  }
+  if (!bytes.equals(Buffer.from(compiled.utf8))) {
+    fail('$.gate1Package.path', 'must remain the exact canonical Gate 1 package bytes');
+  }
+  verifyPackageIdentity(plan, compiled.package);
+
+  return {
+    documentId: plan.edition.documentId,
+    workId: plan.work.workId,
+    editionId: plan.edition.editionId,
+    sectionCount: compiled.package.sections.length,
+    packageSha256: compiled.sha256,
+    packageBytes: bytes.byteLength,
+    firstSectionKey: compiled.package.sections[0]!.sectionKey,
+    lastSectionKey: compiled.package.sections.at(-1)!.sectionKey,
+    browseMaxSectionEntries: plan.delivery.browse.maxSectionEntries,
+  };
+}
+
+function parseDelivery(input: unknown): HistoricalSectionedDeliveryPlan['delivery'] {
+  const path = '$.delivery';
+  const root = objectAt(input, path, ['mode', 'wholeDocumentResource', 'browse', 'exactSectionResource']);
+  literalAt(root.mode, `${path}.mode`, 'sectioned_only');
+
+  const whole = objectAt(root.wholeDocumentResource, `${path}.wholeDocumentResource`, [
+    'representation', 'maxUtf8Bytes', 'fields', 'sectionDirectory', 'body',
+  ]);
+  literalAt(whole.representation, `${path}.wholeDocumentResource.representation`, 'bounded_landing_metadata_only');
+  literalAt(whole.maxUtf8Bytes, `${path}.wholeDocumentResource.maxUtf8Bytes`, 16_384);
+  literalArrayAt(whole.fields, `${path}.wholeDocumentResource.fields`, LANDING_FIELDS);
+  literalAt(whole.sectionDirectory, `${path}.wholeDocumentResource.sectionDirectory`, 'not_included');
+  literalAt(whole.body, `${path}.wholeDocumentResource.body`, 'not_included');
+
+  const browse = objectAt(root.browse, `${path}.browse`, [
+    'maxSectionEntries', 'entryFields', 'body', 'nativeResourceLinks', 'cursor',
+  ]);
+  literalAt(browse.maxSectionEntries, `${path}.browse.maxSectionEntries`, 32);
+  literalArrayAt(browse.entryFields, `${path}.browse.entryFields`, BROWSE_ENTRY_FIELDS);
+  literalAt(browse.body, `${path}.browse.body`, 'not_included');
+  literalAt(browse.nativeResourceLinks, `${path}.browse.nativeResourceLinks`, 'exact_section_only');
+  const cursor = objectAt(browse.cursor, `${path}.browse.cursor`, ['version', 'bindings']);
+  literalAt(cursor.version, `${path}.browse.cursor.version`, HISTORICAL_SECTIONED_DELIVERY_CURSOR_VERSION);
+  literalArrayAt(cursor.bindings, `${path}.browse.cursor.bindings`, CURSOR_BINDINGS);
+
+  const exact = objectAt(root.exactSectionResource, `${path}.exactSectionResource`, ['body']);
+  literalAt(exact.body, `${path}.exactSectionResource.body`, 'only_body_delivery_route');
+
+  return {
+    mode: 'sectioned_only',
+    wholeDocumentResource: {
+      representation: 'bounded_landing_metadata_only',
+      maxUtf8Bytes: 16_384,
+      fields: [...LANDING_FIELDS],
+      sectionDirectory: 'not_included',
+      body: 'not_included',
+    },
+    browse: {
+      maxSectionEntries: 32,
+      entryFields: [...BROWSE_ENTRY_FIELDS],
+      body: 'not_included',
+      nativeResourceLinks: 'exact_section_only',
+      cursor: { version: HISTORICAL_SECTIONED_DELIVERY_CURSOR_VERSION, bindings: [...CURSOR_BINDINGS] },
+    },
+    exactSectionResource: { body: 'only_body_delivery_route' },
+  };
+}
+
+function parseTransform(input: unknown): HistoricalSectionedDeliveryPlan['transform'] {
+  const root = objectAt(input, '$.transform', [
+    'targetTransformVersion', 'predecessor', 'migrationStatus', 'dataManifestStatus',
+  ]);
+  literalAt(root.targetTransformVersion, '$.transform.targetTransformVersion', 9);
+  const predecessor = objectAt(root.predecessor, '$.transform.predecessor', ['transformVersion', 'scope']);
+  literalAt(predecessor.transformVersion, '$.transform.predecessor.transformVersion', 8);
+  literalAt(predecessor.scope, '$.transform.predecessor.scope', 'existing_17_historical_documents_only');
+  literalAt(root.migrationStatus, '$.transform.migrationStatus', 'not_authorized');
+  literalAt(root.dataManifestStatus, '$.transform.dataManifestStatus', 'unchanged');
+  return {
+    targetTransformVersion: 9,
+    predecessor: { transformVersion: 8, scope: 'existing_17_historical_documents_only' },
+    migrationStatus: 'not_authorized',
+    dataManifestStatus: 'unchanged',
+  };
+}
+
+function parseWork(input: unknown): HistoricalSectionedDeliveryPlan['work'] {
+  const root = objectAt(input, '$.work', ['workId', 'title', 'composition', 'metadataProvenance']);
+  literalAt(root.workId, '$.work.workId', NORTON_WORK_ID);
+  literalAt(root.title, '$.work.title', 'Institutes of the Christian Religion');
+  const composition = objectAt(root.composition, '$.work.composition', ['startYear', 'endYear', 'statement']);
+  literalAt(composition.startYear, '$.work.composition.startYear', 1536);
+  literalAt(composition.endYear, '$.work.composition.endYear', 1559);
+  literalAt(composition.statement, '$.work.composition.statement', 'successive Latin editions; final Latin edition 1559');
+  const provenance = objectAt(root.metadataProvenance, '$.work.metadataProvenance', ['authority', 'locator', 'reviewedAt']);
+  literalAt(provenance.authority, '$.work.metadataProvenance.authority', 'Bibliotheque nationale de France canonical work record');
+  literalAt(provenance.locator, '$.work.metadataProvenance.locator', 'https://catalogue.bnf.fr/ark:/12148/cb11963198n');
+  return {
+    workId: NORTON_WORK_ID,
+    title: 'Institutes of the Christian Religion',
+    composition: { startYear: 1536, endYear: 1559, statement: 'successive Latin editions; final Latin edition 1559' },
+    metadataProvenance: {
+      authority: 'Bibliotheque nationale de France canonical work record',
+      locator: 'https://catalogue.bnf.fr/ark:/12148/cb11963198n',
+      reviewedAt: dateAt(provenance.reviewedAt, '$.work.metadataProvenance.reviewedAt'),
+    },
+  };
+}
+
+function parseEdition(input: unknown): HistoricalSectionedDeliveryPlan['edition'] {
+  const root = objectAt(input, '$.edition', [
+    'documentId', 'editionId', 'workId', 'language', 'publication', 'editionProvenance',
+  ]);
+  literalAt(root.documentId, '$.edition.documentId', NORTON_DOCUMENT_ID);
+  literalAt(root.editionId, '$.edition.editionId', NORTON_EDITION_ID);
+  literalAt(root.workId, '$.edition.workId', NORTON_WORK_ID);
+  literalAt(root.language, '$.edition.language', 'en');
+  const publication = objectAt(root.publication, '$.edition.publication', ['year', 'statement']);
+  literalAt(publication.year, '$.edition.publication.year', 1561);
+  literalAt(publication.statement, '$.edition.publication.statement', 'London: Reinolde Wolfe and Richarde Harison, 1561');
+  const provenance = objectAt(root.editionProvenance, '$.edition.editionProvenance', [
+    'sourceId', 'sourceCommit', 'reviewedAt', 'exactArtifactStatus',
+  ]);
+  literalAt(provenance.sourceId, '$.edition.editionProvenance.sourceId', 'eebo-tcp-a17662-norton-1561');
+  literalAt(provenance.sourceCommit, '$.edition.editionProvenance.sourceCommit', '32191150ad4a919dfd2c28c89b1dbc1c2396252a');
+  literalAt(provenance.exactArtifactStatus, '$.edition.editionProvenance.exactArtifactStatus', 'verified_with_uncertainty');
+  return {
+    documentId: NORTON_DOCUMENT_ID,
+    editionId: NORTON_EDITION_ID,
+    workId: NORTON_WORK_ID,
+    language: 'en',
+    publication: { year: 1561, statement: 'London: Reinolde Wolfe and Richarde Harison, 1561' },
+    editionProvenance: {
+      sourceId: 'eebo-tcp-a17662-norton-1561',
+      sourceCommit: '32191150ad4a919dfd2c28c89b1dbc1c2396252a',
+      reviewedAt: dateAt(provenance.reviewedAt, '$.edition.editionProvenance.reviewedAt'),
+      exactArtifactStatus: 'verified_with_uncertainty',
+    },
+  };
+}
+
+function parseGate1Package(input: unknown): HistoricalSectionedDeliveryPlan['gate1Package'] {
+  const root = objectAt(input, '$.gate1Package', ['path', 'sha256', 'bytes', 'sectionCount', 'sectionKeys']);
+  literalAt(root.path, '$.gate1Package.path', NORTON_GATE1_PACKAGE_PATH);
+  literalAt(root.sha256, '$.gate1Package.sha256', NORTON_GATE1_PACKAGE_SHA256);
+  literalAt(root.bytes, '$.gate1Package.bytes', NORTON_GATE1_PACKAGE_BYTES);
+  literalAt(root.sectionCount, '$.gate1Package.sectionCount', NORTON_SECTION_COUNT);
+  const sectionKeys = objectAt(root.sectionKeys, '$.gate1Package.sectionKeys', ['prefix', 'first', 'last']);
+  literalAt(sectionKeys.prefix, '$.gate1Package.sectionKeys.prefix', NORTON_SECTION_KEY_PREFIX);
+  literalAt(sectionKeys.first, '$.gate1Package.sectionKeys.first', sectionKeyForOrdinal(1));
+  literalAt(sectionKeys.last, '$.gate1Package.sectionKeys.last', sectionKeyForOrdinal(NORTON_SECTION_COUNT));
+  return {
+    path: NORTON_GATE1_PACKAGE_PATH,
+    sha256: NORTON_GATE1_PACKAGE_SHA256,
+    bytes: NORTON_GATE1_PACKAGE_BYTES,
+    sectionCount: NORTON_SECTION_COUNT,
+    sectionKeys: {
+      prefix: NORTON_SECTION_KEY_PREFIX,
+      first: 'a17662-source-ordinal-0001',
+      last: 'a17662-source-ordinal-1250',
+    },
+  };
+}
+
+function verifyPackageIdentity(plan: HistoricalSectionedDeliveryPlan, packageValue: EditionCompilationPackage): void {
+  if (packageValue.work.workId !== plan.work.workId) fail('$.work.workId', 'does not match the Gate 1 package');
+  if (packageValue.work.title !== plan.work.title) fail('$.work.title', 'does not match the Gate 1 package');
+  if (packageValue.edition.editionId !== plan.edition.editionId) fail('$.edition.editionId', 'does not match the Gate 1 package');
+  if (packageValue.edition.workId !== plan.edition.workId) fail('$.edition.workId', 'does not match the Gate 1 package');
+  if (packageValue.edition.language !== plan.edition.language) fail('$.edition.language', 'does not match the Gate 1 package');
+  if (packageValue.edition.source.pin.value !== plan.edition.editionProvenance.sourceCommit) {
+    fail('$.edition.editionProvenance.sourceCommit', 'does not match the Gate 1 package source pin');
+  }
+  if (packageValue.edition.provenance.status !== plan.edition.editionProvenance.exactArtifactStatus) {
+    fail('$.edition.editionProvenance.exactArtifactStatus', 'does not match the Gate 1 provenance status');
+  }
+  if (packageValue.sections.length !== plan.gate1Package.sectionCount) {
+    fail('$.gate1Package.sectionCount', `does not match the Gate 1 section count ${packageValue.sections.length}`);
+  }
+  for (const [index, section] of packageValue.sections.entries()) {
+    const ordinal = index + 1;
+    if (section.sourceOrdinal !== ordinal) fail(`$.sections[${index}].sourceOrdinal`, 'does not preserve the frozen source order');
+    const expected = sectionKeyForOrdinal(ordinal);
+    if (section.sectionKey !== expected) fail(`$.sections[${index}].sectionKey`, `must be ${expected}`);
+  }
+}
+
+export function sectionKeyForOrdinal(ordinal: number): string {
+  if (!Number.isInteger(ordinal) || ordinal < 1 || ordinal > NORTON_SECTION_COUNT) {
+    throw new RangeError(`Norton source ordinal must be an integer from 1 through ${NORTON_SECTION_COUNT}`);
+  }
+  return `${NORTON_SECTION_KEY_PREFIX}${String(ordinal).padStart(4, '0')}`;
+}
+
+function readJsonAt(rootDirectory: string, path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(resolve(rootDirectory, path), 'utf8'));
+  } catch (error) {
+    throw new HistoricalSectionedDeliveryValidationError(path, error instanceof Error ? error.message : 'cannot read JSON');
+  }
+}
+
+function objectAt(input: unknown, path: string, keys: readonly string[]): Record<string, unknown> {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) fail(path, 'must be an object');
+  const actual = Object.keys(input).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    fail(path, `must contain exactly: ${expected.join(', ')}`);
+  }
+  return input as Record<string, unknown>;
+}
+
+function literalAt(input: unknown, path: string, expected: string | number): void {
+  if (input !== expected) fail(path, `must be ${JSON.stringify(expected)}`);
+}
+
+function literalArrayAt(input: unknown, path: string, expected: readonly string[]): void {
+  if (!Array.isArray(input) || input.length !== expected.length || input.some((value, index) => value !== expected[index])) {
+    fail(path, `must be exactly [${expected.map(value => JSON.stringify(value)).join(', ')}]`);
+  }
+}
+
+function dateAt(input: unknown, path: string): string {
+  if (typeof input !== 'string' || !ISO_DATE.test(input)) fail(path, 'must be an ISO calendar date');
+  const [year, month, day] = input.split('-').map(Number) as [number, number, number];
+  const daysInMonth = [
+    31,
+    isLeapYear(year) ? 29 : 28,
+    31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+  ];
+  if (month < 1 || month > 12 || day < 1 || day > daysInMonth[month - 1]!) {
+    fail(path, 'must be a real UTC calendar date');
+  }
+  return input;
+}
+
+function isLeapYear(year: number): boolean {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+function sha256(value: Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function fail(path: string, message: string): never {
+  throw new HistoricalSectionedDeliveryValidationError(path, message);
+}
+
+const invokedPath = process.argv[1] === fileURLToPath(import.meta.url);
+if (invokedPath) {
+  const args = process.argv.slice(2);
+  if (args.length !== 1 || args[0] !== '--verify') {
+    throw new Error('usage: historical-sectioned-delivery.ts --verify');
+  }
+  process.stdout.write(`${JSON.stringify(verifyNortonTransform9Preparation())}\n`);
+}

--- a/test/fixtures/historical-sectioned-delivery/norton-transform9-preparation.draft.json
+++ b/test/fixtures/historical-sectioned-delivery/norton-transform9-preparation.draft.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": 1,
+  "kind": "historical_sectioned_delivery_norton_transform9_preparation",
+  "runtimeStatus": "inactive_until_transform_9",
+  "delivery": {
+    "mode": "sectioned_only",
+    "wholeDocumentResource": {
+      "representation": "bounded_landing_metadata_only",
+      "maxUtf8Bytes": 16384,
+      "fields": [
+        "workId",
+        "editionId",
+        "title",
+        "language",
+        "sectionCount",
+        "browseContract"
+      ],
+      "sectionDirectory": "not_included",
+      "body": "not_included"
+    },
+    "browse": {
+      "maxSectionEntries": 32,
+      "entryFields": [
+        "sourceOrdinal",
+        "sectionKey",
+        "displayLabel",
+        "heading",
+        "resourceUri"
+      ],
+      "body": "not_included",
+      "nativeResourceLinks": "exact_section_only",
+      "cursor": {
+        "version": "historical-sectioned-only-cursor-v1",
+        "bindings": [
+          "contractVersion",
+          "documentId",
+          "editionId",
+          "packageSha256",
+          "lastSourceOrdinal"
+        ]
+      }
+    },
+    "exactSectionResource": {
+      "body": "only_body_delivery_route"
+    }
+  },
+  "transform": {
+    "targetTransformVersion": 9,
+    "predecessor": {
+      "transformVersion": 8,
+      "scope": "existing_17_historical_documents_only"
+    },
+    "migrationStatus": "not_authorized",
+    "dataManifestStatus": "unchanged"
+  },
+  "work": {
+    "workId": "calvin-institutes-of-the-christian-religion",
+    "title": "Institutes of the Christian Religion",
+    "composition": {
+      "startYear": 1536,
+      "endYear": 1559,
+      "statement": "successive Latin editions; final Latin edition 1559"
+    },
+    "metadataProvenance": {
+      "authority": "Bibliotheque nationale de France canonical work record",
+      "locator": "https://catalogue.bnf.fr/ark:/12148/cb11963198n",
+      "reviewedAt": "2026-07-18"
+    }
+  },
+  "edition": {
+    "documentId": "calvin-institutes-norton-1561-eebo-tcp-a17662",
+    "editionId": "calvin-institutes-norton-1561-eebo-tcp-a17662",
+    "workId": "calvin-institutes-of-the-christian-religion",
+    "language": "en",
+    "publication": {
+      "year": 1561,
+      "statement": "London: Reinolde Wolfe and Richarde Harison, 1561"
+    },
+    "editionProvenance": {
+      "sourceId": "eebo-tcp-a17662-norton-1561",
+      "sourceCommit": "32191150ad4a919dfd2c28c89b1dbc1c2396252a",
+      "reviewedAt": "2026-07-17",
+      "exactArtifactStatus": "verified_with_uncertainty"
+    }
+  },
+  "gate1Package": {
+    "path": "data/historical-sources/eebo-tcp/A17662/norton-1561.edition.json",
+    "sha256": "3054f4446b2e92af87c1713ee1c44d6745bca42a32aed7c67890d25fedbdff33",
+    "bytes": 4058506,
+    "sectionCount": 1250,
+    "sectionKeys": {
+      "prefix": "a17662-source-ordinal-",
+      "first": "a17662-source-ordinal-0001",
+      "last": "a17662-source-ordinal-1250"
+    }
+  },
+  "genericAliasStatus": "dormant_until_future_activation"
+}

--- a/test/unit/scripts/historicalSectionedDelivery.test.ts
+++ b/test/unit/scripts/historicalSectionedDelivery.test.ts
@@ -1,0 +1,214 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  HISTORICAL_SECTIONED_DELIVERY_CURSOR_VERSION,
+  HISTORICAL_SECTIONED_DELIVERY_KIND,
+  NORTON_DOCUMENT_ID,
+  NORTON_EDITION_ID,
+  NORTON_GATE1_PACKAGE_BYTES,
+  NORTON_GATE1_PACKAGE_PATH,
+  NORTON_GATE1_PACKAGE_SHA256,
+  NORTON_SECTION_COUNT,
+  NORTON_TRANSFORM9_PLAN_PATH,
+  NORTON_WORK_ID,
+  parseHistoricalSectionedDeliveryPlan,
+  sectionKeyForOrdinal,
+  verifyNortonTransform9Preparation,
+} from '../../../scripts/historical-sectioned-delivery.js';
+
+const ROOT = process.cwd();
+const SELF_SCRIPT = 'scripts/historical-sectioned-delivery.ts';
+
+function rawPlan(): Record<string, any> {
+  return JSON.parse(readFileSync(NORTON_TRANSFORM9_PLAN_PATH, 'utf8')) as Record<string, any>;
+}
+
+describe('inactive sectioned_only historical delivery and Norton transform-9 preparation', () => {
+  it('freezes bounded landing, cursor-bound browsing, exact-body routing, and the transform-8 boundary', () => {
+    const plan = parseHistoricalSectionedDeliveryPlan(rawPlan());
+
+    expect(plan).toMatchObject({
+      schemaVersion: 1,
+      kind: HISTORICAL_SECTIONED_DELIVERY_KIND,
+      runtimeStatus: 'inactive_until_transform_9',
+      genericAliasStatus: 'dormant_until_future_activation',
+      delivery: {
+        mode: 'sectioned_only',
+        wholeDocumentResource: {
+          representation: 'bounded_landing_metadata_only',
+          maxUtf8Bytes: 16_384,
+          sectionDirectory: 'not_included',
+          body: 'not_included',
+        },
+        browse: {
+          maxSectionEntries: 32,
+          body: 'not_included',
+          nativeResourceLinks: 'exact_section_only',
+          cursor: {
+            version: HISTORICAL_SECTIONED_DELIVERY_CURSOR_VERSION,
+            bindings: ['contractVersion', 'documentId', 'editionId', 'packageSha256', 'lastSourceOrdinal'],
+          },
+        },
+        exactSectionResource: { body: 'only_body_delivery_route' },
+      },
+      transform: {
+        targetTransformVersion: 9,
+        predecessor: { transformVersion: 8, scope: 'existing_17_historical_documents_only' },
+        migrationStatus: 'not_authorized',
+        dataManifestStatus: 'unchanged',
+      },
+    });
+    expect(plan.delivery.wholeDocumentResource.fields).toEqual([
+      'workId', 'editionId', 'title', 'language', 'sectionCount', 'browseContract',
+    ]);
+    expect(plan.delivery.browse.entryFields).toEqual([
+      'sourceOrdinal', 'sectionKey', 'displayLabel', 'heading', 'resourceUri',
+    ]);
+  });
+
+  it('audits the existing canonical Gate 1 package without duplicating its body', () => {
+    const audit = verifyNortonTransform9Preparation(ROOT);
+    expect(audit).toEqual({
+      documentId: NORTON_DOCUMENT_ID,
+      workId: NORTON_WORK_ID,
+      editionId: NORTON_EDITION_ID,
+      sectionCount: NORTON_SECTION_COUNT,
+      packageSha256: NORTON_GATE1_PACKAGE_SHA256,
+      packageBytes: NORTON_GATE1_PACKAGE_BYTES,
+      firstSectionKey: 'a17662-source-ordinal-0001',
+      lastSectionKey: 'a17662-source-ordinal-1250',
+      browseMaxSectionEntries: 32,
+    });
+
+    const fixture = readFileSync(NORTON_TRANSFORM9_PLAN_PATH, 'utf8');
+    expect(Buffer.byteLength(fixture)).toBeLessThan(8_192);
+    expect(fixture).not.toContain('"sections"');
+    expect(fixture).not.toContain('THE INSTITVTION OF Christian Religion');
+    expect(readFileSync(NORTON_GATE1_PACKAGE_PATH).byteLength).toBe(NORTON_GATE1_PACKAGE_BYTES);
+  });
+
+  it('freezes every Norton source-ordinal key and rejects out-of-range generation', () => {
+    expect(Array.from({ length: NORTON_SECTION_COUNT }, (_, index) => sectionKeyForOrdinal(index + 1))).toEqual([
+      ...Array.from({ length: 1_249 }, (_, index) => `a17662-source-ordinal-${String(index + 1).padStart(4, '0')}`),
+      'a17662-source-ordinal-1250',
+    ]);
+    expect(() => sectionKeyForOrdinal(0)).toThrow('1 through 1250');
+    expect(() => sectionKeyForOrdinal(1.5)).toThrow('1 through 1250');
+    expect(() => sectionKeyForOrdinal(1_251)).toThrow('1 through 1250');
+  });
+
+  it.each([
+    ['unbounded landing', (plan: any) => { plan.delivery.wholeDocumentResource.maxUtf8Bytes = 16_385; }, 'maxUtf8Bytes'],
+    ['whole-document directory', (plan: any) => { plan.delivery.wholeDocumentResource.sectionDirectory = 'included'; }, 'sectionDirectory'],
+    ['whole-document body', (plan: any) => { plan.delivery.wholeDocumentResource.body = 'included'; }, 'wholeDocumentResource.body'],
+    ['browse page over 32 entries', (plan: any) => { plan.delivery.browse.maxSectionEntries = 33; }, 'maxSectionEntries'],
+    ['browse body', (plan: any) => { plan.delivery.browse.body = 'included'; }, 'browse.body'],
+    ['missing cursor identity binding', (plan: any) => { plan.delivery.browse.cursor.bindings.pop(); }, 'cursor.bindings'],
+    ['reordered cursor identity bindings', (plan: any) => { plan.delivery.browse.cursor.bindings.reverse(); }, 'cursor.bindings'],
+    ['non-section exact body route', (plan: any) => { plan.delivery.exactSectionResource.body = 'also_browse'; }, 'exactSectionResource.body'],
+    ['transform-8 inclusion', (plan: any) => { plan.transform.predecessor.scope = 'existing_18_historical_documents'; }, 'predecessor.scope'],
+    ['authorized migration', (plan: any) => { plan.transform.migrationStatus = 'authorized'; }, 'migrationStatus'],
+    ['generic document identity', (plan: any) => { plan.edition.documentId = 'calvin-institutes'; }, 'edition.documentId'],
+    ['wrong work chronology', (plan: any) => { plan.work.composition.endYear = 1561; }, 'composition.endYear'],
+    ['unqualified day field', (plan: any) => { plan.edition.publication.day = 6; }, 'edition.publication'],
+    ['wrong Gate 1 path', (plan: any) => { plan.gate1Package.path = 'data/norton-copy.json'; }, 'gate1Package.path'],
+    ['wrong Gate 1 hash', (plan: any) => { plan.gate1Package.sha256 = '0'.repeat(64); }, 'gate1Package.sha256'],
+    ['wrong key endpoint', (plan: any) => { plan.gate1Package.sectionKeys.last = 'a17662-source-ordinal-1249'; }, 'sectionKeys.last'],
+    ['embedded body field', (plan: any) => { plan.sections = []; }, '$'],
+    ['invalid reviewed month', (plan: any) => { plan.work.metadataProvenance.reviewedAt = '2026-13-01'; }, 'real UTC calendar date'],
+    ['invalid reviewed day', (plan: any) => { plan.edition.editionProvenance.reviewedAt = '2026-04-31'; }, 'real UTC calendar date'],
+    ['invalid non-leap day', (plan: any) => { plan.work.metadataProvenance.reviewedAt = '2025-02-29'; }, 'real UTC calendar date'],
+  ])('fails closed on %s', (_label, mutate, message) => {
+    const plan = rawPlan();
+    mutate(plan);
+    expect(() => parseHistoricalSectionedDeliveryPlan(plan)).toThrow(message);
+  });
+
+  it('accepts a real leap-day review date without permitting calendar rollover', () => {
+    const plan = rawPlan();
+    plan.work.metadataProvenance.reviewedAt = '2024-02-29';
+    plan.edition.editionProvenance.reviewedAt = '2000-02-29';
+    expect(parseHistoricalSectionedDeliveryPlan(plan)).toMatchObject({
+      work: { metadataProvenance: { reviewedAt: '2024-02-29' } },
+      edition: { editionProvenance: { reviewedAt: '2000-02-29' } },
+    });
+  });
+
+  it('provides a manual local verifier but keeps it out of runtime, migrations, data materialization, and workflow wiring', () => {
+    const result = spawnSync(process.execPath, [
+      '--import', 'tsx', resolve('scripts/historical-sectioned-delivery.ts'), '--verify',
+    ], { cwd: ROOT, encoding: 'utf8' });
+    expect(result.status, result.stderr).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      editionId: NORTON_EDITION_ID,
+      packageSha256: NORTON_GATE1_PACKAGE_SHA256,
+      sectionCount: NORTON_SECTION_COUNT,
+    });
+
+    const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as { scripts: Record<string, string> };
+    expect(Object.values(packageJson.scripts).join('\n')).not.toContain('historical-sectioned-delivery');
+    expect(readFileSync('data/data-manifest.json', 'utf8')).not.toContain(NORTON_EDITION_ID);
+    const migrations = walkFiles('migrations');
+    expect(migrations.some(path => /(?:^|\/)0005(?:[_.-]|$)/.test(path))).toBe(false);
+
+    const operationalScripts = walkFiles('scripts')
+      .filter(path => /\.(?:[cm]?[jt]s|sh)$/.test(path))
+      .filter(path => path !== SELF_SCRIPT);
+    const manifestsAndSeeds = [
+      ...walkFiles('data'),
+      ...walkFiles('test/fixtures'),
+    ].filter(path => /(?:^|\/)[^/]*(?:manifest|seed)[^/]*(?:\/|$)/i.test(path));
+    const wranglerConfigs = [
+      ...readdirSync('.').filter(path => /^wrangler.*\.toml$/.test(path)),
+      ...walkFiles('test').filter(path => /(?:^|\/)wrangler[^/]*\.toml$/.test(path)),
+    ];
+    const operationalSurfaces = [...new Set([
+      ...walkFiles('src').filter(path => /\.[cm]?[jt]s$/.test(path)),
+      ...migrations,
+      ...walkFiles('.github/workflows'),
+      ...operationalScripts,
+      ...manifestsAndSeeds,
+      ...wranglerConfigs,
+      'package.json',
+      'package-lock.json',
+    ])].sort();
+    expect(operationalSurfaces).toEqual(expect.arrayContaining([
+      'src/index.ts',
+      'src/worker.ts',
+      'migrations/0001_initial_schema.sql',
+      '.github/workflows/pr.yml',
+      'scripts/build-database.ts',
+      'scripts/export-for-d1.ts',
+      'scripts/export-for-d1.sh',
+      'scripts/d1-seed-manifest.ts',
+      'scripts/d1-seed-utils.ts',
+      'scripts/verify-d1-seed.ts',
+      'scripts/verify-d1-seed-import.ts',
+      'scripts/verify-d1-seed-workerd.ts',
+      'scripts/verify-data-manifest.ts',
+      'data/data-manifest.json',
+      'package.json',
+      'package-lock.json',
+      'wrangler.toml',
+      'wrangler.release.toml',
+      'wrangler.ccel-coordinator.toml',
+      'test/worker-runtime/wrangler.test.toml',
+      'test/ccel-coordinator-runtime/wrangler.test.toml',
+    ]));
+    expect(operationalSurfaces).not.toContain(SELF_SCRIPT);
+    for (const path of operationalSurfaces) {
+      const text = readFileSync(path, 'utf8');
+      expect(text, path).not.toContain(HISTORICAL_SECTIONED_DELIVERY_KIND);
+      expect(text, path).not.toContain('historical-sectioned-delivery');
+    }
+  });
+});
+
+function walkFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? walkFiles(path) : [path];
+  });
+}


### PR DESCRIPTION
## What changed

- Adds a deterministic, content-free preparation contract for the approved 1561 Norton edition of Calvin's *Institutes*.
- Freezes 1,250 contiguous section keys and exact edition/provenance metadata.
- Specifies bounded landing, browse, exact-section, and cursor behavior for `sectioned_only` delivery.
- Adds fail-closed validation and inertness coverage.

## Evidence

- Gate-1 package size: 4,058,506 bytes.
- Gate-1 SHA-256: `3054f4446b2e92af87c1713ee1c44d6745bca42a32aed7c67890d25fedbdff33`.
- 25 focused tests passed.
- Node and Worker typechecks passed.
- Independent Sol release review: GO, zero P0-P3 findings.

## Release boundary

This PR contains no Norton source text and does not add migration 0005, transform 9, D1 data, catalog/runtime/MCP wiring, configuration, preview deployment, or production deployment. No `deploy-preview` authorization is requested.
