### PR TITLE
Bind Transform-8 preview database

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -244,6 +244,22 @@ jobs:
             }
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify preview checkout identity
+        id: preview-checkout
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          checked_out_commit="$(git rev-parse HEAD)"
+          checked_out_tree="$(git rev-parse HEAD^{tree})"
+          if test "$checked_out_commit" != "$EXPECTED_HEAD_SHA"; then
+            echo "::error::Preview checkout does not match the authorized pull-request head. Expected $EXPECTED_HEAD_SHA, got $checked_out_commit."
+            exit 1
+          fi
+          printf 'commit=%s\n' "$checked_out_commit" >> "$GITHUB_OUTPUT"
+          printf 'tree=%s\n' "$checked_out_tree" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -300,9 +316,17 @@ jobs:
 
       - name: Comment preview URL on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECKED_OUT_COMMIT: ${{ steps.preview-checkout.outputs.commit }}
+          CHECKED_OUT_TREE: ${{ steps.preview-checkout.outputs.tree }}
         with:
           script: |
-            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const commit = process.env.CHECKED_OUT_COMMIT;
+            const tree = process.env.CHECKED_OUT_TREE;
+            if (!/^[0-9a-f]{40}$/i.test(commit) || !/^[0-9a-f]{40}$/i.test(tree)) {
+              core.setFailed('Preview checkout identity is missing or malformed.');
+              return;
+            }
             const body = [
               '### Preview Deployed',
               '',
@@ -311,7 +335,7 @@ jobs:
               '**Compatibility alias:** https://theologai-preview.tjfrederick.workers.dev',
               '**Compatibility MCP endpoint:** `https://theologai-preview.tjfrederick.workers.dev/mcp`',
               '',
-              `Deployed from commit \`${sha}\`.`,
+              `Deployed from checked-out commit \`${commit}\` (tree \`${tree}\`).`,
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,26 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reconciled public release documentation through merged PR #83. PR #72
-  remains the
-  deployed Worker baseline: production serves Worker
-  `762485da-9e02-46a0-9777-e0d8743b9dbf`, preview serves Worker
-  `8ed4ad1a-f45f-4cdc-a6de-5358f59b6d44`, and the later behaviorally inert
-  repository merges through `93d5837b05249c15127ab20107f86443cccf4e1e` are
-  not remote deployments.
+- Reconciled release state after the preview-only PR #92 D1 cutover. Production
+  remains PR #72: Cloudflare deployment `a4697fd1-deda-4dae-a16c-635454218bc8`,
+  Worker `762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+  `c6535a4a-1953-4279-b277-7368445fc61a`. The exact deployed and audited
+  preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7` in
+  draft, unmerged PR #92: deployment
+  `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
+  `2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
+  `94c4938b-7800-4d68-9097-0df33c31fdc1`. CI run `30011028739` and both
+  audits passed; its preview authorization was removed and it returned to
+  draft. Any later docs-only PR #92 head is not deployed. This did not deploy
+  production.
 
 - Completed the runtime-inert UBS Hebrew U3-T7 compiler, canonical
   native-to-normalized bridge, content-free reproducibility audit, embedded
   rights/provenance notice, and full-corpus integrity verification. The full
-  semantic artifact remains untracked. The local-only M4A follow-on completes
-  migration `0004`, transform 7, SQLite materialization, deterministic D1
-  seed/import verification, and inactive Node/D1 adapters. None is registered
-  in Worker or Node composition, present in remote D1, bound to a Worker,
-  exposed through MCP, or deployed to preview or production. `SOURCE.json`
-  remains the historical acquisition-gate snapshot rather than deployment
-  evidence. Draft-PR publication of M4A is owner-authorized but had not yet
-  occurred when this entry was authored; remote migration and deployment are
-  still unapproved.
+  semantic artifact remains untracked. M4A completes migration `0004`,
+  transform 7, SQLite materialization, deterministic D1 seed/import
+  verification, and inactive Node/D1 adapters. The exact preview release also
+  materializes migrations `0004` / transform 7 and `0005` / transform 8 in
+  its bound D1. Transform 7's UBS adapters remain runtime-inactive and do not
+  alter MCP output. Transform 8 is active in preview's historical repositories:
+  the existing `classic_text_lookup` has the Baltimore hard cut and
+  canonical/legacy resolution, changing preview output without adding a tool.
+  Production Worker and D1 lack both transforms. `SOURCE.json` remains the
+  historical acquisition-gate snapshot rather than deployment evidence;
+  production data release and any later UBS runtime activation remain separately
+  gated.
 
 - Clarified endpoint migration behavior: ordinary production `workers.dev`
   requests temporarily redirect to the canonical custom domain, while the
@@ -39,12 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   primary-source v4/local-only schema; preview keeps the v5 discovery-only
   schema, with CCEL execution disabled in both environments.
 
-- Recorded that the acquired source packets remain inactive at runtime. M4A
-  adds UBS rows only to derived local SQLite and the deterministic local D1
-  seed; it adds no remote D1 rows or runtime/MCP surface. The remote release of
-  migration `0004`/transform 7, migration `0005`/transform 8, Norton transform
-  9, and subsequent edition transforms remain separately gated; remote
-  `0004`/transform 7 is the required predecessor of `0005`/transform 8.
+- Recorded that the acquired UBS source packet remains inactive at runtime:
+  preview D1 holds its `0004`/transform 7 materialization, but its adapters add
+  no runtime/MCP surface. Preview's separately materialized `0005`/transform 8
+  historical compatibility is active through the existing
+  `classic_text_lookup`, including Baltimore and canonical/legacy behavior;
+  this adds no tool. Production release of both transforms, Norton transform 9,
+  and subsequent edition transforms remain separately gated.
 
 - Retired the unreachable CCEL body reader while retaining the bounded,
   disabled discovery adapter. npm distribution remains unsupported and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,23 +173,31 @@ The SQLite database (`data/theologai.db`) is a derived artifact. Cross-reference
 
 ## Release-state boundary
 
-PR #72 is the deployed remote baseline: production Worker
-`762485da-9e02-46a0-9777-e0d8743b9dbf` and preview Worker
-`8ed4ad1a-f45f-4cdc-a6de-5358f59b6d44`. The production `workers.dev` endpoint
-redirects ordinary requests to the canonical custom domain; the exact
+Production remains the deployed PR #72 baseline: Cloudflare deployment
+`a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
+`762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+`theologai-production-20260715-a`
+(`c6535a4a-1953-4279-b277-7368445fc61a`). The exact deployed and audited
+preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7` in
+unmerged draft PR #92; it is deployed to preview only as
+Cloudflare deployment `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
+`2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
+`theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). CI run `30011028739` and its
+two preview audits passed; `deploy-preview` was removed and the PR returned
+to draft. Any later docs-only PR #92 head is not deployed. This is not a
+production deployment. The production `workers.dev`
+endpoint redirects ordinary requests to the canonical custom domain; the exact
 abusive-poller tuple is rejected instead, while the preview legacy endpoint
