### PR TITLE
Add inactive original language study v2 packet

### DIFF
--- a/src/formatters/originalLanguageStudyV2Formatter.ts
+++ b/src/formatters/originalLanguageStudyV2Formatter.ts
@@ -1,0 +1,80 @@
+import { escapeEditionPlainTextForMarkdown } from '../kernel/editionProvenanceFoundation.js';
+import {
+  ORIGINAL_LANGUAGE_STUDY_V2_ADDED_SEMANTIC_MARKDOWN_BYTES,
+  type OriginalLanguageStudyV2Candidate,
+  type OriginalLanguageStudyV2Result,
+} from '../kernel/originalLanguageStudyV2Contract.js';
+import { serializeValidatedOriginalLanguageStudyV2Output } from '../presenters/originalLanguageStudyV2Structured.js';
+import { presentOriginalLanguageStudy } from '../presenters/originalLanguageStudyStructured.js';
+import { formatOriginalLanguageStudy } from './originalLanguageStudyFormatter.js';
+import type { OriginalLanguageStudyDomainResult } from '../services/languages/OriginalLanguageStudyService.js';
+
+/**
+ * Human-readable presentation of a validated v2 result.  This formatter is
+ * deliberately a dormant library seam, not a registered MCP rendering path.
+ */
+export function formatOriginalLanguageStudyV2(
+  result: OriginalLanguageStudyV2Result,
+  v1Result: OriginalLanguageStudyDomainResult,
+): string {
+  serializeValidatedOriginalLanguageStudyV2Output(result);
+  const composedV1 = presentOriginalLanguageStudy(v1Result, result.request.position);
+  if (JSON.stringify(composedV1) !== JSON.stringify(result.study)) {
+    throw new Error('original_language_study v2 Markdown must receive the exact v1 result composed into structured output');
+  }
+  // The current v1 formatting is a complete, byte-for-byte prefix. Its size
+  // is deliberately not capped by this inactive v2 layer.
+  const v1Markdown = formatOriginalLanguageStudy(v1Result);
+  const semanticSections: string[] = [];
+
+  const evidence = result.semanticEvidence;
+  semanticSections.push('', '### Added Hebrew semantic layer', '', m(evidence.plainLanguage));
+  if ('identity' in evidence) {
+    semanticSections.push('', `Public identity: ${m(evidence.identity.publicStrongs)}. Source identity: ${m(evidence.identity.sourceIdentity)}.`,
+      `Normalized reference: ${m(evidence.normalizedReference)}.`);
+    if ('candidates' in evidence && evidence.candidates.length) {
+      semanticSections.push('', 'Semantic candidates:');
+      for (const candidate of evidence.candidates) renderCandidate(semanticSections, candidate);
+    }
+    semanticSections.push('', `Window: ${m(evidence.resultWindow.returnedCount)} returned; ${m(evidence.resultWindow.consumedCount)} of ${m(evidence.resultWindow.totalCount)} consumed.`);
+    if (evidence.resultWindow.continuation) semanticSections.push(`Continuation: ${m(evidence.resultWindow.continuation.cursor)}`);
+    semanticSections.push('', 'Withheld evidence:');
+    for (const withheld of evidence.withheldEvidence) {
+      semanticSections.push(`- ${m(withheld.source)} ${m(withheld.field)}: ${m(withheld.status)}.`);
+    }
+    semanticSections.push('', 'Semantic provenance:');
+    for (const source of evidence.provenance.sources) {
+      semanticSections.push(`- ${m(source.sourceRole)} ${m(source.artifactName)}; ${m(source.sourceUrl)}; SHA-256 ${m(source.sourceSha256)}.`);
+    }
+  }
+  semanticSections.push('', `Structured response bytes: ${m(result.responseWindow.used)} of ${m(result.responseWindow.maximum)}.`);
+  const semanticSuffix = semanticSections.join('\n');
+  const bytes = new TextEncoder().encode(semanticSuffix).byteLength;
+  if (bytes > ORIGINAL_LANGUAGE_STUDY_V2_ADDED_SEMANTIC_MARKDOWN_BYTES) {
+    throw new Error(
+      `original_language_study v2 added semantic Markdown exceeds ${ORIGINAL_LANGUAGE_STUDY_V2_ADDED_SEMANTIC_MARKDOWN_BYTES} UTF-8 bytes; refusing to truncate the v2 suffix`,
+    );
+  }
+  return `${v1Markdown}${semanticSuffix}`;
+}
+
+function renderCandidate(lines: string[], candidate: OriginalLanguageStudyV2Candidate): void {
+  lines.push(`- ${m(candidate.senseId)} in ${m(candidate.entryId)}; detail ${m(candidate.detailStatus)}.`);
+  if (candidate.detailStatus !== 'detailed') return;
+  lines.push(`  - Lemma: ${m(candidate.lemma)}`);
+  lines.push(candidate.definition === undefined
+    ? `  - Definition: unavailable (${m(candidate.definitionStatus)})`
+    : `  - Definition: ${m(candidate.definition)}`);
+  if (candidate.definitionExclusionReasons.length) {
+    lines.push(`  - Definition exclusion: ${candidate.definitionExclusionReasons.map(m).join('; ')}`);
+  }
+  lines.push(`  - Glosses: ${candidate.glosses.map(m).join('; ')}`);
+  if (candidate.domains.length) lines.push(`  - Domains: ${candidate.domains.map(domain => m(domain.label)).join('; ')}`);
+  if (candidate.referenceEvidence.length) {
+    lines.push(`  - Reference evidence: ${candidate.referenceEvidence.map(reference => `${m(reference.evidenceId)} ${m(reference.sourceReference)}`).join('; ')}`);
+  }
+}
+
+function m(value: unknown): string {
+  return escapeEditionPlainTextForMarkdown(String(value));
+}

--- a/src/kernel/originalLanguageStudyV2Contract.ts
+++ b/src/kernel/originalLanguageStudyV2Contract.ts
@@ -1,0 +1,323 @@
+import type { OriginalLanguageStudyDomainResult } from '../services/languages/OriginalLanguageStudyService.js';
+import { sha256Hex } from './sha256.js';
+import type {
+  FutureExactHebrewTokenAlignmentProof,
+  UbsInternalHebrewLexicalIdentity,
+  UbsPublicHebrewStrongs,
+  UbsSemanticDefinitionExclusionReason,
+} from './ubsSemanticDomain.js';
+
+/**
+ * Inactive, server-owned contract for a future hard cut from the current
+ * original_language_study response to schema v2.  Nothing in this module
+ * registers a tool or gives callers a way to supply semantic identities.
+ */
+export const ORIGINAL_LANGUAGE_STUDY_V2_SCHEMA_VERSION = '2' as const;
+export const ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES = 32 * 1024;
+/**
+ * The exact established v1 Markdown prefix remains uncapped. Only the new v2
+ * semantic suffix is independently bounded, so activating v2 can never make
+ * an otherwise valid v1 rendering fail merely because of its existing size.
+ * The 16 KiB ceiling leaves substantial room beneath the 32 KiB structured
+ * response budget while preventing escaped semantic fields from expanding
+ * without limit in text clients.
+ */
+export const ORIGINAL_LANGUAGE_STUDY_V2_ADDED_SEMANTIC_MARKDOWN_BYTES = 16 * 1024;
+export const ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_MAX_LENGTH = 12 * 1024;
+export const ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION =
+  'original_language_study_semantic_candidates' as const;
+
+export type OriginalLanguageStudyV2Detail = 'summary' | 'detailed';
+
+export interface OriginalLanguageStudyV2Request {
+  reference: string;
+  target: string;
+  position?: number;
+  /** Summary is the public default once this inactive contract is activated. */
+  detail?: OriginalLanguageStudyV2Detail;
+  cursor?: string;
+}
+
+/** A proof may only be copied from a future server-owned verifier. */
+export interface ServerVerifiedHebrewSemanticAlignment extends FutureExactHebrewTokenAlignmentProof {}
+
+/**
+ * Server-owned context.  The coordinator snapshots it before composition so
+ * callers cannot inject source IDs, artifact identities, or alignment proofs.
+ */
+export interface OriginalLanguageStudyV2AuthoritativeContext {
+  v1Result: OriginalLanguageStudyDomainResult;
+  semanticArtifactIdentity?: string;
+  serverVerifiedAlignment?: ServerVerifiedHebrewSemanticAlignment;
+}
+
+export interface IOriginalLanguageStudyV2ContextProvider {
+  resolve(request: Readonly<OriginalLanguageStudyV2ResolvedRequest>):
+    Promise<OriginalLanguageStudyV2AuthoritativeContext>;
+}
+
+export interface OriginalLanguageStudyV2ResolvedRequest {
+  reference: string;
+  target: string;
+  position?: number;
+  detail: OriginalLanguageStudyV2Detail;
+  cursor?: string;
+}
+
+export interface OriginalLanguageStudyV2SelectedTokenWitness {
+  position: number;
+  text: string;
+  lemma: string;
+  strongsNumber: string | null;
+  morphologyCode: string | null;
+  gloss: string | null;
+}
+
+export interface OriginalLanguageStudyV2CursorBinding {
+  requestReference: string;
+  requestTarget: string;
+  requestPosition: number | null;
+  canonicalReference: string;
+  selectedToken: OriginalLanguageStudyV2SelectedTokenWitness;
+  publicStrongs: UbsPublicHebrewStrongs;
+  sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  normalizedReference: string;
+  artifactIdentity: string;
+}
+
+/**
+ * Deterministic witness for the token selected by the composed v1 study.  It
+ * is an integrity binding, not a caller credential or a semantic verdict.
+ */
+export function deriveOriginalLanguageStudyV2MorphologyTokenIdentity(
+  binding: Pick<OriginalLanguageStudyV2CursorBinding,
+    'canonicalReference' | 'normalizedReference' | 'selectedToken'>,
+): string {
+  return `theologai-morphology-token.v1:${sha256Hex(JSON.stringify({
+    version: 1,
+    canonicalReference: binding.canonicalReference,
+    normalizedReference: binding.normalizedReference,
+    selectedToken: binding.selectedToken,
+  }))}`;
+}
+
+export interface OriginalLanguageStudyV2ResultWindow {
+  priorCount: number;
+  returnedCount: number;
+  consumedCount: number;
+  totalCount: number;
+  hasMore: boolean;
+  continuation?: {
+    cursor: string;
+    operation: typeof ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION;
+  };
+}
+
+export interface OriginalLanguageStudyV2CandidateIdentity {
+  sourceId: string;
+  sourceRole: 'dictionary';
+  entryId: string;
+  senseId: string;
+  sourceAttestedReferenceCount: number;
+  referenceEvidenceIds: readonly string[];
+}
+
+export type OriginalLanguageStudyV2Candidate =
+  | (OriginalLanguageStudyV2CandidateIdentity & { detailStatus: 'summary' })
+  | (OriginalLanguageStudyV2CandidateIdentity & { detailStatus: 'omitted_response_byte_budget' })
+  | (OriginalLanguageStudyV2CandidateIdentity & {
+      detailStatus: 'detailed';
+      lemma: string;
+      definitionStatus: 'published' | 'absent_in_source' | 'excluded_unresolved_markup';
+      definition?: string;
+      definitionExclusionReasons: readonly UbsSemanticDefinitionExclusionReason[];
+      glosses: readonly string[];
+      domains: readonly {
+        sourceId: string;
+        sourceRole: 'lexical_domains';
+        domainId: string;
+        label: string;
+        description?: string;
+      }[];
+      domainTotal: number;
+      referenceEvidence: readonly {
+        sourceId: string;
+        sourceRole: 'dictionary';
+        senseId: string;
+        evidenceId: string;
+        sourceReference: string;
+        normalizedReference: string;
+        kind: 'source_attested_sense_reference';
+      }[];
+      referenceEvidenceTotal: number;
+    });
+
+/** Attribution is intentionally limited to the two pinned public artifacts. */
+export interface OriginalLanguageStudyV2ProvenanceSource {
+  sourceId: string;
+  sourceRole: 'dictionary' | 'lexical_domains';
+  artifactName: 'UBSHebrewDic-v0.9.2-en.JSON' | 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON';
+  artifactVersion: '0.9.2';
+  artifactIdentity: string;
+  sourceUrl: string;
+  sourceCommit: string;
+  sourceBlob: string;
+  sourceSha256: string;
+  publisher: 'United Bible Societies';
+  license: 'CC BY-SA 4.0';
+  licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/';
+  transformVersion: 7;
+  modified: true;
+  modificationNote: string;
+}
+
+export interface OriginalLanguageStudyV2AlignmentEvidence
+  extends ServerVerifiedHebrewSemanticAlignment {}
+
+interface HebrewRepositoryEvidenceCommon {
+  language: 'Hebrew';
+  plainLanguage: string;
+  identity: {
+    publicStrongs: UbsPublicHebrewStrongs;
+    sourceIdentity: UbsInternalHebrewLexicalIdentity;
+  };
+  normalizedReference: string;
+  resultWindow: OriginalLanguageStudyV2ResultWindow;
+  provenance: {
+    artifactIdentity: string;
+    sources: readonly [OriginalLanguageStudyV2ProvenanceSource, OriginalLanguageStudyV2ProvenanceSource];
+  };
+  withheldEvidence: readonly [
+    { source: 'TBESH'; field: 'Meaning'; status: 'withheld_rights_boundary' },
+    { source: 'UBS Hebrew dictionary'; field: 'A#### lexical identities'; status: 'withheld_public_v2_scope' },
+  ];
+}
+
+export type OriginalLanguageStudyV2SemanticEvidence =
+  | {
+      language: 'Greek';
+      status: 'not_applicable';
+      reason: 'hebrew_semantic_evidence_not_applicable';
+      plainLanguage: string;
+    }
+  | {
+      language: 'Hebrew';
+      status: 'unavailable';
+      reason: 'selected_token_required' | 'no_usable_hebrew_identity';
+      plainLanguage: string;
+    }
+  | (HebrewRepositoryEvidenceCommon & {
+      status: 'unavailable';
+      reason: 'no_lexical_entry' | 'no_publishable_semantic_evidence';
+      candidates: readonly [];
+    })
+  | (HebrewRepositoryEvidenceCommon & {
+      status: 'lexical_candidates';
+      reason: 'no_reference_evidence' | 'reference_alignment_unproven' | 'ambiguous_reference_alignment';
+      candidates: readonly OriginalLanguageStudyV2Candidate[];
+    })
+  | (HebrewRepositoryEvidenceCommon & {
+      status: 'reference_aligned_source_candidate';
+      candidates: readonly [OriginalLanguageStudyV2Candidate];
+      alignmentEvidence: OriginalLanguageStudyV2AlignmentEvidence;
+    });
+
+export interface OriginalLanguageStudyV2Result {
+  schemaVersion: typeof ORIGINAL_LANGUAGE_STUDY_V2_SCHEMA_VERSION;
+  kind: 'original_language_study';
+  detail: OriginalLanguageStudyV2Detail;
+  request: {
+    reference: string;
+    target: string;
+    position?: number;
+  };
+  /** Exact complete current v1 structured output, composed rather than replaced. */
+  study: Record<string, unknown>;
+  semanticEvidence: OriginalLanguageStudyV2SemanticEvidence;
+  responseWindow: {
+    unit: 'utf8_bytes';
+    maximum: typeof ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES;
+    used: number;
+    truncated: false;
+  };
+}
+
+interface WrapperCursorPayload {
+  version: 1;
+  operation: typeof ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION;
+  contextDigest: string;
+  repositoryCursor: string;
+}
+
+export function originalLanguageStudyV2ContextDigest(
+  binding: OriginalLanguageStudyV2CursorBinding,
+): string {
+  return sha256Hex(JSON.stringify([
+    binding.requestReference,
+    binding.requestTarget,
+    binding.requestPosition,
+    binding.canonicalReference,
+    binding.selectedToken.position,
+    binding.selectedToken.text,
+    binding.selectedToken.lemma,
+    binding.selectedToken.strongsNumber,
+    binding.selectedToken.morphologyCode,
+    binding.selectedToken.gloss,
+    binding.publicStrongs,
+    binding.sourceIdentity,
+    binding.normalizedReference,
+    binding.artifactIdentity,
+  ]));
+}
+
+export function createOriginalLanguageStudyV2Cursor(
+  repositoryCursor: string,
+  binding: OriginalLanguageStudyV2CursorBinding,
+): string {
+  if (!/^ubsa1_(?:[0-9a-f]{2})+$/.test(repositoryCursor) || repositoryCursor.length > 4096) {
+    throw new Error('original_language_study v2 wrapper requires a bounded canonical aggregate cursor');
+  }
+  const payload: WrapperCursorPayload = {
+    version: 1,
+    operation: ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION,
+    contextDigest: originalLanguageStudyV2ContextDigest(binding),
+    repositoryCursor,
+  };
+  const cursor = `olsv2c1_${[...new TextEncoder().encode(JSON.stringify(payload))]
+    .map(byte => byte.toString(16).padStart(2, '0')).join('')}`;
+  if (cursor.length > ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_MAX_LENGTH) {
+    throw new Error('original_language_study v2 context-bound cursor exceeds its byte-safe bound');
+  }
+  return cursor;
+}
+
+export function parseOriginalLanguageStudyV2Cursor(
+  cursor: string,
+  binding: OriginalLanguageStudyV2CursorBinding,
+): string {
+  if (typeof cursor !== 'string' || cursor.length > ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_MAX_LENGTH
+    || !/^olsv2c1_(?:[0-9a-f]{2})+$/.test(cursor)) {
+    throw new Error('original_language_study v2 cursor has an invalid bounded encoding');
+  }
+  let decoded: unknown;
+  try {
+    const bytes = cursor.slice(8).match(/../g)!.map(byte => Number.parseInt(byte, 16));
+    decoded = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(new Uint8Array(bytes)));
+  } catch {
+    throw new Error('original_language_study v2 cursor has an invalid payload');
+  }
+  if (!decoded || typeof decoded !== 'object' || Array.isArray(decoded)) {
+    throw new Error('original_language_study v2 cursor payload must be an object');
+  }
+  const payload = decoded as Partial<WrapperCursorPayload>;
+  if (Object.keys(payload).join(',') !== 'version,operation,contextDigest,repositoryCursor'
+    || payload.version !== 1
+    || payload.operation !== ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION
+    || payload.contextDigest !== originalLanguageStudyV2ContextDigest(binding)
+    || typeof payload.repositoryCursor !== 'string') {
+    throw new Error('original_language_study v2 cursor does not match the full selected-token request context');
+  }
+  const canonical = createOriginalLanguageStudyV2Cursor(payload.repositoryCursor, binding);
+  if (canonical !== cursor) throw new Error('original_language_study v2 cursor is not canonical');
+  return payload.repositoryCursor;
+}

