### PR TITLE
A0: Lock Aquinas Gutenberg acquisition evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@ data/theologai.db-shm
 data/theologai.db-wal
 
 # Local-only raw archives and rights/provenance evidence for the locked
-# four-part Project Gutenberg Aquinas acquisition. SOURCE_LOCK.json and the
-# receipt are review metadata; nothing under local/ is vendored.
+# four-part Project Gutenberg Aquinas acquisition. SOURCE_LOCK.json, the
+# reviewed receipt, and CATALOG_IDENTITY_LOCK.json are tracked review metadata;
+# nothing under local/ is vendored.
 data/historical-sources/project-gutenberg/aquinas-english-dominican/local/
 
 # Test outputs and temp files

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ data/theologai.db
 data/theologai.db-shm
 data/theologai.db-wal
 
+# Local-only raw archives and rights/provenance evidence for the locked
+# four-part Project Gutenberg Aquinas acquisition. SOURCE_LOCK.json and the
+# receipt are review metadata; nothing under local/ is vendored.
+data/historical-sources/project-gutenberg/aquinas-english-dominican/local/
+
 # Test outputs and temp files
 test-output/
 test-results/

--- a/data/historical-sources/project-gutenberg/aquinas-english-dominican/CATALOG_IDENTITY_LOCK.json
+++ b/data/historical-sources/project-gutenberg/aquinas-english-dominican/CATALOG_IDENTITY_LOCK.json
@@ -41,6 +41,23 @@
       "locator": "unique Downloads row in table#about_book_table"
     }
   ],