-remains direct. The later documentation reconciliation through PR #82
-(`023804681d725e9600f3ff3dbfce347417c23eff`) is repository-only and has not
-been deployed. The U3-T7 compiler work carried by PR #83 is also repository-only
-and undeployed.
+remains direct. Repository-only U3-T7/PR #83 work remains outside production.
 
-The acquired UBS Hebrew and historical public-domain packets are deliberately
-outside the runtime, SQLite/D1 materialization, MCP registry, and hosted
-17-work catalog. U3-T7 adds only an inactive in-memory compiler,
-native-to-normalized coordinate bridge, and content-free audit; it does not
-change SQLite/D1, MCP output, or any deployment. Capacity planning and separate
-owner authorization remain required for migration `0004` / transform 7,
-migration `0005` / transform 8, Norton transform 9, and later edition
-transforms. The `0004` / transform 7 data layer must precede `0005` / transform
-8.
+The preview-only D1 has migrations `0004` / transform 7 and `0005` / transform
+8 materialized. Transform 7's UBS adapters remain runtime-inactive: U3-T7's
+in-memory compiler, native-to-normalized coordinate bridge, and content-free
+audit do not register an MCP surface or alter current output. Transform 8 is
+active in preview's historical repositories: the existing `classic_text_lookup`
+has the Baltimore hard cut and canonical/legacy resolution, changing preview
+output without adding a tool. The production Worker and D1 lack both transforms.
+A production D1 release, later UBS runtime activation, Norton transform 9, and
+later edition transforms remain separately owner-gated.
 `package.json` is private: npm distribution is unsupported.

