### PR TITLE
Bind the prepared Transform-8 production D1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   draft. Any later docs-only PR #92 head is not deployed. This did not deploy
   production.
 
+  The checked-in production-binding candidate is
+  `theologai-production-20260723-a`
+  (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
+  deterministic seeding, strict readiness, and the Transform-8 authority audit.
+  No active production Worker uses it: the live deployment, Worker, and old D1
+  above remain the matched rollback pair, and checked-in config is not
+  deployment evidence.
+
 - Completed the runtime-inert UBS Hebrew U3-T7 compiler, canonical
   native-to-normalized bridge, content-free reproducibility audit, embedded
   rights/provenance notice, and full-corpus integrity verification. The full
@@ -35,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alter MCP output. Transform 8 is active in preview's historical repositories:
   the existing `classic_text_lookup` has the Baltimore hard cut and
   canonical/legacy resolution, changing preview output without adding a tool.
-  Production Worker and D1 lack both transforms. `SOURCE.json` remains the
+  The live production Worker and its bound old D1 lack both transforms.
+  `SOURCE.json` remains the
   historical acquisition-gate snapshot rather than deployment evidence;
   production data release and any later UBS runtime activation remain separately
   gated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reconciled release state after the preview-only PR #92 D1 cutover. Production
-  remains PR #72: Cloudflare deployment `a4697fd1-deda-4dae-a16c-635454218bc8`,
-  Worker `762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
-  `c6535a4a-1953-4279-b277-7368445fc61a`. The exact deployed and audited
-  preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7` in
-  draft, unmerged PR #92: deployment
-  `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
-  `2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
-  `94c4938b-7800-4d68-9097-0df33c31fdc1`. CI run `30011028739` and both
-  audits passed; its preview authorization was removed and it returned to
-  draft. Any later docs-only PR #92 head is not deployed. This did not deploy
-  production.
+- Reconciled release state after the PR #92 preview-only D1 cutover. PR #92
+  merged as `cd3d1c38fdf0f939a33a41d4b6d5044eb7f44562`; its exact reviewed
+  head `3a2b5a57b322dce525f27cfa91c9f667d080bca9` is deployed to preview only
+  as Cloudflare deployment `04e7a69a-78d2-447b-ac71-e9fb0bef3695`, Worker
+  `576517dd-84a8-4b5f-a5ea-ed8f124db63d`, and D1
+  `94c4938b-7800-4d68-9097-0df33c31fdc1`. Exact-head CI attempt 2 run
+  `30017722596` and protected preview run `30039858274` passed. The parallel
+  audit passed 22/22 cases; the Transform-8 audit recorded 48 rate-counted
+  requests, 53 total HTTP records, and 11/11 assertion groups. The
+  `deploy-preview` authorization was removed and revocation run `30040550778`
+  passed. This did not deploy production, which remains PR #72: Cloudflare
+  deployment `a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
+  `762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+  `c6535a4a-1953-4279-b277-7368445fc61a`.
 
   The checked-in production-binding candidate is
   `theologai-production-20260723-a`
   (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
   deterministic seeding, strict readiness, and the Transform-8 authority audit.
-  No active production Worker uses it: the live deployment, Worker, and old D1
-  above remain the matched rollback pair, and checked-in config is not
+  No live production Worker is bound to it: the live deployment, Worker, and
+  old D1 above remain the matched rollback pair, and checked-in config is not
   deployment evidence.
 
 - Completed the runtime-inert UBS Hebrew U3-T7 compiler, canonical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,13 +191,22 @@ endpoint redirects ordinary requests to the canonical custom domain; the exact
 abusive-poller tuple is rejected instead, while the preview legacy endpoint
 remains direct. Repository-only U3-T7/PR #83 work remains outside production.
 
+The checked-in production-binding candidate names
+`theologai-production-20260723-a`
+(`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
+deterministic seeding, strict readiness, and the Transform-8 authority audit,
+but no active production Worker uses it. The live production deployment,
+Worker, and old D1 above remain the matched rollback pair; checked-in config is
+not deployment evidence.
+
 The preview-only D1 has migrations `0004` / transform 7 and `0005` / transform
 8 materialized. Transform 7's UBS adapters remain runtime-inactive: U3-T7's
 in-memory compiler, native-to-normalized coordinate bridge, and content-free
 audit do not register an MCP surface or alter current output. Transform 8 is
 active in preview's historical repositories: the existing `classic_text_lookup`
 has the Baltimore hard cut and canonical/legacy resolution, changing preview
-output without adding a tool. The production Worker and D1 lack both transforms.
+output without adding a tool. The live production Worker and its bound old D1
+lack both transforms.
 A production D1 release, later UBS runtime activation, Norton transform 9, and
 later edition transforms remain separately owner-gated.
 `package.json` is private: npm distribution is unsupported.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,20 +173,21 @@ The SQLite database (`data/theologai.db`) is a derived artifact. Cross-reference
 
 ## Release-state boundary
 
-Production remains the deployed PR #72 baseline: Cloudflare deployment
-`a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
-`762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
-`theologai-production-20260715-a`
-(`c6535a4a-1953-4279-b277-7368445fc61a`). The exact deployed and audited
-preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7` in
-unmerged draft PR #92; it is deployed to preview only as
-Cloudflare deployment `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
-`2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
+PR #92 merged as `cd3d1c38fdf0f939a33a41d4b6d5044eb7f44562`; its exact
+reviewed head `3a2b5a57b322dce525f27cfa91c9f667d080bca9` is deployed to
+preview only as Cloudflare deployment `04e7a69a-78d2-447b-ac71-e9fb0bef3695`,
+Worker `576517dd-84a8-4b5f-a5ea-ed8f124db63d`, and D1
 `theologai-preview-20260722-b`
-(`94c4938b-7800-4d68-9097-0df33c31fdc1`). CI run `30011028739` and its
-two preview audits passed; `deploy-preview` was removed and the PR returned
-to draft. Any later docs-only PR #92 head is not deployed. This is not a
-production deployment. The production `workers.dev`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). Exact-head CI attempt 2 run
+`30017722596` and protected preview run `30039858274` passed. The parallel
+audit passed 22/22 cases; the Transform-8 audit recorded 48 rate-counted
+requests, 53 total HTTP records, and 11/11 assertion groups. The
+`deploy-preview` authorization was removed and revocation run `30040550778`
+passed. This is not a production deployment. Production remains the deployed
+PR #72 baseline: Cloudflare deployment `a4697fd1-deda-4dae-a16c-635454218bc8`,
+Worker `762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+`theologai-production-20260715-a`
+(`c6535a4a-1953-4279-b277-7368445fc61a`). The production `workers.dev`
 endpoint redirects ordinary requests to the canonical custom domain; the exact
 abusive-poller tuple is rejected instead, while the preview legacy endpoint
 remains direct. Repository-only U3-T7/PR #83 work remains outside production.
@@ -195,7 +196,7 @@ The checked-in production-binding candidate names
 `theologai-production-20260723-a`
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
 deterministic seeding, strict readiness, and the Transform-8 authority audit,
-but no active production Worker uses it. The live production deployment,
+but no live production Worker is bound to it. The live production deployment,
 Worker, and old D1 above remain the matched rollback pair; checked-in config is
 not deployment evidence.
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ preview audits passed (22/22 cases and 59/59 checks; 48/48 rate-counted
 requests across 11 aggregate groups). The `deploy-preview` authorization was
 then removed and PR #92 returned to draft; it is not a production deployment.
 Any later docs-only PR #92 head is not deployed.
+
+The checked-in production-binding candidate now names
+`theologai-production-20260723-a`
+(`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
+deterministic seeding, strict readiness, and the Transform-8 authority audit,
+but no active production Worker uses it yet. The live production deployment,
+Worker, and old D1 above remain the matched rollback pair; checked-in
+configuration is not deployment evidence.
 For a preview-client rollback without changing server state, use the direct preview
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
@@ -70,11 +78,11 @@ The preview-only data layer has migration `0004` / transform 7 and migration
 remain runtime-inactive: they register no new MCP surface or output. Transform
 8 is active in preview's historical repositories: the existing
 `classic_text_lookup` has the Baltimore hard cut and canonical/legacy
-resolution. That adds no new tool, but it does change preview output.
-Production lacks both migrations, materialized rows, and this Transform-8
-behavior; a production D1 release and any later UBS runtime activation remain
-separately gated. The pinned packet's `SOURCE.json` remains a historical
-acquisition-gate snapshot, not deployment evidence.
+resolution. That adds no new tool, but it does change preview output. The live
+production Worker and its bound old D1 lack both migrations, materialized rows,
+and this Transform-8 behavior; a production D1 release and any later UBS
+runtime activation remain separately gated. The pinned packet's `SOURCE.json`
+remains a historical acquisition-gate snapshot, not deployment evidence.
 
 ## MCP capabilities
 

--- a/README.md
+++ b/README.md
@@ -45,28 +45,29 @@ Remote MCP client configuration:
 }
 ```
 
-Use the preview URL only for explicitly authorized release testing. Production
-remains the PR #72 known-good baseline: Cloudflare deployment
+Use the preview URL only for explicitly authorized release testing. PR #92
+merged as `cd3d1c38fdf0f939a33a41d4b6d5044eb7f44562`; its exact reviewed head
+`3a2b5a57b322dce525f27cfa91c9f667d080bca9` is deployed to preview only as
+Cloudflare deployment `04e7a69a-78d2-447b-ac71-e9fb0bef3695`, Worker
+`576517dd-84a8-4b5f-a5ea-ed8f124db63d`, and D1
+`theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). Exact-head CI attempt 2 run
+`30017722596` and protected preview run `30039858274` passed. The parallel
+audit passed 22/22 cases; the Transform-8 audit recorded 48 rate-counted
+requests, 53 total HTTP records, and 11/11 assertion groups. The
+`deploy-preview` authorization was removed and revocation run `30040550778`
+passed. It is not a production deployment. Production remains the PR #72
+known-good baseline: Cloudflare deployment
 `a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
 `762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
 `theologai-production-20260715-a`