--- a/src/mcp/schemas/originalLanguageStudyV2.ts
+++ b/src/mcp/schemas/originalLanguageStudyV2.ts
@@ -1,0 +1,371 @@
+import { originalLanguageStudyOutputSchema } from './originalLanguageStudy.js';
+import {
+  ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_MAX_LENGTH,
+  ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION,
+  ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES,
+} from '../../kernel/originalLanguageStudyV2Contract.js';
+
+/**
+ * Closed v2 input/output schemas.  They are intentionally inert until a
+ * separately-reviewed hard cut wires them into the existing MCP tool.
+ */
+export const originalLanguageStudyV2InputSchema = {
+  type: 'object',
+  properties: {
+    reference: { type: 'string', minLength: 1, maxLength: 100 },
+    target: { type: 'string', minLength: 1, maxLength: 100 },
+    position: { type: 'integer', minimum: 1, maximum: 200 },
+    detail: { type: 'string', enum: ['summary', 'detailed'], default: 'summary' },
+    cursor: {
+      type: 'string', minLength: 1, maxLength: ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_MAX_LENGTH,
+      pattern: '^olsv2c1_(?:[0-9a-f]{2})+$',
+    },
+  },
+  required: ['reference', 'target'],
+  additionalProperties: false,
+} as const;
+
+const resultWindow = {
+  type: 'object',
+  properties: {
+    priorCount: { type: 'integer', minimum: 0, maximum: 1_000_000 },
+    returnedCount: { type: 'integer', minimum: 0, maximum: 8 },
+    consumedCount: { type: 'integer', minimum: 0, maximum: 1_000_000 },
+    totalCount: { type: 'integer', minimum: 0, maximum: 1_000_000 },
+    hasMore: { type: 'boolean' },
+    continuation: {
+      type: 'object',
+      properties: {
+        cursor: {
+          type: 'string', minLength: 1, maxLength: ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_MAX_LENGTH,
+          pattern: '^olsv2c1_(?:[0-9a-f]{2})+$',
+        },
+        operation: { const: ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION },
+      },
+      required: ['cursor', 'operation'],
+      additionalProperties: false,
+    },
+  },
+  required: ['priorCount', 'returnedCount', 'consumedCount', 'totalCount', 'hasMore'],
+  additionalProperties: false,
+} as const;
+
+const candidateIdentityProperties = {
+  sourceId: { type: 'string', minLength: 1, maxLength: 128 },
+  sourceRole: { const: 'dictionary' },
+  entryId: { type: 'string', minLength: 1, maxLength: 128 },
+  senseId: { type: 'string', minLength: 1, maxLength: 128 },
+  sourceAttestedReferenceCount: { type: 'integer', minimum: 0, maximum: 16 },
+  referenceEvidenceIds: {
+    type: 'array', maxItems: 16, uniqueItems: true,
+    items: { type: 'string', minLength: 1, maxLength: 128 },
+  },
+} as const;
+const candidateIdentityRequired = [
+  'sourceId', 'sourceRole', 'entryId', 'senseId', 'sourceAttestedReferenceCount', 'referenceEvidenceIds',
+] as const;
+
+const summaryCandidate = {
+  type: 'object',
+  properties: { ...candidateIdentityProperties, detailStatus: { const: 'summary' } },
+  required: [...candidateIdentityRequired, 'detailStatus'],
+  additionalProperties: false,
+} as const;
+
+const omittedCandidate = {
+  type: 'object',
+  properties: { ...candidateIdentityProperties, detailStatus: { const: 'omitted_response_byte_budget' } },
+  required: [...candidateIdentityRequired, 'detailStatus'],
+  additionalProperties: false,
+} as const;
+
+const detailedCandidate = {
+  type: 'object',
+  properties: {
+    ...candidateIdentityProperties,
+    detailStatus: { const: 'detailed' },
+    lemma: { type: 'string', minLength: 1, maxLength: 2_000 },
+    definitionStatus: { enum: ['published', 'absent_in_source', 'excluded_unresolved_markup'] },
+    definition: { type: 'string', minLength: 1, maxLength: 20_000 },
+    definitionExclusionReasons: {
+      type: 'array', maxItems: 8, uniqueItems: true,
+      items: { enum: [
+        'unsafe_attribution_markup', 'unsafe_note_markup',
+        'malformed_lexical_link_markup', 'unvalidated_scripture_link_markup',
+        'malformed_or_unknown_markup',
+      ] },
+    },
+    glosses: {
+      type: 'array', minItems: 1, maxItems: 16, uniqueItems: true,
+      items: { type: 'string', minLength: 1, maxLength: 1_000 },
+    },
+    domains: {
+      type: 'array', maxItems: 16,
+      items: {
+        type: 'object',
+        properties: {
+          sourceId: { type: 'string', minLength: 1, maxLength: 128 },
+          sourceRole: { const: 'lexical_domains' },
+          domainId: { type: 'string', minLength: 1, maxLength: 128 },
+          label: { type: 'string', minLength: 1, maxLength: 1_000 },
+          description: { type: 'string', minLength: 1, maxLength: 5_000 },
+        },
+        required: ['sourceId', 'sourceRole', 'domainId', 'label'],
+        additionalProperties: false,
+      },
+    },
+    domainTotal: { type: 'integer', minimum: 0, maximum: 1_000_000 },
+    referenceEvidence: {
+      type: 'array', maxItems: 16,
+      items: {
+        type: 'object',
+        properties: {
+          sourceId: { type: 'string', minLength: 1, maxLength: 128 },
+          sourceRole: { const: 'dictionary' },
+          senseId: { type: 'string', minLength: 1, maxLength: 128 },
+          evidenceId: { type: 'string', minLength: 1, maxLength: 128 },
+          sourceReference: { type: 'string', minLength: 1, maxLength: 100 },
+          normalizedReference: { type: 'string', minLength: 1, maxLength: 100 },
+          kind: { const: 'source_attested_sense_reference' },
+        },
+        required: ['sourceId', 'sourceRole', 'senseId', 'evidenceId', 'sourceReference', 'normalizedReference', 'kind'],
+        additionalProperties: false,
+      },
+    },
+    referenceEvidenceTotal: { type: 'integer', minimum: 0, maximum: 1_000_000 },
+  },
+  required: [...candidateIdentityRequired, 'detailStatus', 'lemma', 'definitionStatus',
+    'definitionExclusionReasons', 'glosses', 'domains',
+    'domainTotal', 'referenceEvidence', 'referenceEvidenceTotal'],
+  allOf: [
+    {
+      if: { properties: { definitionStatus: { const: 'published' } }, required: ['definitionStatus'] },
+      then: {
+        required: ['definition'],
+        properties: {
+          definition: { type: 'string' },
+          definitionExclusionReasons: { type: 'array', maxItems: 0 },
+        },
+      },
+      else: { not: { required: ['definition'] } },
+    },
+    {
+      if: { properties: { definitionStatus: { const: 'excluded_unresolved_markup' } }, required: ['definitionStatus'] },
+      then: { properties: { definitionExclusionReasons: { type: 'array', minItems: 1 } } },
+      else: { properties: { definitionExclusionReasons: { type: 'array', maxItems: 0 } } },
+    },
+  ],
+  additionalProperties: false,
+} as const;
+
+const identity = {
+  type: 'object',
+  properties: {
+    publicStrongs: { type: 'string', pattern: '^H(?:[1-9][0-9]{0,3})$' },
+    sourceIdentity: { type: 'string', pattern: '^H(?!0000$)[0-9]{4}$' },
+  },
+  required: ['publicStrongs', 'sourceIdentity'],
+  additionalProperties: false,
+} as const;
+
+function provenanceSource(
+  role: 'dictionary' | 'lexical_domains',
+  artifactName: 'UBSHebrewDic-v0.9.2-en.JSON' | 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON',
+) {
+  return {
+    type: 'object',
+    properties: {
+      sourceId: { type: 'string', minLength: 1, maxLength: 128 },
+      sourceRole: { const: role }, artifactName: { const: artifactName }, artifactVersion: { const: '0.9.2' },
+      artifactIdentity: { type: 'string', pattern: '^[0-9a-f]{64}$' },
+      sourceUrl: { type: 'string', pattern: '^https://', maxLength: 1_000 },
+      sourceCommit: { type: 'string', pattern: '^[0-9a-f]{40}$' },
+      sourceBlob: { type: 'string', pattern: '^[0-9a-f]{40}$' },
+      sourceSha256: { type: 'string', pattern: '^[0-9a-f]{64}$' },
+      publisher: { const: 'United Bible Societies' }, license: { const: 'CC BY-SA 4.0' },
+      licenseUrl: { const: 'https://creativecommons.org/licenses/by-sa/4.0/' },
+      transformVersion: { const: 7 }, modified: { const: true },
+      modificationNote: { type: 'string', minLength: 1, maxLength: 1_000 },
+    },
+    required: ['sourceId', 'sourceRole', 'artifactName', 'artifactVersion', 'artifactIdentity', 'sourceUrl',
+      'sourceCommit', 'sourceBlob', 'sourceSha256', 'publisher', 'license', 'licenseUrl', 'transformVersion',
+      'modified', 'modificationNote'],
+    additionalProperties: false,
+  } as const;
+}
+
+const provenance = {
+  type: 'object',
+  properties: {
+    artifactIdentity: { type: 'string', pattern: '^[0-9a-f]{64}$' },
+    sources: {
+      type: 'array', minItems: 2, maxItems: 2,
+      prefixItems: [
+        provenanceSource('dictionary', 'UBSHebrewDic-v0.9.2-en.JSON'),
+        provenanceSource('lexical_domains', 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON'),
+      ],
+      items: false,
+    },
+  },
+  required: ['artifactIdentity', 'sources'],
+  additionalProperties: false,
+} as const;
+
+const withheldEvidence = {
+  type: 'array', minItems: 2, maxItems: 2,
+  prefixItems: [
+    {
+      type: 'object', properties: {
+        source: { const: 'TBESH' }, field: { const: 'Meaning' }, status: { const: 'withheld_rights_boundary' },
+      }, required: ['source', 'field', 'status'], additionalProperties: false,
+    },
+    {
+      type: 'object', properties: {
+        source: { const: 'UBS Hebrew dictionary' }, field: { const: 'A#### lexical identities' },
+        status: { const: 'withheld_public_v2_scope' },
+      }, required: ['source', 'field', 'status'], additionalProperties: false,
+    },
+  ],
+  items: false,
+} as const;
+
+const alignmentArtifactSource = {
+  type: 'object',
+  properties: {
+    sourceId: { type: 'string', minLength: 1, maxLength: 128 },
+    sourceRole: { enum: ['dictionary', 'lexical_domains'] },
+    artifactName: { enum: ['UBSHebrewDic-v0.9.2-en.JSON', 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON'] },
+    artifactIdentity: { type: 'string', pattern: '^[0-9a-f]{64}$' },
+    artifactVersion: { const: '0.9.2' },
+    sourceSha256: { type: 'string', pattern: '^[0-9a-f]{64}$' },
+  },
+  required: ['sourceId', 'sourceRole', 'artifactName', 'artifactIdentity', 'artifactVersion', 'sourceSha256'],
+  additionalProperties: false,
+} as const;
+
+const alignment = {
+  type: 'object',
+  properties: {
+    status: { const: 'verified_token_alignment' },
+    proofContract: { const: 'theologai-exact-hebrew-token-alignment.v1' },
+    verifierVersion: { type: 'integer', minimum: 1, maximum: 1_000_000 },
+    sourceIdentity: { type: 'string', pattern: '^H(?!0000$)[0-9]{4}$', minLength: 5, maxLength: 5 },
+    normalizedReference: { type: 'string', minLength: 1, maxLength: 100 },
+    artifactIdentity: { type: 'string', pattern: '^[0-9a-f]{64}$' },
+    artifactVersion: { const: '0.9.2' },
+    artifactSources: {
+      type: 'object', properties: { dictionary: alignmentArtifactSource, lexicalDomains: alignmentArtifactSource },
+      required: ['dictionary', 'lexicalDomains'], additionalProperties: false,
+    },
+    sourceId: { type: 'string', minLength: 1, maxLength: 128 },
+    entryId: { type: 'string', minLength: 1, maxLength: 128 },
+    senseId: { type: 'string', minLength: 1, maxLength: 128 },
+    evidenceId: { type: 'string', minLength: 1, maxLength: 128 },
+    morphologyTokenIdentity: { type: 'string', minLength: 1, maxLength: 512 },
+    morphologyTokenCoordinates: {
+      type: 'object', properties: {
+        canonicalReference: { type: 'string', minLength: 1, maxLength: 100 },
+        normalizedReference: { type: 'string', minLength: 1, maxLength: 100 },
+        position: { type: 'integer', minimum: 1, maximum: 200 },
+      }, required: ['canonicalReference', 'normalizedReference', 'position'], additionalProperties: false,
+    },
+    morphologyTokenWitness: {
+      type: 'object', properties: {
+        text: { type: 'string', minLength: 1, maxLength: 2_000 },
+        lemma: { type: 'string', minLength: 1, maxLength: 2_000 },
+        strongsNumber: { type: ['string', 'null'], maxLength: 128 },
+        morphologyCode: { type: ['string', 'null'], maxLength: 512 },
+        gloss: { type: ['string', 'null'], maxLength: 2_000 },
+      }, required: ['text', 'lemma', 'strongsNumber', 'morphologyCode', 'gloss'], additionalProperties: false,
+    },
+  },
+  required: [
+    'status', 'proofContract', 'verifierVersion', 'sourceIdentity', 'normalizedReference',
+    'artifactIdentity', 'artifactVersion', 'artifactSources', 'sourceId', 'entryId', 'senseId', 'evidenceId',
+    'morphologyTokenIdentity', 'morphologyTokenCoordinates', 'morphologyTokenWitness',
+  ],
+  additionalProperties: false,
+} as const;
+
+const repositoryCommon = {
+  language: { const: 'Hebrew' }, plainLanguage: { type: 'string', minLength: 1, maxLength: 2_000 },
+  identity, normalizedReference: { type: 'string', minLength: 1, maxLength: 100 },
+  resultWindow, provenance, withheldEvidence,
+} as const;
+const repositoryRequired = [
+  'language', 'status', 'plainLanguage', 'identity', 'normalizedReference', 'resultWindow', 'provenance', 'withheldEvidence',
+] as const;
+
+function semanticEvidenceSchema(candidate: typeof summaryCandidate | { readonly oneOf: readonly [typeof detailedCandidate, typeof omittedCandidate] }) {
+  return {
+    oneOf: [
+      {
+        type: 'object', properties: {
+          language: { const: 'Greek' }, status: { const: 'not_applicable' },
+          reason: { const: 'hebrew_semantic_evidence_not_applicable' },
+          plainLanguage: { type: 'string', minLength: 1, maxLength: 2_000 },
+        }, required: ['language', 'status', 'reason', 'plainLanguage'], additionalProperties: false,
+      },
+      {
+        type: 'object', properties: {
+          language: { const: 'Hebrew' }, status: { const: 'unavailable' },
+          reason: { enum: ['selected_token_required', 'no_usable_hebrew_identity'] },
+          plainLanguage: { type: 'string', minLength: 1, maxLength: 2_000 },
+        }, required: ['language', 'status', 'reason', 'plainLanguage'], additionalProperties: false,
+      },
+      {
+        type: 'object', properties: {
+          ...repositoryCommon, status: { const: 'unavailable' },
+          reason: { enum: ['no_lexical_entry', 'no_publishable_semantic_evidence'] },
+          candidates: { type: 'array', minItems: 0, maxItems: 0, items: false },
+        }, required: [...repositoryRequired, 'reason', 'candidates'], additionalProperties: false,
+      },
+      {
+        type: 'object', properties: {
+          ...repositoryCommon, status: { const: 'lexical_candidates' },
+          reason: { enum: ['no_reference_evidence', 'reference_alignment_unproven', 'ambiguous_reference_alignment'] },
+          candidates: { type: 'array', minItems: 1, maxItems: 8, items: candidate },
+        }, required: [...repositoryRequired, 'reason', 'candidates'], additionalProperties: false,
+      },
+      {
+        type: 'object', properties: {
+          ...repositoryCommon, status: { const: 'reference_aligned_source_candidate' },
+          candidates: { type: 'array', minItems: 1, maxItems: 1, items: candidate }, alignmentEvidence: alignment,
+        }, required: [...repositoryRequired, 'candidates', 'alignmentEvidence'], additionalProperties: false,
+      },
+    ],
+  } as const;
+}
+
+function rootSchema(detail: 'summary' | 'detailed') {
+  const candidate = detail === 'summary'
+    ? summaryCandidate : { oneOf: [detailedCandidate, omittedCandidate] } as const;
+  return {
+    type: 'object',
+    properties: {
+      schemaVersion: { const: '2' }, kind: { const: 'original_language_study' }, detail: { const: detail },
+      request: {
+        type: 'object', properties: {
+          reference: { type: 'string', minLength: 1, maxLength: 100 },
+          target: { type: 'string', minLength: 1, maxLength: 100 },
+          position: { type: 'integer', minimum: 1, maximum: 200 },
+        }, required: ['reference', 'target'], additionalProperties: false,
+      },
+      study: originalLanguageStudyOutputSchema,
+      semanticEvidence: semanticEvidenceSchema(candidate),
+      responseWindow: {
+        type: 'object', properties: {
+          unit: { const: 'utf8_bytes' }, maximum: { const: ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES },
+          used: { type: 'integer', minimum: 1, maximum: ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES },
+          truncated: { const: false },
+        }, required: ['unit', 'maximum', 'used', 'truncated'], additionalProperties: false,
+      },
+    },
+    required: ['schemaVersion', 'kind', 'detail', 'request', 'study', 'semanticEvidence', 'responseWindow'],
+    additionalProperties: false,
+  } as const;
+}
+
+export const originalLanguageStudyV2OutputSchema = {
+  oneOf: [rootSchema('summary'), rootSchema('detailed')],
+} as const;

--- a/src/presenters/originalLanguageStudyV2Structured.ts
+++ b/src/presenters/originalLanguageStudyV2Structured.ts
@@ -1,0 +1,309 @@
+import Ajv2020 from 'ajv/dist/2020.js';
+import { formatReference, parseReference, referencesEqual } from '../kernel/reference.js';
+import { parseUbsPublicHebrewIdentity } from '../kernel/ubsSemanticDomain.js';
+import { parseUbsSemanticEvidenceBundleCursor } from '../kernel/ubsSemanticEvidenceBundle.js';
+import {
+  ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES,
+  deriveOriginalLanguageStudyV2MorphologyTokenIdentity,
+  parseOriginalLanguageStudyV2Cursor,
+  type OriginalLanguageStudyV2Candidate,
+  type OriginalLanguageStudyV2CursorBinding,
+  type OriginalLanguageStudyV2ProvenanceSource,
+  type OriginalLanguageStudyV2Result,
+  type OriginalLanguageStudyV2ResultWindow,
+  type OriginalLanguageStudyV2SelectedTokenWitness,
+  type ServerVerifiedHebrewSemanticAlignment,
+} from '../kernel/originalLanguageStudyV2Contract.js';
+import { originalLanguageStudyV2OutputSchema } from '../mcp/schemas/originalLanguageStudyV2.js';
+
+const validateSchema = new Ajv2020({ strict: true, strictTypes: false, allErrors: true })
+  .compile(originalLanguageStudyV2OutputSchema);
+
+export interface OriginalLanguageStudyV2StructuredPresentation {
+  output: OriginalLanguageStudyV2Result;
+  serialized: string;
+}
+
+/**
+ * Deterministically fits detailed candidate evidence, validates every closed
+ * schema and cross-field relation, then reports the exact UTF-8 byte total.
+ * This is a library seam only; the v2 response remains globally unregistered.
+ */
+export function finalizeOriginalLanguageStudyV2Output(
+  input: OriginalLanguageStudyV2Result,
+): OriginalLanguageStudyV2StructuredPresentation {
+  const output = structuredClone(input);
+  if (output.detail === 'detailed' && hasRepositoryCandidates(output)) {
+    const original = output.semanticEvidence.candidates.map(candidate => structuredClone(candidate));
+    output.semanticEvidence.candidates = original.map(omitCandidateDetails) as typeof output.semanticEvidence.candidates;
+    for (let index = 0; index < original.length; index += 1) {
+      const candidate = original[index]!;
+      if (candidate.detailStatus !== 'detailed') continue;
+      const proposed = [...output.semanticEvidence.candidates];
+      proposed[index] = candidate;
+      const prior = output.semanticEvidence.candidates;
+      output.semanticEvidence.candidates = proposed as typeof prior;
+      if (!fitsByteWindow(output)) output.semanticEvidence.candidates = prior;
+    }
+  }
+  const serialized = stableSerializeWithTruthfulWindow(output);
+  validateOutput(output);
+  return { output, serialized };
+}
+
+/** Validates an already materialized output without silently repairing it. */
+export function serializeValidatedOriginalLanguageStudyV2Output(output: unknown): string {
+  const cloned = structuredClone(output) as OriginalLanguageStudyV2Result;
+  validateOutput(cloned);
+  return stableSerializeWithTruthfulWindow(cloned, false);
+}
+
+function validateOutput(output: OriginalLanguageStudyV2Result): void {
+  if (!validateSchema(output)) {
+    throw new Error(`original_language_study v2 output violates its schema: ${JSON.stringify(validateSchema.errors)}`);
+  }
+  validateRelationalContract(output);
+}
+
+function stableSerializeWithTruthfulWindow(
+  output: OriginalLanguageStudyV2Result,
+  permitRepair = true,
+): string {
+  if (!output || typeof output !== 'object' || !output.responseWindow) {
+    throw new Error('original_language_study v2 output must include a response window');
+  }
+  if (!permitRepair && (!Number.isSafeInteger(output.responseWindow.used) || output.responseWindow.used < 1)) {
+    throw new Error('original_language_study v2 response window used bytes must already be truthful');
+  }
+  let expected = permitRepair ? 1 : output.responseWindow.used;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    output.responseWindow.used = expected;
+    const serialized = JSON.stringify(output);
+    const actual = new TextEncoder().encode(serialized).byteLength;
+    if (actual > ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES) {
+      throw new Error(`original_language_study v2 output exceeds ${ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES} serialized UTF-8 bytes`);
+    }
+    if (actual === expected) return serialized;
+    if (!permitRepair) throw new Error('original_language_study v2 response window used bytes are not truthful');
+    expected = actual;
+  }
+  throw new Error('original_language_study v2 response byte accounting did not stabilize');
+}
+
+function fitsByteWindow(output: OriginalLanguageStudyV2Result): boolean {
+  const candidate = structuredClone(output);
+  try {
+    stableSerializeWithTruthfulWindow(candidate);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('serialized UTF-8 bytes')) return false;
+    throw error;
+  }
+}
+
+function hasRepositoryCandidates(output: OriginalLanguageStudyV2Result): output is OriginalLanguageStudyV2Result & {
+  semanticEvidence: Extract<OriginalLanguageStudyV2Result['semanticEvidence'], { status: 'lexical_candidates' | 'reference_aligned_source_candidate' }>;
+} {
+  return output.semanticEvidence.status === 'lexical_candidates'
+    || output.semanticEvidence.status === 'reference_aligned_source_candidate';
+}
+
+function omitCandidateDetails(candidate: OriginalLanguageStudyV2Candidate): OriginalLanguageStudyV2Candidate {
+  const identity = {
+    sourceId: candidate.sourceId, sourceRole: candidate.sourceRole, entryId: candidate.entryId,
+    senseId: candidate.senseId, sourceAttestedReferenceCount: candidate.sourceAttestedReferenceCount,
+    referenceEvidenceIds: [...candidate.referenceEvidenceIds],
+  };
+  return { ...identity, detailStatus: 'omitted_response_byte_budget' };
+}
+
+function validateRelationalContract(output: OriginalLanguageStudyV2Result): void {
+  const study = objectOf(output.study, 'output.study');
+  const studyRequest = objectOf(study.request, 'output.study.request');
+  const context = objectOf(study.context, 'output.study.context');
+  if (study.kind !== 'original_language_study' || study.schemaVersion !== '1'
+    || !sameCanonicalStudyReference(studyRequest.reference, output.request.reference)
+    || !sameCanonicalStudyReference(context.reference, output.request.reference)
+    || studyRequest.target !== output.request.target
+    || (studyRequest.position ?? undefined) !== (output.request.position ?? undefined)) {
+    throw new Error('v2 must compose one semantically matching, canonical-reference, target-, and position-matching complete v1 study result');
+  }
+  const language = context.language;
+  const evidence = output.semanticEvidence;
+  if (language !== evidence.language) throw new Error('semantic evidence language must match the composed v1 study');
+  if (language === 'Greek') {
+    if (evidence.status !== 'not_applicable') throw new Error('Greek semantic evidence must be not_applicable');
+    return;
+  }
+  if (evidence.status === 'unavailable' && (evidence.reason === 'selected_token_required'
+    || evidence.reason === 'no_usable_hebrew_identity')) {
+    if (evidence.reason === 'selected_token_required' && study.status !== 'needs_disambiguation') {
+      throw new Error('selected_token_required must correspond to v1 needs_disambiguation');
+    }
+    if (evidence.reason === 'no_usable_hebrew_identity' && !context.selectedToken) {
+      throw new Error('no_usable_hebrew_identity requires a selected v1 token');
+    }
+    return;
+  }
+  if (!('identity' in evidence) || !('resultWindow' in evidence) || !('provenance' in evidence)) {
+    throw new Error('repository semantic evidence is incomplete');
+  }
+  const selectedToken = objectOf(context.selectedToken, 'output.study.context.selectedToken');
+  const identity = parseUbsPublicHebrewIdentity(evidence.identity.publicStrongs);
+  if (!identity || identity.publicStrongs !== evidence.identity.publicStrongs
+    || identity.sourceIdentity !== evidence.identity.sourceIdentity) {
+    throw new Error('semantic evidence identity must be one canonical public/source H-number pair');
+  }
+  const studyIdentity = study.identity === undefined ? undefined : objectOf(study.identity, 'output.study.identity');
+  if ((studyIdentity?.publicStrongs ?? selectedToken.strongsNumber) !== evidence.identity.publicStrongs) {
+    throw new Error('semantic identity must match the selected token in the composed v1 study');
+  }
+  validateWindow(output, evidence.resultWindow, selectedToken, evidence);
+  const [dictionary, domains] = evidence.provenance.sources;
+  if (dictionary.sourceRole !== 'dictionary' || domains.sourceRole !== 'lexical_domains'
+    || dictionary.artifactIdentity !== evidence.provenance.artifactIdentity
+    || domains.artifactIdentity !== evidence.provenance.artifactIdentity) {
+    throw new Error('provenance must retain exact dictionary/domain roles under one artifact identity');
+  }
+  if ('candidates' in evidence) {
+    if (evidence.resultWindow.returnedCount !== evidence.candidates.length) {
+      throw new Error('candidate count must equal resultWindow.returnedCount');
+    }
+    for (const candidate of evidence.candidates) {
+      validateCandidateRoles(candidate, dictionary.sourceId, domains.sourceId, evidence.normalizedReference);
+    }
+  }
+  if (evidence.status === 'reference_aligned_source_candidate') {
+    if (evidence.candidates.length !== 1 || evidence.resultWindow.priorCount !== 0
+      || evidence.resultWindow.totalCount !== 1 || evidence.resultWindow.hasMore) {
+      throw new Error('reference-aligned status requires one complete terminal candidate');
+    }
+    const candidate = evidence.candidates[0]!;
+    const alignment = evidence.alignmentEvidence;
+    if (alignment.sourceId !== candidate.sourceId || alignment.entryId !== candidate.entryId
+      || alignment.senseId !== candidate.senseId || candidate.referenceEvidenceIds.length !== 1
+      || alignment.evidenceId !== candidate.referenceEvidenceIds[0]
+      || alignment.sourceIdentity !== evidence.identity.sourceIdentity
+      || alignment.normalizedReference !== evidence.normalizedReference
+      || alignment.artifactIdentity !== evidence.provenance.artifactIdentity
+      || alignment.artifactVersion !== dictionary.artifactVersion
+      || !sameAlignmentArtifactSource(alignment.artifactSources.dictionary, dictionary)
+      || !sameAlignmentArtifactSource(alignment.artifactSources.lexicalDomains, domains)
+      || alignment.morphologyTokenCoordinates.canonicalReference !== context.reference
+      || alignment.morphologyTokenCoordinates.normalizedReference !== evidence.normalizedReference
+      || alignment.morphologyTokenCoordinates.position !== selectedToken.position
+      || alignment.morphologyTokenWitness.text !== selectedToken.text
+      || alignment.morphologyTokenWitness.lemma !== selectedToken.lemma
+      || alignment.morphologyTokenWitness.strongsNumber !== selectedToken.strongsNumber
+      || alignment.morphologyTokenWitness.morphologyCode !== selectedToken.morphologyCode
+      || alignment.morphologyTokenWitness.gloss !== selectedToken.gloss
+      || alignment.morphologyTokenIdentity !== deriveOriginalLanguageStudyV2MorphologyTokenIdentity({
+        canonicalReference: context.reference as string,
+        normalizedReference: evidence.normalizedReference,
+        selectedToken: {
+          position: selectedToken.position, text: selectedToken.text, lemma: selectedToken.lemma,
+          strongsNumber: selectedToken.strongsNumber, morphologyCode: selectedToken.morphologyCode,
+          gloss: selectedToken.gloss,
+        } as OriginalLanguageStudyV2SelectedTokenWitness,
+      })) {
+      throw new Error('alignment must bind the exact candidate and reference-evidence identity');
+    }
+  }
+}
+
+/**
+ * `output.request.reference` intentionally records the raw accepted alias so
+ * cursor replay stays bound to the original request. The composed v1 study is
+ * the canonical user-facing result and must represent that exact same verse.
+ */
+function sameCanonicalStudyReference(studyReference: unknown, requestReference: unknown): boolean {
+  if (typeof studyReference !== 'string' || typeof requestReference !== 'string') return false;
+  try {
+    const study = parseReference(studyReference);
+    const request = parseReference(requestReference);
+    return referencesEqual(study, request) && studyReference === formatReference(study);
+  } catch {
+    return false;
+  }
+}
+
+function sameAlignmentArtifactSource(
+  proof: ServerVerifiedHebrewSemanticAlignment['artifactSources']['dictionary'],
+  source: OriginalLanguageStudyV2ProvenanceSource,
+): boolean {
+  return proof.sourceId === source.sourceId
+    && proof.sourceRole === source.sourceRole
+    && proof.artifactName === source.artifactName
+    && proof.artifactIdentity === source.artifactIdentity
+    && proof.artifactVersion === source.artifactVersion
+    && proof.sourceSha256 === source.sourceSha256;
+}
+
+function validateWindow(
+  output: OriginalLanguageStudyV2Result,
+  window: OriginalLanguageStudyV2ResultWindow,
+  selectedToken: Record<string, unknown>,
+  evidence: Extract<OriginalLanguageStudyV2Result['semanticEvidence'], { identity: unknown }>,
+): void {
+  if (window.priorCount + window.returnedCount !== window.consumedCount
+    || window.consumedCount > window.totalCount
+    || window.hasMore !== (window.consumedCount < window.totalCount)
+    || window.hasMore !== (window.continuation !== undefined)) {
+    throw new Error('semantic result-window arithmetic or terminal state is inconsistent');
+  }
+  if (!window.continuation) return;
+  const binding: OriginalLanguageStudyV2CursorBinding = {
+    requestReference: output.request.reference,
+    requestTarget: output.request.target,
+    requestPosition: output.request.position ?? null,
+    canonicalReference: objectOf(
+      objectOf(output.study, 'output.study').context,
+      'output.study.context',
+    ).reference as string,
+    selectedToken: {
+      position: selectedToken.position as number, text: selectedToken.text as string,
+      lemma: selectedToken.lemma as string, strongsNumber: selectedToken.strongsNumber as string | null,
+      morphologyCode: selectedToken.morphologyCode as string | null, gloss: selectedToken.gloss as string | null,
+    },
+    publicStrongs: evidence.identity.publicStrongs,
+    sourceIdentity: evidence.identity.sourceIdentity,
+    normalizedReference: evidence.normalizedReference,
+    artifactIdentity: evidence.provenance.artifactIdentity,
+  };
+  const repositoryCursor = parseOriginalLanguageStudyV2Cursor(window.continuation.cursor, binding);
+  const parsed = parseUbsSemanticEvidenceBundleCursor(repositoryCursor, {
+    artifactIdentity: evidence.provenance.artifactIdentity,
+    sourceIdentity: evidence.identity.sourceIdentity,
+    normalizedReference: evidence.normalizedReference,
+  });
+  if (parsed.priorShowing !== window.consumedCount) {
+    throw new Error('context-bound continuation position must equal consumed results');
+  }
+}
+
+function validateCandidateRoles(
+  candidate: OriginalLanguageStudyV2Candidate,
+  dictionarySourceId: string,
+  domainSourceId: string,
+  normalizedReference: string,
+): void {
+  if (candidate.sourceRole !== 'dictionary' || candidate.sourceId !== dictionarySourceId
+    || candidate.referenceEvidenceIds.length > candidate.sourceAttestedReferenceCount
+    || new Set(candidate.referenceEvidenceIds).size !== candidate.referenceEvidenceIds.length) {
+    throw new Error('candidate identity does not belong to the dictionary provenance source');
+  }
+  if (candidate.detailStatus !== 'detailed') return;
+  if (candidate.domains.some(domain => domain.sourceRole !== 'lexical_domains' || domain.sourceId !== domainSourceId)
+    || candidate.referenceEvidence.some(reference => reference.sourceRole !== 'dictionary'
+      || reference.sourceId !== dictionarySourceId || reference.senseId !== candidate.senseId
+      || reference.normalizedReference !== normalizedReference)
+    || candidate.referenceEvidence.length !== candidate.referenceEvidenceIds.length
+    || candidate.referenceEvidence.some((reference, index) => reference.evidenceId !== candidate.referenceEvidenceIds[index])) {
+    throw new Error('candidate nested evidence does not match provenance roles and source identities');
+  }
+}
+
+function objectOf(value: unknown, path: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error(`${path} must be an object`);
+  return value as Record<string, unknown>;
+}

--- a/src/services/languages/OriginalLanguageStudyV2Coordinator.ts
+++ b/src/services/languages/OriginalLanguageStudyV2Coordinator.ts
@@ -1,0 +1,604 @@
+import {
+  queryUbsSemanticEvidenceBundle,
+  type IUbsSemanticEvidenceBundleRepository,
+  type UbsSemanticEvidenceBundle,
+  type UbsSemanticEvidenceBundleCandidateRow,
+} from '../../kernel/ubsSemanticEvidenceBundle.js';
+import {
+  parseUbsPublicHebrewIdentity,
+  requireUbsSemanticNormalizedReference,
+  type UbsInternalHebrewLexicalIdentity,
+  type UbsPublicHebrewStrongs,
+  type UbsSemanticSource,
+} from '../../kernel/ubsSemanticDomain.js';
+import { formatReference, parseReference, referencesEqual, toHelloAO } from '../../kernel/reference.js';
+import {
+  ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION,
+  ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES,
+  ORIGINAL_LANGUAGE_STUDY_V2_SCHEMA_VERSION,
+  createOriginalLanguageStudyV2Cursor,
+  deriveOriginalLanguageStudyV2MorphologyTokenIdentity,
+  parseOriginalLanguageStudyV2Cursor,
+  type IOriginalLanguageStudyV2ContextProvider,
+  type OriginalLanguageStudyV2AuthoritativeContext,
+  type OriginalLanguageStudyV2Candidate,
+  type OriginalLanguageStudyV2CursorBinding,
+  type OriginalLanguageStudyV2Detail,
+  type OriginalLanguageStudyV2ProvenanceSource,
+  type OriginalLanguageStudyV2ResolvedRequest,
+  type OriginalLanguageStudyV2Result,
+  type OriginalLanguageStudyV2ResultWindow,
+  type OriginalLanguageStudyV2SemanticEvidence,
+  type ServerVerifiedHebrewSemanticAlignment,
+} from '../../kernel/originalLanguageStudyV2Contract.js';
+import { presentOriginalLanguageStudy } from '../../presenters/originalLanguageStudyStructured.js';
+import {
+  finalizeOriginalLanguageStudyV2Output,
+  type OriginalLanguageStudyV2StructuredPresentation,
+} from '../../presenters/originalLanguageStudyV2Structured.js';
+import { formatOriginalLanguageStudyV2 } from '../../formatters/originalLanguageStudyV2Formatter.js';
+import type { OriginalLanguageStudyDomainResult } from './OriginalLanguageStudyService.js';
+
+export type {
+  IOriginalLanguageStudyV2ContextProvider,
+  OriginalLanguageStudyV2AuthoritativeContext,
+  OriginalLanguageStudyV2ResolvedRequest,
+} from '../../kernel/originalLanguageStudyV2Contract.js';
+
+/**
+ * The inactive coordinator returns both the closed structured v2 packet and a
+ * textual rendering that begins with the complete existing v1 rendering.  The
+ * latter is intentionally composed only after the v2 result has passed its
+ * own exact-byte validation; it is not a second, lossy v1 projection.
+ */
+export interface OriginalLanguageStudyV2Presentation extends OriginalLanguageStudyV2StructuredPresentation {
+  markdown: string;
+}
+
+const WITHHELD_EVIDENCE = Object.freeze([
+  Object.freeze({ source: 'TBESH' as const, field: 'Meaning' as const, status: 'withheld_rights_boundary' as const }),
+  Object.freeze({
+    source: 'UBS Hebrew dictionary' as const,
+    field: 'A#### lexical identities' as const,
+    status: 'withheld_public_v2_scope' as const,
+  }),
+] as const);
+
+/**
+ * Inactive v2 coordinator.  A future composition root may instantiate it only
+ * after a separately-approved hard cut.  Eligible Hebrew calls execute one
+ * aggregate repository operation; neither source identity nor alignment proof
+ * is caller-controlled.
+ */
+export class OriginalLanguageStudyV2Coordinator {
+  constructor(
+    private readonly contextProvider: IOriginalLanguageStudyV2ContextProvider,
+    private readonly evidenceRepository: IUbsSemanticEvidenceBundleRepository,
+  ) {}
+
+  async study(input: unknown): Promise<OriginalLanguageStudyV2Presentation> {
+    const request = snapshotRequest(input);
+    const authoritative = snapshotAuthoritativeContext(await this.contextProvider.resolve(request));
+    const canonicalReference = validateV1ResultAgainstRequest(authoritative.v1Result, request);
+    const study = presentOriginalLanguageStudy(authoritative.v1Result, request.position);
+    const semanticEvidence = await this.semanticEvidence(request, authoritative, canonicalReference);
+    const output: OriginalLanguageStudyV2Result = {
+      schemaVersion: ORIGINAL_LANGUAGE_STUDY_V2_SCHEMA_VERSION,
+      kind: 'original_language_study',
+      detail: request.detail,
+      request: {
+        // Keep the supplied spelling as an auditable request record. The
+        // composed v1 study and semantic reference are canonical, while this
+        // raw value remains part of the continuation binding.
+        reference: request.reference,
+        target: request.target,
+        ...(request.position === undefined ? {} : { position: request.position }),
+      },
+      study,
+      semanticEvidence,
+      responseWindow: {
+        unit: 'utf8_bytes', maximum: ORIGINAL_LANGUAGE_STUDY_V2_RESPONSE_BYTES,
+        used: 0, truncated: false,
+      },
+    };
+    const presentation = finalizeOriginalLanguageStudyV2Output(output);
+    return {
+      ...presentation,
+      markdown: formatOriginalLanguageStudyV2(presentation.output, authoritative.v1Result),
+    };
+  }
+
+  private async semanticEvidence(
+    request: OriginalLanguageStudyV2ResolvedRequest,
+    authoritative: OriginalLanguageStudyV2AuthoritativeContext,
+    canonicalReference: CanonicalOriginalLanguageStudyReference,
+  ): Promise<OriginalLanguageStudyV2SemanticEvidence> {
+    const v1 = authoritative.v1Result;
+    if (v1.language === 'Greek') {
+      if (request.cursor !== undefined) throw new Error('original_language_study v2 semantic continuation is Hebrew-only');
+      return {
+        language: 'Greek', status: 'not_applicable', reason: 'hebrew_semantic_evidence_not_applicable',
+        plainLanguage: 'The added UBS semantic layer is Hebrew-only. The complete existing Greek evidence remains in study and is not replaced or reduced.',
+      };
+    }
+    if (v1.status === 'needs_disambiguation' || !v1.selectedToken) {
+      if (request.cursor !== undefined) throw new Error('original_language_study v2 cursor requires one server-selected Hebrew token');
+      return {
+        language: 'Hebrew', status: 'unavailable', reason: 'selected_token_required',
+        plainLanguage: 'Choose one of the verse-token positions in study before requesting Hebrew semantic candidates.',
+      };
+    }
+    const publicStrongs = v1.identity?.publicStrongs ?? v1.selectedToken.strongsNumber;
+    const identity = typeof publicStrongs === 'string' ? parseUbsPublicHebrewIdentity(publicStrongs) : undefined;
+    if (!identity || identity.publicStrongs !== publicStrongs) {
+      if (request.cursor !== undefined) throw new Error('original_language_study v2 cursor requires one canonical public Hebrew H-number');
+      return {
+        language: 'Hebrew', status: 'unavailable', reason: 'no_usable_hebrew_identity',
+        plainLanguage: 'The selected Hebrew token has no canonical public H-number, so the added semantic repository is not queried.',
+      };
+    }
+    if (authoritative.semanticArtifactIdentity === undefined) {
+      throw new Error('server-authoritative Hebrew semantic context must provide the exact artifact identity');
+    }
+    const binding: OriginalLanguageStudyV2CursorBinding = {
+      requestReference: request.reference,
+      requestTarget: request.target,
+      requestPosition: request.position ?? null,
+      canonicalReference: canonicalReference.display,
+      selectedToken: snapshotSelectedToken(v1.selectedToken),
+      publicStrongs: identity.publicStrongs,
+      sourceIdentity: identity.sourceIdentity,
+      normalizedReference: canonicalReference.semanticKey,
+      artifactIdentity: authoritative.semanticArtifactIdentity,
+    };
+    const repositoryCursor = request.cursor === undefined
+      ? undefined : parseOriginalLanguageStudyV2Cursor(request.cursor, binding);
+    const bundle = await queryUbsSemanticEvidenceBundle(this.evidenceRepository, {
+      artifactIdentity: authoritative.semanticArtifactIdentity,
+      sourceIdentity: identity.sourceIdentity,
+      normalizedReference: canonicalReference.semanticKey,
+      ...(repositoryCursor === undefined ? {} : { page: { cursor: repositoryCursor } }),
+    });
+    return buildHebrewEvidence(bundle, request.detail, identity.publicStrongs,
+      authoritative.serverVerifiedAlignment, binding);
+  }
+}
+
+function buildHebrewEvidence(
+  bundle: UbsSemanticEvidenceBundle,
+  detail: OriginalLanguageStudyV2Detail,
+  publicStrongs: UbsPublicHebrewStrongs,
+  alignment: ServerVerifiedHebrewSemanticAlignment | undefined,
+  binding: OriginalLanguageStudyV2CursorBinding,
+): OriginalLanguageStudyV2SemanticEvidence {
+  const candidateWindow = bundle.coverage.candidateWindow;
+  const resultWindow: OriginalLanguageStudyV2ResultWindow = {
+    priorCount: candidateWindow.priorCount,
+    returnedCount: candidateWindow.returnedCount,
+    consumedCount: candidateWindow.consumedCount,
+    totalCount: candidateWindow.totalCount,
+    hasMore: candidateWindow.hasMore,
+    ...(candidateWindow.nextCursor === undefined ? {} : {
+      continuation: {
+        cursor: createOriginalLanguageStudyV2Cursor(candidateWindow.nextCursor, binding),
+        operation: ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION,
+      },
+    }),
+  };
+  const sources = bundle.sources.map(presentProvenanceSource);
+  if (sources.length !== 2) throw new Error('semantic aggregate must retain exactly two provenance sources');
+  const common = {
+    language: 'Hebrew' as const,
+    identity: { publicStrongs, sourceIdentity: bundle.query.sourceIdentity },
+    normalizedReference: bundle.query.normalizedReference,
+    resultWindow,
+    provenance: {
+      artifactIdentity: bundle.query.artifactIdentity,
+      sources: sources as [OriginalLanguageStudyV2ProvenanceSource, OriginalLanguageStudyV2ProvenanceSource],
+    },
+    withheldEvidence: WITHHELD_EVIDENCE,
+  };
+  if (bundle.coverage.semanticSenseTotal === 0) {
+    return {
+      ...common,
+      status: 'unavailable',
+      reason: bundle.coverage.lexicalEntryTotal === 0 ? 'no_lexical_entry' : 'no_publishable_semantic_evidence',
+      plainLanguage: bundle.coverage.lexicalEntryTotal === 0
+        ? 'No publishable Hebrew semantic entry is available for the selected token identity.'
+        : 'A Hebrew lexical entry exists, but no publishable semantic sense is available.',
+      candidates: [],
+    };
+  }
+  const candidates = bundle.candidates.map(candidate => presentCandidate(candidate, detail));
+  const aligned = exactServerVerifiedCandidate(bundle, alignment, binding);
+  if (aligned) {
+    return {
+      ...common,
+      status: 'reference_aligned_source_candidate',
+      plainLanguage: 'One source candidate is attested at this reference and server-verified against the selected token. It remains a candidate, not an adjudicated contextual meaning.',
+      candidates: [candidates[0]!],
+      alignmentEvidence: aligned,
+    };
+  }
+  if (alignment !== undefined) {
+    throw new Error('server-authoritative alignment does not match one complete exact aggregate candidate');
+  }
+  const reason = candidateReason(bundle);
+  return {
+    ...common,
+    status: 'lexical_candidates',
+    reason,
+    plainLanguage: reason === 'no_reference_evidence'
+      ? 'The lexical candidates have no source-attested evidence for this exact reference. No contextual meaning has been resolved.'
+      : reason === 'ambiguous_reference_alignment'
+        ? 'More than one candidate or source-reference row remains. No contextual meaning has been resolved.'
+        : 'Candidate evidence is available, but no single server-verified alignment is available. No contextual meaning has been resolved.',
+    candidates,
+  };
+}
+
+function presentCandidate(
+  candidate: UbsSemanticEvidenceBundleCandidateRow,
+  detail: OriginalLanguageStudyV2Detail,
+): OriginalLanguageStudyV2Candidate {
+  const identity = {
+    sourceId: candidate.sense.sourceId,
+    sourceRole: 'dictionary' as const,
+    entryId: candidate.entry.entryId,
+    senseId: candidate.sense.senseId,
+    sourceAttestedReferenceCount: candidate.matchingReferenceTotal,
+    referenceEvidenceIds: candidate.matchingReferences.map(evidence => evidence.evidenceId),
+  };
+  if (detail === 'summary') return { ...identity, detailStatus: 'summary' };
+  return {
+    ...identity,
+    detailStatus: 'detailed',
+    lemma: candidate.entry.lemma,
+    definitionStatus: candidate.sense.definitionStatus,
+    ...(candidate.sense.definition === undefined ? {} : { definition: candidate.sense.definition }),
+    definitionExclusionReasons: [...candidate.sense.definitionExclusionReasons],
+    glosses: [...candidate.sense.glosses],
+    domains: candidate.domains.map(domain => ({
+      sourceId: domain.sourceId, sourceRole: 'lexical_domains' as const,
+      domainId: domain.domainId, label: domain.label,
+      ...(domain.description === undefined ? {} : { description: domain.description }),
+    })),
+    domainTotal: candidate.domainTotal,
+    referenceEvidence: candidate.matchingReferences.map(evidence => ({
+      sourceId: evidence.sourceId, sourceRole: 'dictionary' as const,
+      senseId: evidence.senseId, evidenceId: evidence.evidenceId,
+      sourceReference: evidence.sourceReference, normalizedReference: evidence.normalizedReference,
+      kind: evidence.evidenceKind,
+    })),
+    referenceEvidenceTotal: candidate.matchingReferenceTotal,
+  };
+}
+
+function exactServerVerifiedCandidate(
+  bundle: UbsSemanticEvidenceBundle,
+  alignment: ServerVerifiedHebrewSemanticAlignment | undefined,
+  binding: OriginalLanguageStudyV2CursorBinding,
+): ServerVerifiedHebrewSemanticAlignment | undefined {
+  if (alignment === undefined || !bundle.coverage.completeForWholeQuery || bundle.candidates.length !== 1
+    || bundle.coverage.semanticSenseTotal !== 1) return undefined;
+  const candidate = bundle.candidates[0]!;
+  const evidence = candidate.matchingReferences[0];
+  const dictionary = bundle.sources.find(source => source.sourceRole === 'dictionary');
+  const lexicalDomains = bundle.sources.find(source => source.sourceRole === 'lexical_domains');
+  if (candidate.matchingReferenceTotal !== 1 || candidate.matchingReferences.length !== 1 || !evidence
+    || bundle.sources.length !== 2 || !dictionary || !lexicalDomains
+    || alignment.sourceIdentity !== bundle.query.sourceIdentity
+    || alignment.normalizedReference !== bundle.query.normalizedReference
+    || alignment.normalizedReference !== binding.normalizedReference
+    || alignment.artifactIdentity !== bundle.query.artifactIdentity
+    || alignment.artifactVersion !== '0.9.2'
+    || !sameArtifactSource(alignment.artifactSources.dictionary, dictionary)
+    || !sameArtifactSource(alignment.artifactSources.lexicalDomains, lexicalDomains)
+    || alignment.morphologyTokenIdentity !== deriveOriginalLanguageStudyV2MorphologyTokenIdentity(binding)
+    || alignment.morphologyTokenCoordinates.canonicalReference !== binding.canonicalReference
+    || alignment.morphologyTokenCoordinates.normalizedReference !== binding.normalizedReference
+    || alignment.morphologyTokenCoordinates.position !== binding.selectedToken.position
+    || !sameSelectedTokenWitness(alignment.morphologyTokenWitness, binding.selectedToken)
+    || alignment.sourceId !== candidate.sense.sourceId || alignment.entryId !== candidate.entry.entryId
+    || alignment.senseId !== candidate.sense.senseId || alignment.evidenceId !== evidence.evidenceId) return undefined;
+  return { ...alignment };
+}
+
+function sameArtifactSource(
+  proof: ServerVerifiedHebrewSemanticAlignment['artifactSources']['dictionary'],
+  source: UbsSemanticSource,
+): boolean {
+  return proof.sourceId === source.sourceId
+    && proof.sourceRole === source.sourceRole
+    && proof.artifactName === source.artifactName
+    && proof.artifactIdentity === source.artifactIdentity
+    && proof.artifactVersion === source.artifactVersion
+    && proof.sourceSha256 === source.sourceSha256;
+}
+
+function sameSelectedTokenWitness(
+  proof: ServerVerifiedHebrewSemanticAlignment['morphologyTokenWitness'],
+  selected: OriginalLanguageStudyV2CursorBinding['selectedToken'],
+): boolean {
+  return proof.text === selected.text
+    && proof.lemma === selected.lemma
+    && proof.strongsNumber === selected.strongsNumber
+    && proof.morphologyCode === selected.morphologyCode
+    && proof.gloss === selected.gloss;
+}
+
+function candidateReason(bundle: UbsSemanticEvidenceBundle):
+  'no_reference_evidence' | 'reference_alignment_unproven' | 'ambiguous_reference_alignment' {
+  if (!bundle.coverage.completeForWholeQuery) return 'reference_alignment_unproven';
+  const total = bundle.candidates.reduce((sum, candidate) => sum + candidate.matchingReferenceTotal, 0);
+  if (total === 0) return 'no_reference_evidence';
+  return bundle.candidates.length !== 1 || total !== 1
+    ? 'ambiguous_reference_alignment' : 'reference_alignment_unproven';
+}
+
+function presentProvenanceSource(source: UbsSemanticSource): OriginalLanguageStudyV2ProvenanceSource {
+  return {
+    sourceId: source.sourceId, sourceRole: source.sourceRole, artifactName: source.artifactName,
+    artifactVersion: source.artifactVersion, artifactIdentity: source.artifactIdentity,
+    sourceUrl: source.sourceUrl, sourceCommit: source.sourceCommit, sourceBlob: source.sourceBlob,
+    sourceSha256: source.sourceSha256, publisher: source.publisher, license: source.license,
+    licenseUrl: source.licenseUrl, transformVersion: source.transformVersion, modified: source.modified,
+    modificationNote: source.modificationNote,
+  };
+}
+
+function snapshotRequest(input: unknown): Readonly<OriginalLanguageStudyV2ResolvedRequest> {
+  const record = objectOf(input, 'original_language_study v2 request');
+  exactKeys(record, ['reference', 'target', 'position', 'detail', 'cursor'], ['reference', 'target']);
+  const reference = text(record.reference, 100, 'request.reference');
+  const target = text(record.target, 100, 'request.target');
+  const position = record.position;
+  if (position !== undefined && (typeof position !== 'number' || !Number.isSafeInteger(position)
+    || position < 1 || position > 200)) throw new Error('request.position must be an integer from 1 through 200');
+  const detail = record.detail;
+  if (detail !== undefined && detail !== 'summary' && detail !== 'detailed') {
+    throw new Error('request.detail must be summary or detailed');
+  }
+  const cursor = record.cursor;
+  if (cursor !== undefined && (typeof cursor !== 'string' || cursor.length < 1 || cursor.length > 12 * 1024)) {
+    throw new Error('request.cursor must be a bounded opaque string');
+  }
+  return Object.freeze({
+    reference, target, ...(position === undefined ? {} : { position }), detail: detail ?? 'summary',
+    ...(cursor === undefined ? {} : { cursor }),
+  });
+}
+
+function snapshotAuthoritativeContext(input: unknown): OriginalLanguageStudyV2AuthoritativeContext {
+  const record = objectOf(input, 'server-authoritative v2 context');
+  exactKeys(record, ['v1Result', 'semanticArtifactIdentity', 'serverVerifiedAlignment'], ['v1Result']);
+  const v1Result = structuredClone(record.v1Result) as OriginalLanguageStudyDomainResult;
+  const artifact = record.semanticArtifactIdentity;
+  if (artifact !== undefined && (typeof artifact !== 'string' || !/^[0-9a-f]{64}$/.test(artifact))) {
+    throw new Error('server-authoritative artifact identity must be a lowercase SHA-256');
+  }
+  const alignment = record.serverVerifiedAlignment === undefined
+    ? undefined : snapshotAlignment(record.serverVerifiedAlignment);
+  return Object.freeze({
+    v1Result, ...(artifact === undefined ? {} : { semanticArtifactIdentity: artifact }),
+    ...(alignment === undefined ? {} : { serverVerifiedAlignment: alignment }),
+  });
+}
+
+interface CanonicalOriginalLanguageStudyReference {
+  display: string;
+  semanticKey: string;
+  language: 'Greek' | 'Hebrew';
+}
+
+function validateV1ResultAgainstRequest(
+  result: OriginalLanguageStudyDomainResult,
+  request: OriginalLanguageStudyV2ResolvedRequest,
+): CanonicalOriginalLanguageStudyReference {
+  const requested = canonicalOriginalLanguageStudyReference(request.reference, 'request.reference');
+  if (!result || (result.language !== 'Greek' && result.language !== 'Hebrew')
+    || result.target !== request.target || result.language !== requested.language) {
+    throw new Error('server-authoritative v1 study does not exactly match the caller reference, target, and language contract');
+  }
+  const resolved = canonicalOriginalLanguageStudyReference(result.reference, 'server-authoritative v1 reference');
+  if (!referencesEqual(parseReference(request.reference), parseReference(result.reference))
+    || resolved.display !== requested.display || result.reference !== requested.display) {
+    throw new Error('server-authoritative v1 study must be semantically equivalent to the caller reference and publish its canonical display reference');
+  }
+  if (result.status !== 'complete' && result.status !== 'partial' && result.status !== 'needs_disambiguation') {
+    throw new Error('server-authoritative v1 study has an unsupported status');
+  }
+  if (request.position !== undefined && result.selectedToken && result.selectedToken.position !== request.position) {
+    throw new Error('server-authoritative selected token does not match the caller position');
+  }
+  return requested;
+}
+
+function canonicalOriginalLanguageStudyReference(
+  raw: string,
+  label: string,
+): CanonicalOriginalLanguageStudyReference {
+  let reference;
+  try {
+    reference = parseReference(raw);
+  } catch {
+    throw new Error(`${label} must be one canonical Bible verse`);
+  }
+  if (reference.startVerse === undefined || reference.endVerse !== undefined) {
+    throw new Error(`${label} must be exactly one Bible verse`);
+  }
+  const display = formatReference(reference);
+  const semanticKey = requireUbsSemanticNormalizedReference(
+    `${toHelloAO(reference).bookCode} ${reference.chapter}:${reference.startVerse}`,
+    `${label} UBS semantic key`,
+  );
+  return {
+    display,
+    semanticKey,
+    language: reference.book.testament === 'NT' ? 'Greek' : 'Hebrew',
+  };
+}
+
+function snapshotSelectedToken(token: NonNullable<OriginalLanguageStudyDomainResult['selectedToken']>) {
+  return Object.freeze({
+    position: token.position, text: token.text, lemma: token.lemma,
+    strongsNumber: token.strongsNumber, morphologyCode: token.morphologyCode, gloss: token.gloss,
+  });
+}
+
+function snapshotAlignment(input: unknown): ServerVerifiedHebrewSemanticAlignment {
+  const record = objectOf(input, 'server-verified alignment');
+  exactKeys(record,
+    [
+      'status', 'proofContract', 'verifierVersion', 'sourceIdentity', 'normalizedReference',
+      'artifactIdentity', 'artifactVersion', 'artifactSources', 'sourceId', 'entryId', 'senseId', 'evidenceId',
+      'morphologyTokenIdentity', 'morphologyTokenCoordinates', 'morphologyTokenWitness',
+    ],
+    [
+      'status', 'proofContract', 'verifierVersion', 'sourceIdentity', 'normalizedReference',
+      'artifactIdentity', 'artifactVersion', 'artifactSources', 'sourceId', 'entryId', 'senseId', 'evidenceId',
+      'morphologyTokenIdentity', 'morphologyTokenCoordinates', 'morphologyTokenWitness',
+    ]);
+  if (record.status !== 'verified_token_alignment') throw new Error('alignment status must be verified_token_alignment');
+  if (record.proofContract !== 'theologai-exact-hebrew-token-alignment.v1') {
+    throw new Error('alignment must use the exact server-side token proof contract');
+  }
+  if (typeof record.verifierVersion !== 'number' || !Number.isSafeInteger(record.verifierVersion)
+    || record.verifierVersion < 1 || record.verifierVersion > 1_000_000) throw new Error('alignment verifier version is invalid');
+  return Object.freeze({
+    status: 'verified_token_alignment',
+    proofContract: 'theologai-exact-hebrew-token-alignment.v1',
+    verifierVersion: record.verifierVersion,
+    sourceIdentity: hebrewIdentity(record.sourceIdentity, 'alignment.sourceIdentity'),
+    normalizedReference: requireUbsSemanticNormalizedReference(
+      record.normalizedReference,
+      'alignment.normalizedReference',
+    ),
+    artifactIdentity: sha256(record.artifactIdentity, 'alignment.artifactIdentity'),
+    artifactVersion: exactArtifactVersion(record.artifactVersion, 'alignment.artifactVersion'),
+    artifactSources: snapshotArtifactSources(record.artifactSources),
+    sourceId: identifier(record.sourceId, 'alignment.sourceId'),
+    entryId: identifier(record.entryId, 'alignment.entryId'),
+    senseId: identifier(record.senseId, 'alignment.senseId'),
+    evidenceId: identifier(record.evidenceId, 'alignment.evidenceId'),
+    morphologyTokenIdentity: text(record.morphologyTokenIdentity, 512, 'alignment.morphologyTokenIdentity'),
+    morphologyTokenCoordinates: snapshotTokenCoordinates(record.morphologyTokenCoordinates),
+    morphologyTokenWitness: snapshotTokenWitness(record.morphologyTokenWitness),
+  });
+}
+
+function snapshotArtifactSources(input: unknown): ServerVerifiedHebrewSemanticAlignment['artifactSources'] {
+  const record = objectOf(input, 'alignment.artifactSources');
+  exactKeys(record, ['dictionary', 'lexicalDomains'], ['dictionary', 'lexicalDomains']);
+  return Object.freeze({
+    dictionary: snapshotArtifactSource(record.dictionary, 'dictionary'),
+    lexicalDomains: snapshotArtifactSource(record.lexicalDomains, 'lexical_domains'),
+  });
+}
+
+function snapshotArtifactSource(
+  input: unknown,
+  expectedRole: 'dictionary' | 'lexical_domains',
+): ServerVerifiedHebrewSemanticAlignment['artifactSources']['dictionary'] {
+  const record = objectOf(input, `alignment.artifactSources.${expectedRole}`);
+  exactKeys(record,
+    ['sourceId', 'sourceRole', 'artifactName', 'artifactIdentity', 'artifactVersion', 'sourceSha256'],
+    ['sourceId', 'sourceRole', 'artifactName', 'artifactIdentity', 'artifactVersion', 'sourceSha256']);
+  if (record.sourceRole !== expectedRole
+    || (expectedRole === 'dictionary' && record.artifactName !== 'UBSHebrewDic-v0.9.2-en.JSON')
+    || (expectedRole === 'lexical_domains' && record.artifactName !== 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON')) {
+    throw new Error(`alignment artifact source must be the exact ${expectedRole} UBS artifact`);
+  }
+  return Object.freeze({
+    sourceId: identifier(record.sourceId, `alignment.${expectedRole}.sourceId`),
+    sourceRole: expectedRole,
+    artifactName: record.artifactName,
+    artifactIdentity: sha256(record.artifactIdentity, `alignment.${expectedRole}.artifactIdentity`),
+    artifactVersion: exactArtifactVersion(record.artifactVersion, `alignment.${expectedRole}.artifactVersion`),
+    sourceSha256: sha256(record.sourceSha256, `alignment.${expectedRole}.sourceSha256`),
+  }) as ServerVerifiedHebrewSemanticAlignment['artifactSources']['dictionary'];
+}
+
+function snapshotTokenCoordinates(
+  input: unknown,
+): ServerVerifiedHebrewSemanticAlignment['morphologyTokenCoordinates'] {
+  const record = objectOf(input, 'alignment.morphologyTokenCoordinates');
+  exactKeys(record, ['canonicalReference', 'normalizedReference', 'position'],
+    ['canonicalReference', 'normalizedReference', 'position']);
+  const position = record.position;
+  if (typeof position !== 'number' || !Number.isSafeInteger(position) || position < 1 || position > 200) {
+    throw new Error('alignment morphology token position is invalid');
+  }
+  return Object.freeze({
+    canonicalReference: text(record.canonicalReference, 100, 'alignment.canonicalReference'),
+    normalizedReference: requireUbsSemanticNormalizedReference(
+      record.normalizedReference,
+      'alignment.morphologyTokenCoordinates.normalizedReference',
+    ),
+    position,
+  });
+}
+
+function snapshotTokenWitness(
+  input: unknown,
+): ServerVerifiedHebrewSemanticAlignment['morphologyTokenWitness'] {
+  const record = objectOf(input, 'alignment.morphologyTokenWitness');
+  exactKeys(record, ['text', 'lemma', 'strongsNumber', 'morphologyCode', 'gloss'],
+    ['text', 'lemma', 'strongsNumber', 'morphologyCode', 'gloss']);
+  return Object.freeze({
+    text: text(record.text, 2_000, 'alignment morphology token text'),
+    lemma: text(record.lemma, 2_000, 'alignment morphology token lemma'),
+    strongsNumber: nullableText(record.strongsNumber, 128, 'alignment morphology token Strong\'s number'),
+    morphologyCode: nullableText(record.morphologyCode, 512, 'alignment morphology token morphology code'),
+    gloss: nullableText(record.gloss, 2_000, 'alignment morphology token gloss'),
+  });
+}
+
+function hebrewIdentity(value: unknown, label: string): UbsInternalHebrewLexicalIdentity {
+  if (typeof value !== 'string' || !/^H(?!0000$)[0-9]{4}$/.test(value)) {
+    throw new Error(`${label} must be a canonical fixed-width H#### identity`);
+  }
+  return value as UbsInternalHebrewLexicalIdentity;
+}
+
+function sha256(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`${label} must be a lowercase SHA-256`);
+  }
+  return value;
+}
+
+function exactArtifactVersion(value: unknown, label: string): '0.9.2' {
+  if (value !== '0.9.2') throw new Error(`${label} must be the pinned UBS artifact version`);
+  return value;
+}
+
+function objectOf(input: unknown, label: string): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error(`${label} must be an object`);
+  return input as Record<string, unknown>;
+}
+
+function exactKeys(record: Record<string, unknown>, allowed: readonly string[], required: readonly string[]): void {
+  if (Object.keys(record).some(key => !allowed.includes(key)) || required.some(key => !(key in record))) {
+    throw new Error('original_language_study v2 context has an unexpected or missing field');
+  }
+}
+
+function text(value: unknown, maximum: number, label: string): string {
+  if (typeof value !== 'string' || !value || value !== value.trim() || value !== value.normalize('NFC')
+    || [...value].length > maximum || /[\p{Cc}\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/u.test(value)) {
+    throw new Error(`${label} must be non-empty, trimmed, NFC, bounded, and control-free`);
+  }
+  return value;
+}
+
+function nullableText(value: unknown, maximum: number, label: string): string | null {
+  if (value === null) return null;
+  return text(value, maximum, label);
+}
+
+function identifier(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length > 128
+    || !/^[a-z][a-z0-9]*(?:[-_.][a-z0-9]+)*$/.test(value)) throw new Error(`${label} is not canonical`);
+  return value;
+}