--- a/README.md
+++ b/README.md
@@ -45,25 +45,36 @@ Remote MCP client configuration:
 }
 ```
 
-Use the preview URL only for explicitly authorized release testing. The current
-known-good remote baseline is PR #72: production Worker
-`762485da-9e02-46a0-9777-e0d8743b9dbf` and preview Worker
-`8ed4ad1a-f45f-4cdc-a6de-5358f59b6d44`. The later repository changes through
-merged PR #83 (`93d5837b05249c15127ab20107f86443cccf4e1e`) are repository-only
-and have not been deployed. For a preview-client rollback without changing
-server state, use the direct preview
+Use the preview URL only for explicitly authorized release testing. Production
+remains the PR #72 known-good baseline: Cloudflare deployment
+`a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
+`762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+`theologai-production-20260715-a`
+(`c6535a4a-1953-4279-b277-7368445fc61a`). Separately, the exact deployed and
+audited preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7`
+in unmerged draft PR #92; it is deployed to preview only:
+Cloudflare deployment `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
+`2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
+`theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). Its CI run `30011028739` and
+preview audits passed (22/22 cases and 59/59 checks; 48/48 rate-counted
+requests across 11 aggregate groups). The `deploy-preview` authorization was
+then removed and PR #92 returned to draft; it is not a production deployment.
+Any later docs-only PR #92 head is not deployed.
+For a preview-client rollback without changing server state, use the direct preview
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
 
-The subsequent UBS Hebrew M4A slice is local-only and inactive: it completes
-migration `0004`, transform 7, local SQLite materialization, deterministic D1
-seed/import verification, and inactive Node/D1 adapters. It is absent from
-both composition roots, remote D1 databases, Worker bindings, preview,
-production, and MCP output. The pinned packet's `SOURCE.json` remains a
-historical acquisition-gate snapshot, not deployment evidence.
-The owner has authorized this M4A branch for draft-PR publication, but at the
-time of this document update it has not yet been published; that authorization
-does not authorize remote D1 work or deployment.
+The preview-only data layer has migration `0004` / transform 7 and migration
+`0005` / transform 8 materialized in its bound D1. Transform 7's UBS adapters
+remain runtime-inactive: they register no new MCP surface or output. Transform
+8 is active in preview's historical repositories: the existing
+`classic_text_lookup` has the Baltimore hard cut and canonical/legacy
+resolution. That adds no new tool, but it does change preview output.
+Production lacks both migrations, materialized rows, and this Transform-8
+behavior; a production D1 release and any later UBS runtime activation remain
+separately gated. The pinned packet's `SOURCE.json` remains a historical
+acquisition-gate snapshot, not deployment evidence.
 
 ## MCP capabilities
 
@@ -253,32 +264,33 @@ catechisms. The exact count is enforced by `data/data-manifest.json`.
 
 Approved UBS Hebrew and public-domain historical-source packets are checked
 into the repository for deterministic verification and future release work.
-M4A now materializes the UBS source pair in the derived local SQLite database
-and deterministic local D1 seed only. Those rows remain absent from remote D1,
-both composition roots, MCP resources, and current tool output. The historical
-source packets remain outside the local and remote 17-work catalog and current
-tool output. U3-T7 provides the in-memory semantic compiler,
-native-to-normalized coordinate bridge, and content-free compilation audit;
-M4A adds local migration `0004` / transform 7, capacity verification, seed
-verification, and inactive adapters. Draft-PR publication of M4A is authorized
-but had not occurred when this text was authored. Any remote migration,
-binding, runtime activation, preview, or production change remains separately
-gated. Historical compatibility migration `0005` / transform 8 follows that
-remote data-layer gate. Norton is a later transform-9,
+M4A materializes the UBS source pair in derived local SQLite, deterministic
+D1 seed, and the preview-only D1. Transform 7's UBS adapters remain inactive
+at runtime. Transform 8 is separately active in preview's historical
+repositories: the existing `classic_text_lookup` exposes the Baltimore hard
+cut and canonical/legacy resolution, changing preview output without adding a
+tool. Production lacks both migrations, materializations, and Transform-8
+behavior. The historical source packets remain outside the local and remote
+17-work catalog and current tool output. U3-T7 provides the in-memory semantic
+compiler, native-to-normalized coordinate bridge, and content-free compilation
+audit; M4A provides capacity and seed verification with inactive adapters. Any
+production migration, binding, or UBS runtime activation remains separately
+gated. Norton is a later transform-9,
 `sectioned_only` candidate. Cyril remains blocked with zero output pending
 reliable translator attribution.
 
-The production tools search and retrieve only the locally indexed collection.
-They do **not** currently fetch CCEL search results or document bodies. This
-unpublished Transform-8 runtime changes the configured public primary-source
-profiles to v6 local-only and v7 CCEL-discovery shape; it does not claim that a
-remote Worker has that code. A separately configured v7 preview may advertise
-external CCEL discovery inputs and guided workflows. In either configuration,
-live search and coordinator execution remain disabled; external preview queries
-therefore return a disabled provider result before adapter
-invocation, Durable Object lookup/RPC, or fetch. MCP clients should reconnect
-and reinitialize after any endpoint/profile change because tool and prompt schemas
-may be cached for an existing connection.
+Production tools search and retrieve only the locally indexed collection and
+do **not** currently fetch CCEL search results or document bodies. The deployed
+preview source contains Transform-8 code with active historical compatibility:
+its existing `classic_text_lookup` provides the Baltimore hard cut and
+canonical/legacy resolution. This changes preview output without adding a new
+tool. Preview retains the v5 CCEL-discovery profile; live search and coordinator execution remain disabled.
+External preview queries return a disabled provider result before adapter invocation.
+That occurs before Durable Object lookup/RPC, or fetch. Production has neither
+the Transform-8 materialization nor behavior.
+The checked-in v6/v7 profile candidate remains unpublished. MCP clients should
+reconnect and reinitialize after any endpoint/profile change because tool and
+prompt schemas may be cached for an existing connection.
 
 The retained `CcelSearchAdapter` remains in the codebase as bounded future
 provider architecture.
@@ -471,8 +483,9 @@ per-request D1 repositories. Both targets share one MCP registry.
   after the PR #10 production baseline.
 - Live CCEL discovery and search remain gated future work; the checked-in,
   unpublished candidate exposes only the non-executing v7 contract while its
-  local production profile remains v6/local-only. The deployed PR #72 baseline
-  remains preview v5 and production v4/local-only.
+  local production profile remains v6/local-only. The current preview-only
+  PR #92 deployment remains v5/discovery-only, while production remains
+  PR #72 v4/local-only.
   The legacy CCEL body reader is retired; the retained discovery adapter is
   bounded, does not fetch until separately authorized, and must never become
   CCEL body mirroring or republication.

--- a/docs/CUSTOM-DOMAIN-MIGRATION.md
+++ b/docs/CUSTOM-DOMAIN-MIGRATION.md
@@ -32,6 +32,24 @@ custom-domain attachment, and the optional `www` redirect may require manual
 Cloudflare dashboard action even though Worker routes are declared in
 `wrangler.toml`.
 
+## Current operational release state (2026-07-23)
+
+Production remains the PR #72 release: Cloudflare deployment
+`a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
+`762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+`theologai-production-20260715-a`
+(`c6535a4a-1953-4279-b277-7368445fc61a`). The exact deployed and audited
+preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7` in
+draft, unmerged PR #92; it is separately deployed to preview only: Cloudflare
+deployment `44a0858f-75ba-497d-b84b-66c14253234a`,
+Worker `2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
+`theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). CI run `30011028739` and both
+preview audits passed (22/22 cases, 59/59 checks, 48/48 rate-counted requests,
+and 11 aggregate groups). The `deploy-preview` authorization was removed and
+PR #92 returned to draft; any later docs-only PR #92 head is not deployed. It
+is not a production release.
+
 ## Release-time known-good baseline
 
 The rollback anchor is deliberately a release-time record, not a stale version