-(`c6535a4a-1953-4279-b277-7368445fc61a`). Separately, the exact deployed and
-audited preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7`
-in unmerged draft PR #92; it is deployed to preview only:
-Cloudflare deployment `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
-`2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
-`theologai-preview-20260722-b`
-(`94c4938b-7800-4d68-9097-0df33c31fdc1`). Its CI run `30011028739` and
-preview audits passed (22/22 cases and 59/59 checks; 48/48 rate-counted
-requests across 11 aggregate groups). The `deploy-preview` authorization was
-then removed and PR #92 returned to draft; it is not a production deployment.
-Any later docs-only PR #92 head is not deployed.
+(`c6535a4a-1953-4279-b277-7368445fc61a`).
 
 The checked-in production-binding candidate now names
 `theologai-production-20260723-a`
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
 deterministic seeding, strict readiness, and the Transform-8 authority audit,
-but no active production Worker uses it yet. The live production deployment,
+but no live production Worker is bound to it. The live production deployment,
 Worker, and old D1 above remain the matched rollback pair; checked-in
 configuration is not deployment evidence.
 For a preview-client rollback without changing server state, use the direct preview

--- a/README.md
+++ b/README.md
@@ -278,8 +278,9 @@ D1 seed, and the preview-only D1. Transform 7's UBS adapters remain inactive
 at runtime. Transform 8 is separately active in preview's historical
 repositories: the existing `classic_text_lookup` exposes the Baltimore hard
 cut and canonical/legacy resolution, changing preview output without adding a
-tool. Production lacks both migrations, materializations, and Transform-8
-behavior. The historical source packets remain outside the local and remote
+tool. The live production Worker and its bound old D1 lack both migrations,
+materializations, and Transform-8 behavior. The historical source packets
+remain outside the local and remote
 17-work catalog and current tool output. U3-T7 provides the in-memory semantic
 compiler, native-to-normalized coordinate bridge, and content-free compilation
 audit; M4A provides capacity and seed verification with inactive adapters. Any

--- a/docs/CUSTOM-DOMAIN-MIGRATION.md
+++ b/docs/CUSTOM-DOMAIN-MIGRATION.md
@@ -34,27 +34,27 @@ Cloudflare dashboard action even though Worker routes are declared in
 
 ## Current operational release state (2026-07-23)
 
-Production remains the PR #72 release: Cloudflare deployment
-`a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
+PR #92 merged as `cd3d1c38fdf0f939a33a41d4b6d5044eb7f44562`; its exact
+reviewed head `3a2b5a57b322dce525f27cfa91c9f667d080bca9` is deployed to
+preview only as Cloudflare deployment `04e7a69a-78d2-447b-ac71-e9fb0bef3695`,
+Worker `576517dd-84a8-4b5f-a5ea-ed8f124db63d`, and D1
+`theologai-preview-20260722-b`
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). Exact-head CI attempt 2 run
+`30017722596` and protected preview run `30039858274` passed. The parallel
+audit passed 22/22 cases; the Transform-8 audit recorded 48 rate-counted
+requests, 53 total HTTP records, and 11/11 assertion groups. The
+`deploy-preview` authorization was removed and revocation run `30040550778`
+passed. It is not a production release. Production remains the PR #72 release:
+Cloudflare deployment `a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
 `762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
 `theologai-production-20260715-a`