--- a/test/helpers/originalLanguageStudyV2ProductionFixtures.ts
+++ b/test/helpers/originalLanguageStudyV2ProductionFixtures.ts
@@ -1,0 +1,323 @@
+/**
+ * Minimal fixtures for the inactive production v2 modules.
+ *
+ * The historic `original-language-study-v2` draft packet remains frozen for
+ * provenance review.  These fixtures intentionally live elsewhere so the
+ * production implementation is tested without editing or importing its
+ * coordinator/support implementation.
+ */
+import {
+  type IUbsSemanticEvidenceBundleRepository,
+  type UbsSemanticEvidenceBundleCandidateRow,
+  type UbsSemanticEvidenceBundleRepositoryPage,
+  type UbsSemanticEvidenceBundleRepositoryQuery,
+} from '../../src/kernel/ubsSemanticEvidenceBundle.js';
+import {
+  type IOriginalLanguageStudyV2ContextProvider,
+  type OriginalLanguageStudyV2AuthoritativeContext,
+  type OriginalLanguageStudyV2CursorBinding,
+  deriveOriginalLanguageStudyV2MorphologyTokenIdentity,
+} from '../../src/kernel/originalLanguageStudyV2Contract.js';
+import {
+  requireUbsInternalLexicalIdentity,
+  type UbsInternalHebrewLexicalIdentity,
+  type UbsSemanticSource,
+} from '../../src/kernel/ubsSemanticDomain.js';
+import { OriginalLanguageStudyV2Coordinator } from '../../src/services/languages/OriginalLanguageStudyV2Coordinator.js';
+import type { OriginalLanguageStudyDomainResult } from '../../src/services/languages/OriginalLanguageStudyService.js';
+
+export const SYNTHETIC_ARTIFACT = 'a'.repeat(64);
+export const SYNTHETIC_H0001 = requireUbsInternalLexicalIdentity('H0001') as UbsInternalHebrewLexicalIdentity;
+
+const CANONICAL_DISPLAY_REFERENCE = 'Genesis 1:1';
+const SEMANTIC_REFERENCE = 'GEN 1:1';
+
+export function productionCandidate(
+  index: number,
+  definitionCharacters = 0,
+): UbsSemanticEvidenceBundleCandidateRow {
+  const suffix = String(index).padStart(2, '0');
+  return {
+    entry: {
+      entryId: `production-entry-${suffix}`,
+      sourceId: 'production-dictionary',
+      sourceOrdinal: index,
+      lemma: `PRODUCTION LEMMA ${suffix}`,
+      lexicalIdentities: [SYNTHETIC_H0001],
+    },
+    sense: {
+      senseId: `production-sense-${suffix}`,
+      sourceId: 'production-dictionary',
+      entryId: `production-entry-${suffix}`,
+      sourceOrdinal: index,
+      definitionStatus: 'published',
+      definition: definitionCharacters > 0
+        ? `PRODUCTION ${'D'.repeat(definitionCharacters - 11)}`
+        : `PRODUCTION DEFINITION ${suffix}`,
+      definitionExclusionReasons: [],
+      glosses: [`PRODUCTION GLOSS ${suffix}`],
+      domainRefs: [{ sourceId: 'production-domains', domainId: `production-domain-${suffix}` }],
+    },
+    domains: [{
+      domainId: `production-domain-${suffix}`,
+      sourceId: 'production-domains',
+      sourceOrdinal: index,
+      label: `PRODUCTION DOMAIN ${suffix}`,
+    }],
+    domainTotal: 1,
+    matchingReferences: [{
+      evidenceId: `production-reference-${suffix}`,
+      sourceId: 'production-dictionary',
+      senseId: `production-sense-${suffix}`,
+      sourceOrdinal: index,
+      sourceReference: CANONICAL_DISPLAY_REFERENCE,
+      normalizedReference: SEMANTIC_REFERENCE,
+      evidenceKind: 'source_attested_sense_reference',
+    }],
+    matchingReferenceTotal: 1,
+  };
+}
+
+export function productionHebrewV1Result(): OriginalLanguageStudyDomainResult {
+  return {
+    status: 'complete', reference: CANONICAL_DISPLAY_REFERENCE, language: 'Hebrew', target: 'H1',
+    selectedToken: {
+      position: 1, text: 'PRODUCTION TOKEN', lemma: 'PRODUCTION LEMMA', strongsNumber: 'H1',
+      morphologyCode: 'HNcmsa', gloss: 'PRODUCTION LOCAL GLOSS',
+    },
+    identity: {
+      publicStrongs: 'H1', morphologyKey: 'H0001', sourceStrongs: 'H1', lemma: 'PRODUCTION LEMMA',
+      transliteration: 'PRODUCTION TRANSLITERATION', joinKind: 'exact',
+    },
+    grammar: { code: 'HNcmsa', expansion: 'PRODUCTION GRAMMAR', certainty: 'expanded' },
+    dictionary: {
+      strongs_number: 'H1', testament: 'OT', lemma: 'PRODUCTION LEMMA',
+      definition: 'PRODUCTION EXISTING V1 DEFINITION', citation: { source: 'PRODUCTION V1 FIXTURE' },
+    },
+    warnings: [],
+  };
+}
+
+export function productionGreekV1Result(): OriginalLanguageStudyDomainResult {
+  return {
+    status: 'complete', reference: 'John 1:1', language: 'Greek', target: 'H1',
+    selectedToken: {
+      position: 1, text: 'PRODUCTION GREEK TOKEN', lemma: 'PRODUCTION GREEK LEMMA', strongsNumber: 'G1',
+      morphologyCode: 'V-PAI-3S', gloss: 'PRODUCTION GREEK GLOSS',
+    },
+    identity: {
+      publicStrongs: 'G1', morphologyKey: 'G0001', sourceStrongs: 'G1', lemma: 'PRODUCTION GREEK LEMMA',
+      joinKind: 'exact',
+    },
+    grammar: { code: 'V-PAI-3S', expansion: 'PRODUCTION GREEK GRAMMAR', certainty: 'expanded' },
+    dictionary: {
+      strongs_number: 'G1', testament: 'NT', lemma: 'PRODUCTION GREEK LEMMA',
+      definition: 'PRODUCTION EXISTING GREEK DEFINITION', citation: { source: 'PRODUCTION V1 FIXTURE' },
+    },
+    warnings: [],
+  };
+}
+
+export function productionContext(
+  language: 'Hebrew' | 'Greek' = 'Hebrew',
+  alignment = false,
+): OriginalLanguageStudyV2AuthoritativeContext {
+  if (language === 'Greek') return { v1Result: productionGreekV1Result() };
+  const v1Result = productionHebrewV1Result();
+  const selectedToken = v1Result.selectedToken!;
+  const binding = {
+    canonicalReference: CANONICAL_DISPLAY_REFERENCE,
+    normalizedReference: SEMANTIC_REFERENCE,
+    selectedToken,
+  };
+  const dictionary = productionSource('dictionary');
+  const lexicalDomains = productionSource('lexical_domains');
+  return {
+    v1Result,
+    semanticArtifactIdentity: SYNTHETIC_ARTIFACT,
+    ...(alignment ? {
+      serverVerifiedAlignment: {
+        status: 'verified_token_alignment' as const,
+        proofContract: 'theologai-exact-hebrew-token-alignment.v1' as const,
+        verifierVersion: 1,
+        sourceIdentity: SYNTHETIC_H0001,
+        normalizedReference: SEMANTIC_REFERENCE,
+        artifactIdentity: SYNTHETIC_ARTIFACT,
+        artifactVersion: '0.9.2' as const,
+        artifactSources: {
+          dictionary: {
+            sourceId: dictionary.sourceId,
+            sourceRole: dictionary.sourceRole,
+            artifactName: dictionary.artifactName,
+            artifactIdentity: dictionary.artifactIdentity,
+            artifactVersion: dictionary.artifactVersion,
+            sourceSha256: dictionary.sourceSha256,
+          },
+          lexicalDomains: {
+            sourceId: lexicalDomains.sourceId,
+            sourceRole: lexicalDomains.sourceRole,
+            artifactName: lexicalDomains.artifactName,
+            artifactIdentity: lexicalDomains.artifactIdentity,
+            artifactVersion: lexicalDomains.artifactVersion,
+            sourceSha256: lexicalDomains.sourceSha256,
+          },
+        },
+        sourceId: 'production-dictionary',
+        entryId: 'production-entry-01',
+        senseId: 'production-sense-01',
+        evidenceId: 'production-reference-01',
+        morphologyTokenIdentity: deriveOriginalLanguageStudyV2MorphologyTokenIdentity(binding),
+        morphologyTokenCoordinates: {
+          canonicalReference: CANONICAL_DISPLAY_REFERENCE,
+          normalizedReference: SEMANTIC_REFERENCE,
+          position: selectedToken.position,
+        },
+        morphologyTokenWitness: {
+          text: selectedToken.text,
+          lemma: selectedToken.lemma,
+          strongsNumber: selectedToken.strongsNumber,
+          morphologyCode: selectedToken.morphologyCode,
+          gloss: selectedToken.gloss,
+        },
+      },
+    } : {}),
+  };
+}
+
+export class ProductionAggregateRepository implements IUbsSemanticEvidenceBundleRepository {
+  queryCount = 0;
+  readonly received: UbsSemanticEvidenceBundleRepositoryQuery[] = [];
+
+  constructor(private readonly candidates: readonly UbsSemanticEvidenceBundleCandidateRow[]) {}
+
+  async getSemanticEvidenceBundle(
+    query: Readonly<UbsSemanticEvidenceBundleRepositoryQuery>,
+  ): Promise<UbsSemanticEvidenceBundleRepositoryPage> {
+    this.queryCount += 1;
+    this.received.push(structuredClone(query));
+    if (query.artifactIdentity !== SYNTHETIC_ARTIFACT
+      || query.sourceIdentity !== SYNTHETIC_H0001
+      || query.normalizedReference !== SEMANTIC_REFERENCE) {
+      throw new Error('production fixture repository received an unbound semantic query');
+    }
+    const start = query.after === undefined ? 0 : this.boundaryStart(query.after.keyset, query.after.priorShowing);
+    return {
+      items: this.candidates.slice(start, start + 8).map(value => structuredClone(value)),
+      lexicalEntryTotal: this.candidates.length,
+      semanticSenseTotal: this.candidates.length,
+      boundary: {
+        artifactIdentity: SYNTHETIC_ARTIFACT,
+        sourceIdentity: SYNTHETIC_H0001,
+        normalizedReference: SEMANTIC_REFERENCE,
+        order: 'entry_source_id_entry_ordinal_entry_id_sense_ordinal_sense_id',
+        priorShowing: start,
+        ...(query.after === undefined ? {} : {
+          after: { keyset: [...query.after.keyset] as [string, string, string, string, string] },
+        }),
+      },
+      sources: [productionSource('dictionary'), productionSource('lexical_domains')],
+    };
+  }
+
+  private boundaryStart(cursorKeyset: readonly string[], priorShowing: number): number {
+    const at = this.candidates.findIndex(value => JSON.stringify(keyset(value)) === JSON.stringify(cursorKeyset));
+    if (at < 0 || priorShowing !== at + 1 || priorShowing >= this.candidates.length) {
+      throw new Error('production fixture rejected a cursor that is not a genuine current continuation boundary');
+    }
+    return priorShowing;
+  }
+}
+
+export class ProductionContextProvider implements IOriginalLanguageStudyV2ContextProvider {
+  calls = 0;
+
+  constructor(private readonly context: OriginalLanguageStudyV2AuthoritativeContext) {}
+
+  async resolve(): Promise<OriginalLanguageStudyV2AuthoritativeContext> {
+    this.calls += 1;
+    return structuredClone(this.context);
+  }
+}
+
+export function productionCoordinator(
+  values: readonly UbsSemanticEvidenceBundleCandidateRow[] = [productionCandidate(1)],
+  context: OriginalLanguageStudyV2AuthoritativeContext = productionContext(),
+) {
+  const repository = new ProductionAggregateRepository(values);
+  const provider = new ProductionContextProvider(context);
+  return { coordinator: new OriginalLanguageStudyV2Coordinator(provider, repository), repository, provider };
+}
+
+export function productionRequest(
+  cursor?: string,
+  detail: 'summary' | 'detailed' = 'summary',
+  reference = 'Gen 1:1',
+) {
+  return {
+    reference,
+    target: 'H1',
+    position: 1,
+    detail,
+    ...(cursor === undefined ? {} : { cursor }),
+  };
+}
+
+export function productionCursorBinding(
+  requestReference = 'Gen 1:1',
+  target = 'H1',
+  position: number | null = 1,
+): OriginalLanguageStudyV2CursorBinding {
+  const token = productionHebrewV1Result().selectedToken!;
+  return {
+    requestReference,
+    requestTarget: target,
+    requestPosition: position,
+    canonicalReference: CANONICAL_DISPLAY_REFERENCE,
+    selectedToken: {
+      position: position ?? token.position,
+      text: token.text,
+      lemma: token.lemma,
+      strongsNumber: token.strongsNumber,
+      morphologyCode: token.morphologyCode,
+      gloss: token.gloss,
+    },
+    publicStrongs: 'H1',
+    sourceIdentity: SYNTHETIC_H0001,
+    normalizedReference: SEMANTIC_REFERENCE,
+    artifactIdentity: SYNTHETIC_ARTIFACT,
+  };
+}
+
+function keyset(value: UbsSemanticEvidenceBundleCandidateRow): [string, string, string, string, string] {
+  return [
+    value.entry.sourceId,
+    String(value.entry.sourceOrdinal),
+    value.entry.entryId,
+    String(value.sense.sourceOrdinal),
+    value.sense.senseId,
+  ];
+}
+
+function productionSource(sourceRole: 'dictionary' | 'lexical_domains'): UbsSemanticSource {
+  const common = {
+    sourceId: sourceRole === 'dictionary' ? 'production-dictionary' : 'production-domains',
+    schemaVersion: 'ubs-semantics.v1',
+    artifactIdentity: SYNTHETIC_ARTIFACT,
+    title: `PRODUCTION FIXTURE ${sourceRole.toUpperCase()}`,
+    artifactVersion: '0.9.2',
+    language: 'Hebrew',
+    publisher: 'United Bible Societies',
+    license: 'CC BY-SA 4.0',
+    licenseUrl: 'https://creativecommons.org/licenses/by-sa/4.0/',
+    sourceUrl: `https://example.invalid/${sourceRole}`,
+    sourceCommit: (sourceRole === 'dictionary' ? '1' : '2').repeat(40),
+    sourceBlob: (sourceRole === 'dictionary' ? '3' : '4').repeat(40),
+    sourceSha256: (sourceRole === 'dictionary' ? '5' : '6').repeat(64),
+    transformVersion: 7,
+    modified: true,
+    modificationNote: 'Invented production-module test fixture only.',
+  } as const;
+  return sourceRole === 'dictionary'
+    ? { ...common, sourceRole, artifactName: 'UBSHebrewDic-v0.9.2-en.JSON' }
+    : { ...common, sourceRole, artifactName: 'UBSHebrewDicLexicalDomains-v0.9.2-en.JSON' };
+}