@@ -58,11 +76,12 @@ not a suitable rollback target. The production D1 remains
 and CCEL flags `000` unless a separately reviewed release changes one of them.
 
 A preview deployment necessarily creates a new Worker version. Record that
-version after each preview deployment; preview must continue to use D1
-`theologai-preview-20260714-a`
-(`0dab804f-8df0-4727-93bd-299612b6e179`), rate namespace `361202`, and CCEL
-flags `100`. Those bindings and environment ownership—not a prior Worker
-version—must remain invariant through this migration.
+version and the reviewed binding current at execution; as of this record the
+preview binding is D1 `theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`), rate namespace `361202`, and CCEL
+flags `100`. This routing-only migration must preserve whichever reviewed
+binding and environment ownership is current at execution; it must not replace
+that binding merely to satisfy a historical record.
 
 ## Reviewable phase split
 
@@ -125,7 +144,7 @@ the explicit dual-origin Wrangler variables provide hosted migration support.
    under-budget rate behavior; and `/mcp` routing.
 6. Repeat a compatibility smoke test through the preview `workers.dev` alias.
    Confirm both hostnames reach only `theologai-preview`, D1
-   `theologai-preview-20260714-a`, rate namespace `361202`, and CCEL state
+   `theologai-preview-20260722-b`, rate namespace `361202`, and CCEL state
    `100`. Record the new preview Worker version. Remove preview authorization
    after the audit and verify revocation.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -206,7 +206,7 @@ is local source context only and does not define the current product contract.
   an MCP response. The future bounded `sectioned_only` publication remains
   transform 9, not a present feature, merged as
   `f6888fc4dbee03a3ccdd20411d284318ea22a21b`.
-- **Legacy production-host migration / PR #72:** established the current
+- **Legacy production-host migration / PR #72:** established the then-current
   known-good remote baseline. It redirects the production
   `theologai.tjfrederick.workers.dev` host to `mcp.theologai.xyz` for ordinary
   requests (while preserving CORS preflight behavior); the exact documented
@@ -287,13 +287,22 @@ is local source context only and does not define the current product contract.
 
 Entries through PR #83 describe merged repository state. PR #83 is
 repository-only and undeployed; its merge is not deployment evidence. M4A is a
-later local-only draft whose publication is authorized but not yet complete.
+later local-only draft whose publication is authorized but not itself a release.
 Deployment state is established only by the relevant protected workflow and
-post-deployment smoke evidence. No merge after PR #72 through PR #83 at
-`93d5837b05249c15127ab20107f86443cccf4e1e` was deployed.
-Production remains the PR #72 Worker
-`762485da-9e02-46a0-9777-e0d8743b9dbf`, and preview remains the PR #72 Worker
-`8ed4ad1a-f45f-4cdc-a6de-5358f59b6d44`.
+post-deployment smoke evidence. Production remains the PR #72 release:
+Cloudflare deployment `a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
+`762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+`c6535a4a-1953-4279-b277-7368445fc61a`. Separately, the exact deployed and
+audited preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7`
+in draft, unmerged PR #92; it is deployed to preview only as Cloudflare
+deployment `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
+`2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
+`theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). CI run `30011028739` and the
+two audits passed (22/22 cases, 59/59 checks, and 48/48 rate-counted requests
+across 11 aggregate groups). Its `deploy-preview` authorization was removed
+and the PR returned to draft; any later docs-only PR #92 head is not deployed.
+No production deployment occurred.
 
 ## Shipped Phase 3 release train
 
@@ -403,8 +412,8 @@ catalog scope for primary-source research. The separate `e6f7f7f` commit
 reconciles release documentation for this candidate.
 
 This transform-version-6 release merged through PR #34 and was released to