-(`c6535a4a-1953-4279-b277-7368445fc61a`). The exact deployed and audited
-preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7` in
-draft, unmerged PR #92; it is separately deployed to preview only: Cloudflare
-deployment `44a0858f-75ba-497d-b84b-66c14253234a`,
-Worker `2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
-`theologai-preview-20260722-b`
-(`94c4938b-7800-4d68-9097-0df33c31fdc1`). CI run `30011028739` and both
-preview audits passed (22/22 cases, 59/59 checks, 48/48 rate-counted requests,
-and 11 aggregate groups). The `deploy-preview` authorization was removed and
-PR #92 returned to draft; any later docs-only PR #92 head is not deployed. It
-is not a production release.
+(`c6535a4a-1953-4279-b277-7368445fc61a`).
 
 The checked-in production-binding candidate is
 `theologai-production-20260723-a`
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
 deterministic seeding, strict readiness, and the Transform-8 authority audit,
-but no active production Worker uses it. The live production deployment,
+but no live production Worker is bound to it. The live production deployment,
 Worker, and old D1 above remain the matched rollback pair; checked-in config is
 not deployment evidence. The live production Worker and its bound old D1 still
 lack Transform-7 and Transform-8 data and behavior.

--- a/docs/CUSTOM-DOMAIN-MIGRATION.md
+++ b/docs/CUSTOM-DOMAIN-MIGRATION.md
@@ -50,6 +50,15 @@ and 11 aggregate groups). The `deploy-preview` authorization was removed and
 PR #92 returned to draft; any later docs-only PR #92 head is not deployed. It
 is not a production release.
 