--- a/test/unit/formatters/originalLanguageStudyV2Formatter.test.ts
+++ b/test/unit/formatters/originalLanguageStudyV2Formatter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { formatOriginalLanguageStudy } from '../../../src/formatters/originalLanguageStudyFormatter.js';
+import { formatOriginalLanguageStudyV2 } from '../../../src/formatters/originalLanguageStudyV2Formatter.js';
+import { ORIGINAL_LANGUAGE_STUDY_V2_ADDED_SEMANTIC_MARKDOWN_BYTES } from '../../../src/kernel/originalLanguageStudyV2Contract.js';
+import { finalizeOriginalLanguageStudyV2Output } from '../../../src/presenters/originalLanguageStudyV2Structured.js';
+import {
+  productionCandidate,
+  productionContext,
+  productionCoordinator,
+  productionRequest,
+} from '../../helpers/originalLanguageStudyV2ProductionFixtures.js';
+
+describe('inactive production original_language_study v2 Markdown formatter', () => {
+  it('begins with the complete unmodified v1 text, retaining local gloss, transliteration, policy, and pinned source', async () => {
+    const context = productionContext();
+    context.v1Result.dictionary!.evidencePolicy = {
+      code: 'tbesh_meaning_withheld',
+      semanticEvidence: 'unavailable',
+      withheldFields: ['tbesh_meaning'],
+      notice: 'PRODUCTION EVIDENCE POLICY NOTICE',
+    };
+    const presentation = await productionCoordinator([productionCandidate(1)], context)
+      .coordinator.study(productionRequest());
+    const existingV1 = formatOriginalLanguageStudy(context.v1Result);
+
+    expect(presentation.markdown.startsWith(existingV1)).toBe(true);
+    expect(presentation.markdown).toContain('PRODUCTION LOCAL GLOSS');
+    expect(presentation.markdown).toContain('PRODUCTION TRANSLITERATION');
+    expect(presentation.markdown).toContain('PRODUCTION EVIDENCE POLICY NOTICE');
+    expect(presentation.markdown).toContain('Pinned STEPBible revision');
+    expect(presentation.markdown).toContain('### Added Hebrew semantic layer');
+  });
+
+  it('uses the established escape boundary for the added semantic fields without changing the v1 section', async () => {
+    const context = productionContext();
+    context.v1Result.selectedToken!.text = 'PRODUCTION *[TOKEN](https://evil.invalid)';
+    const candidate = productionCandidate(1);
+    candidate.sense.definition = 'PRODUCTION **DEFINITION** [link](https://evil.invalid)';
+    candidate.domains[0]!.label = 'PRODUCTION <DOMAIN>';
+    const presentation = await productionCoordinator([candidate], context).coordinator.study(
+      productionRequest(undefined, 'detailed'),
+    );
+
+    expect(presentation.markdown).toContain('PRODUCTION *[TOKEN](https://evil.invalid)');
+    expect(presentation.markdown).toContain('PRODUCTION \\*\\*DEFINITION\\*\\*');
+    expect(presentation.markdown).toContain('https\\:\\/\\/example\\.invalid\\/dictionary');
+    expect(presentation.markdown).not.toContain('[link](https://evil.invalid)');
+  });
+
+  it('fails closed if a caller tries to render v2 with a different v1 result', async () => {
+    const presentation = await productionCoordinator([productionCandidate(1)]).coordinator.study(productionRequest());
+    const different = productionContext().v1Result;
+    different.reference = 'Genesis 1:2';
+    expect(() => formatOriginalLanguageStudyV2(presentation.output, different))
+      .toThrow('exact v1 result composed into structured output');
+  });
+
+  it('enforces the exact additive semantic-suffix boundary without changing the complete v1 prefix', async () => {
+    const regular = await productionCoordinator([productionCandidate(1)]).coordinator
+      .study(productionRequest(undefined, 'detailed'));
+    const boundaryDefinition = semanticBoundaryDefinition(regular.output);
+    const exactBoundary = outputWithEscapedDefinition(regular.output, boundaryDefinition);
+    const exactMarkdown = formatOriginalLanguageStudyV2(exactBoundary, productionContext().v1Result);
+    const exactSuffix = exactMarkdown.slice(formatOriginalLanguageStudy(productionContext().v1Result).length);
+    expect(new TextEncoder().encode(exactSuffix).byteLength)
+      .toBe(ORIGINAL_LANGUAGE_STUDY_V2_ADDED_SEMANTIC_MARKDOWN_BYTES);
+
+    const overflow = outputWithEscapedDefinition(regular.output, `${boundaryDefinition}x`);
+    expect(() => formatOriginalLanguageStudyV2(overflow, productionContext().v1Result))
+      .toThrow('added semantic Markdown exceeds');
+  });
+});
+
+function outputWithEscapedDefinition(
+  baseline: Awaited<ReturnType<ReturnType<typeof productionCoordinator>['coordinator']['study']>>['output'],
+  definition: string,
+) {
+  const output = structuredClone(baseline);
+  if (output.semanticEvidence.status !== 'lexical_candidates') {
+    throw new Error('expected detailed lexical candidate output');
+  }
+  const candidate = output.semanticEvidence.candidates[0];
+  if (!candidate || candidate.detailStatus !== 'detailed') {
+    throw new Error('expected detailed candidate');
+  }
+  candidate.definition = definition;
+  return finalizeOriginalLanguageStudyV2Output(output).output;
+}
+
+function semanticBoundaryDefinition(
+  baseline: Awaited<ReturnType<ReturnType<typeof productionCoordinator>['coordinator']['study']>>['output'],
+): string {
+  const fits = (definition: string): string | undefined => {
+    try {
+      return formatOriginalLanguageStudyV2(outputWithEscapedDefinition(baseline, definition), productionContext().v1Result);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('added semantic Markdown exceeds')) return undefined;
+      throw error;
+    }
+  };
+  let lower = 1;
+  let upper = 1;
+  while (fits('*'.repeat(upper)) !== undefined) upper *= 2;
+  while (lower + 1 < upper) {
+    const middle = Math.floor((lower + upper) / 2);
+    if (fits('*'.repeat(middle)) === undefined) upper = middle;
+    else lower = middle;
+  }
+  const candidate = '*'.repeat(lower);
+  const markdown = fits(candidate);
+  if (markdown === undefined) throw new Error('semantic Markdown boundary search did not retain its lower bound');
+  const prefix = formatOriginalLanguageStudy(productionContext().v1Result);
+  const bytes = new TextEncoder().encode(markdown.slice(prefix.length)).byteLength;
+  const remaining = ORIGINAL_LANGUAGE_STUDY_V2_ADDED_SEMANTIC_MARKDOWN_BYTES - bytes;
+  if (remaining < 0) throw new Error('semantic Markdown boundary fixture has no remaining capacity');
+  return `${candidate}${'x'.repeat(remaining)}`;
+}