-production through the reviewed PR #39 binding cutover. Its protected preview
-uses the fresh preview database
+production through the reviewed PR #39 binding cutover. The 2026-07-14
+protected preview used the fresh preview database
 `theologai-preview-20260714-a`, migrated through schema 0003, populated from all
 36 manifest seed files, and verified by the strict read-only remote readiness
 gate. Its whole-D1 identity
@@ -586,14 +595,16 @@ Code readiness and operational readiness are deliberately separate:
 - The migration-free catalog-capacity prerequisite shipped in PR #56; retain
   its centralized 100-work and 2,000-section ceilings and single D1-safe
   JSON/`json_each` scope bind. The approved UBS artifacts, decoder, coordinate
-  evidence, deterministic U3-T7 compiler/bridge/audit, and M4A local
-  materialization/seed verification are now complete. The next gate is a
-  separately owner-authorized remote migration `0004` / transform 7 release;
-  it may not add semantic runtime behavior or reach preview/production without
-  a new review and release gate. This data layer
-  must complete before the dependent historical migration `0005` / transform
-  8. Keep the existing 32-source provenance cap as a required pack-sizing
-  check.
+  evidence, deterministic U3-T7 compiler/bridge/audit, and M4A materialization
+  and seed verification are complete. The exact preview release has migrations
+  `0004` / transform 7 and `0005` / transform 8 materialized in the bound
+  preview D1. Transform 7's UBS adapters remain runtime-inactive. Transform 8
+  is active in preview's historical repositories: the existing
+  `classic_text_lookup` has the Baltimore hard cut and canonical/legacy
+  resolution, changing preview output without adding a tool. Production Worker
+  and D1 lack both transforms. The next gate is a separately owner-authorized
+  production D1 release followed by a distinct UBS runtime-activation decision.
+  Keep the existing 32-source provenance cap as a required pack-sizing check.
 - PRs #61–#64 and #67 complete the planned inactive semantic and provenance
   foundations: source-free semantic contracts, the unregistered Hebrew
   resolution and aggregate seams, edition/provenance contracts, and a
@@ -607,20 +618,23 @@ Code readiness and operational readiness are deliberately separate:
   controls when a cursor is present, and retains `includeText: false` as the
   existing default. Any future workflow or prompt change remains a separate
   slice rather than another cursor implementation.
-- The primary-source output-profile hard cutover is currently represented by
-  production v6/local-only and preview v7/discovery-only, with CCEL
-  execution still disabled. Prospective corpus work remains limited to
+- In the checked-in unpublished candidate, the primary-source output-profile
+  hard cutover is represented by production v6/local-only and preview
+  v7/discovery-only, with CCEL execution still disabled. Prospective corpus work remains limited to
   explicit searched/read/deferred coverage semantics and future
   edition/provenance fields; it is not a rollout of evidence already present
   in current schemas. Any corpus release remains a **pending rights and release
   decision** and must preserve CCEL-disabled behavior during protected audit.
-- The historical source-first aliases are authoritative for a future
-  compatibility release, but the evidence/compiler remains preparatory.
-  `productionObservedTarget` remains null and Node `.get()`/D1 `.first()`
-  remain `unordered_no_compatibility_proof`. Migration `0005` and transform 8
-  depend on the prior migration `0004` / transform 7 data layer and are then
-  separately gated before any deterministic runtime behavior, D1 rows, preview,
-  or production change. Norton is a later transform-9
+- The historical source-first aliases are authoritative. The exact preview
+  release materializes migration `0005` / transform 8 after its `0004` /
+  transform 7 prerequisite and activates historical compatibility in preview
+  repositories. The existing `classic_text_lookup` therefore exposes the
+  Baltimore hard cut and canonical/legacy resolution: no new tool is
+  registered, but preview output changes. `productionObservedTarget` remains
+  null and Node `.get()`/D1 `.first()` remain
+  `unordered_no_compatibility_proof`. Production D1 and Worker lack both
+  transforms; production materialization and behavior remain separately gated.
+  Norton is a later transform-9
   `sectioned_only` release; Calvin, Aquinas, and Augustine need later
   per-edition transforms and release approvals. Cyril remains a zero-output
   blocked source until translator attribution is established.