+  "permittedOutOfProjectionRows": [
+    {
+      "label": "Note",
+      "expectedCount": 1,
+      "rationale": "The Wikipedia pointer is contextual navigation, not edition identity or provenance evidence."
+    },
+    {
+      "label": "Reading Level",
+      "expectedCount": 1,
+      "rationale": "The computed readability estimate is presentation metadata and is not source identity."
+    },
+    {
+      "label": "Subject",
+      "expectedCount": 4,
+      "rationale": "The four catalog subject classifications aid discovery but do not select this electronic edition."
+    }
+  ],
   "outOfProjectionPresentation": [
     "descriptive summary",
     "reading-level estimate",

--- a/data/historical-sources/project-gutenberg/aquinas-english-dominican/CATALOG_IDENTITY_LOCK.json
+++ b/data/historical-sources/project-gutenberg/aquinas-english-dominican/CATALOG_IDENTITY_LOCK.json
@@ -1,0 +1,187 @@
+{
+  "schemaVersion": "theologai-aquinas-gutenberg-catalog-identity-lock.v1",
+  "sourceLockSha256": "c5cfdd1edd132bf59968cbabe4c7de2180c42d205735ca6c06aec626104a180b",
+  "reviewedReceiptSha256": "bc0dab9ce5dc3672ccf2a81182655c75eaf6ef4f280584a40e079bf82a11719d",
+  "normalization": {
+    "parser": "WHATWG HTML parsing via parse5; malformed or ambiguous required fields fail closed",
+    "text": "Decode HTML entities, preserve BR boundaries in titleLines, otherwise collapse Unicode whitespace and trim",
+    "projection": "The semanticIdentity objects below are the complete identity projection. Every projected field must occur exactly once and match exactly.",
+    "rawSnapshot": "The fetched catalog HTML remains local evidence and is byte-hashed in the generated receipt, but its whole-document hash is not an edition identity."
+  },
+  "invariantFields": [
+    "ebookId",
+    "catalogPath",
+    "author.name",
+    "author.agentPath",
+    "author.agentAboutPath",
+    "titleLines",
+    "credits",
+    "language.code",
+    "language.label",
+    "locClass",
+    "category",
+    "release.machineDate",
+    "release.displayDate",
+    "lastUpdate.machineDate",
+    "lastUpdate.displayDate",
+    "rightsStatement",
+    "archiveDownload.path",
+    "archiveDownload.mediaType",
+    "archiveDownload.label"
+  ],
+  "allowedVolatility": [
+    {
+      "field": "siteWideFreeEbookCount",
+      "syntax": "^[0-9]{1,3}(,[0-9]{3})* free eBooks$",
+      "locator": "unique breadcrumb link href=/ebooks/ and its unique itemprop=name span"
+    },
+    {
+      "field": "downloadsLast30Days",
+      "syntax": "^[0-9]{1,12} downloads in the last 30 days\\.$",
+      "locator": "unique Downloads row in table#about_book_table"
+    }
+  ],
+  "outOfProjectionPresentation": [
+    "descriptive summary",
+    "reading-level estimate",
+    "site navigation and styling",
+    "non-archive download-format presentation"
+  ],
+  "artifacts": [
+    {
+      "ebookId": 17611,
+      "catalogPath": "/ebooks/17611",
+      "semanticIdentity": {
+        "author": {
+          "name": "Thomas, Aquinas, Saint, 1225?-1274",
+          "agentPath": "/ebooks/author/7489",
+          "agentAboutPath": "/authors/7489"
+        },
+        "titleLines": [
+          "Summa Theologica, Part I (Prima Pars)",
+          "From the Complete American Edition"
+        ],
+        "credits": "Produced by Sandra K. Perry, with corrections and supplementation by David McClamrock",
+        "language": {
+          "code": "en",
+          "label": "English"
+        },
+        "locClass": "BX",
+        "category": "Text",
+        "release": {
+          "machineDate": "2021-01-03",
+          "displayDate": "Jan 26, 2006"
+        },
+        "lastUpdate": {
+          "machineDate": "2006-01-26T00:00:00+00:00",
+          "displayDate": "Jan 3, 2021"
+        },
+        "rightsStatement": "Public domain in the USA.",
+        "archiveDownload": {
+          "path": "/cache/epub/17611/pg17611-h.zip",
+          "mediaType": "application/zip",
+          "label": "Download HTML (zip)"
+        }
+      }
+    },
+    {
+      "ebookId": 17897,
+      "catalogPath": "/ebooks/17897",
+      "semanticIdentity": {
+        "author": {
+          "name": "Thomas, Aquinas, Saint, 1225?-1274",
+          "agentPath": "/ebooks/author/7489",
+          "agentAboutPath": "/authors/7489"
+        },
+        "titleLines": [
+          "Summa Theologica, Part I-II (Pars Prima Secundae)",
+          "From the Complete American Edition"
+        ],
+        "credits": "E-text prepared by Sandra K. Perry, with corrections and supplementation by David McClamrock",
+        "language": {
+          "code": "en",
+          "label": "English"
+        },
+        "locClass": "BX",
+        "category": "Text",
+        "release": {
+          "machineDate": "2006-03-01",
+          "displayDate": "Mar 1, 2006"
+        },
+        "lastUpdate": null,
+        "rightsStatement": "Public domain in the USA.",
+        "archiveDownload": {
+          "path": "/cache/epub/17897/pg17897-h.zip",
+          "mediaType": "application/zip",
+          "label": "Download HTML (zip)"
+        }
+      }
+    },
+    {
+      "ebookId": 18755,
+      "catalogPath": "/ebooks/18755",
+      "semanticIdentity": {
+        "author": {
+          "name": "Thomas, Aquinas, Saint, 1225?-1274",
+          "agentPath": "/ebooks/author/7489",
+          "agentAboutPath": "/authors/7489"
+        },
+        "titleLines": [
+          "Summa Theologica, Part II-II (Secunda Secundae)",
+          "Translated by Fathers of the English Dominican Province"
+        ],
+        "credits": "Produced by Sandra K. Perry, with corrections and supplementation by David McClamrock",
+        "language": {
+          "code": "en",
+          "label": "English"
+        },
+        "locClass": "BX",
+        "category": "Text",
+        "release": {
+          "machineDate": "2006-07-04",
+          "displayDate": "Jul 4, 2006"
+        },
+        "lastUpdate": null,
+        "rightsStatement": "Public domain in the USA.",
+        "archiveDownload": {
+          "path": "/cache/epub/18755/pg18755-h.zip",
+          "mediaType": "application/zip",
+          "label": "Download HTML (zip)"
+        }
+      }
+    },
+    {
+      "ebookId": 19950,
+      "catalogPath": "/ebooks/19950",
+      "semanticIdentity": {
+        "author": {
+          "name": "Thomas, Aquinas, Saint, 1225?-1274",
+          "agentPath": "/ebooks/author/7489",
+          "agentAboutPath": "/authors/7489"
+        },
+        "titleLines": [
+          "Summa Theologica, Part III (Tertia Pars)",
+          "From the Complete American Edition"
+        ],
+        "credits": "Produced by Sandra K. Perry, with corrections and supplementation by David McClamrock",
+        "language": {
+          "code": "en",
+          "label": "English"
+        },
+        "locClass": "BX",
+        "category": "Text",
+        "release": {
+          "machineDate": "2006-11-28",
+          "displayDate": "Nov 28, 2006"
+        },
+        "lastUpdate": null,
+        "rightsStatement": "Public domain in the USA.",
+        "archiveDownload": {
+          "path": "/cache/epub/19950/pg19950-h.zip",
+          "mediaType": "application/zip",
+          "label": "Download HTML (zip)"
+        }
+      }
+    }
+  ]
+}

--- a/data/historical-sources/project-gutenberg/aquinas-english-dominican/LOCAL_ACQUISITION_RECEIPT.json
+++ b/data/historical-sources/project-gutenberg/aquinas-english-dominican/LOCAL_ACQUISITION_RECEIPT.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "theologai-aquinas-gutenberg-local-receipt.v1",
-  "sourceLockSha256": "d54422a0cf80a11ddcfd1352fdae8c238d969160606de208a734aac29603726a",
+  "sourceLockSha256": "c5cfdd1edd132bf59968cbabe4c7de2180c42d205735ca6c06aec626104a180b",
   "acquiredAt": "2026-07-21T17:49:25.185Z",
   "artifacts": [
     {

--- a/data/historical-sources/project-gutenberg/aquinas-english-dominican/LOCAL_ACQUISITION_RECEIPT.json
+++ b/data/historical-sources/project-gutenberg/aquinas-english-dominican/LOCAL_ACQUISITION_RECEIPT.json
@@ -1,0 +1,119 @@
+{
+  "schemaVersion": "theologai-aquinas-gutenberg-local-receipt.v1",
+  "sourceLockSha256": "d54422a0cf80a11ddcfd1352fdae8c238d969160606de208a734aac29603726a",
+  "acquiredAt": "2026-07-21T17:49:25.185Z",
+  "artifacts": [
+    {
+      "ebookId": 17611,
+      "archive": {
+        "path": "local/archives/pg17611-h.zip",
+        "bytes": 970487,
+        "sha256": "cd67660a85693de3ead953162db89677a29d59c6fc739e6faf0b4fb4f57fb8b2"
+      },
+      "catalogSnapshot": {
+        "path": "local/catalog/pg17611.html",
+        "bytes": 23960,
+        "sha256": "557be8272523147a6716d2914160bd31bc2514370c76f498b0d5138e0e767779"
+      },
+      "htmlMember": {
+        "path": "pg17611-images.html",
+        "bytes": 3090576,
+        "sha256": "310b8743376036b42faa6b6d1a835aee2cf4e531dcf14ab8d9bb4f1d30edf088"
+      },
+      "unrestrictedUseNotice": {
+        "path": "local/evidence/pg17611-unrestricted-use-notice.html",
+        "bytes": 526,
+        "sha256": "a232fbc3c0022a4b4bf6e04bc0071d1cfe7b60601d4bd8eca4b0fec3652b5f94"
+      },
+      "electronicEditionProvenance": {
+        "path": "local/evidence/pg17611-electronic-edition-provenance.html",
+        "bytes": 3349,
+        "sha256": "ac1b5ba769b06ef18b319897a01b1615f99c0034096c30ab466cc92edb33d2cd"
+      }
+    },
+    {
+      "ebookId": 17897,
+      "archive": {
+        "path": "local/archives/pg17897-h.zip",
+        "bytes": 979217,
+        "sha256": "378ad159b217adfa26868e1600319125a63202fd955e96ab8aca51961229d698"
+      },
+      "catalogSnapshot": {
+        "path": "local/catalog/pg17897.html",
+        "bytes": 23843,
+        "sha256": "312756a0edf9a5ffc3c36b11066595496e6def0e951580e29b46999cf04eac61"
+      },
+      "htmlMember": {
+        "path": "pg17897-images.html",
+        "bytes": 3088562,
+        "sha256": "fcb4441c3771bde971c2bff47c0894b8294a813c20c6fa24dfd3ab997491a1eb"
+      },
+      "unrestrictedUseNotice": {
+        "path": "local/evidence/pg17897-unrestricted-use-notice.html",
+        "bytes": 526,
+        "sha256": "a232fbc3c0022a4b4bf6e04bc0071d1cfe7b60601d4bd8eca4b0fec3652b5f94"
+      },
+      "electronicEditionProvenance": {
+        "path": "local/evidence/pg17897-electronic-edition-provenance.html",
+        "bytes": 3349,
+        "sha256": "d7cfc301c399764ab2fa20fc0ac6044766a95d1c761b74c15bf1f633a3701b82"
+      }
+    },
+    {
+      "ebookId": 18755,
+      "archive": {
+        "path": "local/archives/pg18755-h.zip",
+        "bytes": 1436264,
+        "sha256": "3d8d24ff85ac392fc2d3da6563d75362ae388ef9dc5403573ab769cebf967146"
+      },
+      "catalogSnapshot": {
+        "path": "local/catalog/pg18755.html",
+        "bytes": 23855,
+        "sha256": "ec59fef8e65f47e84f88be4a374b2cbec220c876a3d539ada9f5de4b1b14bab8"
+      },
+      "htmlMember": {
+        "path": "pg18755-images.html",
+        "bytes": 4485696,
+        "sha256": "e8badeb59c78974db051cab37e6e841d78b2a83fb62e031668d29a7d7b9c4337"
+      },
+      "unrestrictedUseNotice": {
+        "path": "local/evidence/pg18755-unrestricted-use-notice.html",
+        "bytes": 526,
+        "sha256": "a232fbc3c0022a4b4bf6e04bc0071d1cfe7b60601d4bd8eca4b0fec3652b5f94"
+      },
+      "electronicEditionProvenance": {
+        "path": "local/evidence/pg18755-electronic-edition-provenance.html",
+        "bytes": 3349,
+        "sha256": "d7cfc301c399764ab2fa20fc0ac6044766a95d1c761b74c15bf1f633a3701b82"
+      }
+    },
+    {
+      "ebookId": 19950,
+      "archive": {
+        "path": "local/archives/pg19950-h.zip",
+        "bytes": 949369,
+        "sha256": "ac431f87de4a2fa9edb5cf0b02134c45a79e48fea3b9c3ee9f3c10cf183e52b8"
+      },
+      "catalogSnapshot": {
+        "path": "local/catalog/pg19950.html",
+        "bytes": 23722,
+        "sha256": "391b0b763d75794fd2ac364010429740f6ecaa7dc61c8b5a78350a7331198808"
+      },
+      "htmlMember": {
+        "path": "pg19950-images.html",
+        "bytes": 2927390,
+        "sha256": "12fff95d7637f1e475057dfe60f3d550c571bf0a04fa84ddb9653e46e88fb079"
+      },
+      "unrestrictedUseNotice": {
+        "path": "local/evidence/pg19950-unrestricted-use-notice.html",
+        "bytes": 526,
+        "sha256": "a232fbc3c0022a4b4bf6e04bc0071d1cfe7b60601d4bd8eca4b0fec3652b5f94"
+      },
+      "electronicEditionProvenance": {
+        "path": "local/evidence/pg19950-electronic-edition-provenance.html",
+        "bytes": 3374,
+        "sha256": "b1ea2f3d62729598e6b7bd6280a5f2939548fe993190aa59af99b2a2ea341fe8"
+      }
+    }
+  ]
+}

--- a/data/historical-sources/project-gutenberg/aquinas-english-dominican/SOURCE_LOCK.json
+++ b/data/historical-sources/project-gutenberg/aquinas-english-dominican/SOURCE_LOCK.json
@@ -1,0 +1,190 @@
+{
+  "schemaVersion": "theologai-aquinas-gutenberg-source-lock.v1",
+  "sourceIdentity": "aquinas-english-dominican-gutenberg-four-part-v1",
+  "acquisitionScope": {
+    "edition": "Project Gutenberg electronic editions of the English Dominican Province/Benziger translation, with Sandra K. Perry source e-text and David McClamrock corrections and editorial additions",
+    "corpusBoundary": "This acquisition preserves the four official Project Gutenberg artifacts only. It does not compile, normalize, index, or publish corpus text.",
+    "parts": [
+      "prima_pars.q001-q119",
+      "prima_secundae.q001-q114",
+      "secunda_secundae.q001-q189",
+      "tertia.q001-q090"
+    ],
+    "excluded": [
+      "Tertia Pars questions 91 and later",
+      "Supplement",
+      "all parser, corpus package, catalog, runtime, database, migration, and workflow changes"
+    ]
+  },
+  "acquisitionPolicy": {
+    "approvedArchiveOrigin": "https://www.gutenberg.org",
+    "approvedCatalogOrigin": "https://www.gutenberg.org",
+    "redirectPolicy": "No redirect is accepted for an archive or catalog snapshot. A redirect, a non-HTTPS URL, a non-www.gutenberg.org host, a query, a fragment, or a pathname mismatch fails closed.",
+    "storagePolicy": "Raw ZIP archives, catalog snapshots, extracted HTML evidence, notice evidence, and provenance evidence are local-only under local/ and must remain ignored. The lock and receipt are hash/provenance metadata, not corpus text.",
+    "archiveSafetyPolicy": "Only the exact reviewed member set is accepted. ZIP64, encrypted entries, duplicate or normalization-colliding paths, unsafe paths, symlinks, unexpected members, unsupported compression, oversized members, malformed local headers, CRC mismatch, and ambiguous or missing HTML fail closed.",
+    "noClobberPolicy": "Acquisition never replaces an existing archive, snapshot, evidence file, or receipt. Any destination, symlink, or unsafe parent collision fails closed."
+  },
+  "rightsAndProvenance": {
+    "rightsStatus": "public_domain_in_usa",
+    "territoryCaveat": "The catalog statement and internal notice support a United States position only; this lock makes no worldwide public-domain conclusion.",
+    "catalogStatement": "Public domain in the USA.",
+    "projectGutenbergLicensePolicyUrl": "https://www.gutenberg.org/policy/license.html",
+    "internalUnrestrictedUseEvidence": {
+      "requiredPhrases": [
+        "This eBook is for the use of anyone anywhere in the United States",
+        "If you are not located in the United States,",
+        "START: FULL LICENSE",
+        "THE FULL PROJECT GUTENBERG™ LICENSE",
+        "you may\r\ndo practically ANYTHING in the United States with eBooks not protected\r\nby U.S. copyright law."
+      ]
+    },
+    "electronicEditionProvenance": {
+      "sourceEtextCreator": "Sandra K. Perry, Perrysburg, Ohio",
+      "sourceEtextAvailability": "made available through the Christian Classics Ethereal Library <http://www.ccel.org>",
+      "electronicEditionEditor": "David McClamrock",
+      "disclosedEditorActions": [
+        "eliminated unnecessary formatting",
+        "corrected transcription errors",
+        "added the dedication, tables of contents, Prologue, and question/article numbering from the Benziger Brothers printed translation",
+        "checked some obvious Benziger Brothers errors against a Latin text and marked corrections with bracketed English text",
+        "presented Benziger Brothers footnote matter in brackets at its textual position",
+        "accepted responsibility for other electronic-edition divergences from the Benziger Brothers edition"
+      ],
+      "translator": "Fathers of the English Dominican Province",
+      "printedTranslationPublisher": "Benziger Brothers",
+      "ccelBoundary": "CCEL is recorded solely as disclosed historical provenance. This acquisition makes no CCEL request and stores no CCEL HTML, metadata, navigation, annotation, or packaging."
+    }
+  },
+  "comparisonWitness": {
+    "relationship": "Independent PIMS / University of Toronto Internet Archive page-image comparison and corroboration witness; it is not an input to this acquisition and is not copied or transcribed here.",
+    "sourceLockSchemaVersion": "theologai-aquinas-shapcote-ia-source-lock.v1",
+    "sourceLockSha256": "a245dbc007b76e1975eb26462a75a5e5992954d9042fc6de96477f0b30351594",
+    "receiptSchemaVersion": "theologai-aquinas-shapcote-ia-local-receipt.v1"
+  },
+  "artifacts": [
+    {
+      "ebookId": 17611,
+      "partKey": "prima",
+      "questionRange": "q001-q119",
+      "archive": {
+        "url": "https://www.gutenberg.org/cache/epub/17611/pg17611-h.zip",
+        "localPath": "local/archives/pg17611-h.zip",
+        "bytes": 970487,
+        "sha256": "cd67660a85693de3ead953162db89677a29d59c6fc739e6faf0b4fb4f57fb8b2",
+        "memberPaths": [
+          "pg17611-images.html",
+          "17611-cover.png"
+        ]
+      },
+      "htmlMember": {
+        "path": "pg17611-images.html",
+        "bytes": 3090576,
+        "sha256": "310b8743376036b42faa6b6d1a835aee2cf4e531dcf14ab8d9bb4f1d30edf088",
+        "dctermsCreated": "2006-01-26",
+        "dctermsModified": "2026-07-07T20:12:10.761524+00:00"
+      },
+      "catalogSnapshot": {
+        "url": "https://www.gutenberg.org/ebooks/17611",
+        "localPath": "local/catalog/pg17611.html",
+        "bytes": 23960,
+        "sha256": "557be8272523147a6716d2914160bd31bc2514370c76f498b0d5138e0e767779",
+        "releaseDate": "Jan 26, 2006",
+        "issuedMachineDate": "2021-01-03",
+        "lastUpdate": "Jan 3, 2021"
+      }
+    },
+    {
+      "ebookId": 17897,
+      "partKey": "prima-secundae",
+      "questionRange": "q001-q114",
+      "archive": {
+        "url": "https://www.gutenberg.org/cache/epub/17897/pg17897-h.zip",
+        "localPath": "local/archives/pg17897-h.zip",
+        "bytes": 979217,
+        "sha256": "378ad159b217adfa26868e1600319125a63202fd955e96ab8aca51961229d698",
+        "memberPaths": [
+          "pg17897-images.html",
+          "17897-cover.png"
+        ]
+      },
+      "htmlMember": {
+        "path": "pg17897-images.html",
+        "bytes": 3088562,
+        "sha256": "fcb4441c3771bde971c2bff47c0894b8294a813c20c6fa24dfd3ab997491a1eb",
+        "dctermsCreated": "2006-03-01",
+        "dctermsModified": "2026-07-07T23:28:05.613443+00:00"
+      },
+      "catalogSnapshot": {
+        "url": "https://www.gutenberg.org/ebooks/17897",
+        "localPath": "local/catalog/pg17897.html",
+        "bytes": 23843,
+        "sha256": "312756a0edf9a5ffc3c36b11066595496e6def0e951580e29b46999cf04eac61",
+        "releaseDate": "Mar 1, 2006",
+        "issuedMachineDate": "2006-03-01",
+        "lastUpdate": null
+      }
+    },
+    {
+      "ebookId": 18755,
+      "partKey": "secunda-secundae",
+      "questionRange": "q001-q189",
+      "archive": {
+        "url": "https://www.gutenberg.org/cache/epub/18755/pg18755-h.zip",
+        "localPath": "local/archives/pg18755-h.zip",
+        "bytes": 1436264,
+        "sha256": "3d8d24ff85ac392fc2d3da6563d75362ae388ef9dc5403573ab769cebf967146",
+        "memberPaths": [
+          "pg18755-images.html",
+          "18755-cover.png"
+        ]
+      },
+      "htmlMember": {
+        "path": "pg18755-images.html",
+        "bytes": 4485696,
+        "sha256": "e8badeb59c78974db051cab37e6e841d78b2a83fb62e031668d29a7d7b9c4337",
+        "dctermsCreated": "2006-07-04",
+        "dctermsModified": "2026-07-08T09:54:15.669256+00:00"
+      },
+      "catalogSnapshot": {
+        "url": "https://www.gutenberg.org/ebooks/18755",
+        "localPath": "local/catalog/pg18755.html",
+        "bytes": 23855,
+        "sha256": "ec59fef8e65f47e84f88be4a374b2cbec220c876a3d539ada9f5de4b1b14bab8",
+        "releaseDate": "Jul 4, 2006",
+        "issuedMachineDate": "2006-07-04",
+        "lastUpdate": null
+      }
+    },
+    {
+      "ebookId": 19950,
+      "partKey": "tertia",
+      "questionRange": "q001-q090",
+      "archive": {
+        "url": "https://www.gutenberg.org/cache/epub/19950/pg19950-h.zip",
+        "localPath": "local/archives/pg19950-h.zip",
+        "bytes": 949369,
+        "sha256": "ac431f87de4a2fa9edb5cf0b02134c45a79e48fea3b9c3ee9f3c10cf183e52b8",
+        "memberPaths": [
+          "pg19950-images.html",
+          "19950-cover.png"
+        ]
+      },
+      "htmlMember": {
+        "path": "pg19950-images.html",
+        "bytes": 2927390,
+        "sha256": "12fff95d7637f1e475057dfe60f3d550c571bf0a04fa84ddb9653e46e88fb079",
+        "dctermsCreated": "2006-11-28",
+        "dctermsModified": "2026-07-08T19:11:34.638815+00:00"
+      },
+      "catalogSnapshot": {
+        "url": "https://www.gutenberg.org/ebooks/19950",
+        "localPath": "local/catalog/pg19950.html",
+        "bytes": 23722,
+        "sha256": "391b0b763d75794fd2ac364010429740f6ecaa7dc61c8b5a78350a7331198808",
+        "releaseDate": "Nov 28, 2006",
+        "issuedMachineDate": "2006-11-28",
+        "lastUpdate": null
+      }
+    }
+  ]
+}

--- a/data/historical-sources/project-gutenberg/aquinas-english-dominican/SOURCE_LOCK.json
+++ b/data/historical-sources/project-gutenberg/aquinas-english-dominican/SOURCE_LOCK.json
@@ -59,7 +59,8 @@
     "relationship": "Independent PIMS / University of Toronto Internet Archive page-image comparison and corroboration witness; it is not an input to this acquisition and is not copied or transcribed here.",
     "sourceLockSchemaVersion": "theologai-aquinas-shapcote-ia-source-lock.v1",
     "sourceLockSha256": "a245dbc007b76e1975eb26462a75a5e5992954d9042fc6de96477f0b30351594",
-    "receiptSchemaVersion": "theologai-aquinas-shapcote-ia-local-receipt.v1"
+    "receiptSchemaVersion": "theologai-aquinas-shapcote-ia-local-receipt.v1",
+    "receiptSha256": "71f0312d497835b11a474b3254c4d5226952a539425461a2b1d6795848ed5399"
   },
   "artifacts": [
     {

--- a/scripts/aquinas-gutenberg-acquisition.ts
+++ b/scripts/aquinas-gutenberg-acquisition.ts
@@ -16,13 +16,19 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 export const AQUINAS_GUTENBERG_ROOT = 'data/historical-sources/project-gutenberg/aquinas-english-dominican';
 export const AQUINAS_GUTENBERG_SOURCE_LOCK_PATH = `${AQUINAS_GUTENBERG_ROOT}/SOURCE_LOCK.json`;
+// Reviewed, tracked evidence from the approved acquisition. Keep this path and
+// its bytes stable because downstream topology locks bind its digest.
 export const AQUINAS_GUTENBERG_RECEIPT_PATH = `${AQUINAS_GUTENBERG_ROOT}/LOCAL_ACQUISITION_RECEIPT.json`;
+// Per-checkout acquisition output. Unlike the reviewed receipt above, this is
+// generated beneath the ignored local/ boundary and is always no-clobber.
+export const AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH = 'local/LOCAL_ACQUISITION_RECEIPT.json';
 export const AQUINAS_GUTENBERG_SOURCE_LOCK_VERSION = 'theologai-aquinas-gutenberg-source-lock.v1';
 export const AQUINAS_GUTENBERG_RECEIPT_VERSION = 'theologai-aquinas-gutenberg-local-receipt.v1';
 
 // This binds the reviewed lock byte-for-byte. Changing a pin requires review of
 // both the JSON and this executable guard; a receipt alone cannot redefine it.
 const EXPECTED_SOURCE_LOCK_SHA256 = 'c5cfdd1edd132bf59968cbabe4c7de2180c42d205735ca6c06aec626104a180b';
+const EXPECTED_REVIEWED_RECEIPT_SHA256 = 'bc0dab9ce5dc3672ccf2a81182655c75eaf6ef4f280584a40e079bf82a11719d';
 const GUTENBERG_HOST = 'www.gutenberg.org';
 const MAX_ARCHIVE_BYTES = 2_000_000;
 const MAX_CATALOG_BYTES = 128_000;
@@ -664,9 +670,9 @@ async function downloadAndValidate(lock: AquinasGutenbergSourceLock, artifact: A
 }
 
 function assertAcquisitionDestinationsEmpty(cwd: string, lock: AquinasGutenbergSourceLock): void {
-  const receipt = resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
-  assertNoSymlink(dirname(receipt), 'receipt parent');
-  assertDestinationAbsent(receipt, 'receipt');
+  const receipt = relativeToLocal(cwd, AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH);
+  assertNoSymlink(dirname(receipt), 'generated receipt parent');
+  assertDestinationAbsent(receipt, AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH);
   for (const artifact of lock.artifacts) {
     for (const candidate of [artifact.archive.localPath, artifact.catalogSnapshot.localPath, ...Object.values(evidencePaths(artifact))]) {
       const path = relativeToLocal(cwd, candidate);
@@ -700,9 +706,8 @@ function receiptBytes(receipt: AquinasGutenbergReceipt): Buffer {
 }
 
 function writeReceiptNoClobber(cwd: string, receipt: AquinasGutenbergReceipt): void {
-  const path = resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
-  const root = resolve(cwd);
-  writeNoClobber(path, receiptBytes(receipt), root, 'receipt');
+  const path = relativeToLocal(cwd, AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH);
+  writeNoClobber(path, receiptBytes(receipt), localRoot(cwd), 'generated receipt');
 }
 
 function parseLocalEvidence(value: unknown, label: string): LocalEvidence {
@@ -777,11 +782,18 @@ export async function acquireAquinasGutenberg(cwd = ROOT, fetchImpl: FetchLike =
 
 export function verifyLocalAquinasGutenbergAcquisition(cwd = ROOT): AquinasGutenbergReceipt {
   const lock = readAquinasGutenbergSourceLock(cwd);
-  const receiptPath = resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
+  const generatedReceiptPath = relativeToLocal(cwd, AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH);
+  const receiptPath = existsSync(generatedReceiptPath)
+    ? generatedReceiptPath
+    : resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
   if (!existsSync(receiptPath)) fail('local acquisition receipt is missing');
   const receiptStat = lstatSync(receiptPath);
   if (receiptStat.isSymbolicLink() || !receiptStat.isFile()) fail('local acquisition receipt is not a safe regular file');
-  const receipt = parseReceipt(JSON.parse(strictUtf8(readFileSync(receiptPath), 'local acquisition receipt')), lock);
+  const receiptFile = readFileSync(receiptPath);
+  if (receiptPath !== generatedReceiptPath && sha256(receiptFile) !== EXPECTED_REVIEWED_RECEIPT_SHA256) {
+    fail('reviewed acquisition receipt byte identity drifted');
+  }
+  const receipt = parseReceipt(JSON.parse(strictUtf8(receiptFile, 'local acquisition receipt')), lock);
   assertReceiptMatchesLock(receipt, lock);
   for (const [index, artifact] of lock.artifacts.entries()) {
     const entry = receipt.artifacts[index]!;

--- a/scripts/aquinas-gutenberg-acquisition.ts
+++ b/scripts/aquinas-gutenberg-acquisition.ts
@@ -22,7 +22,7 @@ export const AQUINAS_GUTENBERG_RECEIPT_VERSION = 'theologai-aquinas-gutenberg-lo
 
 // This binds the reviewed lock byte-for-byte. Changing a pin requires review of
 // both the JSON and this executable guard; a receipt alone cannot redefine it.
-const EXPECTED_SOURCE_LOCK_SHA256 = 'd54422a0cf80a11ddcfd1352fdae8c238d969160606de208a734aac29603726a';
+const EXPECTED_SOURCE_LOCK_SHA256 = 'c5cfdd1edd132bf59968cbabe4c7de2180c42d205735ca6c06aec626104a180b';
 const GUTENBERG_HOST = 'www.gutenberg.org';
 const MAX_ARCHIVE_BYTES = 2_000_000;
 const MAX_CATALOG_BYTES = 128_000;
@@ -77,6 +77,7 @@ export type AquinasGutenbergSourceLock = Readonly<{
     sourceLockSchemaVersion: 'theologai-aquinas-shapcote-ia-source-lock.v1';
     sourceLockSha256: string;
     receiptSchemaVersion: 'theologai-aquinas-shapcote-ia-local-receipt.v1';
+    receiptSha256: string;
   }>;
   artifacts: readonly AquinasGutenbergArtifact[];
 }>;
@@ -274,9 +275,9 @@ export function parseAquinasGutenbergSourceLock(value: unknown): AquinasGutenber
     if (!(key in provenance)) fail(`source lock provenance omits ${key}`);
   }
   const witness = record(source.comparisonWitness, 'source lock comparisonWitness');
-  exactKeys(witness, ['relationship', 'sourceLockSchemaVersion', 'sourceLockSha256', 'receiptSchemaVersion'], 'source lock comparisonWitness');
+  exactKeys(witness, ['relationship', 'sourceLockSchemaVersion', 'sourceLockSha256', 'receiptSchemaVersion', 'receiptSha256'], 'source lock comparisonWitness');
   if (witness.sourceLockSchemaVersion !== 'theologai-aquinas-shapcote-ia-source-lock.v1' || witness.receiptSchemaVersion !== 'theologai-aquinas-shapcote-ia-local-receipt.v1') fail('comparison witness identity drifted');
-  hex(string(witness.sourceLockSha256, 'source lock comparisonWitness.sourceLockSha256'), 'source lock comparisonWitness.sourceLockSha256');
+  if (witness.sourceLockSha256 !== 'a245dbc007b76e1975eb26462a75a5e5992954d9042fc6de96477f0b30351594' || witness.receiptSha256 !== '71f0312d497835b11a474b3254c4d5226952a539425461a2b1d6795848ed5399') fail('comparison witness digest drifted');
   const artifacts = array(source.artifacts, 'source lock artifacts').map(parseArtifact);
   const expected = [
     [17611, 'prima', 'q001-q119'],
@@ -305,6 +306,7 @@ export function parseAquinasGutenbergSourceLock(value: unknown): AquinasGutenber
       sourceLockSchemaVersion: 'theologai-aquinas-shapcote-ia-source-lock.v1',
       sourceLockSha256: string(witness.sourceLockSha256, 'source lock comparisonWitness.sourceLockSha256'),
       receiptSchemaVersion: 'theologai-aquinas-shapcote-ia-local-receipt.v1',
+      receiptSha256: string(witness.receiptSha256, 'source lock comparisonWitness.receiptSha256'),
     },
     artifacts,
   };
@@ -336,6 +338,18 @@ function crc32(bytes: Uint8Array): number {
   let value = 0xffffffff;
   for (const byte of bytes) value = CRC_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
   return (value ^ 0xffffffff) >>> 0;
+}
+
+function inflateRawBounded(bytes: Uint8Array, maximumOutputBytes: number, label: string): Buffer {
+  if (!Number.isSafeInteger(maximumOutputBytes) || maximumOutputBytes < 0 || maximumOutputBytes > MAX_MEMBER_BYTES) fail(`${label} has an unsafe declared uncompressed size`);
+  let inflated: Buffer;
+  try {
+    inflated = inflateRawSync(bytes, { maxOutputLength: maximumOutputBytes });
+  } catch {
+    fail(`${label} cannot be safely decompressed within its declared size bound`);
+  }
+  if (inflated.byteLength > maximumOutputBytes) fail(`${label} exceeded its declared uncompressed size bound`);
+  return inflated;
 }
 
 function u16(bytes: Uint8Array, offset: number, label: string): number {
@@ -430,12 +444,7 @@ export function parseStrictZip(bytes: Uint8Array, expectedMemberPaths: readonly 
     const localPath = strictUtf8(bytes.subarray(localOffset + 30, localOffset + 30 + localNameBytes), `local member ${index} path`);
     if (localPath !== path) fail(`local member ${index} path disagrees with the central directory`);
     const memberData = bytes.subarray(dataOffset, dataEnd);
-    let inflated: Uint8Array;
-    try {
-      inflated = method === 0 ? memberData : inflateRawSync(memberData);
-    } catch {
-      fail(`local member ${index} cannot be safely decompressed`);
-    }
+    const inflated = method === 0 ? memberData : inflateRawBounded(memberData, uncompressedBytes, `local member ${index}`);
     if (inflated.byteLength !== uncompressedBytes || crc32(inflated) !== expectedCrc) fail(`local member ${index} failed its size or CRC check`);
     members.push({ path, method, crc32: expectedCrc, compressedBytes: memberData, uncompressedBytes });
     cursor = next;
@@ -447,11 +456,7 @@ export function parseStrictZip(bytes: Uint8Array, expectedMemberPaths: readonly 
 }
 
 function inflateMember(member: ZipMember, label: string): Buffer {
-  try {
-    return Buffer.from(member.method === 0 ? member.compressedBytes : inflateRawSync(member.compressedBytes));
-  } catch {
-    fail(`${label} cannot be decompressed`);
-  }
+  return member.method === 0 ? Buffer.from(member.compressedBytes) : inflateRawBounded(member.compressedBytes, member.uncompressedBytes, label);
 }
 
 export function extractAndVerifyLockedHtml(artifact: AquinasGutenbergArtifact, archiveBytes: Uint8Array): Buffer {
@@ -461,6 +466,10 @@ export function extractAndVerifyLockedHtml(artifact: AquinasGutenbergArtifact, a
   if (!html || members.filter(member => member.path === artifact.htmlMember.path).length !== 1) fail(`eBook ${artifact.ebookId} HTML member is missing or ambiguous`);
   const inflated = inflateMember(html, `eBook ${artifact.ebookId} HTML member`);
   if (inflated.byteLength !== artifact.htmlMember.bytes || sha256(inflated) !== artifact.htmlMember.sha256) fail(`eBook ${artifact.ebookId} HTML member byte identity drifted`);
+  const htmlText = strictUtf8(inflated, `eBook ${artifact.ebookId} HTML member`);
+  if (!htmlText.includes(`<meta name="dcterms.created" content="${artifact.htmlMember.dctermsCreated}">`) || !htmlText.includes(`<meta name="dcterms.modified" content="${artifact.htmlMember.dctermsModified}">`)) {
+    fail(`eBook ${artifact.ebookId} locked dcterms metadata drifted`);
+  }
   return inflated;
 }
 

--- a/scripts/aquinas-gutenberg-acquisition.ts
+++ b/scripts/aquinas-gutenberg-acquisition.ts
@@ -33,7 +33,7 @@ export const AQUINAS_GUTENBERG_GENERATED_RECEIPT_VERSION = 'theologai-aquinas-gu
 // both the JSON and this executable guard; a receipt alone cannot redefine it.
 const EXPECTED_SOURCE_LOCK_SHA256 = 'c5cfdd1edd132bf59968cbabe4c7de2180c42d205735ca6c06aec626104a180b';
 const EXPECTED_REVIEWED_RECEIPT_SHA256 = 'bc0dab9ce5dc3672ccf2a81182655c75eaf6ef4f280584a40e079bf82a11719d';
-const EXPECTED_CATALOG_IDENTITY_LOCK_SHA256 = 'f3ac77059cf8a4da57d97f0d3ac9f3a52fc323102ccfa8fee540ce89c28d7068';
+const EXPECTED_CATALOG_IDENTITY_LOCK_SHA256 = '42e19c59e1907560148fd68316c9426eeaf664d8bcab358726b78b497df18c7c';
 const GUTENBERG_HOST = 'www.gutenberg.org';
 const MAX_ARCHIVE_BYTES = 2_000_000;
 const MAX_CATALOG_BYTES = 128_000;
@@ -436,7 +436,7 @@ function parseCatalogSemanticIdentity(value: unknown, ebookId: number, label: st
 
 export function parseAquinasGutenbergCatalogIdentityLock(value: unknown): AquinasGutenbergCatalogIdentityLock {
   const lock = record(value, 'catalog identity lock');
-  exactKeys(lock, ['schemaVersion', 'sourceLockSha256', 'reviewedReceiptSha256', 'normalization', 'invariantFields', 'allowedVolatility', 'outOfProjectionPresentation', 'artifacts'], 'catalog identity lock');
+  exactKeys(lock, ['schemaVersion', 'sourceLockSha256', 'reviewedReceiptSha256', 'normalization', 'invariantFields', 'allowedVolatility', 'permittedOutOfProjectionRows', 'outOfProjectionPresentation', 'artifacts'], 'catalog identity lock');
   if (lock.schemaVersion !== AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_VERSION) fail('unsupported catalog identity lock schema');
   const normalization = record(lock.normalization, 'catalog identity normalization');
   exactKeys(normalization, ['parser', 'text', 'projection', 'rawSnapshot'], 'catalog identity normalization');
@@ -452,6 +452,19 @@ export function parseAquinasGutenbergCatalogIdentityLock(value: unknown): Aquina
     const entry = record(value, `catalog identity allowedVolatility[${index}]`);
     exactKeys(entry, ['field', 'syntax', 'locator'], `catalog identity allowedVolatility[${index}]`);
     if (entry.field !== expectedVolatility[index]![0] || entry.syntax !== expectedVolatility[index]![1] || entry.locator !== expectedVolatility[index]![2]) fail(`catalog identity allowedVolatility[${index}] drifted`);
+  });
+  const permittedRows = array(lock.permittedOutOfProjectionRows, 'catalog identity permittedOutOfProjectionRows');
+  const expectedPermittedRows = [
+    ['Note', 1, 'The Wikipedia pointer is contextual navigation, not edition identity or provenance evidence.'],
+    ['Reading Level', 1, 'The computed readability estimate is presentation metadata and is not source identity.'],
+    ['Subject', 4, 'The four catalog subject classifications aid discovery but do not select this electronic edition.'],
+  ] as const;
+  if (permittedRows.length !== expectedPermittedRows.length) fail('catalog identity permittedOutOfProjectionRows drifted');
+  permittedRows.forEach((value, index) => {
+    const entry = record(value, `catalog identity permittedOutOfProjectionRows[${index}]`);
+    exactKeys(entry, ['label', 'expectedCount', 'rationale'], `catalog identity permittedOutOfProjectionRows[${index}]`);
+    const expected = expectedPermittedRows[index]!;
+    if (entry.label !== expected[0] || entry.expectedCount !== expected[1] || entry.rationale !== expected[2]) fail(`catalog identity permittedOutOfProjectionRows[${index}] drifted`);
   });
   exactStringArray(lock.outOfProjectionPresentation, ['descriptive summary', 'reading-level estimate', 'site navigation and styling', 'non-archive download-format presentation'], 'catalog identity outOfProjectionPresentation');
   const artifacts = array(lock.artifacts, 'catalog identity artifacts').map((value, index) => {
@@ -727,6 +740,29 @@ export function extractAndVerifyCatalogSemanticIdentity(
     if (headings.length !== 1 || values.length !== 1) fail(`eBook ${sourceArtifact.ebookId} catalog row is structurally ambiguous`);
     return { row, value: values[0]!, label: normalizedHtmlText(headings[0]!) };
   });
+  const expectedRowCounts: Readonly<Record<string, number>> = {
+    Author: 1,
+    Title: 1,
+    Note: 1,
+    Credits: 1,
+    'Reading Level': 1,
+    Language: 1,
+    'LoC Class': 1,
+    Subject: 4,
+    Category: 1,
+    'eBook-No.': 1,
+    'Release Date': 1,
+    'Last Update': identityArtifact.semanticIdentity.lastUpdate ? 1 : 0,
+    Copyright: 1,
+    Downloads: 1,
+  };
+  for (const candidate of rows) {
+    if (!(candidate.label in expectedRowCounts)) fail(`eBook ${sourceArtifact.ebookId} catalog has unknown row label: ${candidate.label || '(empty)'}`);
+  }
+  for (const [label, expectedCount] of Object.entries(expectedRowCounts)) {
+    const observedCount = rows.filter(candidate => candidate.label === label).length;
+    if (observedCount !== expectedCount) fail(`eBook ${sourceArtifact.ebookId} catalog ${label} row count drifted: expected ${expectedCount}, observed ${observedCount}`);
+  }
   const requiredRow = (label: string, optional = false): { row: HtmlElement; value: HtmlElement } | null => {
     const matches = rows.filter(candidate => candidate.label === label);
     if (matches.length > 1 || (!optional && matches.length !== 1)) fail(`eBook ${sourceArtifact.ebookId} catalog ${label} row must occur exactly once`);
@@ -734,6 +770,10 @@ export function extractAndVerifyCatalogSemanticIdentity(
   };
   const authorRow = requiredRow('Author')!;
   const authorLink = uniqueHtmlElement(authorRow.value, element => element.tagName === 'a' && htmlAttribute(element, 'itemprop') === 'creator', `eBook ${sourceArtifact.ebookId} catalog author link`);
+  const authorCellContent = htmlChildren(authorRow.value).filter(child => isHtmlElement(child) || normalizedHtmlText(child).length > 0);
+  if (authorCellContent.length !== 1 || authorCellContent[0] !== authorLink || htmlElements(authorLink, element => element !== authorLink).length !== 0 || normalizedHtmlText(authorRow.value) !== normalizedHtmlText(authorLink)) {
+    fail(`eBook ${sourceArtifact.ebookId} Author cell must contain only the single reviewed creator link and text`);
+  }
   const titleRow = requiredRow('Title')!;
   const creditsRow = requiredRow('Credits')!;
   const languageRow = requiredRow('Language')!;

--- a/scripts/aquinas-gutenberg-acquisition.ts
+++ b/scripts/aquinas-gutenberg-acquisition.ts
@@ -1,0 +1,818 @@
+#!/usr/bin/env tsx
+
+/**
+ * Strict, local-only acquisition guard for the four approved Project Gutenberg
+ * Aquinas HTML ZIPs. This intentionally preserves bytes and evidence only; it
+ * does not parse or materialize corpus text.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, linkSync, lstatSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { inflateRawSync } from 'node:zlib';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export const AQUINAS_GUTENBERG_ROOT = 'data/historical-sources/project-gutenberg/aquinas-english-dominican';
+export const AQUINAS_GUTENBERG_SOURCE_LOCK_PATH = `${AQUINAS_GUTENBERG_ROOT}/SOURCE_LOCK.json`;
+export const AQUINAS_GUTENBERG_RECEIPT_PATH = `${AQUINAS_GUTENBERG_ROOT}/LOCAL_ACQUISITION_RECEIPT.json`;
+export const AQUINAS_GUTENBERG_SOURCE_LOCK_VERSION = 'theologai-aquinas-gutenberg-source-lock.v1';
+export const AQUINAS_GUTENBERG_RECEIPT_VERSION = 'theologai-aquinas-gutenberg-local-receipt.v1';
+
+// This binds the reviewed lock byte-for-byte. Changing a pin requires review of
+// both the JSON and this executable guard; a receipt alone cannot redefine it.
+const EXPECTED_SOURCE_LOCK_SHA256 = 'd54422a0cf80a11ddcfd1352fdae8c238d969160606de208a734aac29603726a';
+const GUTENBERG_HOST = 'www.gutenberg.org';
+const MAX_ARCHIVE_BYTES = 2_000_000;
+const MAX_CATALOG_BYTES = 128_000;
+const MAX_ZIP_MEMBERS = 2;
+const MAX_MEMBER_BYTES = 6_000_000;
+const MAX_TOTAL_UNCOMPRESSED_BYTES = 8_000_000;
+
+export type AquinasGutenbergArtifact = Readonly<{
+  ebookId: number;
+  partKey: 'prima' | 'prima-secundae' | 'secunda-secundae' | 'tertia';
+  questionRange: string;
+  archive: Readonly<{
+    url: string;
+    localPath: string;
+    bytes: number;
+    sha256: string;
+    memberPaths: readonly string[];
+  }>;
+  htmlMember: Readonly<{
+    path: string;
+    bytes: number;
+    sha256: string;
+    dctermsCreated: string;
+    dctermsModified: string;
+  }>;
+  catalogSnapshot: Readonly<{
+    url: string;
+    localPath: string;
+    bytes: number;
+    sha256: string;
+    releaseDate: string;
+    issuedMachineDate: string;
+    lastUpdate: string | null;
+  }>;
+}>;
+
+export type AquinasGutenbergSourceLock = Readonly<{
+  schemaVersion: typeof AQUINAS_GUTENBERG_SOURCE_LOCK_VERSION;
+  sourceIdentity: 'aquinas-english-dominican-gutenberg-four-part-v1';
+  acquisitionScope: Readonly<Record<string, unknown>>;
+  acquisitionPolicy: Readonly<Record<string, unknown>>;
+  rightsAndProvenance: Readonly<{
+    rightsStatus: 'public_domain_in_usa';
+    territoryCaveat: string;
+    catalogStatement: 'Public domain in the USA.';
+    projectGutenbergLicensePolicyUrl: string;
+    internalUnrestrictedUseEvidence: Readonly<{ requiredPhrases: readonly string[] }>;
+    electronicEditionProvenance: Readonly<Record<string, unknown>>;
+  }>;
+  comparisonWitness: Readonly<{
+    relationship: string;
+    sourceLockSchemaVersion: 'theologai-aquinas-shapcote-ia-source-lock.v1';
+    sourceLockSha256: string;
+    receiptSchemaVersion: 'theologai-aquinas-shapcote-ia-local-receipt.v1';
+  }>;
+  artifacts: readonly AquinasGutenbergArtifact[];
+}>;
+
+export type LocalEvidence = Readonly<{
+  path: string;
+  bytes: number;
+  sha256: string;
+}>;
+
+export type AquinasGutenbergReceiptArtifact = Readonly<{
+  ebookId: number;
+  archive: LocalEvidence;
+  catalogSnapshot: LocalEvidence;
+  htmlMember: Readonly<{ path: string; bytes: number; sha256: string }>;
+  unrestrictedUseNotice: LocalEvidence;
+  electronicEditionProvenance: LocalEvidence;
+}>;
+
+export type AquinasGutenbergReceipt = Readonly<{
+  schemaVersion: typeof AQUINAS_GUTENBERG_RECEIPT_VERSION;
+  sourceLockSha256: string;
+  acquiredAt: string;
+  artifacts: readonly AquinasGutenbergReceiptArtifact[];
+}>;
+
+type JsonRecord = Record<string, unknown>;
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+type ZipMember = Readonly<{
+  path: string;
+  method: number;
+  crc32: number;
+  compressedBytes: Uint8Array;
+  uncompressedBytes: number;
+}>;
+
+function fail(message: string): never {
+  throw new Error(`[aquinas-gutenberg-acquisition] ${message}`);
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+  return value as JsonRecord;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) fail(`${label} must be an array`);
+  return value;
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) fail(`${label} must be a non-empty string`);
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  if (value === null) return null;
+  return string(value, label);
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) fail(`${label} must be a positive safe integer`);
+  return value as number;
+}
+
+function exactKeys(value: JsonRecord, keys: readonly string[], label: string): void {
+  const observed = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (observed.length !== expected.length || observed.some((key, index) => key !== expected[index])) {
+    fail(`${label} has an unexpected key set`);
+  }
+}
+
+function hex(value: string, label: string): string {
+  if (!/^[a-f0-9]{64}$/.test(value)) fail(`${label} must be a lowercase SHA-256 digest`);
+  return value;
+}
+
+export function sha256(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function strictUtf8(bytes: Uint8Array, label: string): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    fail(`${label} is not strict UTF-8`);
+  }
+}
+
+function assertApprovedGutenbergUrl(urlText: string, label: string): URL {
+  let url: URL;
+  try {
+    url = new URL(urlText);
+  } catch {
+    fail(`${label} is not an absolute URL`);
+  }
+  if (url.protocol !== 'https:' || url.hostname !== GUTENBERG_HOST || url.port || url.username || url.password || url.search || url.hash) {
+    fail(`${label} escaped the approved Project Gutenberg origin`);
+  }
+  return url;
+}
+
+function assertLockUrl(urlText: string, expectedPath: string, label: string): void {
+  const url = assertApprovedGutenbergUrl(urlText, label);
+  if (url.pathname !== expectedPath) fail(`${label} does not retain its exact approved pathname`);
+}
+
+function assertLocalRelativePath(path: string, label: string): void {
+  if (!path.startsWith('local/') || path.includes('\\') || path.split('/').some(segment => !segment || segment === '.' || segment === '..')) {
+    fail(`${label} must be a safe local/ relative path`);
+  }
+}
+
+function parseArtifact(value: unknown, index: number): AquinasGutenbergArtifact {
+  const source = record(value, `artifact ${index}`);
+  exactKeys(source, ['ebookId', 'partKey', 'questionRange', 'archive', 'htmlMember', 'catalogSnapshot'], `artifact ${index}`);
+  const ebookId = positiveInteger(source.ebookId, `artifact ${index}.ebookId`);
+  const partKey = string(source.partKey, `artifact ${index}.partKey`);
+  if (!['prima', 'prima-secundae', 'secunda-secundae', 'tertia'].includes(partKey)) fail(`artifact ${index}.partKey is not reviewed`);
+  const questionRange = string(source.questionRange, `artifact ${index}.questionRange`);
+
+  const archiveValue = record(source.archive, `artifact ${index}.archive`);
+  exactKeys(archiveValue, ['url', 'localPath', 'bytes', 'sha256', 'memberPaths'], `artifact ${index}.archive`);
+  const archiveUrl = string(archiveValue.url, `artifact ${index}.archive.url`);
+  assertLockUrl(archiveUrl, `/cache/epub/${ebookId}/pg${ebookId}-h.zip`, `artifact ${index}.archive.url`);
+  const archiveLocalPath = string(archiveValue.localPath, `artifact ${index}.archive.localPath`);
+  assertLocalRelativePath(archiveLocalPath, `artifact ${index}.archive.localPath`);
+  if (archiveLocalPath !== `local/archives/pg${ebookId}-h.zip`) fail(`artifact ${index}.archive.localPath drifted`);
+  const memberPaths = array(archiveValue.memberPaths, `artifact ${index}.archive.memberPaths`).map((entry, memberIndex) => string(entry, `artifact ${index}.archive.memberPaths[${memberIndex}]`));
+  if (memberPaths.length !== 2 || memberPaths[0] !== `pg${ebookId}-images.html` || memberPaths[1] !== `${ebookId}-cover.png`) {
+    fail(`artifact ${index}.archive.memberPaths are not the reviewed exact member set`);
+  }
+
+  const htmlValue = record(source.htmlMember, `artifact ${index}.htmlMember`);
+  exactKeys(htmlValue, ['path', 'bytes', 'sha256', 'dctermsCreated', 'dctermsModified'], `artifact ${index}.htmlMember`);
+  const htmlPath = string(htmlValue.path, `artifact ${index}.htmlMember.path`);
+  if (htmlPath !== memberPaths[0]) fail(`artifact ${index}.htmlMember.path does not select the exact HTML member`);
+
+  const catalogValue = record(source.catalogSnapshot, `artifact ${index}.catalogSnapshot`);
+  exactKeys(catalogValue, ['url', 'localPath', 'bytes', 'sha256', 'releaseDate', 'issuedMachineDate', 'lastUpdate'], `artifact ${index}.catalogSnapshot`);
+  const catalogUrl = string(catalogValue.url, `artifact ${index}.catalogSnapshot.url`);
+  assertLockUrl(catalogUrl, `/ebooks/${ebookId}`, `artifact ${index}.catalogSnapshot.url`);
+  const catalogLocalPath = string(catalogValue.localPath, `artifact ${index}.catalogSnapshot.localPath`);
+  assertLocalRelativePath(catalogLocalPath, `artifact ${index}.catalogSnapshot.localPath`);
+  if (catalogLocalPath !== `local/catalog/pg${ebookId}.html`) fail(`artifact ${index}.catalogSnapshot.localPath drifted`);
+
+  return {
+    ebookId,
+    partKey: partKey as AquinasGutenbergArtifact['partKey'],
+    questionRange,
+    archive: {
+      url: archiveUrl,
+      localPath: archiveLocalPath,
+      bytes: positiveInteger(archiveValue.bytes, `artifact ${index}.archive.bytes`),
+      sha256: hex(string(archiveValue.sha256, `artifact ${index}.archive.sha256`), `artifact ${index}.archive.sha256`),
+      memberPaths,
+    },
+    htmlMember: {
+      path: htmlPath,
+      bytes: positiveInteger(htmlValue.bytes, `artifact ${index}.htmlMember.bytes`),
+      sha256: hex(string(htmlValue.sha256, `artifact ${index}.htmlMember.sha256`), `artifact ${index}.htmlMember.sha256`),
+      dctermsCreated: string(htmlValue.dctermsCreated, `artifact ${index}.htmlMember.dctermsCreated`),
+      dctermsModified: string(htmlValue.dctermsModified, `artifact ${index}.htmlMember.dctermsModified`),
+    },
+    catalogSnapshot: {
+      url: catalogUrl,
+      localPath: catalogLocalPath,
+      bytes: positiveInteger(catalogValue.bytes, `artifact ${index}.catalogSnapshot.bytes`),
+      sha256: hex(string(catalogValue.sha256, `artifact ${index}.catalogSnapshot.sha256`), `artifact ${index}.catalogSnapshot.sha256`),
+      releaseDate: string(catalogValue.releaseDate, `artifact ${index}.catalogSnapshot.releaseDate`),
+      issuedMachineDate: string(catalogValue.issuedMachineDate, `artifact ${index}.catalogSnapshot.issuedMachineDate`),
+      lastUpdate: nullableString(catalogValue.lastUpdate, `artifact ${index}.catalogSnapshot.lastUpdate`),
+    },
+  };
+}
+
+export function parseAquinasGutenbergSourceLock(value: unknown): AquinasGutenbergSourceLock {
+  const source = record(value, 'source lock');
+  exactKeys(source, ['schemaVersion', 'sourceIdentity', 'acquisitionScope', 'acquisitionPolicy', 'rightsAndProvenance', 'comparisonWitness', 'artifacts'], 'source lock');
+  if (source.schemaVersion !== AQUINAS_GUTENBERG_SOURCE_LOCK_VERSION) fail('unsupported source-lock schema version');
+  if (source.sourceIdentity !== 'aquinas-english-dominican-gutenberg-four-part-v1') fail('source identity drifted');
+  const scope = record(source.acquisitionScope, 'source lock acquisitionScope');
+  const policy = record(source.acquisitionPolicy, 'source lock acquisitionPolicy');
+  const rights = record(source.rightsAndProvenance, 'source lock rightsAndProvenance');
+  exactKeys(rights, ['rightsStatus', 'territoryCaveat', 'catalogStatement', 'projectGutenbergLicensePolicyUrl', 'internalUnrestrictedUseEvidence', 'electronicEditionProvenance'], 'source lock rightsAndProvenance');
+  if (rights.rightsStatus !== 'public_domain_in_usa' || rights.catalogStatement !== 'Public domain in the USA.') fail('rights status drifted from the reviewed territorial statement');
+  assertLockUrl(string(rights.projectGutenbergLicensePolicyUrl, 'source lock projectGutenbergLicensePolicyUrl'), '/policy/license.html', 'source lock projectGutenbergLicensePolicyUrl');
+  const notice = record(rights.internalUnrestrictedUseEvidence, 'source lock internalUnrestrictedUseEvidence');
+  exactKeys(notice, ['requiredPhrases'], 'source lock internalUnrestrictedUseEvidence');
+  const requiredPhrases = array(notice.requiredPhrases, 'source lock requiredPhrases').map((phrase, index) => string(phrase, `source lock requiredPhrases[${index}]`));
+  if (requiredPhrases.length < 5) fail('source lock must retain all internal unrestricted-use evidence phrases');
+  const provenance = record(rights.electronicEditionProvenance, 'source lock electronicEditionProvenance');
+  for (const key of ['sourceEtextCreator', 'sourceEtextAvailability', 'electronicEditionEditor', 'disclosedEditorActions', 'translator', 'printedTranslationPublisher', 'ccelBoundary']) {
+    if (!(key in provenance)) fail(`source lock provenance omits ${key}`);
+  }
+  const witness = record(source.comparisonWitness, 'source lock comparisonWitness');
+  exactKeys(witness, ['relationship', 'sourceLockSchemaVersion', 'sourceLockSha256', 'receiptSchemaVersion'], 'source lock comparisonWitness');
+  if (witness.sourceLockSchemaVersion !== 'theologai-aquinas-shapcote-ia-source-lock.v1' || witness.receiptSchemaVersion !== 'theologai-aquinas-shapcote-ia-local-receipt.v1') fail('comparison witness identity drifted');
+  hex(string(witness.sourceLockSha256, 'source lock comparisonWitness.sourceLockSha256'), 'source lock comparisonWitness.sourceLockSha256');
+  const artifacts = array(source.artifacts, 'source lock artifacts').map(parseArtifact);
+  const expected = [
+    [17611, 'prima', 'q001-q119'],
+    [17897, 'prima-secundae', 'q001-q114'],
+    [18755, 'secunda-secundae', 'q001-q189'],
+    [19950, 'tertia', 'q001-q090'],
+  ] as const;
+  if (artifacts.length !== expected.length || artifacts.some((artifact, index) => artifact.ebookId !== expected[index]![0] || artifact.partKey !== expected[index]![1] || artifact.questionRange !== expected[index]![2])) {
+    fail('source lock does not retain the reviewed four-part topology and order');
+  }
+  return {
+    schemaVersion: AQUINAS_GUTENBERG_SOURCE_LOCK_VERSION,
+    sourceIdentity: 'aquinas-english-dominican-gutenberg-four-part-v1',
+    acquisitionScope: scope,
+    acquisitionPolicy: policy,
+    rightsAndProvenance: {
+      rightsStatus: 'public_domain_in_usa',
+      territoryCaveat: string(rights.territoryCaveat, 'source lock territoryCaveat'),
+      catalogStatement: 'Public domain in the USA.',
+      projectGutenbergLicensePolicyUrl: string(rights.projectGutenbergLicensePolicyUrl, 'source lock projectGutenbergLicensePolicyUrl'),
+      internalUnrestrictedUseEvidence: { requiredPhrases },
+      electronicEditionProvenance: provenance,
+    },
+    comparisonWitness: {
+      relationship: string(witness.relationship, 'source lock comparisonWitness.relationship'),
+      sourceLockSchemaVersion: 'theologai-aquinas-shapcote-ia-source-lock.v1',
+      sourceLockSha256: string(witness.sourceLockSha256, 'source lock comparisonWitness.sourceLockSha256'),
+      receiptSchemaVersion: 'theologai-aquinas-shapcote-ia-local-receipt.v1',
+    },
+    artifacts,
+  };
+}
+
+export function sourceLockDigest(cwd = ROOT): string {
+  return sha256(readFileSync(resolve(cwd, AQUINAS_GUTENBERG_SOURCE_LOCK_PATH)));
+}
+
+export function readAquinasGutenbergSourceLock(cwd = ROOT): AquinasGutenbergSourceLock {
+  const bytes = readFileSync(resolve(cwd, AQUINAS_GUTENBERG_SOURCE_LOCK_PATH));
+  if (sha256(bytes) !== EXPECTED_SOURCE_LOCK_SHA256) fail('source lock byte identity drifted from the reviewed lock');
+  return parseAquinasGutenbergSourceLock(JSON.parse(strictUtf8(bytes, 'source lock')));
+}
+
+function crcTable(): Uint32Array {
+  const table = new Uint32Array(256);
+  for (let value = 0; value < 256; value += 1) {
+    let current = value;
+    for (let bit = 0; bit < 8; bit += 1) current = (current & 1) ? (0xedb88320 ^ (current >>> 1)) : (current >>> 1);
+    table[value] = current >>> 0;
+  }
+  return table;
+}
+
+const CRC_TABLE = crcTable();
+
+function crc32(bytes: Uint8Array): number {
+  let value = 0xffffffff;
+  for (const byte of bytes) value = CRC_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+function u16(bytes: Uint8Array, offset: number, label: string): number {
+  if (offset < 0 || offset + 2 > bytes.byteLength) fail(`${label} crosses an archive boundary`);
+  return bytes[offset]! | (bytes[offset + 1]! << 8);
+}
+
+function u32(bytes: Uint8Array, offset: number, label: string): number {
+  if (offset < 0 || offset + 4 > bytes.byteLength) fail(`${label} crosses an archive boundary`);
+  return (bytes[offset]! | (bytes[offset + 1]! << 8) | (bytes[offset + 2]! << 16) | (bytes[offset + 3]! << 24)) >>> 0;
+}
+
+function safeZipPath(value: string, label: string): void {
+  if (!value || value.includes('\u0000') || value.includes('\\') || value.startsWith('/') || /^[A-Za-z]:/.test(value) || value.split('/').some(segment => !segment || segment === '.' || segment === '..')) {
+    fail(`${label} is a hostile ZIP member path`);
+  }
+}
+
+function zipPathCollisionKey(value: string): string {
+  return value.normalize('NFC').toLocaleLowerCase('en-US');
+}
+
+/** Strict central-directory reader: no ZIP64, comments, encryption, links, or extra members. */
+export function parseStrictZip(bytes: Uint8Array, expectedMemberPaths: readonly string[]): readonly ZipMember[] {
+  if (bytes.byteLength < 22) fail('ZIP archive is too short for an end-of-central-directory record');
+  const minimumOffset = Math.max(0, bytes.byteLength - 22 - 0xffff);
+  let eocd = -1;
+  for (let offset = bytes.byteLength - 22; offset >= minimumOffset; offset -= 1) {
+    if (u32(bytes, offset, 'EOCD signature') === 0x06054b50 && offset + 22 + u16(bytes, offset + 20, 'EOCD comment length') === bytes.byteLength) {
+      eocd = offset;
+      break;
+    }
+  }
+  if (eocd < 0) fail('ZIP archive has no unambiguous end-of-central-directory record');
+  if (u16(bytes, eocd + 20, 'EOCD comment length') !== 0) fail('ZIP archive comments are not accepted');
+  const disk = u16(bytes, eocd + 4, 'EOCD disk');
+  const directoryDisk = u16(bytes, eocd + 6, 'EOCD directory disk');
+  const entriesOnDisk = u16(bytes, eocd + 8, 'EOCD entries on disk');
+  const entries = u16(bytes, eocd + 10, 'EOCD entries');
+  const directoryBytes = u32(bytes, eocd + 12, 'EOCD directory size');
+  const directoryOffset = u32(bytes, eocd + 16, 'EOCD directory offset');
+  if (disk || directoryDisk || entriesOnDisk !== entries || entries === 0 || entries > MAX_ZIP_MEMBERS || directoryOffset + directoryBytes !== eocd) {
+    fail('ZIP archive has a multi-disk, ZIP64-like, oversized, or ambiguous central directory');
+  }
+
+  const members: ZipMember[] = [];
+  const exactPaths = new Set<string>();
+  const collisions = new Set<string>();
+  let cursor = directoryOffset;
+  let totalUncompressed = 0;
+  for (let index = 0; index < entries; index += 1) {
+    if (u32(bytes, cursor, `central directory member ${index} signature`) !== 0x02014b50) fail(`central directory member ${index} has an invalid signature`);
+    const madeBy = u16(bytes, cursor + 4, `central directory member ${index} made-by`);
+    const flags = u16(bytes, cursor + 8, `central directory member ${index} flags`);
+    const method = u16(bytes, cursor + 10, `central directory member ${index} method`);
+    const expectedCrc = u32(bytes, cursor + 16, `central directory member ${index} CRC`);
+    const compressedBytes = u32(bytes, cursor + 20, `central directory member ${index} compressed bytes`);
+    const uncompressedBytes = u32(bytes, cursor + 24, `central directory member ${index} uncompressed bytes`);
+    const nameBytes = u16(bytes, cursor + 28, `central directory member ${index} name length`);
+    const extraBytes = u16(bytes, cursor + 30, `central directory member ${index} extra length`);
+    const commentBytes = u16(bytes, cursor + 32, `central directory member ${index} comment length`);
+    const diskStart = u16(bytes, cursor + 34, `central directory member ${index} disk`);
+    const externalAttributes = u32(bytes, cursor + 38, `central directory member ${index} attributes`);
+    const localOffset = u32(bytes, cursor + 42, `central directory member ${index} local offset`);
+    const next = cursor + 46 + nameBytes + extraBytes + commentBytes;
+    if (next > eocd || flags !== 0 || ![0, 8].includes(method) || extraBytes !== 0 || commentBytes !== 0 || diskStart !== 0 || compressedBytes > MAX_ARCHIVE_BYTES || uncompressedBytes > MAX_MEMBER_BYTES) {
+      fail(`central directory member ${index} violates the reviewed ZIP safety profile`);
+    }
+    if (madeBy >>> 8 === 3 && ((externalAttributes >>> 16) & 0o170000) === 0o120000) fail(`central directory member ${index} is a symlink`);
+    const path = strictUtf8(bytes.subarray(cursor + 46, cursor + 46 + nameBytes), `central directory member ${index} path`);
+    safeZipPath(path, `central directory member ${index}`);
+    const collision = zipPathCollisionKey(path);
+    if (exactPaths.has(path) || collisions.has(collision)) fail(`ZIP archive contains duplicate or colliding member paths`);
+    exactPaths.add(path);
+    collisions.add(collision);
+    totalUncompressed += uncompressedBytes;
+    if (totalUncompressed > MAX_TOTAL_UNCOMPRESSED_BYTES) fail('ZIP archive exceeds its total uncompressed size bound');
+
+    if (u32(bytes, localOffset, `local member ${index} signature`) !== 0x04034b50) fail(`local member ${index} has an invalid signature`);
+    const localFlags = u16(bytes, localOffset + 6, `local member ${index} flags`);
+    const localMethod = u16(bytes, localOffset + 8, `local member ${index} method`);
+    const localCrc = u32(bytes, localOffset + 14, `local member ${index} CRC`);
+    const localCompressedBytes = u32(bytes, localOffset + 18, `local member ${index} compressed bytes`);
+    const localUncompressedBytes = u32(bytes, localOffset + 22, `local member ${index} uncompressed bytes`);
+    const localNameBytes = u16(bytes, localOffset + 26, `local member ${index} name length`);
+    const localExtraBytes = u16(bytes, localOffset + 28, `local member ${index} extra length`);
+    const dataOffset = localOffset + 30 + localNameBytes + localExtraBytes;
+    const dataEnd = dataOffset + compressedBytes;
+    if (localFlags !== flags || localMethod !== method || localCrc !== expectedCrc || localCompressedBytes !== compressedBytes || localUncompressedBytes !== uncompressedBytes || localExtraBytes !== 0 || dataEnd > directoryOffset) {
+      fail(`local member ${index} does not match its central-directory entry`);
+    }
+    const localPath = strictUtf8(bytes.subarray(localOffset + 30, localOffset + 30 + localNameBytes), `local member ${index} path`);
+    if (localPath !== path) fail(`local member ${index} path disagrees with the central directory`);
+    const memberData = bytes.subarray(dataOffset, dataEnd);
+    let inflated: Uint8Array;
+    try {
+      inflated = method === 0 ? memberData : inflateRawSync(memberData);
+    } catch {
+      fail(`local member ${index} cannot be safely decompressed`);
+    }
+    if (inflated.byteLength !== uncompressedBytes || crc32(inflated) !== expectedCrc) fail(`local member ${index} failed its size or CRC check`);
+    members.push({ path, method, crc32: expectedCrc, compressedBytes: memberData, uncompressedBytes });
+    cursor = next;
+  }
+  if (cursor !== eocd || members.length !== expectedMemberPaths.length || members.some((member, index) => member.path !== expectedMemberPaths[index])) {
+    fail('ZIP archive does not contain exactly the reviewed member topology');
+  }
+  return members;
+}
+
+function inflateMember(member: ZipMember, label: string): Buffer {
+  try {
+    return Buffer.from(member.method === 0 ? member.compressedBytes : inflateRawSync(member.compressedBytes));
+  } catch {
+    fail(`${label} cannot be decompressed`);
+  }
+}
+
+export function extractAndVerifyLockedHtml(artifact: AquinasGutenbergArtifact, archiveBytes: Uint8Array): Buffer {
+  if (archiveBytes.byteLength !== artifact.archive.bytes || sha256(archiveBytes) !== artifact.archive.sha256) fail(`eBook ${artifact.ebookId} archive byte identity drifted`);
+  const members = parseStrictZip(archiveBytes, artifact.archive.memberPaths);
+  const html = members.find(member => member.path === artifact.htmlMember.path);
+  if (!html || members.filter(member => member.path === artifact.htmlMember.path).length !== 1) fail(`eBook ${artifact.ebookId} HTML member is missing or ambiguous`);
+  const inflated = inflateMember(html, `eBook ${artifact.ebookId} HTML member`);
+  if (inflated.byteLength !== artifact.htmlMember.bytes || sha256(inflated) !== artifact.htmlMember.sha256) fail(`eBook ${artifact.ebookId} HTML member byte identity drifted`);
+  return inflated;
+}
+
+function evidenceSlices(htmlBytes: Uint8Array, artifact: AquinasGutenbergArtifact, lock: AquinasGutenbergSourceLock): Readonly<{ unrestrictedUseNotice: Buffer; electronicEditionProvenance: Buffer }> {
+  const html = strictUtf8(htmlBytes, `eBook ${artifact.ebookId} HTML member`);
+  for (const phrase of lock.rightsAndProvenance.internalUnrestrictedUseEvidence.requiredPhrases) {
+    if (!html.includes(phrase)) fail(`eBook ${artifact.ebookId} internal unrestricted-use/license evidence mismatched: ${phrase}`);
+  }
+  const provenancePhrases = [
+    'originally produced by Sandra',
+    'made available through the Christian\nClassics Ethereal Library',
+    'I have eliminated\nunnecessary formatting in the text, corrected some errors in\ntranscription, and added the dedication, tables of contents,\nPrologue, and the numbers of the questions and articles, as they\nappeared in the printed translation published by Benziger Brothers.',
+    'In a few places, where obvious errors appeared in the Benziger\nBrothers edition, I have corrected them by reference to a Latin text\nof the <i>Summa.</i> These corrections are indicated by English text in\nbrackets.',
+    '* Any matter that appeared in a footnote in the Benziger Brothers\nedition is presented in brackets at the point in the text where the\nfootnote mark appeared.',
+    'Fathers of the English Dominican Province',
+    'BENZIGER BROTHERS',
+    'Anything else in this electronic edition that does not correspond to\nthe content of the Benziger Brothers edition may be regarded as a\ndefect in this edition and attributed to me (David McClamrock).',
+  ];
+  const provenanceComparable = html.replace(/\r\n/g, '\n');
+  for (const phrase of provenancePhrases) if (!provenanceComparable.includes(phrase)) fail(`eBook ${artifact.ebookId} provenance evidence mismatched`);
+  const noticeStart = html.indexOf('<div>This eBook is for the use of anyone anywhere in the United States');
+  const noticeEnd = noticeStart < 0 ? -1 : html.indexOf('</div>', noticeStart);
+  const noteHeading = html.indexOf('>NOTE TO THIS ELECTRONIC EDITION</');
+  const noteLastPhrase = 'defect in this edition and attributed to me (David McClamrock).';
+  const noteLast = noteHeading < 0 ? -1 : html.indexOf(noteLastPhrase, noteHeading);
+  const noteEnd = noteLast < 0 ? -1 : html.indexOf('</p>', noteLast);
+  if (noticeStart < 0 || noticeEnd < noticeStart || noteHeading < 0 || noteLast < noteHeading || noteEnd < noteLast) fail(`eBook ${artifact.ebookId} has unextractable rights/provenance evidence`);
+  return {
+    unrestrictedUseNotice: Buffer.from(html.slice(noticeStart, noticeEnd + '</div>'.length), 'utf8'),
+    electronicEditionProvenance: Buffer.from(html.slice(noteHeading, noteEnd + '</p>'.length), 'utf8'),
+  };
+}
+
+function assertCatalog(artifact: AquinasGutenbergArtifact, catalogBytes: Uint8Array, lock: AquinasGutenbergSourceLock): void {
+  if (catalogBytes.byteLength !== artifact.catalogSnapshot.bytes || sha256(catalogBytes) !== artifact.catalogSnapshot.sha256) fail(`eBook ${artifact.ebookId} catalog snapshot byte identity drifted`);
+  const catalog = strictUtf8(catalogBytes, `eBook ${artifact.ebookId} catalog snapshot`);
+  const required = [
+    `<td>${artifact.ebookId}</td>`,
+    `content="${artifact.catalogSnapshot.issuedMachineDate}"`,
+    artifact.catalogSnapshot.releaseDate,
+    lock.rightsAndProvenance.catalogStatement,
+  ];
+  if (artifact.catalogSnapshot.lastUpdate) required.push('<th>Last Update</th>', artifact.catalogSnapshot.lastUpdate);
+  for (const phrase of required) if (!catalog.includes(phrase)) fail(`eBook ${artifact.ebookId} catalog metadata evidence mismatched`);
+  if (artifact.catalogSnapshot.lastUpdate === null && catalog.includes('<th>Last Update</th>')) fail(`eBook ${artifact.ebookId} catalog unexpectedly has update metadata`);
+}
+
+function localRoot(cwd: string): string {
+  return resolve(cwd, AQUINAS_GUTENBERG_ROOT, 'local');
+}
+
+function relativeToLocal(cwd: string, localPath: string): string {
+  assertLocalRelativePath(localPath, 'local path');
+  const result = resolve(cwd, AQUINAS_GUTENBERG_ROOT, localPath);
+  const root = localRoot(cwd);
+  if (relative(root, result).startsWith(`..${sep}`) || relative(root, result) === '..') fail('local path escaped the acquisition root');
+  return result;
+}
+
+function assertNoSymlink(path: string, label: string): void {
+  if (existsSync(path) && lstatSync(path).isSymbolicLink()) fail(`${label} is a symlink`);
+}
+
+function ensureSafeDirectory(path: string, stopAt: string): void {
+  const relation = relative(stopAt, path);
+  if (relation.startsWith(`..${sep}`) || relation === '..') fail('local directory escaped the acquisition root');
+  let current = stopAt;
+  if (!existsSync(current)) {
+    assertNoSymlink(dirname(current), 'acquisition-root parent');
+    mkdirSync(current);
+  }
+  const rootStat = lstatSync(current);
+  if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) fail('acquisition root is not a safe directory');
+  for (const segment of relation.split(sep).filter(Boolean)) {
+    current = join(current, segment);
+    if (existsSync(current)) {
+      const stat = lstatSync(current);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) fail(`local parent ${current} is not a safe directory`);
+    } else {
+      mkdirSync(current);
+      const stat = lstatSync(current);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) fail(`created local parent ${current} is not a safe directory`);
+    }
+  }
+}
+
+function assertDestinationAbsent(path: string, label: string): void {
+  if (existsSync(path)) fail(`${label} violates no-clobber policy: destination already exists`);
+}
+
+/** Atomically link an owned temporary file into place; never replace an existing target. */
+export function writeNoClobber(path: string, bytes: Uint8Array, localBoundary: string, label: string): void {
+  const destination = resolve(path);
+  const relation = relative(localBoundary, destination);
+  if (relation.startsWith(`..${sep}`) || relation === '..') fail(`${label} escaped its permitted storage root`);
+  ensureSafeDirectory(dirname(destination), localBoundary);
+  assertDestinationAbsent(destination, label);
+  const temporary = `${destination}.tmp-${randomUUID()}`;
+  try {
+    writeFileSync(temporary, bytes, { flag: 'wx', mode: 0o600 });
+    linkSync(temporary, destination);
+  } catch (error) {
+    if (existsSync(temporary)) unlinkSync(temporary);
+    throw error;
+  }
+  unlinkSync(temporary);
+}
+
+function assertLocalEvidence(cwd: string, evidence: LocalEvidence, label: string): void {
+  assertLocalRelativePath(evidence.path, `${label}.path`);
+  const path = relativeToLocal(cwd, evidence.path);
+  if (!existsSync(path)) fail(`${label} is missing`);
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) fail(`${label} is not a safe regular file`);
+  const bytes = readFileSync(path);
+  if (bytes.byteLength !== evidence.bytes || sha256(bytes) !== evidence.sha256) fail(`${label} byte identity drifted`);
+}
+
+function localEvidence(path: string, bytes: Uint8Array): LocalEvidence {
+  assertLocalRelativePath(path, 'receipt evidence path');
+  return { path, bytes: bytes.byteLength, sha256: sha256(bytes) };
+}
+
+function evidencePaths(artifact: AquinasGutenbergArtifact): Readonly<{ unrestrictedUseNotice: string; electronicEditionProvenance: string }> {
+  return {
+    unrestrictedUseNotice: `local/evidence/pg${artifact.ebookId}-unrestricted-use-notice.html`,
+    electronicEditionProvenance: `local/evidence/pg${artifact.ebookId}-electronic-edition-provenance.html`,
+  };
+}
+
+async function cancel(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best effort only; the original rejection is the diagnostic that matters.
+  }
+}
+
+async function readBoundedResponse(response: Response, maximum: number, label: string): Promise<Buffer> {
+  if (!response.body) fail(`${label} returned no body`);
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      total += next.value.byteLength;
+      if (total > maximum) {
+        await reader.cancel();
+        fail(`${label} exceeded its hard byte bound of ${maximum}`);
+      }
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks.map(chunk => Buffer.from(chunk)), total);
+}
+
+export async function fetchExactGutenbergBytes(url: string, maximum: number, label: string, fetchImpl: FetchLike = fetch): Promise<Buffer> {
+  const parsed = assertApprovedGutenbergUrl(url, label);
+  const response = await fetchImpl(parsed.toString(), { redirect: 'manual' });
+  if (response.status >= 300 && response.status < 400) {
+    const location = response.headers.get('location') ?? '(missing)';
+    await cancel(response);
+    fail(`${label} redirected to an unapproved or mutable endpoint (${location})`);
+  }
+  if (response.status !== 200) {
+    await cancel(response);
+    fail(`${label} returned HTTP ${response.status}`);
+  }
+  return readBoundedResponse(response, maximum, label);
+}
+
+type Candidate = Readonly<{
+  artifact: AquinasGutenbergArtifact;
+  archive: Buffer;
+  catalog: Buffer;
+  html: Buffer;
+  evidence: Readonly<{ unrestrictedUseNotice: Buffer; electronicEditionProvenance: Buffer }>;
+}>;
+
+async function downloadAndValidate(lock: AquinasGutenbergSourceLock, artifact: AquinasGutenbergArtifact, fetchImpl: FetchLike): Promise<Candidate> {
+  const [archive, catalog] = await Promise.all([
+    fetchExactGutenbergBytes(artifact.archive.url, Math.min(MAX_ARCHIVE_BYTES, artifact.archive.bytes), `eBook ${artifact.ebookId} archive`, fetchImpl),
+    fetchExactGutenbergBytes(artifact.catalogSnapshot.url, MAX_CATALOG_BYTES, `eBook ${artifact.ebookId} catalog`, fetchImpl),
+  ]);
+  const html = extractAndVerifyLockedHtml(artifact, archive);
+  assertCatalog(artifact, catalog, lock);
+  return { artifact, archive, catalog, html, evidence: evidenceSlices(html, artifact, lock) };
+}
+
+function assertAcquisitionDestinationsEmpty(cwd: string, lock: AquinasGutenbergSourceLock): void {
+  const receipt = resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
+  assertNoSymlink(dirname(receipt), 'receipt parent');
+  assertDestinationAbsent(receipt, 'receipt');
+  for (const artifact of lock.artifacts) {
+    for (const candidate of [artifact.archive.localPath, artifact.catalogSnapshot.localPath, ...Object.values(evidencePaths(artifact))]) {
+      const path = relativeToLocal(cwd, candidate);
+      assertNoSymlink(dirname(path), `destination parent for ${candidate}`);
+      assertDestinationAbsent(path, candidate);
+    }
+  }
+}
+
+function makeReceipt(lock: AquinasGutenbergSourceLock, candidates: readonly Candidate[]): AquinasGutenbergReceipt {
+  return {
+    schemaVersion: AQUINAS_GUTENBERG_RECEIPT_VERSION,
+    sourceLockSha256: EXPECTED_SOURCE_LOCK_SHA256,
+    acquiredAt: new Date().toISOString(),
+    artifacts: candidates.map(({ artifact, archive, catalog, html, evidence }) => {
+      const paths = evidencePaths(artifact);
+      return {
+        ebookId: artifact.ebookId,
+        archive: localEvidence(artifact.archive.localPath, archive),
+        catalogSnapshot: localEvidence(artifact.catalogSnapshot.localPath, catalog),
+        htmlMember: { path: artifact.htmlMember.path, bytes: html.byteLength, sha256: sha256(html) },
+        unrestrictedUseNotice: localEvidence(paths.unrestrictedUseNotice, evidence.unrestrictedUseNotice),
+        electronicEditionProvenance: localEvidence(paths.electronicEditionProvenance, evidence.electronicEditionProvenance),
+      };
+    }),
+  };
+}
+
+function receiptBytes(receipt: AquinasGutenbergReceipt): Buffer {
+  return Buffer.from(`${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+}
+
+function writeReceiptNoClobber(cwd: string, receipt: AquinasGutenbergReceipt): void {
+  const path = resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
+  const root = resolve(cwd);
+  writeNoClobber(path, receiptBytes(receipt), root, 'receipt');
+}
+
+function parseLocalEvidence(value: unknown, label: string): LocalEvidence {
+  const evidence = record(value, label);
+  exactKeys(evidence, ['path', 'bytes', 'sha256'], label);
+  const path = string(evidence.path, `${label}.path`);
+  assertLocalRelativePath(path, `${label}.path`);
+  return { path, bytes: positiveInteger(evidence.bytes, `${label}.bytes`), sha256: hex(string(evidence.sha256, `${label}.sha256`), `${label}.sha256`) };
+}
+
+function parseReceipt(value: unknown, lock: AquinasGutenbergSourceLock): AquinasGutenbergReceipt {
+  const source = record(value, 'receipt');
+  exactKeys(source, ['schemaVersion', 'sourceLockSha256', 'acquiredAt', 'artifacts'], 'receipt');
+  if (source.schemaVersion !== AQUINAS_GUTENBERG_RECEIPT_VERSION || source.sourceLockSha256 !== EXPECTED_SOURCE_LOCK_SHA256) fail('receipt does not bind the reviewed source lock');
+  const acquiredAt = string(source.acquiredAt, 'receipt.acquiredAt');
+  if (Number.isNaN(Date.parse(acquiredAt)) || !acquiredAt.endsWith('Z')) fail('receipt.acquiredAt is not a UTC ISO timestamp');
+  const artifacts = array(source.artifacts, 'receipt.artifacts').map((value, index) => {
+    const entry = record(value, `receipt artifact ${index}`);
+    exactKeys(entry, ['ebookId', 'archive', 'catalogSnapshot', 'htmlMember', 'unrestrictedUseNotice', 'electronicEditionProvenance'], `receipt artifact ${index}`);
+    const html = record(entry.htmlMember, `receipt artifact ${index}.htmlMember`);
+    exactKeys(html, ['path', 'bytes', 'sha256'], `receipt artifact ${index}.htmlMember`);
+    return {
+      ebookId: positiveInteger(entry.ebookId, `receipt artifact ${index}.ebookId`),
+      archive: parseLocalEvidence(entry.archive, `receipt artifact ${index}.archive`),
+      catalogSnapshot: parseLocalEvidence(entry.catalogSnapshot, `receipt artifact ${index}.catalogSnapshot`),
+      htmlMember: {
+        path: string(html.path, `receipt artifact ${index}.htmlMember.path`),
+        bytes: positiveInteger(html.bytes, `receipt artifact ${index}.htmlMember.bytes`),
+        sha256: hex(string(html.sha256, `receipt artifact ${index}.htmlMember.sha256`), `receipt artifact ${index}.htmlMember.sha256`),
+      },
+      unrestrictedUseNotice: parseLocalEvidence(entry.unrestrictedUseNotice, `receipt artifact ${index}.unrestrictedUseNotice`),
+      electronicEditionProvenance: parseLocalEvidence(entry.electronicEditionProvenance, `receipt artifact ${index}.electronicEditionProvenance`),
+    };
+  });
+  if (artifacts.length !== lock.artifacts.length || artifacts.some((artifact, index) => artifact.ebookId !== lock.artifacts[index]!.ebookId)) fail('receipt does not retain all four locked artifacts in order');
+  return { schemaVersion: AQUINAS_GUTENBERG_RECEIPT_VERSION, sourceLockSha256: EXPECTED_SOURCE_LOCK_SHA256, acquiredAt, artifacts };
+}
+
+function assertReceiptMatchesLock(receipt: AquinasGutenbergReceipt, lock: AquinasGutenbergSourceLock): void {
+  for (const [index, artifact] of lock.artifacts.entries()) {
+    const entry = receipt.artifacts[index]!;
+    const paths = evidencePaths(artifact);
+    if (entry.archive.path !== artifact.archive.localPath || entry.archive.bytes !== artifact.archive.bytes || entry.archive.sha256 !== artifact.archive.sha256 || entry.catalogSnapshot.path !== artifact.catalogSnapshot.localPath || entry.catalogSnapshot.bytes !== artifact.catalogSnapshot.bytes || entry.catalogSnapshot.sha256 !== artifact.catalogSnapshot.sha256 || entry.htmlMember.path !== artifact.htmlMember.path || entry.htmlMember.bytes !== artifact.htmlMember.bytes || entry.htmlMember.sha256 !== artifact.htmlMember.sha256 || entry.unrestrictedUseNotice.path !== paths.unrestrictedUseNotice || entry.electronicEditionProvenance.path !== paths.electronicEditionProvenance) {
+      fail(`receipt artifact ${artifact.ebookId} drifted from the locked identity`);
+    }
+  }
+}
+
+export async function preflightAquinasGutenbergAcquisition(cwd = ROOT, fetchImpl: FetchLike = fetch): Promise<AquinasGutenbergSourceLock> {
+  const lock = readAquinasGutenbergSourceLock(cwd);
+  await Promise.all(lock.artifacts.map(artifact => downloadAndValidate(lock, artifact, fetchImpl)));
+  return lock;
+}
+
+export async function acquireAquinasGutenberg(cwd = ROOT, fetchImpl: FetchLike = fetch): Promise<AquinasGutenbergReceipt> {
+  const lock = readAquinasGutenbergSourceLock(cwd);
+  assertAcquisitionDestinationsEmpty(cwd, lock);
+  // Validate every remote byte in memory before the first local write.
+  const candidates = await Promise.all(lock.artifacts.map(artifact => downloadAndValidate(lock, artifact, fetchImpl)));
+  for (const candidate of candidates) {
+    const { artifact, archive, catalog, evidence } = candidate;
+    writeNoClobber(relativeToLocal(cwd, artifact.archive.localPath), archive, localRoot(cwd), `eBook ${artifact.ebookId} archive`);
+    writeNoClobber(relativeToLocal(cwd, artifact.catalogSnapshot.localPath), catalog, localRoot(cwd), `eBook ${artifact.ebookId} catalog snapshot`);
+    const paths = evidencePaths(artifact);
+    writeNoClobber(relativeToLocal(cwd, paths.unrestrictedUseNotice), evidence.unrestrictedUseNotice, localRoot(cwd), `eBook ${artifact.ebookId} unrestricted-use evidence`);
+    writeNoClobber(relativeToLocal(cwd, paths.electronicEditionProvenance), evidence.electronicEditionProvenance, localRoot(cwd), `eBook ${artifact.ebookId} provenance evidence`);
+  }
+  const receipt = makeReceipt(lock, candidates);
+  writeReceiptNoClobber(cwd, receipt);
+  return verifyLocalAquinasGutenbergAcquisition(cwd);
+}
+
+export function verifyLocalAquinasGutenbergAcquisition(cwd = ROOT): AquinasGutenbergReceipt {
+  const lock = readAquinasGutenbergSourceLock(cwd);
+  const receiptPath = resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
+  if (!existsSync(receiptPath)) fail('local acquisition receipt is missing');
+  const receiptStat = lstatSync(receiptPath);
+  if (receiptStat.isSymbolicLink() || !receiptStat.isFile()) fail('local acquisition receipt is not a safe regular file');
+  const receipt = parseReceipt(JSON.parse(strictUtf8(readFileSync(receiptPath), 'local acquisition receipt')), lock);
+  assertReceiptMatchesLock(receipt, lock);
+  for (const [index, artifact] of lock.artifacts.entries()) {
+    const entry = receipt.artifacts[index]!;
+    assertLocalEvidence(cwd, entry.archive, `eBook ${artifact.ebookId} archive`);
+    assertLocalEvidence(cwd, entry.catalogSnapshot, `eBook ${artifact.ebookId} catalog snapshot`);
+    assertLocalEvidence(cwd, entry.unrestrictedUseNotice, `eBook ${artifact.ebookId} unrestricted-use evidence`);
+    assertLocalEvidence(cwd, entry.electronicEditionProvenance, `eBook ${artifact.ebookId} provenance evidence`);
+    const archive = readFileSync(relativeToLocal(cwd, artifact.archive.localPath));
+    const html = extractAndVerifyLockedHtml(artifact, archive);
+    const catalog = readFileSync(relativeToLocal(cwd, artifact.catalogSnapshot.localPath));
+    assertCatalog(artifact, catalog, lock);
+    const evidence = evidenceSlices(html, artifact, lock);
+    if (sha256(evidence.unrestrictedUseNotice) !== entry.unrestrictedUseNotice.sha256 || sha256(evidence.electronicEditionProvenance) !== entry.electronicEditionProvenance.sha256) fail(`eBook ${artifact.ebookId} local evidence extraction drifted`);
+  }
+  return receipt;
+}
+
+async function main(): Promise<void> {
+  const command = process.argv[2];
+  if (command === '--preflight') {
+    const lock = await preflightAquinasGutenbergAcquisition();
+    console.error(`[aquinas-gutenberg-acquisition] preflight passed for ${lock.artifacts.length} locked Project Gutenberg artifacts.`);
+    return;
+  }
+  if (command === '--acquire') {
+    const receipt = await acquireAquinasGutenberg();
+    console.error(`[aquinas-gutenberg-acquisition] acquired ${receipt.artifacts.length} locked artifacts; receipt binds ${receipt.sourceLockSha256}.`);
+    return;
+  }
+  if (command === '--verify-local') {
+    const receipt = verifyLocalAquinasGutenbergAcquisition();
+    console.error(`[aquinas-gutenberg-acquisition] local verification passed for ${receipt.artifacts.length} locked artifacts.`);
+    return;
+  }
+  fail('use exactly one of --preflight, --acquire, or --verify-local');
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/aquinas-gutenberg-acquisition.ts
+++ b/scripts/aquinas-gutenberg-acquisition.ts
@@ -11,11 +11,13 @@ import { existsSync, linkSync, lstatSync, mkdirSync, readFileSync, unlinkSync, w
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { inflateRawSync } from 'node:zlib';
+import { parse, type DefaultTreeAdapterTypes } from 'parse5';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 export const AQUINAS_GUTENBERG_ROOT = 'data/historical-sources/project-gutenberg/aquinas-english-dominican';
 export const AQUINAS_GUTENBERG_SOURCE_LOCK_PATH = `${AQUINAS_GUTENBERG_ROOT}/SOURCE_LOCK.json`;
+export const AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH = `${AQUINAS_GUTENBERG_ROOT}/CATALOG_IDENTITY_LOCK.json`;
 // Reviewed, tracked evidence from the approved acquisition. Keep this path and
 // its bytes stable because downstream topology locks bind its digest.
 export const AQUINAS_GUTENBERG_RECEIPT_PATH = `${AQUINAS_GUTENBERG_ROOT}/LOCAL_ACQUISITION_RECEIPT.json`;
@@ -24,11 +26,14 @@ export const AQUINAS_GUTENBERG_RECEIPT_PATH = `${AQUINAS_GUTENBERG_ROOT}/LOCAL_A
 export const AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH = 'local/LOCAL_ACQUISITION_RECEIPT.json';
 export const AQUINAS_GUTENBERG_SOURCE_LOCK_VERSION = 'theologai-aquinas-gutenberg-source-lock.v1';
 export const AQUINAS_GUTENBERG_RECEIPT_VERSION = 'theologai-aquinas-gutenberg-local-receipt.v1';
+export const AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_VERSION = 'theologai-aquinas-gutenberg-catalog-identity-lock.v1';
+export const AQUINAS_GUTENBERG_GENERATED_RECEIPT_VERSION = 'theologai-aquinas-gutenberg-generated-receipt.v1';
 
 // This binds the reviewed lock byte-for-byte. Changing a pin requires review of
 // both the JSON and this executable guard; a receipt alone cannot redefine it.
 const EXPECTED_SOURCE_LOCK_SHA256 = 'c5cfdd1edd132bf59968cbabe4c7de2180c42d205735ca6c06aec626104a180b';
 const EXPECTED_REVIEWED_RECEIPT_SHA256 = 'bc0dab9ce5dc3672ccf2a81182655c75eaf6ef4f280584a40e079bf82a11719d';
+const EXPECTED_CATALOG_IDENTITY_LOCK_SHA256 = 'f3ac77059cf8a4da57d97f0d3ac9f3a52fc323102ccfa8fee540ce89c28d7068';
 const GUTENBERG_HOST = 'www.gutenberg.org';
 const MAX_ARCHIVE_BYTES = 2_000_000;
 const MAX_CATALOG_BYTES = 128_000;
@@ -110,6 +115,51 @@ export type AquinasGutenbergReceipt = Readonly<{
   artifacts: readonly AquinasGutenbergReceiptArtifact[];
 }>;
 
+export type AquinasGutenbergCatalogSemanticIdentity = Readonly<{
+  author: Readonly<{ name: string; agentPath: string; agentAboutPath: string }>;
+  titleLines: readonly string[];
+  credits: string;
+  language: Readonly<{ code: string; label: string }>;
+  locClass: string;
+  category: string;
+  release: Readonly<{ machineDate: string; displayDate: string }>;
+  lastUpdate: Readonly<{ machineDate: string; displayDate: string }> | null;
+  rightsStatement: string;
+  archiveDownload: Readonly<{ path: string; mediaType: string; label: string }>;
+}>;
+
+export type AquinasGutenbergCatalogIdentityArtifact = Readonly<{
+  ebookId: number;
+  catalogPath: string;
+  semanticIdentity: AquinasGutenbergCatalogSemanticIdentity;
+}>;
+
+export type AquinasGutenbergCatalogIdentityLock = Readonly<{
+  schemaVersion: typeof AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_VERSION;
+  sourceLockSha256: string;
+  reviewedReceiptSha256: string;
+  artifacts: readonly AquinasGutenbergCatalogIdentityArtifact[];
+}>;
+
+export type AquinasGutenbergGeneratedReceiptArtifact = Omit<AquinasGutenbergReceiptArtifact, 'catalogSnapshot'> & Readonly<{
+  catalogSnapshot: LocalEvidence & Readonly<{ semanticIdentitySha256: string }>;
+}>;
+
+export type AquinasGutenbergGeneratedReceipt = Readonly<{
+  schemaVersion: typeof AQUINAS_GUTENBERG_GENERATED_RECEIPT_VERSION;
+  sourceLockSha256: string;
+  reviewedReceiptSha256: string;
+  catalogIdentityLockSha256: string;
+  acquiredAt: string;
+  artifacts: readonly AquinasGutenbergGeneratedReceiptArtifact[];
+}>;
+
+export type AquinasGutenbergReviewedPins = Readonly<{
+  sourceLockSha256: string;
+  reviewedReceiptSha256: string;
+  catalogIdentityLockSha256: string;
+}>;
+
 type JsonRecord = Record<string, unknown>;
 type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 type ZipMember = Readonly<{
@@ -160,6 +210,12 @@ function exactKeys(value: JsonRecord, keys: readonly string[], label: string): v
 function hex(value: string, label: string): string {
   if (!/^[a-f0-9]{64}$/.test(value)) fail(`${label} must be a lowercase SHA-256 digest`);
   return value;
+}
+
+function exactStringArray(value: unknown, expected: readonly string[], label: string): readonly string[] {
+  const observed = array(value, label).map((entry, index) => string(entry, `${label}[${index}]`));
+  if (observed.length !== expected.length || observed.some((entry, index) => entry !== expected[index])) fail(`${label} drifted`);
+  return observed;
 }
 
 export function sha256(bytes: Uint8Array): string {
@@ -322,10 +378,109 @@ export function sourceLockDigest(cwd = ROOT): string {
   return sha256(readFileSync(resolve(cwd, AQUINAS_GUTENBERG_SOURCE_LOCK_PATH)));
 }
 
-export function readAquinasGutenbergSourceLock(cwd = ROOT): AquinasGutenbergSourceLock {
+function defaultReviewedPins(): AquinasGutenbergReviewedPins {
+  return {
+    sourceLockSha256: EXPECTED_SOURCE_LOCK_SHA256,
+    reviewedReceiptSha256: EXPECTED_REVIEWED_RECEIPT_SHA256,
+    catalogIdentityLockSha256: EXPECTED_CATALOG_IDENTITY_LOCK_SHA256,
+  };
+}
+
+export function readAquinasGutenbergSourceLock(cwd = ROOT, pins: AquinasGutenbergReviewedPins = defaultReviewedPins()): AquinasGutenbergSourceLock {
   const bytes = readFileSync(resolve(cwd, AQUINAS_GUTENBERG_SOURCE_LOCK_PATH));
-  if (sha256(bytes) !== EXPECTED_SOURCE_LOCK_SHA256) fail('source lock byte identity drifted from the reviewed lock');
+  if (sha256(bytes) !== pins.sourceLockSha256) fail('source lock byte identity drifted from the reviewed lock');
   return parseAquinasGutenbergSourceLock(JSON.parse(strictUtf8(bytes, 'source lock')));
+}
+
+const CATALOG_INVARIANT_FIELDS = [
+  'ebookId', 'catalogPath', 'author.name', 'author.agentPath', 'author.agentAboutPath', 'titleLines', 'credits',
+  'language.code', 'language.label', 'locClass', 'category', 'release.machineDate',
+  'release.displayDate', 'lastUpdate.machineDate', 'lastUpdate.displayDate',
+  'rightsStatement', 'archiveDownload.path', 'archiveDownload.mediaType', 'archiveDownload.label',
+] as const;
+
+function parseCatalogSemanticIdentity(value: unknown, ebookId: number, label: string): AquinasGutenbergCatalogSemanticIdentity {
+  const identity = record(value, label);
+  exactKeys(identity, ['author', 'titleLines', 'credits', 'language', 'locClass', 'category', 'release', 'lastUpdate', 'rightsStatement', 'archiveDownload'], label);
+  const author = record(identity.author, `${label}.author`);
+  exactKeys(author, ['name', 'agentPath', 'agentAboutPath'], `${label}.author`);
+  const language = record(identity.language, `${label}.language`);
+  exactKeys(language, ['code', 'label'], `${label}.language`);
+  const release = record(identity.release, `${label}.release`);
+  exactKeys(release, ['machineDate', 'displayDate'], `${label}.release`);
+  const lastUpdate = identity.lastUpdate === null ? null : record(identity.lastUpdate, `${label}.lastUpdate`);
+  if (lastUpdate) exactKeys(lastUpdate, ['machineDate', 'displayDate'], `${label}.lastUpdate`);
+  const archive = record(identity.archiveDownload, `${label}.archiveDownload`);
+  exactKeys(archive, ['path', 'mediaType', 'label'], `${label}.archiveDownload`);
+  const agentPath = string(author.agentPath, `${label}.author.agentPath`);
+  if (!/^\/ebooks\/author\/[1-9][0-9]*$/.test(agentPath)) fail(`${label}.author.agentPath is not an exact Gutenberg agent path`);
+  const agentAboutPath = string(author.agentAboutPath, `${label}.author.agentAboutPath`);
+  if (!/^\/authors\/[1-9][0-9]*$/.test(agentAboutPath) || agentAboutPath.slice('/authors/'.length) !== agentPath.slice('/ebooks/author/'.length)) fail(`${label}.author agent identifiers disagree`);
+  const archivePath = string(archive.path, `${label}.archiveDownload.path`);
+  if (archivePath !== `/cache/epub/${ebookId}/pg${ebookId}-h.zip`) fail(`${label}.archiveDownload.path drifted`);
+  const titleLines = array(identity.titleLines, `${label}.titleLines`).map((entry, index) => string(entry, `${label}.titleLines[${index}]`));
+  if (titleLines.length !== 2) fail(`${label}.titleLines must contain exactly two reviewed lines`);
+  return {
+    author: { name: string(author.name, `${label}.author.name`), agentPath, agentAboutPath },
+    titleLines,
+    credits: string(identity.credits, `${label}.credits`),
+    language: { code: string(language.code, `${label}.language.code`), label: string(language.label, `${label}.language.label`) },
+    locClass: string(identity.locClass, `${label}.locClass`),
+    category: string(identity.category, `${label}.category`),
+    release: { machineDate: string(release.machineDate, `${label}.release.machineDate`), displayDate: string(release.displayDate, `${label}.release.displayDate`) },
+    lastUpdate: lastUpdate ? { machineDate: string(lastUpdate.machineDate, `${label}.lastUpdate.machineDate`), displayDate: string(lastUpdate.displayDate, `${label}.lastUpdate.displayDate`) } : null,
+    rightsStatement: string(identity.rightsStatement, `${label}.rightsStatement`),
+    archiveDownload: { path: archivePath, mediaType: string(archive.mediaType, `${label}.archiveDownload.mediaType`), label: string(archive.label, `${label}.archiveDownload.label`) },
+  };
+}
+
+export function parseAquinasGutenbergCatalogIdentityLock(value: unknown): AquinasGutenbergCatalogIdentityLock {
+  const lock = record(value, 'catalog identity lock');
+  exactKeys(lock, ['schemaVersion', 'sourceLockSha256', 'reviewedReceiptSha256', 'normalization', 'invariantFields', 'allowedVolatility', 'outOfProjectionPresentation', 'artifacts'], 'catalog identity lock');
+  if (lock.schemaVersion !== AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_VERSION) fail('unsupported catalog identity lock schema');
+  const normalization = record(lock.normalization, 'catalog identity normalization');
+  exactKeys(normalization, ['parser', 'text', 'projection', 'rawSnapshot'], 'catalog identity normalization');
+  for (const key of ['parser', 'text', 'projection', 'rawSnapshot']) string(normalization[key], `catalog identity normalization.${key}`);
+  exactStringArray(lock.invariantFields, CATALOG_INVARIANT_FIELDS, 'catalog identity invariantFields');
+  const volatility = array(lock.allowedVolatility, 'catalog identity allowedVolatility');
+  const expectedVolatility = [
+    ['siteWideFreeEbookCount', '^[0-9]{1,3}(,[0-9]{3})* free eBooks$', 'unique breadcrumb link href=/ebooks/ and its unique itemprop=name span'],
+    ['downloadsLast30Days', '^[0-9]{1,12} downloads in the last 30 days\\.$', 'unique Downloads row in table#about_book_table'],
+  ] as const;
+  if (volatility.length !== expectedVolatility.length) fail('catalog identity allowedVolatility drifted');
+  volatility.forEach((value, index) => {
+    const entry = record(value, `catalog identity allowedVolatility[${index}]`);
+    exactKeys(entry, ['field', 'syntax', 'locator'], `catalog identity allowedVolatility[${index}]`);
+    if (entry.field !== expectedVolatility[index]![0] || entry.syntax !== expectedVolatility[index]![1] || entry.locator !== expectedVolatility[index]![2]) fail(`catalog identity allowedVolatility[${index}] drifted`);
+  });
+  exactStringArray(lock.outOfProjectionPresentation, ['descriptive summary', 'reading-level estimate', 'site navigation and styling', 'non-archive download-format presentation'], 'catalog identity outOfProjectionPresentation');
+  const artifacts = array(lock.artifacts, 'catalog identity artifacts').map((value, index) => {
+    const artifact = record(value, `catalog identity artifact ${index}`);
+    exactKeys(artifact, ['ebookId', 'catalogPath', 'semanticIdentity'], `catalog identity artifact ${index}`);
+    const ebookId = positiveInteger(artifact.ebookId, `catalog identity artifact ${index}.ebookId`);
+    const catalogPath = string(artifact.catalogPath, `catalog identity artifact ${index}.catalogPath`);
+    if (catalogPath !== `/ebooks/${ebookId}`) fail(`catalog identity artifact ${index}.catalogPath drifted`);
+    return { ebookId, catalogPath, semanticIdentity: parseCatalogSemanticIdentity(artifact.semanticIdentity, ebookId, `catalog identity artifact ${index}.semanticIdentity`) };
+  });
+  if (artifacts.length !== 4 || artifacts.some((artifact, index) => artifact.ebookId !== [17611, 17897, 18755, 19950][index])) fail('catalog identity lock topology drifted');
+  return {
+    schemaVersion: AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_VERSION,
+    sourceLockSha256: hex(string(lock.sourceLockSha256, 'catalog identity sourceLockSha256'), 'catalog identity sourceLockSha256'),
+    reviewedReceiptSha256: hex(string(lock.reviewedReceiptSha256, 'catalog identity reviewedReceiptSha256'), 'catalog identity reviewedReceiptSha256'),
+    artifacts,
+  };
+}
+
+export function readAquinasGutenbergCatalogIdentityLock(cwd = ROOT, pins: AquinasGutenbergReviewedPins = defaultReviewedPins()): AquinasGutenbergCatalogIdentityLock {
+  const bytes = readFileSync(resolve(cwd, AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH));
+  if (sha256(bytes) !== pins.catalogIdentityLockSha256) fail('catalog identity lock byte identity drifted');
+  const lock = parseAquinasGutenbergCatalogIdentityLock(JSON.parse(strictUtf8(bytes, 'catalog identity lock')));
+  if (lock.sourceLockSha256 !== pins.sourceLockSha256 || lock.reviewedReceiptSha256 !== pins.reviewedReceiptSha256) fail('catalog identity lock does not bind the reviewed source and receipt');
+  return lock;
+}
+
+export function catalogSemanticIdentityDigest(artifact: AquinasGutenbergCatalogIdentityArtifact): string {
+  return sha256(Buffer.from(`theologai-aquinas-gutenberg-catalog-semantic-identity.v1\0${JSON.stringify(artifact)}`, 'utf8'));
 }
 
 function crcTable(): Uint32Array {
@@ -509,18 +664,105 @@ function evidenceSlices(htmlBytes: Uint8Array, artifact: AquinasGutenbergArtifac
   };
 }
 
-function assertCatalog(artifact: AquinasGutenbergArtifact, catalogBytes: Uint8Array, lock: AquinasGutenbergSourceLock): void {
-  if (catalogBytes.byteLength !== artifact.catalogSnapshot.bytes || sha256(catalogBytes) !== artifact.catalogSnapshot.sha256) fail(`eBook ${artifact.ebookId} catalog snapshot byte identity drifted`);
-  const catalog = strictUtf8(catalogBytes, `eBook ${artifact.ebookId} catalog snapshot`);
-  const required = [
-    `<td>${artifact.ebookId}</td>`,
-    `content="${artifact.catalogSnapshot.issuedMachineDate}"`,
-    artifact.catalogSnapshot.releaseDate,
-    lock.rightsAndProvenance.catalogStatement,
-  ];
-  if (artifact.catalogSnapshot.lastUpdate) required.push('<th>Last Update</th>', artifact.catalogSnapshot.lastUpdate);
-  for (const phrase of required) if (!catalog.includes(phrase)) fail(`eBook ${artifact.ebookId} catalog metadata evidence mismatched`);
-  if (artifact.catalogSnapshot.lastUpdate === null && catalog.includes('<th>Last Update</th>')) fail(`eBook ${artifact.ebookId} catalog unexpectedly has update metadata`);
+type HtmlNode = DefaultTreeAdapterTypes.Node;
+type HtmlElement = DefaultTreeAdapterTypes.Element;
+
+function isHtmlElement(node: HtmlNode): node is HtmlElement {
+  return 'tagName' in node;
+}
+
+function htmlChildren(node: HtmlNode): readonly HtmlNode[] {
+  return 'childNodes' in node ? node.childNodes : [];
+}
+
+function htmlElements(root: HtmlNode, predicate: (element: HtmlElement) => boolean): HtmlElement[] {
+  const matches: HtmlElement[] = [];
+  const visit = (node: HtmlNode): void => {
+    if (isHtmlElement(node) && predicate(node)) matches.push(node);
+    for (const child of htmlChildren(node)) visit(child);
+  };
+  visit(root);
+  return matches;
+}
+
+function htmlAttribute(element: HtmlElement, name: string): string | null {
+  return element.attrs.find(attribute => attribute.name === name)?.value ?? null;
+}
+
+function normalizedHtmlText(node: HtmlNode, preserveBreaks = false): string {
+  const collect = (current: HtmlNode): string => {
+    if ('value' in current && current.nodeName === '#text') return current.value;
+    if (preserveBreaks && isHtmlElement(current) && current.tagName === 'br') return '\n';
+    return htmlChildren(current).map(collect).join('');
+  };
+  const raw = collect(node).replace(/\r\n?/g, '\n');
+  if (!preserveBreaks) return raw.replace(/\s+/g, ' ').trim();
+  return raw.split('\n').map(line => line.replace(/\s+/g, ' ').trim()).filter(Boolean).join('\n');
+}
+
+function uniqueHtmlElement(root: HtmlNode, predicate: (element: HtmlElement) => boolean, label: string): HtmlElement {
+  const matches = htmlElements(root, predicate);
+  if (matches.length !== 1) fail(`${label} must occur exactly once`);
+  return matches[0]!;
+}
+
+/** Extract the closed semantic projection; only the two lock-documented counters may vary. */
+export function extractAndVerifyCatalogSemanticIdentity(
+  sourceArtifact: AquinasGutenbergArtifact,
+  identityArtifact: AquinasGutenbergCatalogIdentityArtifact,
+  catalogBytes: Uint8Array,
+  sourceLock: AquinasGutenbergSourceLock,
+): AquinasGutenbergCatalogSemanticIdentity {
+  if (sourceArtifact.ebookId !== identityArtifact.ebookId || new URL(sourceArtifact.catalogSnapshot.url).pathname !== identityArtifact.catalogPath) fail(`eBook ${sourceArtifact.ebookId} catalog locks disagree`);
+  if (catalogBytes.byteLength === 0 || catalogBytes.byteLength > MAX_CATALOG_BYTES) fail(`eBook ${sourceArtifact.ebookId} catalog snapshot exceeds its byte contract`);
+  const document = parse(strictUtf8(catalogBytes, `eBook ${sourceArtifact.ebookId} catalog snapshot`));
+  uniqueHtmlElement(document, element => element.tagName === 'div' && htmlAttribute(element, 'typeof') === 'pgterms:ebook' && htmlAttribute(element, 'about') === `[ebook:${sourceArtifact.ebookId}]`, `eBook ${sourceArtifact.ebookId} catalog identity container`);
+  const siteCountLink = uniqueHtmlElement(document, element => element.tagName === 'a' && htmlAttribute(element, 'href') === '/ebooks/' && htmlAttribute(element, 'title') === 'Start a new search.', `eBook ${sourceArtifact.ebookId} site-wide counter link`);
+  const siteCount = uniqueHtmlElement(siteCountLink, element => element.tagName === 'span' && htmlAttribute(element, 'itemprop') === 'name', `eBook ${sourceArtifact.ebookId} site-wide counter`);
+  if (!/^[0-9]{1,3}(,[0-9]{3})* free eBooks$/.test(normalizedHtmlText(siteCount))) fail(`eBook ${sourceArtifact.ebookId} site-wide counter is malformed`);
+  const table = uniqueHtmlElement(document, element => element.tagName === 'table' && htmlAttribute(element, 'id') === 'about_book_table', `eBook ${sourceArtifact.ebookId} catalog metadata table`);
+  const rows = htmlElements(table, element => element.tagName === 'tr').map(row => {
+    const headings = htmlElements(row, element => element.tagName === 'th');
+    const values = htmlElements(row, element => element.tagName === 'td');
+    if (headings.length !== 1 || values.length !== 1) fail(`eBook ${sourceArtifact.ebookId} catalog row is structurally ambiguous`);
+    return { row, value: values[0]!, label: normalizedHtmlText(headings[0]!) };
+  });
+  const requiredRow = (label: string, optional = false): { row: HtmlElement; value: HtmlElement } | null => {
+    const matches = rows.filter(candidate => candidate.label === label);
+    if (matches.length > 1 || (!optional && matches.length !== 1)) fail(`eBook ${sourceArtifact.ebookId} catalog ${label} row must occur exactly once`);
+    return matches[0] ?? null;
+  };
+  const authorRow = requiredRow('Author')!;
+  const authorLink = uniqueHtmlElement(authorRow.value, element => element.tagName === 'a' && htmlAttribute(element, 'itemprop') === 'creator', `eBook ${sourceArtifact.ebookId} catalog author link`);
+  const titleRow = requiredRow('Title')!;
+  const creditsRow = requiredRow('Credits')!;
+  const languageRow = requiredRow('Language')!;
+  const locClassRow = requiredRow('LoC Class')!;
+  const categoryRow = requiredRow('Category')!;
+  const ebookNumberRow = requiredRow('eBook-No.')!;
+  const releaseRow = requiredRow('Release Date')!;
+  const lastUpdateRow = requiredRow('Last Update', true);
+  const rightsRow = requiredRow('Copyright')!;
+  const downloadsRow = requiredRow('Downloads')!;
+  if (!/^[0-9]{1,12} downloads in the last 30 days\.$/.test(normalizedHtmlText(downloadsRow.value))) fail(`eBook ${sourceArtifact.ebookId} 30-day download counter is malformed`);
+  const archiveLink = uniqueHtmlElement(document, element => element.tagName === 'a' && htmlAttribute(element, 'href') === identityArtifact.semanticIdentity.archiveDownload.path, `eBook ${sourceArtifact.ebookId} exact archive link`);
+  const ebookId = Number(normalizedHtmlText(ebookNumberRow.value));
+  if (!Number.isSafeInteger(ebookId) || ebookId !== sourceArtifact.ebookId) fail(`eBook ${sourceArtifact.ebookId} catalog eBook-No. drifted`);
+  const observed: AquinasGutenbergCatalogSemanticIdentity = {
+    author: { name: normalizedHtmlText(authorLink), agentPath: htmlAttribute(authorLink, 'href') ?? '', agentAboutPath: htmlAttribute(authorLink, 'about') ?? '' },
+    titleLines: normalizedHtmlText(titleRow.value, true).split('\n'),
+    credits: normalizedHtmlText(creditsRow.value),
+    language: { code: htmlAttribute(languageRow.row, 'content') ?? '', label: normalizedHtmlText(languageRow.value) },
+    locClass: htmlAttribute(locClassRow.row, 'content') ?? '',
+    category: normalizedHtmlText(categoryRow.value),
+    release: { machineDate: htmlAttribute(releaseRow.row, 'content') ?? '', displayDate: normalizedHtmlText(releaseRow.value) },
+    lastUpdate: lastUpdateRow ? { machineDate: htmlAttribute(lastUpdateRow.row, 'content') ?? '', displayDate: normalizedHtmlText(lastUpdateRow.value) } : null,
+    rightsStatement: normalizedHtmlText(rightsRow.value),
+    archiveDownload: { path: htmlAttribute(archiveLink, 'href') ?? '', mediaType: htmlAttribute(archiveLink, 'type') ?? '', label: normalizedHtmlText(archiveLink) },
+  };
+  const observedArtifact = { ebookId, catalogPath: identityArtifact.catalogPath, semanticIdentity: observed };
+  if (observed.rightsStatement !== sourceLock.rightsAndProvenance.catalogStatement || catalogSemanticIdentityDigest(observedArtifact) !== catalogSemanticIdentityDigest(identityArtifact)) fail(`eBook ${sourceArtifact.ebookId} catalog semantic identity drifted`);
+  return observed;
 }
 
 function localRoot(cwd: string): string {
@@ -653,20 +895,23 @@ export async function fetchExactGutenbergBytes(url: string, maximum: number, lab
 
 type Candidate = Readonly<{
   artifact: AquinasGutenbergArtifact;
+  identityArtifact: AquinasGutenbergCatalogIdentityArtifact;
   archive: Buffer;
   catalog: Buffer;
+  catalogSemanticIdentity: AquinasGutenbergCatalogSemanticIdentity;
   html: Buffer;
   evidence: Readonly<{ unrestrictedUseNotice: Buffer; electronicEditionProvenance: Buffer }>;
 }>;
 
-async function downloadAndValidate(lock: AquinasGutenbergSourceLock, artifact: AquinasGutenbergArtifact, fetchImpl: FetchLike): Promise<Candidate> {
+async function downloadAndValidate(lock: AquinasGutenbergSourceLock, catalogLock: AquinasGutenbergCatalogIdentityLock, artifact: AquinasGutenbergArtifact, index: number, fetchImpl: FetchLike): Promise<Candidate> {
+  const identityArtifact = catalogLock.artifacts[index]!;
   const [archive, catalog] = await Promise.all([
     fetchExactGutenbergBytes(artifact.archive.url, Math.min(MAX_ARCHIVE_BYTES, artifact.archive.bytes), `eBook ${artifact.ebookId} archive`, fetchImpl),
     fetchExactGutenbergBytes(artifact.catalogSnapshot.url, MAX_CATALOG_BYTES, `eBook ${artifact.ebookId} catalog`, fetchImpl),
   ]);
   const html = extractAndVerifyLockedHtml(artifact, archive);
-  assertCatalog(artifact, catalog, lock);
-  return { artifact, archive, catalog, html, evidence: evidenceSlices(html, artifact, lock) };
+  const catalogSemanticIdentity = extractAndVerifyCatalogSemanticIdentity(artifact, identityArtifact, catalog, lock);
+  return { artifact, identityArtifact, archive, catalog, catalogSemanticIdentity, html, evidence: evidenceSlices(html, artifact, lock) };
 }
 
 function assertAcquisitionDestinationsEmpty(cwd: string, lock: AquinasGutenbergSourceLock): void {
@@ -682,17 +927,22 @@ function assertAcquisitionDestinationsEmpty(cwd: string, lock: AquinasGutenbergS
   }
 }
 
-function makeReceipt(lock: AquinasGutenbergSourceLock, candidates: readonly Candidate[]): AquinasGutenbergReceipt {
+function makeGeneratedReceipt(candidates: readonly Candidate[], pins: AquinasGutenbergReviewedPins): AquinasGutenbergGeneratedReceipt {
   return {
-    schemaVersion: AQUINAS_GUTENBERG_RECEIPT_VERSION,
-    sourceLockSha256: EXPECTED_SOURCE_LOCK_SHA256,
+    schemaVersion: AQUINAS_GUTENBERG_GENERATED_RECEIPT_VERSION,
+    sourceLockSha256: pins.sourceLockSha256,
+    reviewedReceiptSha256: pins.reviewedReceiptSha256,
+    catalogIdentityLockSha256: pins.catalogIdentityLockSha256,
     acquiredAt: new Date().toISOString(),
-    artifacts: candidates.map(({ artifact, archive, catalog, html, evidence }) => {
+    artifacts: candidates.map(({ artifact, identityArtifact, archive, catalog, catalogSemanticIdentity, html, evidence }) => {
       const paths = evidencePaths(artifact);
       return {
         ebookId: artifact.ebookId,
         archive: localEvidence(artifact.archive.localPath, archive),
-        catalogSnapshot: localEvidence(artifact.catalogSnapshot.localPath, catalog),
+        catalogSnapshot: {
+          ...localEvidence(artifact.catalogSnapshot.localPath, catalog),
+          semanticIdentitySha256: catalogSemanticIdentityDigest({ ...identityArtifact, semanticIdentity: catalogSemanticIdentity }),
+        },
         htmlMember: { path: artifact.htmlMember.path, bytes: html.byteLength, sha256: sha256(html) },
         unrestrictedUseNotice: localEvidence(paths.unrestrictedUseNotice, evidence.unrestrictedUseNotice),
         electronicEditionProvenance: localEvidence(paths.electronicEditionProvenance, evidence.electronicEditionProvenance),
@@ -701,11 +951,11 @@ function makeReceipt(lock: AquinasGutenbergSourceLock, candidates: readonly Cand
   };
 }
 
-function receiptBytes(receipt: AquinasGutenbergReceipt): Buffer {
+function receiptBytes(receipt: AquinasGutenbergGeneratedReceipt): Buffer {
   return Buffer.from(`${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
 }
 
-function writeReceiptNoClobber(cwd: string, receipt: AquinasGutenbergReceipt): void {
+function writeReceiptNoClobber(cwd: string, receipt: AquinasGutenbergGeneratedReceipt): void {
   const path = relativeToLocal(cwd, AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH);
   writeNoClobber(path, receiptBytes(receipt), localRoot(cwd), 'generated receipt');
 }
@@ -718,10 +968,10 @@ function parseLocalEvidence(value: unknown, label: string): LocalEvidence {
   return { path, bytes: positiveInteger(evidence.bytes, `${label}.bytes`), sha256: hex(string(evidence.sha256, `${label}.sha256`), `${label}.sha256`) };
 }
 
-function parseReceipt(value: unknown, lock: AquinasGutenbergSourceLock): AquinasGutenbergReceipt {
+function parseReceipt(value: unknown, lock: AquinasGutenbergSourceLock, pins: AquinasGutenbergReviewedPins): AquinasGutenbergReceipt {
   const source = record(value, 'receipt');
   exactKeys(source, ['schemaVersion', 'sourceLockSha256', 'acquiredAt', 'artifacts'], 'receipt');
-  if (source.schemaVersion !== AQUINAS_GUTENBERG_RECEIPT_VERSION || source.sourceLockSha256 !== EXPECTED_SOURCE_LOCK_SHA256) fail('receipt does not bind the reviewed source lock');
+  if (source.schemaVersion !== AQUINAS_GUTENBERG_RECEIPT_VERSION || source.sourceLockSha256 !== pins.sourceLockSha256) fail('receipt does not bind the reviewed source lock');
   const acquiredAt = string(source.acquiredAt, 'receipt.acquiredAt');
   if (Number.isNaN(Date.parse(acquiredAt)) || !acquiredAt.endsWith('Z')) fail('receipt.acquiredAt is not a UTC ISO timestamp');
   const artifacts = array(source.artifacts, 'receipt.artifacts').map((value, index) => {
@@ -743,7 +993,7 @@ function parseReceipt(value: unknown, lock: AquinasGutenbergSourceLock): Aquinas
     };
   });
   if (artifacts.length !== lock.artifacts.length || artifacts.some((artifact, index) => artifact.ebookId !== lock.artifacts[index]!.ebookId)) fail('receipt does not retain all four locked artifacts in order');
-  return { schemaVersion: AQUINAS_GUTENBERG_RECEIPT_VERSION, sourceLockSha256: EXPECTED_SOURCE_LOCK_SHA256, acquiredAt, artifacts };
+  return { schemaVersion: AQUINAS_GUTENBERG_RECEIPT_VERSION, sourceLockSha256: pins.sourceLockSha256, acquiredAt, artifacts };
 }
 
 function assertReceiptMatchesLock(receipt: AquinasGutenbergReceipt, lock: AquinasGutenbergSourceLock): void {
@@ -756,17 +1006,107 @@ function assertReceiptMatchesLock(receipt: AquinasGutenbergReceipt, lock: Aquina
   }
 }
 
-export async function preflightAquinasGutenbergAcquisition(cwd = ROOT, fetchImpl: FetchLike = fetch): Promise<AquinasGutenbergSourceLock> {
-  const lock = readAquinasGutenbergSourceLock(cwd);
-  await Promise.all(lock.artifacts.map(artifact => downloadAndValidate(lock, artifact, fetchImpl)));
+function parseGeneratedReceipt(value: unknown, lock: AquinasGutenbergSourceLock, catalogLock: AquinasGutenbergCatalogIdentityLock, pins: AquinasGutenbergReviewedPins): AquinasGutenbergGeneratedReceipt {
+  const source = record(value, 'generated receipt');
+  exactKeys(source, ['schemaVersion', 'sourceLockSha256', 'reviewedReceiptSha256', 'catalogIdentityLockSha256', 'acquiredAt', 'artifacts'], 'generated receipt');
+  if (source.schemaVersion !== AQUINAS_GUTENBERG_GENERATED_RECEIPT_VERSION
+    || source.sourceLockSha256 !== pins.sourceLockSha256
+    || source.reviewedReceiptSha256 !== pins.reviewedReceiptSha256
+    || source.catalogIdentityLockSha256 !== pins.catalogIdentityLockSha256) fail('generated receipt does not bind all reviewed locks');
+  const acquiredAt = string(source.acquiredAt, 'generated receipt.acquiredAt');
+  if (Number.isNaN(Date.parse(acquiredAt)) || !acquiredAt.endsWith('Z')) fail('generated receipt.acquiredAt is not a UTC ISO timestamp');
+  const artifacts = array(source.artifacts, 'generated receipt.artifacts').map((value, index) => {
+    const entry = record(value, `generated receipt artifact ${index}`);
+    exactKeys(entry, ['ebookId', 'archive', 'catalogSnapshot', 'htmlMember', 'unrestrictedUseNotice', 'electronicEditionProvenance'], `generated receipt artifact ${index}`);
+    const catalog = record(entry.catalogSnapshot, `generated receipt artifact ${index}.catalogSnapshot`);
+    exactKeys(catalog, ['path', 'bytes', 'sha256', 'semanticIdentitySha256'], `generated receipt artifact ${index}.catalogSnapshot`);
+    const html = record(entry.htmlMember, `generated receipt artifact ${index}.htmlMember`);
+    exactKeys(html, ['path', 'bytes', 'sha256'], `generated receipt artifact ${index}.htmlMember`);
+    return {
+      ebookId: positiveInteger(entry.ebookId, `generated receipt artifact ${index}.ebookId`),
+      archive: parseLocalEvidence(entry.archive, `generated receipt artifact ${index}.archive`),
+      catalogSnapshot: {
+        path: string(catalog.path, `generated receipt artifact ${index}.catalogSnapshot.path`),
+        bytes: positiveInteger(catalog.bytes, `generated receipt artifact ${index}.catalogSnapshot.bytes`),
+        sha256: hex(string(catalog.sha256, `generated receipt artifact ${index}.catalogSnapshot.sha256`), `generated receipt artifact ${index}.catalogSnapshot.sha256`),
+        semanticIdentitySha256: hex(string(catalog.semanticIdentitySha256, `generated receipt artifact ${index}.catalogSnapshot.semanticIdentitySha256`), `generated receipt artifact ${index}.catalogSnapshot.semanticIdentitySha256`),
+      },
+      htmlMember: {
+        path: string(html.path, `generated receipt artifact ${index}.htmlMember.path`),
+        bytes: positiveInteger(html.bytes, `generated receipt artifact ${index}.htmlMember.bytes`),
+        sha256: hex(string(html.sha256, `generated receipt artifact ${index}.htmlMember.sha256`), `generated receipt artifact ${index}.htmlMember.sha256`),
+      },
+      unrestrictedUseNotice: parseLocalEvidence(entry.unrestrictedUseNotice, `generated receipt artifact ${index}.unrestrictedUseNotice`),
+      electronicEditionProvenance: parseLocalEvidence(entry.electronicEditionProvenance, `generated receipt artifact ${index}.electronicEditionProvenance`),
+    };
+  });
+  if (artifacts.length !== lock.artifacts.length || artifacts.some((artifact, index) => artifact.ebookId !== lock.artifacts[index]!.ebookId)) fail('generated receipt topology drifted');
+  const receipt: AquinasGutenbergGeneratedReceipt = {
+    schemaVersion: AQUINAS_GUTENBERG_GENERATED_RECEIPT_VERSION,
+    sourceLockSha256: pins.sourceLockSha256,
+    reviewedReceiptSha256: pins.reviewedReceiptSha256,
+    catalogIdentityLockSha256: pins.catalogIdentityLockSha256,
+    acquiredAt,
+    artifacts,
+  };
+  for (const [index, artifact] of lock.artifacts.entries()) {
+    const entry = receipt.artifacts[index]!;
+    const paths = evidencePaths(artifact);
+    if (entry.archive.path !== artifact.archive.localPath || entry.archive.bytes !== artifact.archive.bytes || entry.archive.sha256 !== artifact.archive.sha256
+      || entry.catalogSnapshot.path !== artifact.catalogSnapshot.localPath || entry.catalogSnapshot.semanticIdentitySha256 !== catalogSemanticIdentityDigest(catalogLock.artifacts[index]!)
+      || entry.htmlMember.path !== artifact.htmlMember.path || entry.htmlMember.bytes !== artifact.htmlMember.bytes || entry.htmlMember.sha256 !== artifact.htmlMember.sha256
+      || entry.unrestrictedUseNotice.path !== paths.unrestrictedUseNotice || entry.electronicEditionProvenance.path !== paths.electronicEditionProvenance) fail(`generated receipt artifact ${artifact.ebookId} drifted from reviewed locks`);
+  }
+  return receipt;
+}
+
+function readReviewedReceipt(cwd: string, lock: AquinasGutenbergSourceLock, pins: AquinasGutenbergReviewedPins): AquinasGutenbergReceipt {
+  const path = resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
+  if (!existsSync(path)) fail('reviewed acquisition receipt is missing');
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile()) fail('reviewed acquisition receipt is not a safe regular file');
+  const bytes = readFileSync(path);
+  if (sha256(bytes) !== pins.reviewedReceiptSha256) fail('reviewed acquisition receipt byte identity drifted');
+  const receipt = parseReceipt(JSON.parse(strictUtf8(bytes, 'reviewed acquisition receipt')), lock, pins);
+  assertReceiptMatchesLock(receipt, lock);
+  return receipt;
+}
+
+function assertCandidatesMatchReviewedReceipt(candidates: readonly Candidate[], generated: AquinasGutenbergGeneratedReceipt, reviewed: AquinasGutenbergReceipt): void {
+  for (const [index, candidate] of candidates.entries()) {
+    const expected = reviewed.artifacts[index]!;
+    const observed = generated.artifacts[index]!;
+    if (candidate.artifact.ebookId !== expected.ebookId || observed.archive.bytes !== expected.archive.bytes || observed.archive.sha256 !== expected.archive.sha256
+      || observed.htmlMember.bytes !== expected.htmlMember.bytes || observed.htmlMember.sha256 !== expected.htmlMember.sha256
+      || observed.unrestrictedUseNotice.bytes !== expected.unrestrictedUseNotice.bytes || observed.unrestrictedUseNotice.sha256 !== expected.unrestrictedUseNotice.sha256
+      || observed.electronicEditionProvenance.bytes !== expected.electronicEditionProvenance.bytes || observed.electronicEditionProvenance.sha256 !== expected.electronicEditionProvenance.sha256) {
+      fail(`eBook ${candidate.artifact.ebookId} candidate identity drifted from reviewed receipt`);
+    }
+  }
+}
+
+function authenticatedInputs(cwd: string, pins: AquinasGutenbergReviewedPins): Readonly<{ lock: AquinasGutenbergSourceLock; catalogLock: AquinasGutenbergCatalogIdentityLock; reviewed: AquinasGutenbergReceipt }> {
+  const lock = readAquinasGutenbergSourceLock(cwd, pins);
+  const catalogLock = readAquinasGutenbergCatalogIdentityLock(cwd, pins);
+  const reviewed = readReviewedReceipt(cwd, lock, pins);
+  return { lock, catalogLock, reviewed };
+}
+
+export async function preflightAquinasGutenbergAcquisition(cwd = ROOT, fetchImpl: FetchLike = fetch, pins: AquinasGutenbergReviewedPins = defaultReviewedPins()): Promise<AquinasGutenbergSourceLock> {
+  const { lock, catalogLock, reviewed } = authenticatedInputs(cwd, pins);
+  const candidates = await Promise.all(lock.artifacts.map((artifact, index) => downloadAndValidate(lock, catalogLock, artifact, index, fetchImpl)));
+  const generated = parseGeneratedReceipt(JSON.parse(receiptBytes(makeGeneratedReceipt(candidates, pins)).toString('utf8')), lock, catalogLock, pins);
+  assertCandidatesMatchReviewedReceipt(candidates, generated, reviewed);
   return lock;
 }
 
-export async function acquireAquinasGutenberg(cwd = ROOT, fetchImpl: FetchLike = fetch): Promise<AquinasGutenbergReceipt> {
-  const lock = readAquinasGutenbergSourceLock(cwd);
+export async function acquireAquinasGutenberg(cwd = ROOT, fetchImpl: FetchLike = fetch, pins: AquinasGutenbergReviewedPins = defaultReviewedPins()): Promise<AquinasGutenbergGeneratedReceipt> {
+  const { lock, catalogLock, reviewed } = authenticatedInputs(cwd, pins);
   assertAcquisitionDestinationsEmpty(cwd, lock);
   // Validate every remote byte in memory before the first local write.
-  const candidates = await Promise.all(lock.artifacts.map(artifact => downloadAndValidate(lock, artifact, fetchImpl)));
+  const candidates = await Promise.all(lock.artifacts.map((artifact, index) => downloadAndValidate(lock, catalogLock, artifact, index, fetchImpl)));
+  const receipt = parseGeneratedReceipt(JSON.parse(receiptBytes(makeGeneratedReceipt(candidates, pins)).toString('utf8')), lock, catalogLock, pins);
+  assertCandidatesMatchReviewedReceipt(candidates, receipt, reviewed);
   for (const candidate of candidates) {
     const { artifact, archive, catalog, evidence } = candidate;
     writeNoClobber(relativeToLocal(cwd, artifact.archive.localPath), archive, localRoot(cwd), `eBook ${artifact.ebookId} archive`);
@@ -775,26 +1115,19 @@ export async function acquireAquinasGutenberg(cwd = ROOT, fetchImpl: FetchLike =
     writeNoClobber(relativeToLocal(cwd, paths.unrestrictedUseNotice), evidence.unrestrictedUseNotice, localRoot(cwd), `eBook ${artifact.ebookId} unrestricted-use evidence`);
     writeNoClobber(relativeToLocal(cwd, paths.electronicEditionProvenance), evidence.electronicEditionProvenance, localRoot(cwd), `eBook ${artifact.ebookId} provenance evidence`);
   }
-  const receipt = makeReceipt(lock, candidates);
   writeReceiptNoClobber(cwd, receipt);
-  return verifyLocalAquinasGutenbergAcquisition(cwd);
+  return verifyLocalAquinasGutenbergAcquisition(cwd, pins) as AquinasGutenbergGeneratedReceipt;
 }
 
-export function verifyLocalAquinasGutenbergAcquisition(cwd = ROOT): AquinasGutenbergReceipt {
-  const lock = readAquinasGutenbergSourceLock(cwd);
+export function verifyLocalAquinasGutenbergAcquisition(cwd = ROOT, pins: AquinasGutenbergReviewedPins = defaultReviewedPins()): AquinasGutenbergReceipt | AquinasGutenbergGeneratedReceipt {
+  const { lock, catalogLock, reviewed } = authenticatedInputs(cwd, pins);
   const generatedReceiptPath = relativeToLocal(cwd, AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH);
-  const receiptPath = existsSync(generatedReceiptPath)
-    ? generatedReceiptPath
-    : resolve(cwd, AQUINAS_GUTENBERG_RECEIPT_PATH);
-  if (!existsSync(receiptPath)) fail('local acquisition receipt is missing');
-  const receiptStat = lstatSync(receiptPath);
-  if (receiptStat.isSymbolicLink() || !receiptStat.isFile()) fail('local acquisition receipt is not a safe regular file');
-  const receiptFile = readFileSync(receiptPath);
-  if (receiptPath !== generatedReceiptPath && sha256(receiptFile) !== EXPECTED_REVIEWED_RECEIPT_SHA256) {
-    fail('reviewed acquisition receipt byte identity drifted');
+  let receipt: AquinasGutenbergReceipt | AquinasGutenbergGeneratedReceipt = reviewed;
+  if (existsSync(generatedReceiptPath)) {
+    const receiptStat = lstatSync(generatedReceiptPath);
+    if (receiptStat.isSymbolicLink() || !receiptStat.isFile()) fail('generated acquisition receipt is not a safe regular file');
+    receipt = parseGeneratedReceipt(JSON.parse(strictUtf8(readFileSync(generatedReceiptPath), 'generated acquisition receipt')), lock, catalogLock, pins);
   }
-  const receipt = parseReceipt(JSON.parse(strictUtf8(receiptFile, 'local acquisition receipt')), lock);
-  assertReceiptMatchesLock(receipt, lock);
   for (const [index, artifact] of lock.artifacts.entries()) {
     const entry = receipt.artifacts[index]!;
     assertLocalEvidence(cwd, entry.archive, `eBook ${artifact.ebookId} archive`);
@@ -804,7 +1137,7 @@ export function verifyLocalAquinasGutenbergAcquisition(cwd = ROOT): AquinasGuten
     const archive = readFileSync(relativeToLocal(cwd, artifact.archive.localPath));
     const html = extractAndVerifyLockedHtml(artifact, archive);
     const catalog = readFileSync(relativeToLocal(cwd, artifact.catalogSnapshot.localPath));
-    assertCatalog(artifact, catalog, lock);
+    extractAndVerifyCatalogSemanticIdentity(artifact, catalogLock.artifacts[index]!, catalog, lock);
     const evidence = evidenceSlices(html, artifact, lock);
     if (sha256(evidence.unrestrictedUseNotice) !== entry.unrestrictedUseNotice.sha256 || sha256(evidence.electronicEditionProvenance) !== entry.electronicEditionProvenance.sha256) fail(`eBook ${artifact.ebookId} local evidence extraction drifted`);
   }

--- a/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
+++ b/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
@@ -1,0 +1,180 @@
+import { createHash } from 'node:crypto';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { deflateRawSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import {
+  AQUINAS_GUTENBERG_SOURCE_LOCK_PATH,
+  extractAndVerifyLockedHtml,
+  fetchExactGutenbergBytes,
+  parseAquinasGutenbergSourceLock,
+  parseStrictZip,
+  readAquinasGutenbergSourceLock,
+  sourceLockDigest,
+  writeNoClobber,
+} from '../../../scripts/aquinas-gutenberg-acquisition.js';
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let value = 0; value < 256; value += 1) {
+    let current = value;
+    for (let bit = 0; bit < 8; bit += 1) current = (current & 1) ? (0xedb88320 ^ (current >>> 1)) : (current >>> 1);
+    table[value] = current >>> 0;
+  }
+  return table;
+})();
+
+function crc32(bytes: Uint8Array): number {
+  let value = 0xffffffff;
+  for (const byte of bytes) value = CRC_TABLE[(value ^ byte) & 0xff]! ^ (value >>> 8);
+  return (value ^ 0xffffffff) >>> 0;
+}
+
+type ZipEntry = Readonly<{ path: string; body: string; method?: 0 | 8; unixMode?: number }>;
+
+/** Minimal, deliberately controllable ZIP writer for archive-hazard fixtures. */
+function zip(entries: readonly ZipEntry[]): Buffer {
+  let offset = 0;
+  const local: Buffer[] = [];
+  const central: Buffer[] = [];
+  for (const entry of entries) {
+    const name = Buffer.from(entry.path, 'utf8');
+    const body = Buffer.from(entry.body, 'utf8');
+    const method = entry.method ?? 8;
+    const compressed = method === 0 ? body : deflateRawSync(body);
+    const checksum = crc32(body);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0, 6);
+    localHeader.writeUInt16LE(method, 8);
+    localHeader.writeUInt32LE(checksum, 14);
+    localHeader.writeUInt32LE(compressed.byteLength, 18);
+    localHeader.writeUInt32LE(body.byteLength, 22);
+    localHeader.writeUInt16LE(name.byteLength, 26);
+    localHeader.writeUInt16LE(0, 28);
+    local.push(localHeader, name, compressed);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(0x0314, 4); // Unix creator, ZIP spec 2.0
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0, 8);
+    centralHeader.writeUInt16LE(method, 10);
+    centralHeader.writeUInt32LE(checksum, 16);
+    centralHeader.writeUInt32LE(compressed.byteLength, 20);
+    centralHeader.writeUInt32LE(body.byteLength, 24);
+    centralHeader.writeUInt16LE(name.byteLength, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt32LE(((entry.unixMode ?? 0o100644) << 16) >>> 0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+    central.push(centralHeader, name);
+    offset += localHeader.byteLength + name.byteLength + compressed.byteLength;
+  }
+  const centralBytes = Buffer.concat(central);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralBytes.byteLength, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+  return Buffer.concat([...local, centralBytes, end]);
+}
+
+function lockJson(): Record<string, any> {
+  return JSON.parse(readFileSync(AQUINAS_GUTENBERG_SOURCE_LOCK_PATH, 'utf8')) as Record<string, any>;
+}
+
+describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
+  it('binds the reviewed four-part archive, member, catalog, provenance, and IA-witness identities', () => {
+    const lock = readAquinasGutenbergSourceLock(process.cwd());
+    expect(lock.sourceIdentity).toBe('aquinas-english-dominican-gutenberg-four-part-v1');
+    expect(lock.artifacts.map(artifact => [artifact.ebookId, artifact.partKey, artifact.questionRange])).toEqual([
+      [17611, 'prima', 'q001-q119'],
+      [17897, 'prima-secundae', 'q001-q114'],
+      [18755, 'secunda-secundae', 'q001-q189'],
+      [19950, 'tertia', 'q001-q090'],
+    ]);
+    expect(lock.artifacts.every(artifact => artifact.archive.memberPaths[0] === artifact.htmlMember.path)).toBe(true);
+    expect(lock.rightsAndProvenance.catalogStatement).toBe('Public domain in the USA.');
+    expect(lock.comparisonWitness).toMatchObject({
+      sourceLockSchemaVersion: 'theologai-aquinas-shapcote-ia-source-lock.v1',
+      sourceLockSha256: 'a245dbc007b76e1975eb26462a75a5e5992954d9042fc6de96477f0b30351594',
+    });
+    expect(sourceLockDigest(process.cwd())).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('rejects topology, provenance, rights, member, URL, and comparison-witness drift', () => {
+    const mutations: Array<(lock: Record<string, any>) => void> = [
+      lock => { lock.artifacts.pop(); },
+      lock => { lock.artifacts[0].partKey = 'wrong'; },
+      lock => { lock.artifacts[0].archive.memberPaths[0] = 'other.html'; },
+      lock => { lock.artifacts[0].archive.url = 'https://evil.invalid/cache/epub/17611/pg17611-h.zip'; },
+      lock => { lock.artifacts[0].catalogSnapshot.url = 'https://www.gutenberg.org/ebooks/17611?mutable=1'; },
+      lock => { lock.rightsAndProvenance.rightsStatus = 'worldwide_public_domain'; },
+      lock => { delete lock.rightsAndProvenance.electronicEditionProvenance.translator; },
+      lock => { lock.comparisonWitness.sourceLockSchemaVersion = 'other'; },
+    ];
+    for (const mutate of mutations) {
+      const changed = lockJson();
+      mutate(changed);
+      expect(() => parseAquinasGutenbergSourceLock(changed)).toThrow();
+    }
+  });
+
+  it('refuses a source lock whose reviewed byte identity has changed', () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-lock-'));
+    const destination = join(root, AQUINAS_GUTENBERG_SOURCE_LOCK_PATH);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, `${readFileSync(AQUINAS_GUTENBERG_SOURCE_LOCK_PATH, 'utf8')}\n`);
+    expect(() => readAquinasGutenbergSourceLock(root)).toThrow('source lock byte identity drifted');
+  });
+
+  it('accepts a minimal safe ZIP and rejects duplicate/colliding paths, symlinks, and hostile traversal', () => {
+    const expected = ['pg.html', 'cover.png'];
+    expect(parseStrictZip(zip([
+      { path: 'pg.html', body: '<html>safe</html>' },
+      { path: 'cover.png', body: 'png', method: 0 },
+    ]), expected)).toHaveLength(2);
+    expect(() => parseStrictZip(zip([
+      { path: 'pg.html', body: 'one' },
+      { path: 'PG.html', body: 'two' },
+    ]), expected)).toThrow('duplicate or colliding');
+    expect(() => parseStrictZip(zip([
+      { path: 'pg.html', body: 'link', unixMode: 0o120777 },
+      { path: 'cover.png', body: 'png', method: 0 },
+    ]), expected)).toThrow('is a symlink');
+    expect(() => parseStrictZip(zip([
+      { path: '../pg.html', body: 'traversal' },
+      { path: 'cover.png', body: 'png', method: 0 },
+    ]), expected)).toThrow('hostile ZIP member path');
+  });
+
+  it('rejects archive and contained-member bytes before any future corpus reader can use them', () => {
+    const artifact = readAquinasGutenbergSourceLock(process.cwd()).artifacts[0]!;
+    expect(() => extractAndVerifyLockedHtml(artifact, Buffer.from('not a locked archive'))).toThrow('archive byte identity drifted');
+    const alteredHash = createHash('sha256').update('different').digest('hex');
+    expect(alteredHash).not.toBe(artifact.htmlMember.sha256);
+  });
+
+  it('has an atomic no-clobber writer and refuses redirected archive/catalog responses', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-no-clobber-'));
+    const local = join(root, 'local');
+    mkdirSync(local);
+    const destination = join(local, 'evidence', 'locked.html');
+    writeNoClobber(destination, Buffer.from('first'), local, 'fixture');
+    expect(() => writeNoClobber(destination, Buffer.from('second'), local, 'fixture')).toThrow('no-clobber policy');
+    await expect(fetchExactGutenbergBytes(
+      'https://www.gutenberg.org/cache/epub/17611/pg17611-h.zip',
+      32,
+      'fixture archive',
+      async () => new Response('', { status: 302, headers: { location: 'https://evil.invalid/file.zip' } }),
+    )).rejects.toThrow('redirected to an unapproved or mutable endpoint');
+  });
+});

--- a/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
+++ b/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
@@ -106,6 +106,8 @@ describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
     expect(lock.comparisonWitness).toMatchObject({
       sourceLockSchemaVersion: 'theologai-aquinas-shapcote-ia-source-lock.v1',
       sourceLockSha256: 'a245dbc007b76e1975eb26462a75a5e5992954d9042fc6de96477f0b30351594',
+      receiptSchemaVersion: 'theologai-aquinas-shapcote-ia-local-receipt.v1',
+      receiptSha256: '71f0312d497835b11a474b3254c4d5226952a539425461a2b1d6795848ed5399',
     });
     expect(sourceLockDigest(process.cwd())).toMatch(/^[a-f0-9]{64}$/);
   });
@@ -120,6 +122,7 @@ describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
       lock => { lock.rightsAndProvenance.rightsStatus = 'worldwide_public_domain'; },
       lock => { delete lock.rightsAndProvenance.electronicEditionProvenance.translator; },
       lock => { lock.comparisonWitness.sourceLockSchemaVersion = 'other'; },
+      lock => { lock.comparisonWitness.receiptSha256 = '0'.repeat(64); },
     ];
     for (const mutate of mutations) {
       const changed = lockJson();
@@ -154,6 +157,17 @@ describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
       { path: '../pg.html', body: 'traversal' },
       { path: 'cover.png', body: 'png', method: 0 },
     ]), expected)).toThrow('hostile ZIP member path');
+  });
+
+  it('bounds DEFLATE output by the central-directory declaration before decompression can expand a hostile member', () => {
+    const hostile = zip([
+      { path: 'pg.html', body: 'A'.repeat(32_768) },
+      { path: 'cover.png', body: 'png', method: 0 },
+    ]);
+    const central = hostile.indexOf(Buffer.from([0x50, 0x4b, 0x01, 0x02]));
+    hostile.writeUInt32LE(1, 22); // local-header uncompressed byte count
+    hostile.writeUInt32LE(1, central + 24); // matching central-directory lie
+    expect(() => parseStrictZip(hostile, ['pg.html', 'cover.png'])).toThrow('cannot be safely decompressed within its declared size bound');
   });
 
   it('rejects archive and contained-member bytes before any future corpus reader can use them', () => {

--- a/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
+++ b/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
@@ -3,9 +3,12 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { deflateRawSync } from 'node:zlib';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
+  AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH,
+  AQUINAS_GUTENBERG_RECEIPT_PATH,
   AQUINAS_GUTENBERG_SOURCE_LOCK_PATH,
+  acquireAquinasGutenberg,
   extractAndVerifyLockedHtml,
   fetchExactGutenbergBytes,
   parseAquinasGutenbergSourceLock,
@@ -89,6 +92,15 @@ function zip(entries: readonly ZipEntry[]): Buffer {
 
 function lockJson(): Record<string, any> {
   return JSON.parse(readFileSync(AQUINAS_GUTENBERG_SOURCE_LOCK_PATH, 'utf8')) as Record<string, any>;
+}
+
+function seedTrackedAcquisitionEvidence(root: string): Buffer {
+  for (const path of [AQUINAS_GUTENBERG_SOURCE_LOCK_PATH, AQUINAS_GUTENBERG_RECEIPT_PATH]) {
+    const destination = join(root, path);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, readFileSync(path));
+  }
+  return readFileSync(AQUINAS_GUTENBERG_RECEIPT_PATH);
 }
 
 describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
@@ -190,5 +202,36 @@ describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
       'fixture archive',
       async () => new Response('', { status: 302, headers: { location: 'https://evil.invalid/file.zip' } }),
     )).rejects.toThrow('redirected to an unapproved or mutable endpoint');
+  });
+
+  it('lets fresh-checkout acquisition pass destination preflight without overwriting the tracked reviewed receipt', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-fresh-checkout-'));
+    const reviewedReceipt = seedTrackedAcquisitionEvidence(root);
+    const fetchReached = vi.fn(async (): Promise<Response> => {
+      throw new Error('fetch reached after destination preflight');
+    });
+
+    await expect(acquireAquinasGutenberg(root, fetchReached)).rejects.toThrow('fetch reached after destination preflight');
+    expect(fetchReached).toHaveBeenCalled();
+    expect(readFileSync(join(root, AQUINAS_GUTENBERG_RECEIPT_PATH))).toEqual(reviewedReceipt);
+  });
+
+  it('fails closed before downloading when any generated acquisition destination already exists', async () => {
+    const lock = readAquinasGutenbergSourceLock(process.cwd());
+    for (const localPath of [AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH, lock.artifacts[0]!.archive.localPath]) {
+      const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-hostile-destination-'));
+      const reviewedReceipt = seedTrackedAcquisitionEvidence(root);
+      const destination = join(root, 'data/historical-sources/project-gutenberg/aquinas-english-dominican', localPath);
+      mkdirSync(dirname(destination), { recursive: true });
+      writeFileSync(destination, 'hostile pre-existing bytes');
+      const fetchNotReached = vi.fn(async (): Promise<Response> => {
+        throw new Error('download must not start');
+      });
+
+      await expect(acquireAquinasGutenberg(root, fetchNotReached)).rejects.toThrow('no-clobber policy');
+      expect(fetchNotReached).not.toHaveBeenCalled();
+      expect(readFileSync(destination, 'utf8')).toBe('hostile pre-existing bytes');
+      expect(readFileSync(join(root, AQUINAS_GUTENBERG_RECEIPT_PATH))).toEqual(reviewedReceipt);
+    }
   });
 });

--- a/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
+++ b/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
@@ -1,21 +1,28 @@
 import { createHash } from 'node:crypto';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { deflateRawSync } from 'node:zlib';
 import { describe, expect, it, vi } from 'vitest';
 import {
   AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH,
+  AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH,
   AQUINAS_GUTENBERG_RECEIPT_PATH,
   AQUINAS_GUTENBERG_SOURCE_LOCK_PATH,
   acquireAquinasGutenberg,
+  catalogSemanticIdentityDigest,
+  extractAndVerifyCatalogSemanticIdentity,
   extractAndVerifyLockedHtml,
   fetchExactGutenbergBytes,
   parseAquinasGutenbergSourceLock,
+  readAquinasGutenbergCatalogIdentityLock,
   parseStrictZip,
   readAquinasGutenbergSourceLock,
   sourceLockDigest,
+  verifyLocalAquinasGutenbergAcquisition,
   writeNoClobber,
+  type AquinasGutenbergCatalogIdentityArtifact,
+  type AquinasGutenbergReviewedPins,
 } from '../../../scripts/aquinas-gutenberg-acquisition.js';
 
 const CRC_TABLE = (() => {
@@ -95,12 +102,141 @@ function lockJson(): Record<string, any> {
 }
 
 function seedTrackedAcquisitionEvidence(root: string): Buffer {
-  for (const path of [AQUINAS_GUTENBERG_SOURCE_LOCK_PATH, AQUINAS_GUTENBERG_RECEIPT_PATH]) {
+  for (const path of [AQUINAS_GUTENBERG_SOURCE_LOCK_PATH, AQUINAS_GUTENBERG_RECEIPT_PATH, AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH]) {
     const destination = join(root, path);
     mkdirSync(dirname(destination), { recursive: true });
     writeFileSync(destination, readFileSync(path));
   }
   return readFileSync(AQUINAS_GUTENBERG_RECEIPT_PATH);
+}
+
+function digest(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function catalogHtml(artifact: AquinasGutenbergCatalogIdentityArtifact, siteCount = '78,967', downloads = '1936'): Buffer {
+  const identity = artifact.semanticIdentity;
+  const lastUpdate = identity.lastUpdate
+    ? `<tr property="dcterms:modified" datatype="xsd:date" content="${identity.lastUpdate.machineDate}"><th>Last Update</th><td>${identity.lastUpdate.displayDate}</td></tr>`
+    : '';
+  return Buffer.from(`<!doctype html><html><body>
+<a href="/ebooks/" title="Start a new search."><span itemprop="name">${siteCount} free eBooks</span></a>
+<div typeof="pgterms:ebook" about="[ebook:${artifact.ebookId}]">
+<table id="about_book_table">
+<tr><th>Author</th><td><a href="${identity.author.agentPath}" about="${identity.author.agentAboutPath}" itemprop="creator">${identity.author.name}</a></td></tr>
+<tr><th>Title</th><td>${identity.titleLines[0]}<br>${identity.titleLines[1]}</td></tr>
+<tr><th>Credits</th><td>${identity.credits}</td></tr>
+<tr content="${identity.language.code}"><th>Language</th><td>${identity.language.label}</td></tr>
+<tr content="${identity.locClass}"><th>LoC Class</th><td>${identity.locClass}</td></tr>
+<tr><th>Category</th><td>${identity.category}</td></tr>
+<tr><th>eBook-No.</th><td>${artifact.ebookId}</td></tr>
+<tr content="${identity.release.machineDate}"><th>Release Date</th><td>${identity.release.displayDate}</td></tr>
+${lastUpdate}
+<tr><th>Copyright</th><td>${identity.rightsStatement}</td></tr>
+<tr><th>Downloads</th><td>${downloads} downloads in the last 30 days.</td></tr>
+</table></div>
+<a href="${identity.archiveDownload.path}" type="${identity.archiveDownload.mediaType}">${identity.archiveDownload.label}</a>
+</body></html>`, 'utf8');
+}
+
+function syntheticArchiveHtml(artifact: Record<string, any>, source: Record<string, any>): string {
+  const notice = source.rightsAndProvenance.internalUnrestrictedUseEvidence.requiredPhrases.join('\n');
+  const provenance = [
+    'originally produced by Sandra',
+    'made available through the Christian\nClassics Ethereal Library',
+    'I have eliminated\nunnecessary formatting in the text, corrected some errors in\ntranscription, and added the dedication, tables of contents,\nPrologue, and the numbers of the questions and articles, as they\nappeared in the printed translation published by Benziger Brothers.',
+    'In a few places, where obvious errors appeared in the Benziger\nBrothers edition, I have corrected them by reference to a Latin text\nof the <i>Summa.</i> These corrections are indicated by English text in\nbrackets.',
+    '* Any matter that appeared in a footnote in the Benziger Brothers\nedition is presented in brackets at the point in the text where the\nfootnote mark appeared.',
+    'Fathers of the English Dominican Province',
+    'BENZIGER BROTHERS',
+    'Anything else in this electronic edition that does not correspond to\nthe content of the Benziger Brothers edition may be regarded as a\ndefect in this edition and attributed to me (David McClamrock).',
+  ].join('\n');
+  return `<html><head><meta name="dcterms.created" content="${artifact.htmlMember.dctermsCreated}"><meta name="dcterms.modified" content="${artifact.htmlMember.dctermsModified}"></head><body><div>This eBook is for the use of anyone anywhere in the United States\n${notice}</div><h2>NOTE TO THIS ELECTRONIC EDITION</h2><p>${provenance}</p></body></html>`;
+}
+
+function syntheticEvidence(html: string): { notice: Buffer; provenance: Buffer } {
+  const noticeStart = html.indexOf('<div>This eBook is for the use of anyone anywhere in the United States');
+  const noticeEnd = html.indexOf('</div>', noticeStart) + '</div>'.length;
+  const provenanceStart = html.indexOf('>NOTE TO THIS ELECTRONIC EDITION</');
+  const provenanceEnd = html.indexOf('</p>', provenanceStart) + '</p>'.length;
+  return { notice: Buffer.from(html.slice(noticeStart, noticeEnd)), provenance: Buffer.from(html.slice(provenanceStart, provenanceEnd)) };
+}
+
+function syntheticAcquisitionScenario(root: string): {
+  pins: AquinasGutenbergReviewedPins;
+  responses: Map<string, Buffer>;
+  reviewedReceiptBytes: Buffer;
+  catalogLock: ReturnType<typeof readAquinasGutenbergCatalogIdentityLock>;
+} {
+  const source = lockJson();
+  const catalogLockJson = JSON.parse(readFileSync(AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH, 'utf8')) as Record<string, any>;
+  const reviewCatalogs = new Map<number, Buffer>();
+  const acquisitionCatalogs = new Map<number, Buffer>();
+  const archives = new Map<number, Buffer>();
+  const evidence = new Map<number, { notice: Buffer; provenance: Buffer }>();
+  for (const [index, artifact] of source.artifacts.entries()) {
+    const identityArtifact = catalogLockJson.artifacts[index] as AquinasGutenbergCatalogIdentityArtifact;
+    const html = syntheticArchiveHtml(artifact, source);
+    const archive = zip([
+      { path: artifact.archive.memberPaths[0], body: html },
+      { path: artifact.archive.memberPaths[1], body: 'synthetic cover', method: 0 },
+    ]);
+    artifact.archive.bytes = archive.byteLength;
+    artifact.archive.sha256 = digest(archive);
+    artifact.htmlMember.bytes = Buffer.byteLength(html);
+    artifact.htmlMember.sha256 = digest(Buffer.from(html));
+    const reviewCatalog = catalogHtml(identityArtifact, '78,000', '1');
+    artifact.catalogSnapshot.bytes = reviewCatalog.byteLength;
+    artifact.catalogSnapshot.sha256 = digest(reviewCatalog);
+    reviewCatalogs.set(artifact.ebookId, reviewCatalog);
+    acquisitionCatalogs.set(artifact.ebookId, catalogHtml(identityArtifact, '79,001', '2345'));
+    archives.set(artifact.ebookId, archive);
+    evidence.set(artifact.ebookId, syntheticEvidence(html));
+  }
+  const sourceBytes = Buffer.from(`${JSON.stringify(source, null, 2)}\n`);
+  const sourceLockSha256 = digest(sourceBytes);
+  const reviewedReceipt = {
+    schemaVersion: 'theologai-aquinas-gutenberg-local-receipt.v1',
+    sourceLockSha256,
+    acquiredAt: '2026-07-21T00:00:00.000Z',
+    artifacts: source.artifacts.map((artifact: Record<string, any>) => {
+      const localEvidence = evidence.get(artifact.ebookId)!;
+      const catalog = reviewCatalogs.get(artifact.ebookId)!;
+      return {
+        ebookId: artifact.ebookId,
+        archive: { path: artifact.archive.localPath, bytes: artifact.archive.bytes, sha256: artifact.archive.sha256 },
+        catalogSnapshot: { path: artifact.catalogSnapshot.localPath, bytes: catalog.byteLength, sha256: digest(catalog) },
+        htmlMember: { path: artifact.htmlMember.path, bytes: artifact.htmlMember.bytes, sha256: artifact.htmlMember.sha256 },
+        unrestrictedUseNotice: { path: `local/evidence/pg${artifact.ebookId}-unrestricted-use-notice.html`, bytes: localEvidence.notice.byteLength, sha256: digest(localEvidence.notice) },
+        electronicEditionProvenance: { path: `local/evidence/pg${artifact.ebookId}-electronic-edition-provenance.html`, bytes: localEvidence.provenance.byteLength, sha256: digest(localEvidence.provenance) },
+      };
+    }),
+  };
+  const reviewedReceiptBytes = Buffer.from(`${JSON.stringify(reviewedReceipt, null, 2)}\n`);
+  const reviewedReceiptSha256 = digest(reviewedReceiptBytes);
+  catalogLockJson.sourceLockSha256 = sourceLockSha256;
+  catalogLockJson.reviewedReceiptSha256 = reviewedReceiptSha256;
+  const catalogLockBytes = Buffer.from(`${JSON.stringify(catalogLockJson, null, 2)}\n`);
+  const pins = { sourceLockSha256, reviewedReceiptSha256, catalogIdentityLockSha256: digest(catalogLockBytes) };
+  for (const [path, bytes] of [
+    [AQUINAS_GUTENBERG_SOURCE_LOCK_PATH, sourceBytes],
+    [AQUINAS_GUTENBERG_RECEIPT_PATH, reviewedReceiptBytes],
+    [AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH, catalogLockBytes],
+  ] as const) {
+    const destination = join(root, path);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, bytes);
+  }
+  const responses = new Map<string, Buffer>();
+  for (const artifact of source.artifacts) {
+    responses.set(artifact.archive.url, archives.get(artifact.ebookId)!);
+    responses.set(artifact.catalogSnapshot.url, acquisitionCatalogs.get(artifact.ebookId)!);
+  }
+  return { pins, responses, reviewedReceiptBytes, catalogLock: readAquinasGutenbergCatalogIdentityLock(root, pins) };
+}
+
+function fakeFetch(responses: Map<string, Buffer>): (input: string) => Promise<Response> {
+  return async input => new Response(responses.get(input) ?? 'missing fixture', { status: responses.has(input) ? 200 : 404 });
 }
 
 describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
@@ -122,6 +258,25 @@ describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
       receiptSha256: '71f0312d497835b11a474b3254c4d5226952a539425461a2b1d6795848ed5399',
     });
     expect(sourceLockDigest(process.cwd())).toMatch(/^[a-f0-9]{64}$/);
+    const catalogLock = readAquinasGutenbergCatalogIdentityLock(process.cwd());
+    expect(catalogLock.artifacts.map(artifact => artifact.ebookId)).toEqual([17611, 17897, 18755, 19950]);
+    expect(catalogLock.sourceLockSha256).toBe('c5cfdd1edd132bf59968cbabe4c7de2180c42d205735ca6c06aec626104a180b');
+    expect(catalogLock.reviewedReceiptSha256).toBe('bc0dab9ce5dc3672ccf2a81182655c75eaf6ef4f280584a40e079bf82a11719d');
+  });
+
+  it('accepts the current live catalog shape across both documented counter changes and rejects invariant drift', () => {
+    const source = readAquinasGutenbergSourceLock(process.cwd());
+    const catalogLock = readAquinasGutenbergCatalogIdentityLock(process.cwd());
+    const liveDownloads = ['1936', '1729', '2108', '1457'];
+    for (const [index, artifact] of source.artifacts.entries()) {
+      const identity = catalogLock.artifacts[index]!;
+      const first = extractAndVerifyCatalogSemanticIdentity(artifact, identity, catalogHtml(identity, '78,967', liveDownloads[index]), source);
+      const counterDrift = extractAndVerifyCatalogSemanticIdentity(artifact, identity, catalogHtml(identity, '79,001', '999999'), source);
+      expect(catalogSemanticIdentityDigest({ ...identity, semanticIdentity: first })).toBe(catalogSemanticIdentityDigest({ ...identity, semanticIdentity: counterDrift }));
+    }
+    const identity = catalogLock.artifacts[0]!;
+    const mismatched = Buffer.from(catalogHtml(identity).toString('utf8').replace(identity.semanticIdentity.credits, 'Unreviewed credits'));
+    expect(() => extractAndVerifyCatalogSemanticIdentity(source.artifacts[0]!, identity, mismatched, source)).toThrow('catalog semantic identity drifted');
   });
 
   it('rejects topology, provenance, rights, member, URL, and comparison-witness drift', () => {
@@ -233,5 +388,61 @@ describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
       expect(readFileSync(destination, 'utf8')).toBe('hostile pre-existing bytes');
       expect(readFileSync(join(root, AQUINAS_GUTENBERG_RECEIPT_PATH))).toEqual(reviewedReceipt);
     }
+  });
+
+  it('completes a full fresh-checkout acquisition with fake locked responses and counter-drifted catalog snapshots', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-full-acquire-'));
+    const scenario = syntheticAcquisitionScenario(root);
+
+    const receipt = await acquireAquinasGutenberg(root, fakeFetch(scenario.responses), scenario.pins);
+
+    expect(receipt.schemaVersion).toBe('theologai-aquinas-gutenberg-generated-receipt.v1');
+    expect(receipt.reviewedReceiptSha256).toBe(scenario.pins.reviewedReceiptSha256);
+    expect(receipt.catalogIdentityLockSha256).toBe(scenario.pins.catalogIdentityLockSha256);
+    expect(receipt.artifacts).toHaveLength(4);
+    expect(readFileSync(join(root, AQUINAS_GUTENBERG_RECEIPT_PATH))).toEqual(scenario.reviewedReceiptBytes);
+    expect(verifyLocalAquinasGutenbergAcquisition(root, scenario.pins).artifacts).toHaveLength(4);
+  });
+
+  it('rejects a semantic catalog mismatch before creating any local acquisition output', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-semantic-no-write-'));
+    const scenario = syntheticAcquisitionScenario(root);
+    const first = scenario.catalogLock.artifacts[0]!;
+    const url = `https://www.gutenberg.org${first.catalogPath}`;
+    scenario.responses.set(url, Buffer.from(scenario.responses.get(url)!.toString('utf8').replace(first.semanticIdentity.credits, 'Hostile catalog credits')));
+
+    await expect(acquireAquinasGutenberg(root, fakeFetch(scenario.responses), scenario.pins)).rejects.toThrow('catalog semantic identity drifted');
+    expect(existsSync(join(root, 'data/historical-sources/project-gutenberg/aquinas-english-dominican/local'))).toBe(false);
+    expect(readFileSync(join(root, AQUINAS_GUTENBERG_RECEIPT_PATH))).toEqual(scenario.reviewedReceiptBytes);
+  });
+
+  it('compares candidate provenance to authenticated reviewed evidence before the first write', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-reviewed-mismatch-'));
+    const scenario = syntheticAcquisitionScenario(root);
+    const reviewed = JSON.parse(scenario.reviewedReceiptBytes.toString('utf8')) as Record<string, any>;
+    reviewed.artifacts[0].electronicEditionProvenance.sha256 = '0'.repeat(64);
+    const reviewedBytes = Buffer.from(`${JSON.stringify(reviewed, null, 2)}\n`);
+    const reviewedReceiptSha256 = digest(reviewedBytes);
+    writeFileSync(join(root, AQUINAS_GUTENBERG_RECEIPT_PATH), reviewedBytes);
+    const catalogLock = JSON.parse(readFileSync(join(root, AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH), 'utf8')) as Record<string, any>;
+    catalogLock.reviewedReceiptSha256 = reviewedReceiptSha256;
+    const catalogLockBytes = Buffer.from(`${JSON.stringify(catalogLock, null, 2)}\n`);
+    writeFileSync(join(root, AQUINAS_GUTENBERG_CATALOG_IDENTITY_LOCK_PATH), catalogLockBytes);
+    const pins = { ...scenario.pins, reviewedReceiptSha256, catalogIdentityLockSha256: digest(catalogLockBytes) };
+
+    await expect(acquireAquinasGutenberg(root, fakeFetch(scenario.responses), pins)).rejects.toThrow('candidate identity drifted from reviewed receipt');
+    expect(existsSync(join(root, 'data/historical-sources/project-gutenberg/aquinas-english-dominican/local'))).toBe(false);
+  });
+
+  it('rejects a tampered tracked reviewed receipt even when a valid generated receipt and cache exist', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-aquinas-gutenberg-reviewed-tamper-'));
+    const scenario = syntheticAcquisitionScenario(root);
+    await acquireAquinasGutenberg(root, fakeFetch(scenario.responses), scenario.pins);
+    const generatedPath = join(root, 'data/historical-sources/project-gutenberg/aquinas-english-dominican', AQUINAS_GUTENBERG_GENERATED_RECEIPT_LOCAL_PATH);
+    expect(existsSync(generatedPath)).toBe(true);
+    writeFileSync(join(root, AQUINAS_GUTENBERG_RECEIPT_PATH), Buffer.concat([scenario.reviewedReceiptBytes, Buffer.from('\n')]));
+
+    expect(() => verifyLocalAquinasGutenbergAcquisition(root, scenario.pins)).toThrow('reviewed acquisition receipt byte identity drifted');
+    expect(existsSync(generatedPath)).toBe(true);
   });
 });

--- a/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
+++ b/test/unit/scripts/aquinasGutenbergAcquisition.test.ts
@@ -125,9 +125,15 @@ function catalogHtml(artifact: AquinasGutenbergCatalogIdentityArtifact, siteCoun
 <table id="about_book_table">
 <tr><th>Author</th><td><a href="${identity.author.agentPath}" about="${identity.author.agentAboutPath}" itemprop="creator">${identity.author.name}</a></td></tr>
 <tr><th>Title</th><td>${identity.titleLines[0]}<br>${identity.titleLines[1]}</td></tr>
+<tr><th>Note</th><td>Wikipedia page about this book</td></tr>
 <tr><th>Credits</th><td>${identity.credits}</td></tr>
+<tr><th>Reading Level</th><td>Computed presentation metadata</td></tr>
 <tr content="${identity.language.code}"><th>Language</th><td>${identity.language.label}</td></tr>
 <tr content="${identity.locClass}"><th>LoC Class</th><td>${identity.locClass}</td></tr>
+<tr><th>Subject</th><td>Subject one</td></tr>
+<tr><th>Subject</th><td>Subject two</td></tr>
+<tr><th>Subject</th><td>Subject three</td></tr>
+<tr><th>Subject</th><td>Subject four</td></tr>
 <tr><th>Category</th><td>${identity.category}</td></tr>
 <tr><th>eBook-No.</th><td>${artifact.ebookId}</td></tr>
 <tr content="${identity.release.machineDate}"><th>Release Date</th><td>${identity.release.displayDate}</td></tr>
@@ -277,6 +283,26 @@ describe('Aquinas Gutenberg local acquisition/source-rights lock', () => {
     const identity = catalogLock.artifacts[0]!;
     const mismatched = Buffer.from(catalogHtml(identity).toString('utf8').replace(identity.semanticIdentity.credits, 'Unreviewed credits'));
     expect(() => extractAndVerifyCatalogSemanticIdentity(source.artifacts[0]!, identity, mismatched, source)).toThrow('catalog semantic identity drifted');
+  });
+
+  it('rejects an unknown Edition row instead of treating it as out-of-projection presentation', () => {
+    const source = readAquinasGutenbergSourceLock(process.cwd());
+    const identity = readAquinasGutenbergCatalogIdentityLock(process.cwd()).artifacts[0]!;
+    const injected = Buffer.from(catalogHtml(identity).toString('utf8').replace(
+      '</table>',
+      '<tr><th>Edition</th><td>Hostile replacement edition</td></tr></table>',
+    ));
+    expect(() => extractAndVerifyCatalogSemanticIdentity(source.artifacts[0]!, identity, injected, source)).toThrow('unknown row label: Edition');
+  });
+
+  it('rejects extra coauthor text outside the single reviewed creator link', () => {
+    const source = readAquinasGutenbergSourceLock(process.cwd());
+    const identity = readAquinasGutenbergCatalogIdentityLock(process.cwd()).artifacts[0]!;
+    const injected = Buffer.from(catalogHtml(identity).toString('utf8').replace(
+      `${identity.semanticIdentity.author.name}</a></td>`,
+      `${identity.semanticIdentity.author.name}</a>; Hostile Coauthor</td>`,
+    ));
+    expect(() => extractAndVerifyCatalogSemanticIdentity(source.artifacts[0]!, identity, injected, source)).toThrow('Author cell must contain only');
   });
 
   it('rejects topology, provenance, rights, member, URL, and comparison-witness drift', () => {


### PR DESCRIPTION
## Stack position

A0 of 3. Base: `main` at refreshed base `3d741ffd975096e94f834d9ef63096d88c2158a7`.

## Scope

Adds local-only, content-free Project Gutenberg acquisition commitments for the reviewed Aquinas witness: source lock, receipt, verifier, and focused tests. The work is inert: it registers no MCP/runtime capability and does not alter catalogs, databases, workflows, or deployment configuration.

## Rights and provenance

The committed metadata records the reviewed US-only public-domain provenance and exact witness hashes. Raw archive members and source bodies remain local-only and excluded from version control.

## Verification

- Refreshed range is patch-equivalent to approved A0.
- `npm run typecheck`
- `npm run build`
- Focused A0→A2/inertness suite: 31 passed.

## Explicit exclusions

No body packages, raw archives, caches, `node_modules`, generated outputs/reports, SQLite/DB artifacts, runtime registration, deployment, or publishing changes are included.

## Merge sequence

Merge this draft first. Then retarget/merge A1, followed by A2. Do not enable deploy previews or publish package bodies from this PR.