--- a/test/unit/mcp/originalLanguageStudyV2Schema.test.ts
+++ b/test/unit/mcp/originalLanguageStudyV2Schema.test.ts
@@ -1,0 +1,63 @@
+import Ajv2020 from 'ajv/dist/2020.js';
+import { describe, expect, it } from 'vitest';
+import {
+  originalLanguageStudyV2InputSchema,
+  originalLanguageStudyV2OutputSchema,
+} from '../../../src/mcp/schemas/originalLanguageStudyV2.js';
+import {
+  productionCandidate,
+  productionCoordinator,
+  productionRequest,
+} from '../../helpers/originalLanguageStudyV2ProductionFixtures.js';
+
+const ajv = new Ajv2020({ strict: true, strictTypes: false, allErrors: true });
+const validateInput = ajv.compile(originalLanguageStudyV2InputSchema);
+const validateOutput = ajv.compile(originalLanguageStudyV2OutputSchema);
+
+describe('inactive production original_language_study v2 schema', () => {
+  it('accepts only the call boundary and omits all server-owned semantic identities', () => {
+    expect(Object.keys(originalLanguageStudyV2InputSchema.properties)).toEqual([
+      'reference', 'target', 'position', 'detail', 'cursor',
+    ]);
+    expect(JSON.stringify(originalLanguageStudyV2InputSchema))
+      .not.toMatch(/artifactIdentity|sourceIdentity|serverVerifiedAlignment|verifierVersion/);
+    expect(validateInput(productionRequest()), JSON.stringify(validateInput.errors)).toBe(true);
+    expect(validateInput({ ...productionRequest(), artifactIdentity: 'forged' })).toBe(false);
+  });
+
+  it('closes each object and discriminates every semantic branch', () => {
+    const openPaths: string[] = [];
+    visitSchema(originalLanguageStudyV2OutputSchema, '$', openPaths);
+    expect(openPaths).toEqual([]);
+    const source = JSON.stringify(originalLanguageStudyV2OutputSchema);
+    for (const value of [
+      'not_applicable', 'selected_token_required', 'no_usable_hebrew_identity', 'no_lexical_entry',
+      'no_publishable_semantic_evidence', 'lexical_candidates', 'reference_aligned_source_candidate',
+      'summary', 'detailed', 'omitted_response_byte_budget', 'dictionary', 'lexical_domains',
+    ]) expect(source).toContain(value);
+  });
+
+  it('accepts production coordinator output and rejects a mismatched status/detail relationship', async () => {
+    for (const detail of ['summary', 'detailed'] as const) {
+      const output = (await productionCoordinator([productionCandidate(1)]).coordinator
+        .study(productionRequest(undefined, detail))).output;
+      expect(validateOutput(output), JSON.stringify(validateOutput.errors)).toBe(true);
+    }
+    const output = (await productionCoordinator([productionCandidate(1)]).coordinator.study(productionRequest())).output;
+    if (output.semanticEvidence.status !== 'lexical_candidates') throw new Error('expected candidate evidence');
+    const invalid = structuredClone(output) as typeof output;
+    invalid.semanticEvidence.reason = 'no_lexical_entry' as never;
+    expect(validateOutput(invalid)).toBe(false);
+  });
+});
+
+function visitSchema(value: unknown, path: string, openPaths: string[]): void {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => visitSchema(item, `${path}[${index}]`, openPaths));
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.type === 'object' && record.additionalProperties !== false) openPaths.push(path);
+  for (const [key, child] of Object.entries(record)) visitSchema(child, `${path}.${key}`, openPaths);
+}