@@ -651,13 +665,14 @@ Code readiness and operational readiness are deliberately separate:
 - Broaden original-language study for both beginners and readers of Greek or
   Hebrew using the already selected and acquired UBS Hebrew v0.9.2 semantic
   source (PRs #75 and #79), rather than selecting another semantic-domain
-  source. U3-T7 deterministic compilation and M4A local-only materialization
-  are complete and runtime-inert. Next comes the separately owner-gated remote
-  migration `0004` / transform 7 release, which requires explicit
-  authorization; only after that data layer is remotely verified may a separate
-  runtime-activation release extend the existing
-  `original_language_study` tool. This prerequisite comes before migration
-  `0005` / transform 8. Evaluate MACULA
+  source. U3-T7 deterministic compilation and the Transform-7 data layer are
+  complete, while its UBS adapters remain runtime-inactive. Preview also has
+  active Transform-8 historical compatibility through the existing
+  `classic_text_lookup`; it changes preview output but adds no tool. Production
+  lacks both transforms. A separately owner-gated production data release and
+  then a distinct UBS runtime-activation release would be required before
+  extending the existing `original_language_study` tool.
+  Evaluate MACULA
   discourse/context evidence only after that foundation is active and reviewed.
   The owner approved a hard cutover that withholds the TBESH `Meaning` field,
   which derives from Online Bible material whose source notice says permission

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -1,23 +1,27 @@
 # Worker operations
 
-## Current known-good PR #72 remote baseline (2026-07-17)
+## Current split release state (2026-07-23)
 
-PR #72 merge `72a8ee5eef9b909a373b085d1a4f193484ddfe8a` is the current
-known-good remote baseline. Protected preview run `29621708718` deployed
-preview Worker `8ed4ad1a-f45f-4cdc-a6de-5358f59b6d44`; protected production
-run `29622634088` and Cloudflare deployment
-`a4697fd1-deda-4dae-a16c-635454218bc8` deployed production Worker
-`762485da-9e02-46a0-9777-e0d8743b9dbf`. The release retained production D1
+Production remains the PR #72 known-good release: protected production run
+`29622634088` and Cloudflare deployment
+`a4697fd1-deda-4dae-a16c-635454218bc8` serve Worker
+`762485da-9e02-46a0-9777-e0d8743b9dbf` with D1
 `theologai-production-20260715-a`
-(`c6535a4a-1953-4279-b277-7368445fc61a`), preview D1
-`theologai-preview-20260714-a`
-(`0dab804f-8df0-4727-93bd-299612b6e179`), rate namespaces `361201` and
-`361202` at 120/60, and CCEL flags `000` (production) / `100` (preview).
+(`c6535a4a-1953-4279-b277-7368445fc61a`). Its independent audit returned GO
+with no P0-P3 findings across 22 read-only requests and a 22/22
+source-attested regression.
 
-The independent preview audit returned GO with no P0-P3 findings across 22
-read-only requests, and its source-attested regression passed 22/22. The
-independent production audit likewise returned GO with no P0-P3 findings in no
-more than 22 read-only requests; its source-attested regression passed 22/22.
+The exact deployed and audited preview source commit is
+`bb8ed4c8f025f697502a274986205f92bdf520b7` in draft, unmerged PR #92; it is
+the separate preview-only release: CI run `30011028739` passed, Cloudflare
+deployment `44a0858f-75ba-497d-b84b-66c14253234a` serves Worker
+`2b540a47-0937-4c00-9d44-de1199e09e6c`, and its only D1 binding is
+`theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). The preview audits passed 22/22
+cases and 59/59 checks, plus 48/48 rate-counted requests across 11 aggregate
+groups. The `deploy-preview` label was removed and PR #92 returned to draft;
+any later docs-only PR #92 head is not deployed. This state is not a production
+deployment.
 
 Ordinary requests to the production `theologai.tjfrederick.workers.dev` host
 now return a no-store 308 to `mcp.theologai.xyz`. The exact abusive-poller
@@ -31,26 +35,24 @@ environments. The checked-in v6/v7 schema pair is an unpublished repository
 candidate, not evidence of a deployed Worker or a changed remote contract.
 
 The later repository changes through merged PR #83
-(`93d5837b05249c15127ab20107f86443cccf4e1e`) are repository-only and have not
-been deployed. U3-T7 adds an inactive in-memory semantic compiler,
-native-to-normalized coordinate bridge, and content-free audit. The later M4A
-local-only slice adds migration `0004`, transform 7, local SQLite
-materialization, deterministic D1 seed/import verification, and inactive
-Node/D1 adapters. The unpublished candidate also advances the local
-primary-source schema pair to production v6/local-only and preview
-v7/discovery-only. Neither candidate changes the deployed Workers, remote D1
-databases or bindings, historical catalog, deployed MCP output, UBS semantic
-runtime, or CCEL execution state. No deletion, route replacement, or other
-destructive cleanup is authorized by this record.
+(`93d5837b05249c15127ab20107f86443cccf4e1e`) remain outside production.
+U3-T7 adds an inactive in-memory semantic compiler,
+native-to-normalized coordinate bridge, and content-free audit. The exact PR
+#92 preview Worker and D1 above are the sole remote exception: its D1 has
+migrations `0004` / transform 7 and `0005` / transform 8 materialized.
+Transform 7's UBS adapters remain runtime-inactive. Transform 8 is active in
+preview's historical repositories: the existing `classic_text_lookup` has the
+Baltimore hard cut and canonical/legacy resolution, changing preview output
+without adding a tool. Production Worker and D1 lack both transforms and
+production runtime activation remains unchanged. The unpublished candidate also
+advances the local primary-source schema pair to production v6/local-only and
+preview v7/discovery-only. No deletion, route replacement, or other destructive
+cleanup is authorized by this record.
 
-Draft-PR publication of M4A is owner-authorized but had not yet occurred when
-this record was authored; no remote migration or deployment is authorized.
-
-Any eventual UBS semantic D1 release must separately authorize remote migration
-`0004` / transform 7 and a reviewed binding/deployment sequence before the
-dependent historical migration `0005` / transform 8. The completed local
-capacity and seed checks are not remote-release evidence and neither is part of
-this deployed baseline.
+Any eventual UBS semantic production release must separately authorize a
+production D1 migration/binding/deployment sequence. The preview data layer is
+not production-release evidence, and a later runtime-activation release is
+separately gated.
 
 ## Historical PR #50 pre-custom-domain rollback anchor (2026-07-16)
 

--- a/scripts/ccel-operator-secret-release.ts
+++ b/scripts/ccel-operator-secret-release.ts
@@ -5,7 +5,7 @@ import { parse as parseToml } from 'smol-toml';
 export const CCEL_OPERATOR_SECRET = 'THEOLOGAI_CCEL_OPERATOR_TOKEN';
 export const PRODUCTION_WORKER = 'theologai';
 export const PRODUCTION_D1_ID = 'c6535a4a-1953-4279-b277-7368445fc61a';
-export const PREVIEW_D1_ID = '0dab804f-8df0-4727-93bd-299612b6e179';
+export const PREVIEW_D1_ID = '94c4938b-7800-4d68-9097-0df33c31fdc1';
 export const STAGE_CONFIRMATION = 'I AUTHORIZE PROVISIONING THE PROTECTED CCEL OPERATOR SECRET';
 export const PROMOTE_CONFIRMATION = 'PROMOTE THEOLOGAI CCEL OPERATOR SECRET';
 export const ROLLBACK_CONFIRMATION = 'ROLL BACK THEOLOGAI TO THE EXACT SECRETLESS BASELINE';
@@ -137,7 +137,7 @@ export function assertWorkerConfig(configText: string): void {
   validateEnvironmentConfig(preview, {
     worker: 'theologai-preview',
     d1Id: PREVIEW_D1_ID,
-    d1Name: 'theologai-preview-20260714-a',
+    d1Name: 'theologai-preview-20260722-b',
     requestNamespace: '361202',
     operatorNamespace: '361204',
     vars: PREVIEW_VARS,

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -84,8 +84,23 @@ describe('custom-domain infrastructure contract', () => {
     expect(previewWorkflow).toContain('contains(github.event.pull_request.labels.*.name, \'deploy-preview\')');
     expect(previewWorkflow).toContain("if (!labels.includes('deploy-preview')) failures.push('the deploy-preview label is absent')");
     expect(previewWorkflow.match(/github\.rest\.pulls\.get/g)).toHaveLength(2);
+    const previewJob = previewWorkflow.slice(previewWorkflow.indexOf('  preview-deploy:'));
+    const previewCheckoutStart = previewJob.indexOf('- uses: actions/checkout@');
+    const previewCheckoutEnd = previewJob.indexOf('- uses: actions/setup-node@', previewCheckoutStart);
+    const previewCheckout = previewJob.slice(previewCheckoutStart, previewCheckoutEnd);
+    expect(previewCheckout).toContain('ref: ${{ github.event.pull_request.head.sha }}');
+    expect(previewCheckout).toContain('- name: Verify preview checkout identity');
+    expect(previewCheckout).toContain('EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}');
+    expect(previewCheckout).toContain('git rev-parse HEAD');
+    expect(previewCheckout).toContain('git rev-parse HEAD^{tree}');
+    expect(previewCheckout).toContain('Preview checkout does not match the authorized pull-request head');
+    expect(previewCheckout).toContain("printf 'commit=%s\\n' \"$checked_out_commit\" >> \"$GITHUB_OUTPUT\"");
+    expect(previewCheckout).toContain("printf 'tree=%s\\n' \"$checked_out_tree\" >> \"$GITHUB_OUTPUT\"");
     expect(previewWorkflow).toContain('**Canonical MCP Endpoint:** `https://preview-mcp.theologai.xyz/mcp`');
     expect(previewWorkflow).toContain('**Compatibility MCP endpoint:** `https://theologai-preview.tjfrederick.workers.dev/mcp`');
+    expect(previewWorkflow).toContain('CHECKED_OUT_COMMIT: ${{ steps.preview-checkout.outputs.commit }}');
+    expect(previewWorkflow).toContain('CHECKED_OUT_TREE: ${{ steps.preview-checkout.outputs.tree }}');
+    expect(previewWorkflow).toContain('Deployed from checked-out commit \\`${commit}\\` (tree \\`${tree}\\`).');
   });
 
   it('keeps fallback origin behavior on the legacy Pages site during the staged cutover', () => {

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -26,8 +26,8 @@ describe('custom-domain infrastructure contract', () => {
     expect(preview).toContain('workers_dev = true');
     expect(preview).toContain('{ pattern = "preview-mcp.theologai.xyz", custom_domain = true }');
     expect(preview).not.toContain('{ pattern = "mcp.theologai.xyz", custom_domain = true }');
-    expect(preview).toContain('database_name = "theologai-preview-20260714-a"');
-    expect(preview).toContain('database_id = "0dab804f-8df0-4727-93bd-299612b6e179"');
+    expect(preview).toContain('database_name = "theologai-preview-20260722-b"');
+    expect(preview).toContain('database_id = "94c4938b-7800-4d68-9097-0df33c31fdc1"');
     expect(preview).toContain('namespace_id = "361202"');
 
     for (const environment of [production, preview]) {

--- a/test/unit/scripts/ccelOperatorSecretRelease.test.ts
+++ b/test/unit/scripts/ccelOperatorSecretRelease.test.ts
@@ -81,7 +81,7 @@ describe('CCEL operator-secret staged release policy', () => {
     expect(() => assertReleaseConfig(releaseConfig)).not.toThrow();
     expect(() => assertWorkerConfig(workerConfig.replace('namespace_id = "361203"', 'namespace_id = "361201"')))
       .toThrow('namespace mismatch');
-    expect(() => assertWorkerConfig(workerConfig.replace('database_id = "0dab804f-8df0-4727-93bd-299612b6e179"', `database_id = "${baselineId}"`)))
+    expect(() => assertWorkerConfig(workerConfig.replace('database_id = "94c4938b-7800-4d68-9097-0df33c31fdc1"', `database_id = "${baselineId}"`)))
       .toThrow('D1 binding mismatch');
     expect(() => assertWorkerConfig(workerConfig.replace('THEOLOGAI_REQUEST_LOGS = "true"', 'THEOLOGAI_REQUEST_LOGS = "false"')))
       .toThrow('theologai-preview THEOLOGAI_REQUEST_LOGS mismatch');

--- a/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
@@ -11,7 +11,7 @@ const reviewedBasePins = {
   'src/tools/worker/index.ts': 'feb1679a520185d11f2b6082b70ea3ef6c2b87652ff49c97c0acedfb76d83b90',
   'src/worker.ts': '619a0a66c30ade7ec8f78f13c59ed0791c67d1ae956eb69e0b126ba20f7dc92d',
   'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
-  'wrangler.toml': '7517fc557138cc8ada6de692c3603248b221e4e5c7bbd45cf8de8b06459cf0af',
+  'wrangler.toml': '46862ae67027c460a94932a1284e0885bbaf3d1699a11887f235e645fe50b04f',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
 } as const;
 

--- a/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
@@ -15,7 +15,7 @@ const activeIdentityPins = {
   'src/mcp/schemas/originalLanguageStudy.ts': 'a98e5966d8a2a850487b4882c49f04c48fc697eee308f6e89c67e06af50fefac',
   'src/presenters/originalLanguageStudyStructured.ts': '49818eb62e89980498669442a4bfc1886944d7751fc675940b17368a030995d9',
   'src/formatters/originalLanguageStudyFormatter.ts': '30a10bf826c6c3174f2e0fb00907f6104735b165fdbfd5915a0ff22bc09b2536',
-  'wrangler.toml': '7517fc557138cc8ada6de692c3603248b221e4e5c7bbd45cf8de8b06459cf0af',
+  'wrangler.toml': '46862ae67027c460a94932a1284e0885bbaf3d1699a11887f235e645fe50b04f',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
   'test/fixtures/ubs-semantics/structured-output-contract.draft.json': 'c5c11254fc84e1ac75200b5b93cb967dfe17e99150e88525cb95d6f58d05c8f2',
 } as const;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -109,8 +109,8 @@ script_name = "theologai-ccel-coordinator"
 
 [[env.preview.d1_databases]]
 binding = "THEOLOGAI_DB"
-database_name = "theologai-preview-20260714-a"
-database_id = "0dab804f-8df0-4727-93bd-299612b6e179"
+database_name = "theologai-preview-20260722-b"
+database_id = "94c4938b-7800-4d68-9097-0df33c31fdc1"
 migrations_dir = "migrations"
 
 # Preview uses a distinct namespace so load tests and PR validation cannot


### PR DESCRIPTION
## Summary

- bind the checked-in preview Worker configuration to the reviewed Transform-8 D1 `theologai-preview-20260722-b`
- preserve production behavior and its current D1 binding until the separate production-binding release
- harden protected preview checkout so deployment uses the exact live pull-request head
- reconcile current operational documentation for the Transform-8 preview release

## Verified preview release

- exact pull-request head: `3a2b5a57b322dce525f27cfa91c9f667d080bca9`
- tree: `12d51c914b5397b908022c524275a59508d69f68`
- GitHub run: `30039858274`
- Cloudflare deployment: `04e7a69a-78d2-447b-ac71-e9fb0bef3695`
- Worker version: `576517dd-84a8-4b5f-a5ea-ed8f124db63d`
- preview D1: `theologai-preview-20260722-b` (`94c4938b-7800-4d68-9097-0df33c31fdc1`)
- all five required checks and the protected preview deployment passed
- parallel-passage audit: 22/22 cases
- Transform-8 black-box audit: 48/48 bounded requests with all assertion groups passing
- preview authorization removed; revocation run `30040550778` passed

## Release boundary

The owner authorized merge after the verified preview release. Merging this PR does not authorize deploying its unchanged production binding: production remains on `theologai-production-20260715-a` until the separate reviewed binding-only PR targets prepared candidate `theologai-production-20260723-a`.

The historical-source experiment remains a separate workstream. Its database is retained, but its application/schema work is not included here and will be ported onto current `main` as migration `0006`.