+The checked-in production-binding candidate is
+`theologai-production-20260723-a`
+(`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
+deterministic seeding, strict readiness, and the Transform-8 authority audit,
+but no active production Worker uses it. The live production deployment,
+Worker, and old D1 above remain the matched rollback pair; checked-in config is
+not deployment evidence. The live production Worker and its bound old D1 still
+lack Transform-7 and Transform-8 data and behavior.
+
 ## Release-time known-good baseline
 
 The rollback anchor is deliberately a release-time record, not a stale version

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -642,8 +642,9 @@ Code readiness and operational readiness are deliberately separate:
   Baltimore hard cut and canonical/legacy resolution: no new tool is
   registered, but preview output changes. `productionObservedTarget` remains
   null and Node `.get()`/D1 `.first()` remain
-  `unordered_no_compatibility_proof`. Production D1 and Worker lack both
-  transforms; production materialization and behavior remain separately gated.
+  `unordered_no_compatibility_proof`. The live production Worker and its bound
+  old D1 lack both transforms; production materialization and behavior remain
+  separately gated.
   Norton is a later transform-9
   `sectioned_only` release; Calvin, Aquinas, and Augustine need later
   per-edition transforms and release approvals. Cyril remains a zero-output

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -679,8 +679,9 @@ Code readiness and operational readiness are deliberately separate:
   source. U3-T7 deterministic compilation and the Transform-7 data layer are
   complete, while its UBS adapters remain runtime-inactive. Preview also has
   active Transform-8 historical compatibility through the existing
-  `classic_text_lookup`; it changes preview output but adds no tool. Production
-  lacks both transforms. A separately owner-gated production data release and
+  `classic_text_lookup`; it changes preview output but adds no tool. The live
+  production Worker and its bound old D1 lack both transforms. A separately
+  owner-gated production data release and
   then a distinct UBS runtime-activation release would be required before
   extending the existing `original_language_study` tool.
   Evaluate MACULA

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -302,7 +302,14 @@ deployment `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
 two audits passed (22/22 cases, 59/59 checks, and 48/48 rate-counted requests
 across 11 aggregate groups). Its `deploy-preview` authorization was removed
 and the PR returned to draft; any later docs-only PR #92 head is not deployed.
-No production deployment occurred.
+No production deployment occurred. The checked-in production-binding candidate
+is `theologai-production-20260723-a`
+(`3f7faa0e-689f-47aa-a601-dc662db9a6cf`), which passed migrations `0001`–`0005`,
+deterministic seeding, strict readiness, and the Transform-8 authority audit.
+No active production Worker uses it: live production remains the deployment,
+Worker, and old D1 above as a matched rollback pair, and checked-in config is
+not deployment evidence. The live production Worker and its bound old D1 still
+lack Transform-7 and Transform-8 data and behavior.
 
 ## Shipped Phase 3 release train
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -275,40 +275,42 @@ is local source context only and does not define the current product contract.
   migration `0004` / transform 7 were the next gates; M4A records their
   completed local-only successor below.
 
-- **UBS Hebrew M4A local materialization (draft publication authorized):**
-  completed migration
-  `0004`, transform 7, local SQLite materialization, deterministic D1
-  seed/import verification, and inactive Node/D1 aggregate adapters. This is
-  local-only and runtime-inert: no composition-root registration, remote D1
-  import, binding change, preview/prod deployment, or MCP behavior is present
-  or authorized. The owner authorized draft-PR publication, but the branch had
-  not yet been published when this record was authored. `SOURCE.json` remains
-  the historical acquisition-gate snapshot, not a release-state record.
+- **UBS Hebrew M4A local materialization (merged through PR #92):** completed
+  migration `0004`, transform 7, local SQLite materialization, deterministic D1
+  seed/import verification, and inactive Node/D1 aggregate adapters. The
+  adapters remain runtime-inert: they add no composition-root registration or
+  MCP surface. The exact reviewed PR #92 head later materialized transforms 7
+  and 8 in preview only; that final preview release is recorded below.
+  `SOURCE.json` remains the historical acquisition-gate snapshot, not a
+  release-state record.
 
 Entries through PR #83 describe merged repository state. PR #83 is
-repository-only and undeployed; its merge is not deployment evidence. M4A is a
-later local-only draft whose publication is authorized but not itself a release.
+repository-only and undeployed; its merge is not deployment evidence. The M4A
+local-only stage has since merged through PR #92, whose preview-only deployment
+does not establish a production release.
 Deployment state is established only by the relevant protected workflow and
-post-deployment smoke evidence. Production remains the PR #72 release:
-Cloudflare deployment `a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
-`762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
-`c6535a4a-1953-4279-b277-7368445fc61a`. Separately, the exact deployed and
-audited preview source commit is `bb8ed4c8f025f697502a274986205f92bdf520b7`
-in draft, unmerged PR #92; it is deployed to preview only as Cloudflare
-deployment `44a0858f-75ba-497d-b84b-66c14253234a`, Worker
-`2b540a47-0937-4c00-9d44-de1199e09e6c`, and D1
+post-deployment smoke evidence. PR #92 merged as
+`cd3d1c38fdf0f939a33a41d4b6d5044eb7f44562`; its exact reviewed head
+`3a2b5a57b322dce525f27cfa91c9f667d080bca9` is deployed to preview only as
+Cloudflare deployment `04e7a69a-78d2-447b-ac71-e9fb0bef3695`, Worker
+`576517dd-84a8-4b5f-a5ea-ed8f124db63d`, and D1
 `theologai-preview-20260722-b`
-(`94c4938b-7800-4d68-9097-0df33c31fdc1`). CI run `30011028739` and the
-two audits passed (22/22 cases, 59/59 checks, and 48/48 rate-counted requests
-across 11 aggregate groups). Its `deploy-preview` authorization was removed
-and the PR returned to draft; any later docs-only PR #92 head is not deployed.
-No production deployment occurred. The checked-in production-binding candidate
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). Exact-head CI attempt 2 run
+`30017722596` and protected preview run `30039858274` passed. The parallel
+audit passed 22/22 cases; the Transform-8 audit recorded 48 rate-counted
+requests, 53 total HTTP records, and 11/11 assertion groups. The
+`deploy-preview` authorization was removed and revocation run `30040550778`
+passed. No production deployment occurred. Production remains the PR #72
+release: Cloudflare deployment `a4697fd1-deda-4dae-a16c-635454218bc8`, Worker
+`762485da-9e02-46a0-9777-e0d8743b9dbf`, and D1
+`c6535a4a-1953-4279-b277-7368445fc61a`. The checked-in production-binding candidate
 is `theologai-production-20260723-a`
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`), which passed migrations `0001`–`0005`,
 deterministic seeding, strict readiness, and the Transform-8 authority audit.
-No active production Worker uses it: live production remains the deployment,
-Worker, and old D1 above as a matched rollback pair, and checked-in config is
-not deployment evidence. The live production Worker and its bound old D1 still
+No live production Worker is bound to it: live production remains the
+deployment, Worker, and old D1 above as a matched rollback pair, and
+checked-in config is not deployment evidence. The live production Worker and
+its bound old D1 still
 lack Transform-7 and Transform-8 data and behavior.
 
 ## Shipped Phase 3 release train

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -610,8 +610,9 @@ Code readiness and operational readiness are deliberately separate:
   preview D1. Transform 7's UBS adapters remain runtime-inactive. Transform 8
   is active in preview's historical repositories: the existing
   `classic_text_lookup` has the Baltimore hard cut and canonical/legacy
-  resolution, changing preview output without adding a tool. Production Worker
-  and D1 lack both transforms. The next gate is a separately owner-authorized
+  resolution, changing preview output without adding a tool. The live
+  production Worker and its bound old D1 lack both transforms. The next gate is
+  a separately owner-authorized
   production D1 release followed by a distinct UBS runtime-activation decision.
   Keep the existing 32-source provenance cap as a required pack-sizing check.
 - PRs #61–#64 and #67 complete the planned inactive semantic and provenance

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -15,20 +15,21 @@ The checked-in production-binding candidate is
 `theologai-production-20260723-a`
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
 deterministic seeding, strict readiness, and the Transform-8 authority audit,
-but no active production Worker uses it. The live deployment, Worker, and old
-D1 above remain the matched rollback pair; checked-in config is not deployment
-evidence.
+but no live production Worker is bound to it. The live deployment, Worker, and
+old D1 above remain the matched rollback pair; checked-in config is not
+deployment evidence.
 
-The exact deployed and audited preview source commit is
-`bb8ed4c8f025f697502a274986205f92bdf520b7` in draft, unmerged PR #92; it is
-the separate preview-only release: CI run `30011028739` passed, Cloudflare
-deployment `44a0858f-75ba-497d-b84b-66c14253234a` serves Worker
-`2b540a47-0937-4c00-9d44-de1199e09e6c`, and its only D1 binding is
+PR #92 merged as `cd3d1c38fdf0f939a33a41d4b6d5044eb7f44562`; its exact
+reviewed head `3a2b5a57b322dce525f27cfa91c9f667d080bca9` is the separate
+preview-only release. Exact-head CI attempt 2 run `30017722596` and protected
+preview run `30039858274` passed. Cloudflare deployment
+`04e7a69a-78d2-447b-ac71-e9fb0bef3695` serves Worker
+`576517dd-84a8-4b5f-a5ea-ed8f124db63d`, and its only D1 binding is
 `theologai-preview-20260722-b`
-(`94c4938b-7800-4d68-9097-0df33c31fdc1`). The preview audits passed 22/22
-cases and 59/59 checks, plus 48/48 rate-counted requests across 11 aggregate
-groups. The `deploy-preview` label was removed and PR #92 returned to draft;
-any later docs-only PR #92 head is not deployed. This state is not a production
+(`94c4938b-7800-4d68-9097-0df33c31fdc1`). The parallel audit passed 22/22
+cases; the Transform-8 audit recorded 48 rate-counted requests, 53 total HTTP
+records, and 11/11 assertion groups. The `deploy-preview` label was removed
+and revocation run `30040550778` passed. This state is not a production
 deployment.
 
 Ordinary requests to the production `theologai.tjfrederick.workers.dev` host

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -11,6 +11,14 @@ Production remains the PR #72 known-good release: protected production run
 with no P0-P3 findings across 22 read-only requests and a 22/22
 source-attested regression.
 
+The checked-in production-binding candidate is
+`theologai-production-20260723-a`
+(`3f7faa0e-689f-47aa-a601-dc662db9a6cf`). It passed migrations `0001`–`0005`,
+deterministic seeding, strict readiness, and the Transform-8 authority audit,
+but no active production Worker uses it. The live deployment, Worker, and old
+D1 above remain the matched rollback pair; checked-in config is not deployment
+evidence.
+
 The exact deployed and audited preview source commit is
 `bb8ed4c8f025f697502a274986205f92bdf520b7` in draft, unmerged PR #92; it is
 the separate preview-only release: CI run `30011028739` passed, Cloudflare
@@ -43,11 +51,11 @@ migrations `0004` / transform 7 and `0005` / transform 8 materialized.
 Transform 7's UBS adapters remain runtime-inactive. Transform 8 is active in
 preview's historical repositories: the existing `classic_text_lookup` has the
 Baltimore hard cut and canonical/legacy resolution, changing preview output
-without adding a tool. Production Worker and D1 lack both transforms and
-production runtime activation remains unchanged. The unpublished candidate also
-advances the local primary-source schema pair to production v6/local-only and
-preview v7/discovery-only. No deletion, route replacement, or other destructive
-cleanup is authorized by this record.
+without adding a tool. The live production Worker and its bound old D1 lack
+both transforms and production runtime activation remains unchanged. The
+unpublished candidate also advances the local primary-source schema pair to
+production v6/local-only and preview v7/discovery-only. No deletion, route
+replacement, or other destructive cleanup is authorized by this record.
 
 Any eventual UBS semantic production release must separately authorize a
 production D1 migration/binding/deployment sequence. The preview data layer is

--- a/scripts/ccel-operator-secret-release.ts
+++ b/scripts/ccel-operator-secret-release.ts
@@ -4,7 +4,7 @@ import { parse as parseToml } from 'smol-toml';
 
 export const CCEL_OPERATOR_SECRET = 'THEOLOGAI_CCEL_OPERATOR_TOKEN';
 export const PRODUCTION_WORKER = 'theologai';
-export const PRODUCTION_D1_ID = 'c6535a4a-1953-4279-b277-7368445fc61a';
+export const PRODUCTION_D1_ID = '3f7faa0e-689f-47aa-a601-dc662db9a6cf';
 export const PREVIEW_D1_ID = '94c4938b-7800-4d68-9097-0df33c31fdc1';
 export const STAGE_CONFIRMATION = 'I AUTHORIZE PROVISIONING THE PROTECTED CCEL OPERATOR SECRET';
 export const PROMOTE_CONFIRMATION = 'PROMOTE THEOLOGAI CCEL OPERATOR SECRET';
@@ -127,7 +127,7 @@ export function assertWorkerConfig(configText: string): void {
   validateEnvironmentConfig(root, {
     worker: PRODUCTION_WORKER,
     d1Id: PRODUCTION_D1_ID,
-    d1Name: 'theologai-production-20260715-a',
+    d1Name: 'theologai-production-20260723-a',
     requestNamespace: '361201',
     operatorNamespace: '361203',
     vars: PRODUCTION_VARS,

--- a/test/fixtures/wrangler/baseline-version-view.json
+++ b/test/fixtures/wrangler/baseline-version-view.json
@@ -20,7 +20,7 @@
       "compatibility_flags": ["nodejs_compat"]
     },
     "bindings": [
-      { "name": "THEOLOGAI_DB", "type": "d1", "id": "c6535a4a-1953-4279-b277-7368445fc61a" },
+      { "name": "THEOLOGAI_DB", "type": "d1", "id": "3f7faa0e-689f-47aa-a601-dc662db9a6cf" },
       { "name": "THEOLOGAI_CCEL_COORDINATOR", "type": "durable_object_namespace", "class_name": "CcelGlobalCoordinator", "script_name": "theologai-ccel-coordinator" },
       { "name": "THEOLOGAI_RATE_LIMITER", "type": "ratelimit", "namespace_id": "361201", "simple": { "limit": 120, "period": 60 } },
       { "name": "THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER", "type": "ratelimit", "namespace_id": "361203", "simple": { "limit": 12, "period": 60 } },

--- a/test/fixtures/wrangler/staged-version-view.json
+++ b/test/fixtures/wrangler/staged-version-view.json
@@ -21,7 +21,7 @@
       "compatibility_flags": ["nodejs_compat"]
     },
     "bindings": [
-      { "name": "THEOLOGAI_DB", "type": "d1", "id": "c6535a4a-1953-4279-b277-7368445fc61a" },
+      { "name": "THEOLOGAI_DB", "type": "d1", "id": "3f7faa0e-689f-47aa-a601-dc662db9a6cf" },
       { "name": "THEOLOGAI_CCEL_COORDINATOR", "type": "durable_object_namespace", "class_name": "CcelGlobalCoordinator", "script_name": "theologai-ccel-coordinator" },
       { "name": "THEOLOGAI_RATE_LIMITER", "type": "ratelimit", "namespace_id": "361201", "simple": { "limit": 120, "period": 60 } },
       { "name": "THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER", "type": "ratelimit", "namespace_id": "361203", "simple": { "limit": 12, "period": 60 } },

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -19,8 +19,8 @@ describe('custom-domain infrastructure contract', () => {
     expect(production).toContain('workers_dev = true');
     expect(production).toContain('{ pattern = "mcp.theologai.xyz", custom_domain = true }');
     expect(production).not.toContain('preview-mcp.theologai.xyz');
-    expect(production).toContain('database_name = "theologai-production-20260715-a"');
-    expect(production).toContain('database_id = "c6535a4a-1953-4279-b277-7368445fc61a"');
+    expect(production).toContain('database_name = "theologai-production-20260723-a"');
+    expect(production).toContain('database_id = "3f7faa0e-689f-47aa-a601-dc662db9a6cf"');
     expect(production).toContain('namespace_id = "361201"');
 
     expect(preview).toContain('workers_dev = true');

--- a/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticAggregateInertness.test.ts
@@ -11,7 +11,7 @@ const reviewedBasePins = {
   'src/tools/worker/index.ts': 'feb1679a520185d11f2b6082b70ea3ef6c2b87652ff49c97c0acedfb76d83b90',
   'src/worker.ts': '619a0a66c30ade7ec8f78f13c59ed0791c67d1ae956eb69e0b126ba20f7dc92d',
   'src/worker-server.ts': '3f65b62179b267ac9b15fe682c69342be7ebee8a09430473b797c113e812782a',
-  'wrangler.toml': '46862ae67027c460a94932a1284e0885bbaf3d1699a11887f235e645fe50b04f',
+  'wrangler.toml': 'e2a395dc97b53f0b8da4786a7076dfde76e377fc79eb2058c3e8601fb624ec16',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
 } as const;
 

--- a/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
+++ b/test/unit/scripts/ubsSemanticResolutionInertness.test.ts
@@ -15,7 +15,7 @@ const activeIdentityPins = {
   'src/mcp/schemas/originalLanguageStudy.ts': 'a98e5966d8a2a850487b4882c49f04c48fc697eee308f6e89c67e06af50fefac',
   'src/presenters/originalLanguageStudyStructured.ts': '49818eb62e89980498669442a4bfc1886944d7751fc675940b17368a030995d9',
   'src/formatters/originalLanguageStudyFormatter.ts': '30a10bf826c6c3174f2e0fb00907f6104735b165fdbfd5915a0ff22bc09b2536',
-  'wrangler.toml': '46862ae67027c460a94932a1284e0885bbaf3d1699a11887f235e645fe50b04f',
+  'wrangler.toml': 'e2a395dc97b53f0b8da4786a7076dfde76e377fc79eb2058c3e8601fb624ec16',
   'worker-configuration.d.ts': 'e316f64679951b32417f0c85b02fc92e61dae25d879d28921df15caf8706fe55',
   'test/fixtures/ubs-semantics/structured-output-contract.draft.json': 'c5c11254fc84e1ac75200b5b93cb967dfe17e99150e88525cb95d6f58d05c8f2',
 } as const;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,8 +45,8 @@ script_name = "theologai-ccel-coordinator"
 # For multi-environment setups, use [env.staging] / [env.production] sections.
 [[d1_databases]]
 binding = "THEOLOGAI_DB"
-database_name = "theologai-production-20260715-a"
-database_id = "c6535a4a-1953-4279-b277-7368445fc61a"
+database_name = "theologai-production-20260723-a"
+database_id = "3f7faa0e-689f-47aa-a601-dc662db9a6cf"
 migrations_dir = "migrations"
 
 # Anonymous abuse control. Counters are intentionally local to each Cloudflare


### PR DESCRIPTION
## Scope

This is the isolated production-binding release for the already prepared Transform-8 database.

- Changes the checked-in production D1 binding to theologai-production-20260723-a (3f7faa0e-689f-47aa-a601-dc662db9a6cf).
- Updates only binding guard fixtures/tests, the CCEL operator release guard, and current-state release documentation.
- Keeps preview on theologai-preview-20260722-b (94c4938b-7800-4d68-9097-0df33c31fdc1).
- Makes no application behavior, route, secret, rate-limit, CCEL flag, corpus, or historical-source change.

## Prepared database evidence

The candidate is unbound and passed migrations 0001-0005, deterministic seeding (42 files / 1,624,856 rows), strict remote readiness, and the Transform-8 authority audit. The live production Worker still uses the old production D1 until a separately approved protected production deployment.

## Verification

Independent Sol review returned GO at exact head 682e920ae225076c73b584fcf3d66c16eac7f634 (tree aca88fb1ca470689dff9df46664ccfe80dcb01b8).

- 38/38 focused tests
- Worker types current
- Production and preview Wrangler dry-runs pass
- 113 canonical source files verified
- 42 D1 seed files / 1,624,856 rows verified
- Existing exact preview evidence: 22/22 cases, 59/59 checks, 53 HTTP records / 48 rate-counted requests, 11/11 Transform-8 assertion groups

## Release sequence

After fresh PR CI, this PR will be made ready and deployed to preview only for a fresh audit. Preview authorization will then be revoked and independently reviewed before merge. Only after merge will the protected production deployment be approved and audited. The current production Worker/D1 pair remains the rollback baseline. Historical-source migration work is excluded.