--- a/test/unit/presenters/originalLanguageStudyV2Structured.test.ts
+++ b/test/unit/presenters/originalLanguageStudyV2Structured.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { serializeValidatedOriginalLanguageStudyV2Output } from '../../../src/presenters/originalLanguageStudyV2Structured.js';
+import {
+  productionCandidate,
+  productionContext,
+  productionCoordinator,
+  productionRequest,
+} from '../../helpers/originalLanguageStudyV2ProductionFixtures.js';
+
+describe('inactive production original_language_study v2 structured presenter', () => {
+  it('validates coordinator-produced summary and detailed outputs with truthful serialized bytes', async () => {
+    for (const detail of ['summary', 'detailed'] as const) {
+      const presentation = await productionCoordinator([productionCandidate(1)]).coordinator
+        .study(productionRequest(undefined, detail));
+      expect(JSON.parse(presentation.serialized)).toEqual(presentation.output);
+      expect(presentation.output.responseWindow.used)
+        .toBe(new TextEncoder().encode(presentation.serialized).byteLength);
+      expect(serializeValidatedOriginalLanguageStudyV2Output(presentation.output)).toBe(presentation.serialized);
+    }
+  });
+
+  it('rejects false-terminal arithmetic, provenance swaps, and dishonest byte accounting', async () => {
+    const baseline = (await productionCoordinator([productionCandidate(1)]).coordinator.study(productionRequest())).output;
+    const terminal = structuredClone(baseline);
+    if (!('resultWindow' in terminal.semanticEvidence)) throw new Error('expected repository evidence');
+    terminal.semanticEvidence.resultWindow.totalCount = 2;
+    expect(() => serializeValidatedOriginalLanguageStudyV2Output(terminal)).toThrow('terminal state');
+
+    const swapped = structuredClone(baseline);
+    if (!('provenance' in swapped.semanticEvidence) || !('candidates' in swapped.semanticEvidence)) {
+      throw new Error('expected repository evidence');
+    }
+    swapped.semanticEvidence.candidates[0]!.sourceId = swapped.semanticEvidence.provenance.sources[1].sourceId;
+    expect(() => serializeValidatedOriginalLanguageStudyV2Output(swapped)).toThrow('dictionary provenance source');
+
+    const dishonest = structuredClone(baseline);
+    dishonest.responseWindow.used += 1;
+    expect(() => serializeValidatedOriginalLanguageStudyV2Output(dishonest)).toThrow('used bytes are not truthful');
+  });
+
+  it('rejects invented alignment identities and fails closed when v1 alone exceeds the structured packet limit', async () => {
+    const aligned = (await productionCoordinator([productionCandidate(1)], productionContext('Hebrew', true))
+      .coordinator.study(productionRequest(undefined, 'detailed'))).output;
+    if (aligned.semanticEvidence.status !== 'reference_aligned_source_candidate') {
+      throw new Error('expected aligned production output');
+    }
+    const forged = structuredClone(aligned);
+    forged.semanticEvidence.alignmentEvidence.evidenceId = 'synthetic-reference-forged';
+    expect(() => serializeValidatedOriginalLanguageStudyV2Output(forged)).toThrow('alignment must bind');
+
+    const tooLarge = productionContext();
+    tooLarge.v1Result.dictionary!.definition = `PRODUCTION ${'X'.repeat(33_000)}`;
+    await expect(productionCoordinator([productionCandidate(1)], tooLarge).coordinator.study(productionRequest()))
+      .rejects.toThrow('serialized UTF-8 bytes');
+  });
+});

--- a/test/unit/scripts/originalLanguageStudyV2Inertness.test.ts
+++ b/test/unit/scripts/originalLanguageStudyV2Inertness.test.ts
@@ -1,0 +1,135 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { originalLanguageStudyV2InputSchema } from '../../../src/mcp/schemas/originalLanguageStudyV2.js';
+
+const repoPath = fileURLToPath(new URL('../../../', import.meta.url));
+const frozenDraftFixtureRoot = 'test/fixtures/original-language-study-v2/';
+const inactiveModules = [
+  'src/kernel/originalLanguageStudyV2Contract.ts',
+  'src/mcp/schemas/originalLanguageStudyV2.ts',
+  'src/presenters/originalLanguageStudyV2Structured.ts',
+  'src/formatters/originalLanguageStudyV2Formatter.ts',
+  'src/services/languages/OriginalLanguageStudyV2Coordinator.ts',
+] as const;
+const runtimeEntrypoints = [
+  'src/index.ts',
+  'src/worker.ts',
+  'src/ccel-coordinator-worker.ts',
+] as const;
+const registrationAndCompositionRoots = [
+  'src/server.ts',
+  'src/worker-server.ts',
+  'src/mcp/server.ts',
+  'src/mcp/tools.ts',
+  'src/mcp/prompts.ts',
+  'src/tools/toolRegistry.ts',
+  'src/tools/v2/index.ts',
+  'src/tools/worker/index.ts',
+] as const;
+const productionTestAndFixtureModules = [
+  'test/helpers/originalLanguageStudyV2ProductionFixtures.ts',
+  'test/unit/formatters/originalLanguageStudyV2Formatter.test.ts',
+  'test/unit/mcp/originalLanguageStudyV2Schema.test.ts',
+  'test/unit/presenters/originalLanguageStudyV2Structured.test.ts',
+  'test/unit/services/languages/OriginalLanguageStudyV2Coordinator.test.ts',
+  'test/unit/scripts/originalLanguageStudyV2Inertness.test.ts',
+] as const;
+
+describe('inactive original_language_study v2 implementation', () => {
+  it('is absent from every Node, Worker, and coordinator runtime import graph', () => {
+    const unreachable = new Set(inactiveModules);
+    for (const entrypoint of runtimeEntrypoints) {
+      const reachable = reachableModules(entrypoint);
+      expect([...unreachable].filter(path => reachable.has(path)), entrypoint).toEqual([]);
+    }
+  });
+
+  it('does not alter public registration, composition, or prompt surfaces', () => {
+    for (const path of registrationAndCompositionRoots) {
+      const source = read(path);
+      expect(source, path).not.toMatch(/originalLanguageStudyV2|OriginalLanguageStudyV2/);
+      expect(source, path).not.toMatch(/semantic_candidates|schemaVersion:\s*['"]2['"]/);
+    }
+  });
+
+  it('keeps the v2 implementation storage-agnostic and rejects test-fixture/runtime backdoors', () => {
+    for (const path of inactiveModules) {
+      const source = read(path);
+      expect(source, path).not.toMatch(/originalLanguageStudyV2Draft|test\/fixtures|D1Database|better-sqlite3|wrangler|THEOLOGAI_|CREATE\s+TABLE|INSERT\s+INTO/i);
+    }
+    expect(JSON.stringify(originalLanguageStudyV2InputSchema))
+      .not.toMatch(/artifactIdentity|sourceIdentity|serverVerifiedAlignment|verifierVersion/);
+  });
+
+  it('keeps production behavior tests and helpers independent of the frozen draft fixture graph', () => {
+    const reachable = new Set<string>();
+    for (const path of productionTestAndFixtureModules) {
+      for (const dependency of reachableModules(path)) reachable.add(dependency);
+    }
+    expect([...reachable].filter(isFrozenDraftFixtureModule)).toEqual([]);
+  });
+
+  it('detects a transitive archive import even when its raw relative specifier omits test/fixtures', () => {
+    const entry = 'test/helpers/productionProbe.ts';
+    const intermediate = 'test/helpers/productionProbeIndirect.ts';
+    const archiveSpecifier = '../fixtures/original-language-study-v2/support/syntheticOriginalLanguageStudyV2Fixtures.js';
+    const archive = resolveImport(intermediate, archiveSpecifier);
+    expect(archive).toBe(`${frozenDraftFixtureRoot}support/syntheticOriginalLanguageStudyV2Fixtures.ts`);
+
+    const virtualSources: Record<string, string> = {
+      [entry]: "import './productionProbeIndirect.js';",
+      [intermediate]: `import '${archiveSpecifier}';`,
+    };
+    const reachable = reachableModules(
+      entry,
+      path => virtualSources[path] ?? read(path),
+      (from, specifier) => from === entry && specifier === './productionProbeIndirect.js'
+        ? intermediate : resolveImport(from, specifier),
+    );
+    const archived = [...reachable].filter(isFrozenDraftFixtureModule);
+    expect(archived).toContain(`${frozenDraftFixtureRoot}support/syntheticOriginalLanguageStudyV2Fixtures.ts`);
+    expect(archived.every(isFrozenDraftFixtureModule)).toBe(true);
+  });
+});
+
+function reachableModules(
+  entrypoint: string,
+  readModule: (path: string) => string = read,
+  resolveModule: (from: string, specifier: string) => string | undefined = resolveImport,
+): Set<string> {
+  const reached = new Set<string>();
+  const visit = (path: string) => {
+    if (reached.has(path)) return;
+    reached.add(path);
+    for (const dependency of relativeImports(readModule(path))) {
+      const resolved = resolveModule(path, dependency);
+      if (resolved) visit(resolved);
+    }
+  };
+  visit(entrypoint);
+  return reached;
+}
+
+function isFrozenDraftFixtureModule(path: string): boolean {
+  return path.startsWith(frozenDraftFixtureRoot);
+}
+
+function relativeImports(source: string): string[] {
+  return ts.preProcessFile(source, true, true).importedFiles
+    .map(reference => reference.fileName)
+    .filter(specifier => specifier.startsWith('.'));
+}
+
+function resolveImport(from: string, specifier: string): string | undefined {
+  const base = resolve(repoPath, dirname(from), specifier);
+  const candidates = [base, base.replace(/\.js$/, '.ts'), `${base}.ts`, resolve(base, 'index.ts')];
+  const file = candidates.find(candidate => existsSync(candidate));
+  return file === undefined ? undefined : relative(repoPath, file).replaceAll('\\', '/');
+}
+
+function read(path: string): string {
+  return readFileSync(resolve(repoPath, path), 'utf8');
+}

--- a/test/unit/services/languages/OriginalLanguageStudyV2Coordinator.test.ts
+++ b/test/unit/services/languages/OriginalLanguageStudyV2Coordinator.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { createUbsSemanticEvidenceBundleCursor } from '../../../../src/kernel/ubsSemanticEvidenceBundle.js';
+import { createOriginalLanguageStudyV2Cursor } from '../../../../src/kernel/originalLanguageStudyV2Contract.js';
+import {
+  SYNTHETIC_ARTIFACT,
+  SYNTHETIC_H0001,
+  productionCandidate,
+  productionContext,
+  productionCoordinator,
+  productionCursorBinding,
+  productionRequest,
+} from '../../../helpers/originalLanguageStudyV2ProductionFixtures.js';
+
+describe('inactive production original_language_study v2 coordinator', () => {
+  it('canonicalizes an accepted alias for output and queries the authoritative USFM semantic key', async () => {
+    const current = productionCoordinator([productionCandidate(1)]);
+    const presentation = await current.coordinator.study(productionRequest());
+
+    expect(presentation.output.request.reference).toBe('Gen 1:1');
+    expect(presentation.output.study).toMatchObject({
+      request: { reference: 'Genesis 1:1' },
+      context: { reference: 'Genesis 1:1', language: 'Hebrew' },
+    });
+    expect(current.repository.received).toEqual([expect.objectContaining({ normalizedReference: 'GEN 1:1' })]);
+  });
+
+  it('accepts semantically equal aliases, but binds a continuation to the raw request spelling', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => productionCandidate(index + 1));
+    const first = await productionCoordinator(values).coordinator.study(productionRequest());
+    if (!('resultWindow' in first.output.semanticEvidence) || !first.output.semanticEvidence.resultWindow.continuation) {
+      throw new Error('expected a first-page continuation');
+    }
+    const cursor = first.output.semanticEvidence.resultWindow.continuation.cursor;
+
+    const sameAlias = await productionCoordinator(values).coordinator.study(productionRequest(undefined, 'summary', 'Genesis 1:1'));
+    expect(sameAlias.output.request.reference).toBe('Genesis 1:1');
+
+    await expect(productionCoordinator(values).coordinator.study(
+      productionRequest(cursor, 'summary', 'Genesis 1:1'),
+    )).rejects.toThrow('full selected-token request context');
+    const second = await productionCoordinator(values).coordinator.study(productionRequest(cursor));
+    if (!('resultWindow' in second.output.semanticEvidence)) throw new Error('expected semantic continuation');
+    expect(second.output.semanticEvidence.resultWindow).toMatchObject({ priorCount: 8, returnedCount: 2, hasMore: false });
+  });
+
+  it('rejects an authoritative result that is semantically different or noncanonical before querying evidence', async () => {
+    const different = productionContext();
+    different.v1Result.reference = 'Genesis 1:2';
+    const differentCurrent = productionCoordinator([productionCandidate(1)], different);
+    await expect(differentCurrent.coordinator.study(productionRequest())).rejects.toThrow('semantically equivalent');
+    expect(differentCurrent.repository.queryCount).toBe(0);
+
+    const noncanonical = productionContext();
+    noncanonical.v1Result.reference = 'Gen 1:1';
+    const noncanonicalCurrent = productionCoordinator([productionCandidate(1)], noncanonical);
+    await expect(noncanonicalCurrent.coordinator.study(productionRequest())).rejects.toThrow('canonical display reference');
+    expect(noncanonicalCurrent.repository.queryCount).toBe(0);
+  });
+
+  it('keeps the complete existing Greek study and does not query Hebrew semantic evidence', async () => {
+    const current = productionCoordinator([productionCandidate(1)], productionContext('Greek'));
+    const presentation = await current.coordinator.study({
+      reference: 'Jn 1:1', target: 'H1', position: 1, detail: 'summary',
+    });
+    expect(presentation.output.study).toMatchObject({
+      context: { reference: 'John 1:1', language: 'Greek', selectedToken: { text: 'PRODUCTION GREEK TOKEN' } },
+      lexiconEvidence: [{ definition: 'PRODUCTION EXISTING GREEK DEFINITION' }],
+    });
+    expect(presentation.output.semanticEvidence).toMatchObject({ language: 'Greek', status: 'not_applicable' });
+    expect(current.repository.queryCount).toBe(0);
+  });
+
+  it('uses detail only for candidate volume and preserves honest byte accounting', async () => {
+    // The structured packet must omit details deterministically before the
+    // added text suffix reaches its separate 16 KiB cap.
+    const values = [productionCandidate(1, 14_000), productionCandidate(2, 14_000)];
+    const summary = (await productionCoordinator(values).coordinator.study(productionRequest(undefined, 'summary'))).output;
+    const detailed = (await productionCoordinator(values).coordinator.study(productionRequest(undefined, 'detailed'))).output;
+    expect(summary.semanticEvidence.status).toBe(detailed.semanticEvidence.status);
+    if (!('candidates' in summary.semanticEvidence) || !('candidates' in detailed.semanticEvidence)) {
+      throw new Error('expected candidate evidence');
+    }
+    expect(summary.semanticEvidence.candidates.map(candidate => candidate.senseId))
+      .toEqual(detailed.semanticEvidence.candidates.map(candidate => candidate.senseId));
+    expect(detailed.semanticEvidence.candidates.map(candidate => candidate.detailStatus))
+      .toContain('omitted_response_byte_budget');
+    expect(detailed.responseWindow.used).toBeLessThanOrEqual(32 * 1024);
+  });
+
+  it('rejects caller-supplied source and proof identities before provider or repository access', async () => {
+    for (const forbidden of ['sourceIdentity', 'artifactIdentity', 'serverVerifiedAlignment', 'verifierVersion']) {
+      const current = productionCoordinator();
+      await expect(current.coordinator.study({ ...productionRequest(), [forbidden]: 'forged' }))
+        .rejects.toThrow('unexpected or missing field');
+      expect(current.provider.calls).toBe(0);
+      expect(current.repository.queryCount).toBe(0);
+    }
+  });
+
+  it('rejects malformed, forged, stale, nonboundary, and false-terminal repository continuations', async () => {
+    const values = Array.from({ length: 10 }, (_, index) => productionCandidate(index + 1));
+    const query = {
+      artifactIdentity: SYNTHETIC_ARTIFACT,
+      sourceIdentity: SYNTHETIC_H0001,
+      normalizedReference: 'GEN 1:1',
+    };
+    const wrapped = (cursor: string) => createOriginalLanguageStudyV2Cursor(cursor, productionCursorBinding());
+    const cursors = [
+      ['malformed', 'olsv2c1_7b7d'],
+      ['forged', wrapped(createUbsSemanticEvidenceBundleCursor(query, values[1]!, 99))],
+      ['nonboundary', wrapped(createUbsSemanticEvidenceBundleCursor(query, values[1]!, 1))],
+      ['false-terminal', wrapped(createUbsSemanticEvidenceBundleCursor(query, values[1]!, 10))],
+    ] as const;
+    for (const [name, cursor] of cursors) {
+      const current = productionCoordinator(values);
+      await expect(current.coordinator.study(productionRequest(cursor)), name)
+        .rejects.toThrow(/cursor|genuine current continuation boundary/i);
+      expect(current.repository.queryCount, name).toBe(name === 'malformed' ? 0 : 1);
+    }
+  });
+
+  it('requires the entire current server proof before exposing a reference-aligned source candidate', async () => {
+    const aligned = await productionCoordinator([productionCandidate(1)], productionContext('Hebrew', true))
+      .coordinator.study(productionRequest(undefined, 'detailed'));
+    expect(aligned.output.semanticEvidence).toMatchObject({
+      status: 'reference_aligned_source_candidate',
+      alignmentEvidence: { normalizedReference: 'GEN 1:1', evidenceId: 'production-reference-01' },
+    });
+    expect(aligned.output.semanticEvidence.plainLanguage).toContain('not an adjudicated contextual meaning');
+
+    const mismatched = productionContext('Hebrew', true);
+    mismatched.serverVerifiedAlignment!.morphologyTokenCoordinates.normalizedReference = 'GEN 1:2';
+    await expect(productionCoordinator([productionCandidate(1)], mismatched).coordinator.study(productionRequest()))
+      .rejects.toThrow('does not match one complete exact aggregate candidate');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the reviewed, inactive `original_language_study` v2 implementation packet: its bounded contract, input/output schemas, coordinator, structured presenter, Markdown formatter, deterministic production fixtures, and focused tests.

## Scope

- The packet is intentionally **unregistered**: it does not change the existing tool schema, tool registry, composition roots, server registration, Worker registration, prompts, resources, database schema, D1 bindings, or deployment configuration.
- The current public `original_language_study` v1 behavior and tool inventory remain unchanged.
- The inertness test guards this boundary explicitly.

## Validation

- `vitest run` for the five focused v2 test files: 23 passing tests.
- `npm run typecheck:node`
- `npm run typecheck:worker`
- `npm run build`

## Local diagnostic

This worktree has an untracked `node_modules` symlink to the primary checkout for local dependency resolution. It is ignored and excluded from this commit/PR.

## Explicitly not authorized by this PR

This draft does not authorize merge, public runtime activation, schema replacement, preview deployment, production deployment, database migration or binding changes, or any Cloudflare change.
