### PR TITLE
feat: add release corpus capacity gate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -101,11 +101,13 @@ jobs:
       - name: Build SQLite database from tracked sources
         run: npm run build:db -- --output "$RUNNER_TEMP/theologai.db"
 
-      - name: Verify generated SQLite database
-        run: npm run data:verify-db -- --database "$RUNNER_TEMP/theologai.db"
-
+      # Runs its own full semantic verifier with only the duplicate early size
+      # abort deferred, so an over-limit candidate prints structured evidence.
       - name: Report release-wide SQLite/D1 corpus capacity
         run: npm run audit:release-corpus-capacity
+
+      - name: Verify generated SQLite database
+        run: npm run data:verify-db -- --database "$RUNNER_TEMP/theologai.db"
 
       - name: Exercise D1 readiness checks against generated database
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Verify generated SQLite database
         run: npm run data:verify-db -- --database "$RUNNER_TEMP/theologai.db"
 
+      - name: Report release-wide SQLite/D1 corpus capacity
+        run: npm run audit:release-corpus-capacity
+
       - name: Exercise D1 readiness checks against generated database
         run: |
           test -f "$THEOLOGAI_TEST_DATABASE_PATH"

--- a/docs/RELEASE-CORPUS-CAPACITY.md
+++ b/docs/RELEASE-CORPUS-CAPACITY.md
@@ -17,6 +17,14 @@ below the operating system temporary directory, checks that the stored D1
 corpus identity agrees with `data/data-manifest.json`, and removes all temporary
 files. Tests alone can inject a fixture builder or baseline.
 
+The audit runs the normal full database verifier. For this one call, the
+verifier defers only its duplicate early 350 MiB abort to the audit; integrity,
+foreign keys, schema, row counts, corpus identity, D1 readiness, source
+authority, hierarchy, and language checks still run normally. The audit then
+prints the complete structured capacity/growth report and returns exit 1 when
+the measured database is over the ceiling. Running `data:verify-db` directly
+retains its existing early size guard.
+
 ## Controlling measurement and thresholds
 
 The controlling value is `capacity.preVacuumBytes`: the direct fresh database
@@ -58,10 +66,12 @@ Output contains no timestamps, temporary paths, or unordered collections. The
 same checkout and SQLite build therefore produce stable, reviewable JSON.
 
 The `Fresh Checkout & Data` pull-request job runs this command as a
-non-mutating capacity check. It builds only below runner temporary storage,
-prints the warning and complete growth report, and blocks the check above the
-350 MiB ceiling. Operators should also run the same command manually when
-preparing release evidence; CI does not update the recorded baseline.
+non-mutating capacity check before its generic verifier step. It builds only
+below runner temporary storage, prints the warning and complete growth report,
+and blocks the check above the 350 MiB ceiling. This order ensures capacity
+evidence is retained before the generic verifier can issue its terse early
+size error. Operators should also run the same command manually when preparing
+release evidence; CI does not update the recorded baseline.
 
 ## Transform 10 release interpretation
 

--- a/docs/RELEASE-CORPUS-CAPACITY.md
+++ b/docs/RELEASE-CORPUS-CAPACITY.md
@@ -27,7 +27,7 @@ size after `ANALYZE` and before `VACUUM`. `capacity.headroomBytes` is exactly
 |---|---|
 | Below 315 MiB (90%) | `within_capacity` |
 | 315 MiB through 350 MiB inclusive | `warning_at_or_above_90_percent`; report succeeds |
-| Above 350 MiB | `exceeds_350_mib`; command exits nonzero |
+| Above 350 MiB | Full `exceeds_350_mib` report is printed, then the command exits nonzero |
 
 The 350 MiB ceiling is the existing conservative D1 database limit used by the
 UBS and Aquinas capacity gates. The report’s `postVacuumDiagnostic` is useful
@@ -36,16 +36,32 @@ pre-`VACUUM` value.
 
 ## Growth evidence and baseline
 
-`docs/release-corpus-capacity-baseline-transform9.json` records the prior
-Transform 9 release measurement. Its commit, D1 corpus identity, Node/SQLite
-versions, database size, and sorted `dbstat` inventory are immutable release
-evidence. The new report compares every named `dbstat` object—tables, explicit
-and automatic indexes, FTS tables/shadows, and SQLite internals—against that
-baseline. Added and removed objects appear with a zero value on the absent
-side, so a storage change cannot disappear from the comparison.
+`docs/release-corpus-capacity-baseline-transform9.json` records the exact
+reviewed PR95 pre-Transform-10 head
+`9f8c2f16ae81bcdcf684840b91e920481c18430c`, with corpus identity
+`4e182bfd2953fe06e7c8d7e13a705988e85b5a58001e7fe72440333d34f6d442`.
+This is source-controlled release evidence; it does not independently claim a
+remote deployment. The record includes its Node/SQLite versions, database
+size, and complete sorted `dbstat` inventory. The report compares every named
+`dbstat` object—tables, explicit and automatic indexes, FTS tables/shadows, and
+SQLite internals—against that baseline. Added and removed objects appear with
+a zero value on the absent side. Growth rows are ordered by descending byte
+growth, with lexical object names breaking ties.
+
+Every baseline and current `dbstat` row must satisfy
+`bytes == pages * pageSize`. The sum of all `dbstat` pages plus
+`freelistPages` must equal `pageCount` and the corresponding bytes must equal
+the complete file size. A stale, truncated, or tampered baseline therefore
+fails before comparison.
 
 Output contains no timestamps, temporary paths, or unordered collections. The
 same checkout and SQLite build therefore produce stable, reviewable JSON.
+
+The `Fresh Checkout & Data` pull-request job runs this command as a
+non-mutating capacity check. It builds only below runner temporary storage,
+prints the warning and complete growth report, and blocks the check above the
+350 MiB ceiling. Operators should also run the same command manually when
+preparing release evidence; CI does not update the recorded baseline.
 
 ## Transform 10 release interpretation
 

--- a/docs/RELEASE-CORPUS-CAPACITY.md
+++ b/docs/RELEASE-CORPUS-CAPACITY.md
@@ -1,0 +1,71 @@
+# Release-wide SQLite/D1 corpus capacity gate
+
+`npm run audit:release-corpus-capacity` is the release-wide storage gate for
+the SQLite corpus that is exported to D1. It is capacity tooling only: it does
+not alter schema, corpus inputs, D1 bindings, a remote database, deployment,
+or runtime MCP behavior.
+
+Run it from a clean checkout with installed dependencies and Node 22:
+
+```bash
+npm run audit:release-corpus-capacity
+```
+
+The public command accepts no paths, output directories, database targets, or
+baseline overrides. It builds and verifies the normal current-checkout corpus
+below the operating system temporary directory, checks that the stored D1
+corpus identity agrees with `data/data-manifest.json`, and removes all temporary
+files. Tests alone can inject a fixture builder or baseline.
+
+## Controlling measurement and thresholds
+
+The controlling value is `capacity.preVacuumBytes`: the direct fresh database
+size after `ANALYZE` and before `VACUUM`. `capacity.headroomBytes` is exactly
+`350 MiB - capacity.preVacuumBytes`; it is negative only after a hard failure.
+
+| Boundary | Behavior |
+|---|---|
+| Below 315 MiB (90%) | `within_capacity` |
+| 315 MiB through 350 MiB inclusive | `warning_at_or_above_90_percent`; report succeeds |
+| Above 350 MiB | `exceeds_350_mib`; command exits nonzero |
+
+The 350 MiB ceiling is the existing conservative D1 database limit used by the
+UBS and Aquinas capacity gates. The report’s `postVacuumDiagnostic` is useful
+for packing analysis but is deliberately not a substitute for the controlling
+pre-`VACUUM` value.
+
+## Growth evidence and baseline
+
+`docs/release-corpus-capacity-baseline-transform9.json` records the prior
+Transform 9 release measurement. Its commit, D1 corpus identity, Node/SQLite
+versions, database size, and sorted `dbstat` inventory are immutable release
+evidence. The new report compares every named `dbstat` object—tables, explicit
+and automatic indexes, FTS tables/shadows, and SQLite internals—against that
+baseline. Added and removed objects appear with a zero value on the absent
+side, so a storage change cannot disappear from the comparison.
+
+Output contains no timestamps, temporary paths, or unordered collections. The
+same checkout and SQLite build therefore produce stable, reviewable JSON.
+
+## Transform 10 release interpretation
+
+Transform 10 is measured through the complete normal database build, rather
+than through the older Aquinas candidate-layout experiment. This makes its
+3,184 authority bodies, 3,185 hierarchy nodes, and external-content FTS part
+of the one release-wide SQLite/D1 measurement. Current checked-in release
+evidence puts Transform 10 at 339,603,456 bytes pre-`VACUUM`: it is above the
+315 MiB warning threshold but below the 350 MiB hard ceiling, leaving
+27,398,144 bytes of headroom. Re-run the command with Node 22 before any
+release decision because physical SQLite page packing can vary with the bundled
+SQLite build.
+
+## Operator response
+
+At a warning, inspect `growthSinceBaseline.dbstat` (largest positive
+`byteGrowth` first) and record the intended release evidence; do not use a
+post-`VACUUM` result to clear it. Above 350 MiB, the command is a release block:
+do not export/import a seed or deploy on the assumption that D1 will compact it.
+Reduce the proposed corpus/storage scope or obtain an explicitly reviewed
+capacity change, then rebuild and re-run the gate. Updating the recorded
+baseline is a separate, reviewable release-record action after a successful
+release; it must never be changed merely to silence a warning or failure.

--- a/docs/release-corpus-capacity-baseline-transform9.json
+++ b/docs/release-corpus-capacity-baseline-transform9.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "theologai-release-corpus-capacity-baseline.v1",
   "release": {
-    "id": "transform-9",
-    "commit": "e797b466d641146ff58f473bbb21a7ee920c7eaf",
-    "corpusIdentity": "ad2967a2de806a31e2d25b9dd60747d58739bd741ecb315b0e5d83f3a61649fd",
+    "id": "transform-9-reviewed-pre-transform-10",
+    "commit": "9f8c2f16ae81bcdcf684840b91e920481c18430c",
+    "corpusIdentity": "4e182bfd2953fe06e7c8d7e13a705988e85b5a58001e7fe72440333d34f6d442",
     "measuredWith": {
       "node": "v22.23.1",
       "sqlite": "3.51.2"

--- a/docs/release-corpus-capacity-baseline-transform9.json
+++ b/docs/release-corpus-capacity-baseline-transform9.json
@@ -1,0 +1,725 @@
+{
+  "schemaVersion": "theologai-release-corpus-capacity-baseline.v1",
+  "release": {
+    "id": "transform-9",
+    "commit": "e797b466d641146ff58f473bbb21a7ee920c7eaf",
+    "corpusIdentity": "ad2967a2de806a31e2d25b9dd60747d58739bd741ecb315b0e5d83f3a61649fd",
+    "measuredWith": {
+      "node": "v22.23.1",
+      "sqlite": "3.51.2"
+    }
+  },
+  "measurement": {
+    "fileBytes": 315211776,
+    "pageSize": 4096,
+    "pageCount": 76956,
+    "pageCountBytes": 315211776,
+    "freelistPages": 0,
+    "dbstat": [
+      {
+        "name": "cross_references",
+        "pages": 2620,
+        "bytes": 10731520,
+        "kind": "table"
+      },
+      {
+        "name": "document_sections",
+        "pages": 2669,
+        "bytes": 10932224,
+        "kind": "table"
+      },
+      {
+        "name": "documents",
+        "pages": 14,
+        "bytes": 57344,
+        "kind": "table"
+      },
+      {
+        "name": "historical_document_delivery_profiles",
+        "pages": 12,
+        "bytes": 49152,
+        "kind": "table"
+      },
+      {
+        "name": "historical_edition_sections",
+        "pages": 2146,
+        "bytes": 8790016,
+        "kind": "table"
+      },
+      {
+        "name": "historical_edition_sections_fts_config",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "historical_edition_sections_fts_content",
+        "pages": 2144,
+        "bytes": 8781824,
+        "kind": "table"
+      },
+      {
+        "name": "historical_edition_sections_fts_data",
+        "pages": 956,
+        "bytes": 3915776,
+        "kind": "table"
+      },
+      {
+        "name": "historical_edition_sections_fts_docsize",
+        "pages": 3,
+        "bytes": 12288,
+        "kind": "table"
+      },
+      {
+        "name": "historical_edition_sections_fts_idx",
+        "pages": 6,
+        "bytes": 24576,
+        "kind": "table"
+      },
+      {
+        "name": "historical_editions",
+        "pages": 9,
+        "bytes": 36864,
+        "kind": "table"
+      },
+      {
+        "name": "historical_section_aliases",
+        "pages": 26,
+        "bytes": 106496,
+        "kind": "table"
+      },
+      {
+        "name": "historical_section_identities",
+        "pages": 35,
+        "bytes": 143360,
+        "kind": "table"
+      },
+      {
+        "name": "historical_source_artifacts",
+        "pages": 4,
+        "bytes": 16384,
+        "kind": "table"
+      },
+      {
+        "name": "historical_source_packs",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "historical_works",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "idx_document_sections_id_document",
+        "pages": 31,
+        "bytes": 126976,
+        "kind": "index"
+      },
+      {
+        "name": "idx_historical_edition_sections_order",
+        "pages": 8,
+        "bytes": 32768,
+        "kind": "index"
+      },
+      {
+        "name": "idx_historical_editions_pack",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "idx_historical_editions_work",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "idx_historical_section_aliases_target",
+        "pages": 27,
+        "bytes": 110592,
+        "kind": "index"
+      },
+      {
+        "name": "idx_historical_section_identities_browse",
+        "pages": 38,
+        "bytes": 155648,
+        "kind": "index"
+      },
+      {
+        "name": "idx_historical_source_artifacts_edition",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "idx_morph_strongs",
+        "pages": 1721,
+        "bytes": 7049216,
+        "kind": "index"
+      },
+      {
+        "name": "idx_morph_strongs_canonical",
+        "pages": 2703,
+        "bytes": 11071488,
+        "kind": "index"
+      },
+      {
+        "name": "idx_morph_verse",
+        "pages": 2460,
+        "bytes": 10076160,
+        "kind": "index"
+      },
+      {
+        "name": "idx_strongs_book_stats_order",
+        "pages": 251,
+        "bytes": 1028096,
+        "kind": "index"
+      },
+      {
+        "name": "idx_strongs_form_stats_rank",
+        "pages": 1436,
+        "bytes": 5881856,
+        "kind": "index"
+      },
+      {
+        "name": "idx_ubs_groups_source_order",
+        "pages": 72,
+        "bytes": 294912,
+        "kind": "index"
+      },
+      {
+        "name": "idx_ubs_segments_lookup",
+        "pages": 126,
+        "bytes": 516096,
+        "kind": "index"
+      },
+      {
+        "name": "idx_ubs_semantic_coordinate_lookup",
+        "pages": 1733,
+        "bytes": 7098368,
+        "kind": "index"
+      },
+      {
+        "name": "idx_ubs_semantic_evidence_sense_order",
+        "pages": 2801,
+        "bytes": 11472896,
+        "kind": "index"
+      },
+      {
+        "name": "idx_ubs_semantic_identity_candidate",
+        "pages": 293,
+        "bytes": 1200128,
+        "kind": "index"
+      },
+      {
+        "name": "idx_ubs_semantic_sense_candidate_order",
+        "pages": 525,
+        "bytes": 2150400,
+        "kind": "index"
+      },
+      {
+        "name": "idx_ubs_semantic_sense_domain_order",
+        "pages": 520,
+        "bytes": 2129920,
+        "kind": "index"
+      },
+      {
+        "name": "idx_xref_from",
+        "pages": 1682,
+        "bytes": 6889472,
+        "kind": "index"
+      },
+      {
+        "name": "idx_xref_votes",
+        "pages": 937,
+        "bytes": 3837952,
+        "kind": "index"
+      },
+      {
+        "name": "morph_codes",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "morphology",
+        "pages": 8284,
+        "bytes": 33931264,
+        "kind": "table"
+      },
+      {
+        "name": "sections_fts_config",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "sections_fts_content",
+        "pages": 2643,
+        "bytes": 10825728,
+        "kind": "table"
+      },
+      {
+        "name": "sections_fts_data",
+        "pages": 1229,
+        "bytes": 5033984,
+        "kind": "table"
+      },
+      {
+        "name": "sections_fts_docsize",
+        "pages": 11,
+        "bytes": 45056,
+        "kind": "table"
+      },
+      {
+        "name": "sections_fts_idx",
+        "pages": 7,
+        "bytes": 28672,
+        "kind": "table"
+      },
+      {
+        "name": "sqlite_autoindex_cross_references_1",
+        "pages": 2841,
+        "bytes": 11636736,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_documents_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_document_delivery_profiles_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_document_delivery_profiles_2",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_edition_sections_1",
+        "pages": 9,
+        "bytes": 36864,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_edition_sections_2",
+        "pages": 8,
+        "bytes": 32768,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_editions_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_section_aliases_1",
+        "pages": 25,
+        "bytes": 102400,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_section_identities_1",
+        "pages": 11,
+        "bytes": 45056,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_section_identities_2",
+        "pages": 36,
+        "bytes": 147456,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_section_identities_3",
+        "pages": 32,
+        "bytes": 131072,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_section_identities_4",
+        "pages": 38,
+        "bytes": 155648,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_source_artifacts_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_source_packs_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_source_packs_2",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_historical_works_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_morph_codes_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_morphology_1",
+        "pages": 2691,
+        "bytes": 11022336,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_stepbible_lexicons_1",
+        "pages": 73,
+        "bytes": 299008,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_strongs_1",
+        "pages": 51,
+        "bytes": 208896,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_strongs_book_stats_1",
+        "pages": 348,
+        "bytes": 1425408,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_strongs_form_stats_1",
+        "pages": 1343,
+        "bytes": 5500928,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_strongs_usage_stats_1",
+        "pages": 51,
+        "bytes": 208896,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_theologai_metadata_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_parallel_groups_1",
+        "pages": 48,
+        "bytes": 196608,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_parallel_groups_2",
+        "pages": 26,
+        "bytes": 106496,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_parallel_members_1",
+        "pages": 123,
+        "bytes": 503808,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_parallel_segments_1",
+        "pages": 123,
+        "bytes": 503808,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_parallel_sources_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_parallel_sources_2",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_artifacts_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_domains_1",
+        "pages": 12,
+        "bytes": 49152,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_domains_2",
+        "pages": 14,
+        "bytes": 57344,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_entries_1",
+        "pages": 231,
+        "bytes": 946176,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_entries_2",
+        "pages": 253,
+        "bytes": 1036288,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_entries_3",
+        "pages": 308,
+        "bytes": 1261568,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_entry_identities_1",
+        "pages": 295,
+        "bytes": 1208320,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_normalized_coordinates_1",
+        "pages": 893,
+        "bytes": 3657728,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_sense_domains_1",
+        "pages": 517,
+        "bytes": 2117632,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_sense_domains_2",
+        "pages": 433,
+        "bytes": 1773568,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_senses_1",
+        "pages": 422,
+        "bytes": 1728512,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_senses_2",
+        "pages": 561,
+        "bytes": 2297856,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_senses_3",
+        "pages": 560,
+        "bytes": 2293760,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_sources_1",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_autoindex_ubs_semantic_sources_2",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "index"
+      },
+      {
+        "name": "sqlite_schema",
+        "pages": 11,
+        "bytes": 45056,
+        "kind": "internal"
+      },
+      {
+        "name": "sqlite_sequence",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "sqlite_stat1",
+        "pages": 3,
+        "bytes": 12288,
+        "kind": "table"
+      },
+      {
+        "name": "sqlite_stat4",
+        "pages": 55,
+        "bytes": 225280,
+        "kind": "table"
+      },
+      {
+        "name": "stepbible_lexicons",
+        "pages": 2404,
+        "bytes": 9846784,
+        "kind": "table"
+      },
+      {
+        "name": "strongs",
+        "pages": 694,
+        "bytes": 2842624,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_book_stats",
+        "pages": 368,
+        "bytes": 1507328,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_form_stats",
+        "pages": 1786,
+        "bytes": 7315456,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_fts_config",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_fts_content",
+        "pages": 438,
+        "bytes": 1794048,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_fts_data",
+        "pages": 368,
+        "bytes": 1507328,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_fts_docsize",
+        "pages": 44,
+        "bytes": 180224,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_fts_idx",
+        "pages": 3,
+        "bytes": 12288,
+        "kind": "table"
+      },
+      {
+        "name": "strongs_usage_stats",
+        "pages": 65,
+        "bytes": 266240,
+        "kind": "table"
+      },
+      {
+        "name": "theologai_metadata",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_parallel_groups",
+        "pages": 83,
+        "bytes": 339968,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_parallel_members",
+        "pages": 176,
+        "bytes": 720896,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_parallel_segments",
+        "pages": 119,
+        "bytes": 487424,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_parallel_sources",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_artifacts",
+        "pages": 2,
+        "bytes": 8192,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_domains",
+        "pages": 25,
+        "bytes": 102400,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_entries",
+        "pages": 362,
+        "bytes": 1482752,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_entry_identities",
+        "pages": 257,
+        "bytes": 1052672,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_normalized_coordinates",
+        "pages": 2253,
+        "bytes": 9228288,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_reference_evidence",
+        "pages": 13189,
+        "bytes": 54022144,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_sense_domains",
+        "pages": 467,
+        "bytes": 1912832,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_senses",
+        "pages": 1198,
+        "bytes": 4907008,
+        "kind": "table"
+      },
+      {
+        "name": "ubs_semantic_sources",
+        "pages": 1,
+        "bytes": 4096,
+        "kind": "table"
+      }
+    ],
+    "integrityCheck": "ok",
+    "foreignKeyViolations": 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:stepbible": "tsx scripts/build-stepbible-json.ts",
     "build:stepbible:lexicons": "tsx scripts/build-stepbible-lexicons.ts",
     "audit:aquinas-source-pack-capacity": "tsx scripts/aquinas-source-pack-capacity-comparison.ts",
+    "audit:release-corpus-capacity": "tsx scripts/release-corpus-capacity.ts",
     "build:db": "tsx scripts/build-database.ts",
     "data:verify-sources": "tsx scripts/verify-data-manifest.ts",
     "data:verify-section-keys": "tsx scripts/historical-section-key-plan.ts",

--- a/scripts/release-corpus-capacity-policy.ts
+++ b/scripts/release-corpus-capacity-policy.ts
@@ -1,0 +1,5 @@
+/**
+ * Internal handoff used only when the release-capacity audit owns the final
+ * structured size decision. The verifier still runs every semantic check.
+ */
+export const VERIFY_DATABASE_DEFER_CAPACITY_FLAG = '--defer-capacity-to-release-report';

--- a/scripts/release-corpus-capacity.ts
+++ b/scripts/release-corpus-capacity.ts
@@ -112,6 +112,55 @@ type UnknownRecord = Record<string, unknown>;
 
 function fail(message: string): never { throw new Error(`[release-corpus-capacity] ${message}`); }
 
+/** Fail closed unless dbstat plus the freelist accounts for every database page. */
+export function assertDatabaseCapacityMeasurement(
+  measurement: DatabaseCapacityMeasurement,
+  label = 'database capacity measurement',
+): void {
+  for (const [field, value] of Object.entries({
+    fileBytes: measurement.fileBytes,
+    pageSize: measurement.pageSize,
+    pageCount: measurement.pageCount,
+    pageCountBytes: measurement.pageCountBytes,
+    freelistPages: measurement.freelistPages,
+  })) {
+    if (!Number.isSafeInteger(value) || value < 0) fail(`${label}.${field} must be a non-negative safe integer`);
+  }
+  if (measurement.pageSize === 0 || measurement.pageCount === 0
+    || measurement.pageCountBytes !== measurement.pageSize * measurement.pageCount
+    || measurement.fileBytes !== measurement.pageCountBytes) {
+    fail(`${label} must retain matching non-zero page and file byte measurements`);
+  }
+  if (measurement.integrityCheck !== 'ok' || measurement.foreignKeyViolations !== 0) {
+    fail(`${label} must retain clean integrity checks`);
+  }
+  if (measurement.dbstat.length === 0) fail(`${label}.dbstat must not be empty`);
+
+  const names = measurement.dbstat.map(entry => entry.name);
+  if (new Set(names).size !== names.length || JSON.stringify(names) !== JSON.stringify([...names].sort())) {
+    fail(`${label}.dbstat must have unique, lexically ordered names`);
+  }
+
+  let allocatedPages = 0;
+  let allocatedBytes = 0;
+  for (const entry of measurement.dbstat) {
+    if (!entry.name || !Number.isSafeInteger(entry.pages) || entry.pages <= 0
+      || !Number.isSafeInteger(entry.bytes) || entry.bytes <= 0) {
+      fail(`${label}.dbstat entry ${entry.name || '<unnamed>'} must have positive safe page and byte measurements`);
+    }
+    if (entry.bytes !== entry.pages * measurement.pageSize) {
+      fail(`${label}.dbstat entry ${entry.name} bytes must equal pages multiplied by pageSize`);
+    }
+    allocatedPages += entry.pages;
+    allocatedBytes += entry.bytes;
+  }
+  if (!Number.isSafeInteger(allocatedPages) || !Number.isSafeInteger(allocatedBytes)
+    || allocatedPages + measurement.freelistPages !== measurement.pageCount
+    || allocatedBytes + measurement.freelistPages * measurement.pageSize !== measurement.fileBytes) {
+    fail(`${label} dbstat allocations plus freelist pages must conserve the complete database file`);
+  }
+}
+
 function asRecord(value: unknown, label: string): UnknownRecord {
   if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
   return value as UnknownRecord;
@@ -164,7 +213,7 @@ export function measureDatabaseCapacity(database: Database.Database, path: strin
   const fileBytes = statSync(path).size;
   if (fileBytes !== pageCountBytes) fail('SQLite file size differs from its page count');
 
-  return {
+  const measurement: DatabaseCapacityMeasurement = {
     fileBytes,
     pageSize,
     pageCount,
@@ -174,6 +223,8 @@ export function measureDatabaseCapacity(database: Database.Database, path: strin
     integrityCheck: 'ok',
     foreignKeyViolations: 0,
   };
+  assertDatabaseCapacityMeasurement(measurement);
+  return measurement;
 }
 
 /** The authoritative measurement: fresh database after ANALYZE and before VACUUM. */
@@ -222,11 +273,13 @@ function parseMeasurement(value: unknown, label: string): DatabaseCapacityMeasur
   if (new Set(names).size !== names.length || JSON.stringify(names) !== JSON.stringify([...names].sort())) {
     fail(`${label}.dbstat must have unique, lexically ordered names`);
   }
-  return {
+  const measurement: DatabaseCapacityMeasurement = {
     fileBytes, pageSize, pageCount, pageCountBytes,
     freelistPages: asInteger(raw.freelistPages, `${label}.freelistPages`), dbstat,
     integrityCheck: 'ok', foreignKeyViolations: 0,
   };
+  assertDatabaseCapacityMeasurement(measurement, label);
+  return measurement;
 }
 
 /** Load and validate the prior, checked-in release measurement. */
@@ -273,7 +326,10 @@ export function assertCorpusCapacity(preVacuumBytes: number): ReturnType<typeof 
   return assessment;
 }
 
-/** Compare every table, index, FTS shadow, and SQLite-internal dbstat object in lexical order. */
+/**
+ * Compare every table, index, FTS shadow, and SQLite-internal dbstat object.
+ * Largest byte growth is first; lexical name order breaks ties deterministically.
+ */
 export function compareDbstatGrowth(
   baseline: readonly DbstatObjectMeasurement[],
   current: readonly DbstatObjectMeasurement[],
@@ -293,7 +349,8 @@ export function compareDbstatGrowth(
       name, kind, baselinePages, currentPages, pageGrowth: currentPages - baselinePages,
       baselineBytes, currentBytes, byteGrowth: currentBytes - baselineBytes,
     };
-  });
+  }).sort((left, right) => right.byteGrowth - left.byteGrowth
+    || (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
 }
 
 export function buildReleaseCorpusCapacityReport(
@@ -384,6 +441,10 @@ export function parseReleaseCorpusCapacityArguments(argv: readonly string[]): vo
   if (argv.length !== 0) fail('this release-wide capacity command accepts no arguments and always uses a disposable fresh database');
 }
 
+export function releaseCorpusCapacityExitCode(report: ReleaseCorpusCapacityReport): 0 | 1 {
+  return report.capacity.withinLimit ? 0 : 1;
+}
+
 function assertNode22(): void {
   if (process.versions.node.split('.')[0] !== '22') fail(`requires Node 22; received ${process.version}`);
 }
@@ -393,7 +454,7 @@ function main(argv: readonly string[]): void {
   assertNode22();
   const report = runReleaseCorpusCapacityReport();
   process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-  if (!report.capacity.withinLimit) process.exitCode = 1;
+  process.exitCode = releaseCorpusCapacityExitCode(report);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/release-corpus-capacity.ts
+++ b/scripts/release-corpus-capacity.ts
@@ -1,0 +1,404 @@
+#!/usr/bin/env tsx
+/**
+ * Release-wide capacity gate for the SQLite database that is also materialized
+ * into D1. It always builds a disposable database from the current checkout;
+ * it neither opens a remote D1 database nor writes a corpus artifact.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+import { computeD1CorpusIdentity, parseDataManifest } from './d1-corpus-identity.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILD_SCRIPT = 'scripts/build-database.ts';
+const VERIFY_SCRIPT = 'scripts/verify-database.ts';
+
+export const D1_CORPUS_CAPACITY_LIMIT_BYTES = 350 * 1024 * 1024;
+export const D1_CORPUS_CAPACITY_WARNING_RATIO = 0.9;
+export const D1_CORPUS_CAPACITY_WARNING_BYTES = D1_CORPUS_CAPACITY_LIMIT_BYTES * D1_CORPUS_CAPACITY_WARNING_RATIO;
+export const RECORDED_CAPACITY_BASELINE_PATH = 'docs/release-corpus-capacity-baseline-transform9.json';
+
+export type DbstatObjectKind = 'index' | 'internal' | 'table';
+export type CapacityStatus = 'exceeds_350_mib' | 'warning_at_or_above_90_percent' | 'within_capacity';
+
+export interface DbstatObjectMeasurement {
+  name: string;
+  kind: DbstatObjectKind;
+  pages: number;
+  bytes: number;
+}
+
+export interface DatabaseCapacityMeasurement {
+  fileBytes: number;
+  pageSize: number;
+  pageCount: number;
+  pageCountBytes: number;
+  freelistPages: number;
+  dbstat: DbstatObjectMeasurement[];
+  integrityCheck: 'ok';
+  foreignKeyViolations: 0;
+}
+
+export interface RecordedCapacityBaseline {
+  schemaVersion: 'theologai-release-corpus-capacity-baseline.v1';
+  release: {
+    id: string;
+    commit: string;
+    corpusIdentity: string;
+    measuredWith: { node: string; sqlite: string };
+  };
+  measurement: DatabaseCapacityMeasurement;
+}
+
+export interface DbstatGrowth {
+  name: string;
+  kind: DbstatObjectKind;
+  baselinePages: number;
+  currentPages: number;
+  pageGrowth: number;
+  baselineBytes: number;
+  currentBytes: number;
+  byteGrowth: number;
+}
+
+export interface ReleaseCorpusCapacityReport {
+  schemaVersion: 'theologai-release-corpus-capacity-report.v1';
+  corpus: {
+    storage: 'sqlite_d1_materialized';
+    corpusIdentity: string;
+    freshBuildVerified: true;
+  };
+  capacity: {
+    basis: 'direct_fresh_database_after_analyze_pre_vacuum';
+    limitBytes: number;
+    warningThresholdBytes: number;
+    preVacuumBytes: number;
+    headroomBytes: number;
+    status: CapacityStatus;
+    warning: boolean;
+    withinLimit: boolean;
+  };
+  current: {
+    preVacuum: DatabaseCapacityMeasurement;
+    postVacuumDiagnostic: DatabaseCapacityMeasurement;
+  };
+  baseline: RecordedCapacityBaseline['release'] & { preVacuumBytes: number };
+  growthSinceBaseline: {
+    databaseBytes: number;
+    databaseBasisPoints: number;
+    dbstat: DbstatGrowth[];
+  };
+}
+
+export interface ReleaseCorpusCapacityBuilderContext {
+  root: string;
+  outputPath: string;
+}
+
+export interface ReleaseCorpusCapacityRunOptions {
+  /** Test-only injection. The public command always performs the normal build. */
+  buildDatabase?: (context: ReleaseCorpusCapacityBuilderContext) => void;
+  /** Test-only injection. The public command always performs normal verification. */
+  verifyDatabase?: (context: ReleaseCorpusCapacityBuilderContext) => void;
+  /** Test-only injection. The public command always uses the checked-in release baseline. */
+  baseline?: RecordedCapacityBaseline;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function fail(message: string): never { throw new Error(`[release-corpus-capacity] ${message}`); }
+
+function asRecord(value: unknown, label: string): UnknownRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+  return value as UnknownRecord;
+}
+
+function asString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) fail(`${label} must be non-empty text`);
+  return value;
+}
+
+function asInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) fail(`${label} must be a non-negative safe integer`);
+  return value as number;
+}
+
+function asKind(value: unknown, label: string): DbstatObjectKind {
+  if (value === 'index' || value === 'internal' || value === 'table') return value;
+  return fail(`${label} must be table, index, or internal`);
+}
+
+function pragmaInteger(database: Database.Database, sql: string): number {
+  const row = database.prepare(sql).get() as Record<string, unknown> | undefined;
+  const value = row === undefined ? undefined : Object.values(row)[0];
+  if (!Number.isSafeInteger(value)) fail(`SQLite did not return an integer for ${sql}`);
+  return value as number;
+}
+
+function databaseObjectKinds(database: Database.Database): Map<string, DbstatObjectKind> {
+  const rows = database.prepare(`SELECT name, type FROM sqlite_master
+    WHERE type IN ('index', 'table') ORDER BY name`).all() as Array<{ name: string; type: string }>;
+  return new Map(rows.map(row => [row.name, row.type === 'index' ? 'index' : 'table']));
+}
+
+/** Measure physical B-tree/FTS allocations after the caller has run ANALYZE. */
+export function measureDatabaseCapacity(database: Database.Database, path: string): DatabaseCapacityMeasurement {
+  const integrity = database.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>;
+  if (integrity.length !== 1 || Object.values(integrity[0]!)[0] !== 'ok') fail('SQLite integrity_check failed');
+  if (database.prepare('PRAGMA foreign_key_check').all().length !== 0) fail('SQLite foreign_key_check found violations');
+
+  const kinds = databaseObjectKinds(database);
+  const dbstat = database.prepare(`SELECT name, COUNT(*) AS pages, SUM(pgsize) AS bytes
+    FROM dbstat GROUP BY name ORDER BY name`).all() as Array<{ name: string; pages: number; bytes: number }>;
+  if (dbstat.length === 0 || dbstat.some(row => !Number.isSafeInteger(row.pages) || !Number.isSafeInteger(row.bytes))) {
+    fail('SQLite dbstat measurement is unavailable');
+  }
+
+  const pageSize = pragmaInteger(database, 'PRAGMA page_size');
+  const pageCount = pragmaInteger(database, 'PRAGMA page_count');
+  const pageCountBytes = pageSize * pageCount;
+  const fileBytes = statSync(path).size;
+  if (fileBytes !== pageCountBytes) fail('SQLite file size differs from its page count');
+
+  return {
+    fileBytes,
+    pageSize,
+    pageCount,
+    pageCountBytes,
+    freelistPages: pragmaInteger(database, 'PRAGMA freelist_count'),
+    dbstat: dbstat.map(row => ({ ...row, kind: kinds.get(row.name) ?? 'internal' })),
+    integrityCheck: 'ok',
+    foreignKeyViolations: 0,
+  };
+}
+
+/** The authoritative measurement: fresh database after ANALYZE and before VACUUM. */
+export function measurePreVacuumDatabase(path: string): DatabaseCapacityMeasurement {
+  const database = new Database(path, { fileMustExist: true });
+  try {
+    database.exec('ANALYZE');
+    return measureDatabaseCapacity(database, path);
+  } finally {
+    database.close();
+  }
+}
+
+/** A non-gating diagnostic that never replaces the pre-VACUUM capacity gate. */
+export function measurePostVacuumDiagnostic(path: string): DatabaseCapacityMeasurement {
+  const database = new Database(path, { fileMustExist: true });
+  try {
+    database.exec('VACUUM');
+    return measureDatabaseCapacity(database, path);
+  } finally {
+    database.close();
+  }
+}
+
+function parseMeasurement(value: unknown, label: string): DatabaseCapacityMeasurement {
+  const raw = asRecord(value, label);
+  const fileBytes = asInteger(raw.fileBytes, `${label}.fileBytes`);
+  const pageSize = asInteger(raw.pageSize, `${label}.pageSize`);
+  const pageCount = asInteger(raw.pageCount, `${label}.pageCount`);
+  const pageCountBytes = asInteger(raw.pageCountBytes, `${label}.pageCountBytes`);
+  if (pageSize === 0 || pageCount === 0 || pageCountBytes !== pageSize * pageCount || fileBytes !== pageCountBytes) {
+    fail(`${label} must retain matching non-zero page and file byte measurements`);
+  }
+  if (raw.integrityCheck !== 'ok' || raw.foreignKeyViolations !== 0) fail(`${label} must retain clean integrity checks`);
+  if (!Array.isArray(raw.dbstat) || raw.dbstat.length === 0) fail(`${label}.dbstat must not be empty`);
+  const dbstat = raw.dbstat.map((entry, index) => {
+    const row = asRecord(entry, `${label}.dbstat[${index}]`);
+    return {
+      name: asString(row.name, `${label}.dbstat[${index}].name`),
+      kind: asKind(row.kind, `${label}.dbstat[${index}].kind`),
+      pages: asInteger(row.pages, `${label}.dbstat[${index}].pages`),
+      bytes: asInteger(row.bytes, `${label}.dbstat[${index}].bytes`),
+    };
+  });
+  const names = dbstat.map(entry => entry.name);
+  if (new Set(names).size !== names.length || JSON.stringify(names) !== JSON.stringify([...names].sort())) {
+    fail(`${label}.dbstat must have unique, lexically ordered names`);
+  }
+  return {
+    fileBytes, pageSize, pageCount, pageCountBytes,
+    freelistPages: asInteger(raw.freelistPages, `${label}.freelistPages`), dbstat,
+    integrityCheck: 'ok', foreignKeyViolations: 0,
+  };
+}
+
+/** Load and validate the prior, checked-in release measurement. */
+export function readRecordedCapacityBaseline(root = ROOT): RecordedCapacityBaseline {
+  const raw = asRecord(JSON.parse(readFileSync(join(root, RECORDED_CAPACITY_BASELINE_PATH), 'utf8')), 'recorded baseline');
+  if (raw.schemaVersion !== 'theologai-release-corpus-capacity-baseline.v1') fail('unsupported recorded baseline schema');
+  const release = asRecord(raw.release, 'recorded baseline.release');
+  const measuredWith = asRecord(release.measuredWith, 'recorded baseline.release.measuredWith');
+  const commit = asString(release.commit, 'recorded baseline.release.commit');
+  const corpusIdentity = asString(release.corpusIdentity, 'recorded baseline.release.corpusIdentity');
+  if (!/^[a-f0-9]{40}$/.test(commit) || !/^[a-f0-9]{64}$/.test(corpusIdentity)) fail('recorded baseline release identity is malformed');
+  return {
+    schemaVersion: 'theologai-release-corpus-capacity-baseline.v1',
+    release: {
+      id: asString(release.id, 'recorded baseline.release.id'), commit, corpusIdentity,
+      measuredWith: {
+        node: asString(measuredWith.node, 'recorded baseline.release.measuredWith.node'),
+        sqlite: asString(measuredWith.sqlite, 'recorded baseline.release.measuredWith.sqlite'),
+      },
+    },
+    measurement: parseMeasurement(raw.measurement, 'recorded baseline.measurement'),
+  };
+}
+
+export function assessCorpusCapacity(preVacuumBytes: number): {
+  status: CapacityStatus;
+  warning: boolean;
+  withinLimit: boolean;
+  headroomBytes: number;
+} {
+  if (!Number.isSafeInteger(preVacuumBytes) || preVacuumBytes < 0) fail('pre-VACUUM size must be a non-negative safe integer');
+  const withinLimit = preVacuumBytes <= D1_CORPUS_CAPACITY_LIMIT_BYTES;
+  const warning = preVacuumBytes >= D1_CORPUS_CAPACITY_WARNING_BYTES;
+  return {
+    status: !withinLimit ? 'exceeds_350_mib' : warning ? 'warning_at_or_above_90_percent' : 'within_capacity',
+    warning, withinLimit, headroomBytes: D1_CORPUS_CAPACITY_LIMIT_BYTES - preVacuumBytes,
+  };
+}
+
+/** Fail only above the conservative 350 MiB ceiling; the 90% threshold warns. */
+export function assertCorpusCapacity(preVacuumBytes: number): ReturnType<typeof assessCorpusCapacity> {
+  const assessment = assessCorpusCapacity(preVacuumBytes);
+  if (!assessment.withinLimit) fail(`SQLite/D1 corpus exceeds the conservative 350 MiB capacity limit by ${-assessment.headroomBytes} bytes`);
+  return assessment;
+}
+
+/** Compare every table, index, FTS shadow, and SQLite-internal dbstat object in lexical order. */
+export function compareDbstatGrowth(
+  baseline: readonly DbstatObjectMeasurement[],
+  current: readonly DbstatObjectMeasurement[],
+): DbstatGrowth[] {
+  const baselineByName = new Map(baseline.map(entry => [entry.name, entry]));
+  const currentByName = new Map(current.map(entry => [entry.name, entry]));
+  return [...new Set([...baselineByName.keys(), ...currentByName.keys()])].sort().map(name => {
+    const before = baselineByName.get(name);
+    const after = currentByName.get(name);
+    const kind = after?.kind ?? before?.kind;
+    if (!kind) fail(`missing dbstat object kind for ${name}`);
+    const baselinePages = before?.pages ?? 0;
+    const currentPages = after?.pages ?? 0;
+    const baselineBytes = before?.bytes ?? 0;
+    const currentBytes = after?.bytes ?? 0;
+    return {
+      name, kind, baselinePages, currentPages, pageGrowth: currentPages - baselinePages,
+      baselineBytes, currentBytes, byteGrowth: currentBytes - baselineBytes,
+    };
+  });
+}
+
+export function buildReleaseCorpusCapacityReport(
+  corpusIdentity: string,
+  preVacuum: DatabaseCapacityMeasurement,
+  postVacuumDiagnostic: DatabaseCapacityMeasurement,
+  baseline: RecordedCapacityBaseline,
+): ReleaseCorpusCapacityReport {
+  if (!/^[a-f0-9]{64}$/.test(corpusIdentity)) fail('current corpus identity is malformed');
+  const capacity = assessCorpusCapacity(preVacuum.fileBytes);
+  const databaseBytes = preVacuum.fileBytes - baseline.measurement.fileBytes;
+  return {
+    schemaVersion: 'theologai-release-corpus-capacity-report.v1',
+    corpus: { storage: 'sqlite_d1_materialized', corpusIdentity, freshBuildVerified: true },
+    capacity: {
+      basis: 'direct_fresh_database_after_analyze_pre_vacuum',
+      limitBytes: D1_CORPUS_CAPACITY_LIMIT_BYTES,
+      warningThresholdBytes: D1_CORPUS_CAPACITY_WARNING_BYTES,
+      preVacuumBytes: preVacuum.fileBytes,
+      headroomBytes: capacity.headroomBytes,
+      status: capacity.status,
+      warning: capacity.warning,
+      withinLimit: capacity.withinLimit,
+    },
+    current: { preVacuum, postVacuumDiagnostic },
+    baseline: { ...baseline.release, preVacuumBytes: baseline.measurement.fileBytes },
+    growthSinceBaseline: {
+      databaseBytes,
+      databaseBasisPoints: Math.trunc((databaseBytes * 10_000) / baseline.measurement.fileBytes),
+      dbstat: compareDbstatGrowth(baseline.measurement.dbstat, preVacuum.dbstat),
+    },
+  };
+}
+
+function runCurrentCheckoutCommand(root: string, script: string, args: string[]): void {
+  const result = spawnSync(process.execPath, ['--import', 'tsx', resolve(root, script), ...args], {
+    cwd: root, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    const detail = `${result.stderr ?? ''}${result.stdout ?? ''}`.trim().slice(-2_000);
+    fail(`${script} failed while preparing a disposable capacity database${detail ? `: ${detail}` : ''}`);
+  }
+}
+
+/** Build and verify the normal SQLite/D1 materialization at a temporary output path. */
+export function buildFreshReleaseCorpusCapacityDatabase(context: ReleaseCorpusCapacityBuilderContext): void {
+  runCurrentCheckoutCommand(context.root, BUILD_SCRIPT, ['--output', context.outputPath]);
+  runCurrentCheckoutCommand(context.root, VERIFY_SCRIPT, ['--database', context.outputPath]);
+}
+
+function expectedCorpusIdentity(root: string): string {
+  return computeD1CorpusIdentity(parseDataManifest(readFileSync(join(root, 'data', 'data-manifest.json'))));
+}
+
+function assertStoredCorpusIdentity(path: string, expected: string): void {
+  const database = new Database(path, { readonly: true, fileMustExist: true });
+  try {
+    const row = database.prepare("SELECT value FROM theologai_metadata WHERE key = 'corpus_manifest_sha256'").get() as { value?: unknown } | undefined;
+    if (row?.value !== expected) fail('fresh database corpus identity does not match the current checkout');
+  } finally {
+    database.close();
+  }
+}
+
+/** Public runner: temporary fresh build, verified identity, pre-VACUUM gate, and baseline comparison. */
+export function runReleaseCorpusCapacityReport(root = ROOT, options: ReleaseCorpusCapacityRunOptions = {}): ReleaseCorpusCapacityReport {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'theologai-release-corpus-capacity-'));
+  try {
+    const databasePath = join(temporaryDirectory, 'theologai.sqlite');
+    const context = { root, outputPath: databasePath };
+    (options.buildDatabase ?? buildFreshReleaseCorpusCapacityDatabase)(context);
+    if (options.verifyDatabase !== undefined) options.verifyDatabase(context);
+    const corpusIdentity = expectedCorpusIdentity(root);
+    assertStoredCorpusIdentity(databasePath, corpusIdentity);
+    const preVacuum = measurePreVacuumDatabase(databasePath);
+    const vacuumDiagnosticPath = join(temporaryDirectory, 'theologai-vacuum-diagnostic.sqlite');
+    copyFileSync(databasePath, vacuumDiagnosticPath);
+    const postVacuumDiagnostic = measurePostVacuumDiagnostic(vacuumDiagnosticPath);
+    return buildReleaseCorpusCapacityReport(
+      corpusIdentity, preVacuum, postVacuumDiagnostic, options.baseline ?? readRecordedCapacityBaseline(root),
+    );
+  } finally {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+export function parseReleaseCorpusCapacityArguments(argv: readonly string[]): void {
+  if (argv.length !== 0) fail('this release-wide capacity command accepts no arguments and always uses a disposable fresh database');
+}
+
+function assertNode22(): void {
+  if (process.versions.node.split('.')[0] !== '22') fail(`requires Node 22; received ${process.version}`);
+}
+
+function main(argv: readonly string[]): void {
+  parseReleaseCorpusCapacityArguments(argv);
+  assertNode22();
+  const report = runReleaseCorpusCapacityReport();
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  if (!report.capacity.withinLimit) process.exitCode = 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try { main(process.argv.slice(2)); } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : 'unknown failure'}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-corpus-capacity.ts
+++ b/scripts/release-corpus-capacity.ts
@@ -12,6 +12,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { computeD1CorpusIdentity, parseDataManifest } from './d1-corpus-identity.js';
+import { VERIFY_DATABASE_DEFER_CAPACITY_FLAG } from './release-corpus-capacity-policy.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const BUILD_SCRIPT = 'scripts/build-database.ts';
@@ -106,7 +107,15 @@ export interface ReleaseCorpusCapacityRunOptions {
   verifyDatabase?: (context: ReleaseCorpusCapacityBuilderContext) => void;
   /** Test-only injection. The public command always uses the checked-in release baseline. */
   baseline?: RecordedCapacityBaseline;
+  /** Test-only injection for proving the default build/verify command path. */
+  commandRunner?: ReleaseCorpusCapacityCommandRunner;
+  /** Test-only injection for physical threshold boundary coverage. */
+  measurePreVacuum?: (path: string) => DatabaseCapacityMeasurement;
+  /** Test-only injection for physical threshold boundary coverage. */
+  measurePostVacuum?: (path: string) => DatabaseCapacityMeasurement;
 }
+
+export type ReleaseCorpusCapacityCommandRunner = (root: string, script: string, args: string[]) => void;
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -396,9 +405,14 @@ function runCurrentCheckoutCommand(root: string, script: string, args: string[])
 }
 
 /** Build and verify the normal SQLite/D1 materialization at a temporary output path. */
-export function buildFreshReleaseCorpusCapacityDatabase(context: ReleaseCorpusCapacityBuilderContext): void {
-  runCurrentCheckoutCommand(context.root, BUILD_SCRIPT, ['--output', context.outputPath]);
-  runCurrentCheckoutCommand(context.root, VERIFY_SCRIPT, ['--database', context.outputPath]);
+export function buildFreshReleaseCorpusCapacityDatabase(
+  context: ReleaseCorpusCapacityBuilderContext,
+  runCommand: ReleaseCorpusCapacityCommandRunner = runCurrentCheckoutCommand,
+): void {
+  runCommand(context.root, BUILD_SCRIPT, ['--output', context.outputPath]);
+  runCommand(context.root, VERIFY_SCRIPT, [
+    '--database', context.outputPath, VERIFY_DATABASE_DEFER_CAPACITY_FLAG,
+  ]);
 }
 
 function expectedCorpusIdentity(root: string): string {
@@ -421,14 +435,20 @@ export function runReleaseCorpusCapacityReport(root = ROOT, options: ReleaseCorp
   try {
     const databasePath = join(temporaryDirectory, 'theologai.sqlite');
     const context = { root, outputPath: databasePath };
-    (options.buildDatabase ?? buildFreshReleaseCorpusCapacityDatabase)(context);
+    if (options.buildDatabase === undefined) {
+      buildFreshReleaseCorpusCapacityDatabase(context, options.commandRunner);
+    } else {
+      options.buildDatabase(context);
+    }
     if (options.verifyDatabase !== undefined) options.verifyDatabase(context);
     const corpusIdentity = expectedCorpusIdentity(root);
     assertStoredCorpusIdentity(databasePath, corpusIdentity);
-    const preVacuum = measurePreVacuumDatabase(databasePath);
+    const preVacuum = (options.measurePreVacuum ?? measurePreVacuumDatabase)(databasePath);
+    assertDatabaseCapacityMeasurement(preVacuum, 'current pre-VACUUM measurement');
     const vacuumDiagnosticPath = join(temporaryDirectory, 'theologai-vacuum-diagnostic.sqlite');
     copyFileSync(databasePath, vacuumDiagnosticPath);
-    const postVacuumDiagnostic = measurePostVacuumDiagnostic(vacuumDiagnosticPath);
+    const postVacuumDiagnostic = (options.measurePostVacuum ?? measurePostVacuumDiagnostic)(vacuumDiagnosticPath);
+    assertDatabaseCapacityMeasurement(postVacuumDiagnostic, 'current post-VACUUM diagnostic');
     return buildReleaseCorpusCapacityReport(
       corpusIdentity, preVacuum, postVacuumDiagnostic, options.baseline ?? readRecordedCapacityBaseline(root),
     );
@@ -445,6 +465,15 @@ export function releaseCorpusCapacityExitCode(report: ReleaseCorpusCapacityRepor
   return report.capacity.withinLimit ? 0 : 1;
 }
 
+/** Print the complete structured report before returning its public process status. */
+export function emitReleaseCorpusCapacityReport(
+  report: ReleaseCorpusCapacityReport,
+  write: (value: string) => void = value => { process.stdout.write(value); },
+): 0 | 1 {
+  write(`${JSON.stringify(report, null, 2)}\n`);
+  return releaseCorpusCapacityExitCode(report);
+}
+
 function assertNode22(): void {
   if (process.versions.node.split('.')[0] !== '22') fail(`requires Node 22; received ${process.version}`);
 }
@@ -453,8 +482,7 @@ function main(argv: readonly string[]): void {
   parseReleaseCorpusCapacityArguments(argv);
   assertNode22();
   const report = runReleaseCorpusCapacityReport();
-  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-  process.exitCode = releaseCorpusCapacityExitCode(report);
+  process.exitCode = emitReleaseCorpusCapacityReport(report);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/verify-database.ts
+++ b/scripts/verify-database.ts
@@ -27,6 +27,7 @@ import {
 } from './historical-hierarchy.js';
 import { HistoricalDocumentRepository } from '../src/adapters/data/HistoricalDocumentRepository.js';
 import { buildD1ReadinessSql } from './check-remote-d1-readiness.js';
+import { VERIFY_DATABASE_DEFER_CAPACITY_FLAG } from './release-corpus-capacity-policy.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
@@ -50,7 +51,9 @@ function getDatabasePath(argv: string[]): string {
   return join(ROOT, 'data', 'theologai.db');
 }
 
-const databasePath = getDatabasePath(process.argv.slice(2));
+const verifyArguments = process.argv.slice(2);
+const databasePath = getDatabasePath(verifyArguments);
+const deferCapacityToReleaseReport = verifyArguments.includes(VERIFY_DATABASE_DEFER_CAPACITY_FLAG);
 if (!existsSync(databasePath)) throw new Error(`Database not found: ${databasePath}`);
 
 const manifest = parseDataManifest(readFileSync(MANIFEST_PATH));
@@ -322,7 +325,7 @@ function assertHistoricalTransform9SourcePackMaterialization(database: Database.
 
 try {
   const databaseBytes = statSync(databasePath).size;
-  if (databaseBytes > UBS_SEMANTICS_DATABASE_CEILING_BYTES) {
+  if (!deferCapacityToReleaseReport && databaseBytes > UBS_SEMANTICS_DATABASE_CEILING_BYTES) {
     throw new Error(`SQLite database exceeds the 350 MiB UBS semantic capacity gate: ${databaseBytes} bytes`);
   }
   const integrityRows = db.pragma('integrity_check') as Array<Record<string, string>>;

--- a/test/unit/scripts/releaseCorpusCapacity.test.ts
+++ b/test/unit/scripts/releaseCorpusCapacity.test.ts
@@ -1,0 +1,140 @@
+import Database from 'better-sqlite3';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  D1_CORPUS_CAPACITY_LIMIT_BYTES,
+  D1_CORPUS_CAPACITY_WARNING_BYTES,
+  assessCorpusCapacity,
+  assertCorpusCapacity,
+  buildReleaseCorpusCapacityReport,
+  compareDbstatGrowth,
+  measurePreVacuumDatabase,
+  parseReleaseCorpusCapacityArguments,
+  readRecordedCapacityBaseline,
+  runReleaseCorpusCapacityReport,
+  type DatabaseCapacityMeasurement,
+  type RecordedCapacityBaseline,
+} from '../../../scripts/release-corpus-capacity.js';
+import { computeD1CorpusIdentity, parseDataManifest } from '../../../scripts/d1-corpus-identity.js';
+
+const ROOT = process.cwd();
+
+function fixtureDatabase(path: string, corpusIdentity = 'a'.repeat(64)): void {
+  const database = new Database(path);
+  try {
+    database.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE theologai_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+      CREATE TABLE capacity_rows (id INTEGER PRIMARY KEY, content TEXT NOT NULL);
+      CREATE INDEX idx_capacity_rows_content ON capacity_rows(content);
+    `);
+    database.prepare("INSERT INTO theologai_metadata VALUES ('corpus_manifest_sha256', ?)").run(corpusIdentity);
+    const insert = database.prepare('INSERT INTO capacity_rows(content) VALUES (?)');
+    database.transaction(() => {
+      for (let index = 0; index < 40; index++) insert.run(`row-${String(index).padStart(3, '0')}`);
+    })();
+  } finally {
+    database.close();
+  }
+}
+
+function measurement(fileBytes: number, dbstat: DatabaseCapacityMeasurement['dbstat']): DatabaseCapacityMeasurement {
+  return {
+    fileBytes, pageSize: 4_096, pageCount: fileBytes / 4_096, pageCountBytes: fileBytes,
+    freelistPages: 0, dbstat, integrityCheck: 'ok', foreignKeyViolations: 0,
+  };
+}
+
+function baseline(value: DatabaseCapacityMeasurement): RecordedCapacityBaseline {
+  return {
+    schemaVersion: 'theologai-release-corpus-capacity-baseline.v1',
+    release: { id: 'fixture', commit: 'b'.repeat(40), corpusIdentity: 'c'.repeat(64), measuredWith: { node: 'v22.fixture', sqlite: 'fixture' } },
+    measurement: value,
+  };
+}
+
+describe('release-wide SQLite/D1 corpus capacity report', () => {
+  it('measures pre-VACUUM dbstat allocations and classifies table/index growth deterministically', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'theologai-release-capacity-test-'));
+    const path = join(directory, 'fixture.sqlite');
+    try {
+      fixtureDatabase(path);
+      const result = measurePreVacuumDatabase(path);
+      expect(result.fileBytes).toBe(result.pageCountBytes);
+      expect(result.integrityCheck).toBe('ok');
+      expect(result.foreignKeyViolations).toBe(0);
+      expect(result.dbstat.map(entry => entry.name)).toEqual([...result.dbstat.map(entry => entry.name)].sort());
+      expect(result.dbstat).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'capacity_rows', kind: 'table' }),
+        expect.objectContaining({ name: 'idx_capacity_rows_content', kind: 'index' }),
+      ]));
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the documented 90% warning and inclusive 350 MiB hard ceiling', () => {
+    expect(assessCorpusCapacity(D1_CORPUS_CAPACITY_WARNING_BYTES - 1)).toMatchObject({
+      status: 'within_capacity', warning: false, withinLimit: true,
+    });
+    expect(assessCorpusCapacity(D1_CORPUS_CAPACITY_WARNING_BYTES)).toMatchObject({
+      status: 'warning_at_or_above_90_percent', warning: true, withinLimit: true,
+    });
+    expect(assertCorpusCapacity(D1_CORPUS_CAPACITY_LIMIT_BYTES)).toMatchObject({ withinLimit: true });
+    expect(assessCorpusCapacity(D1_CORPUS_CAPACITY_LIMIT_BYTES + 1)).toMatchObject({
+      status: 'exceeds_350_mib', warning: true, withinLimit: false, headroomBytes: -1,
+    });
+    expect(() => assertCorpusCapacity(D1_CORPUS_CAPACITY_LIMIT_BYTES + 1)).toThrow('350 MiB');
+  });
+
+  it('includes new and removed dbstat objects with zero-sided growth, in lexical order', () => {
+    const growth = compareDbstatGrowth(
+      [{ name: 'alpha', kind: 'table', pages: 3, bytes: 12_288 }, { name: 'removed_idx', kind: 'index', pages: 2, bytes: 8_192 }],
+      [{ name: 'alpha', kind: 'table', pages: 5, bytes: 20_480 }, { name: 'new_fts_data', kind: 'table', pages: 4, bytes: 16_384 }],
+    );
+    expect(growth).toEqual([
+      { name: 'alpha', kind: 'table', baselinePages: 3, currentPages: 5, pageGrowth: 2, baselineBytes: 12_288, currentBytes: 20_480, byteGrowth: 8_192 },
+      { name: 'new_fts_data', kind: 'table', baselinePages: 0, currentPages: 4, pageGrowth: 4, baselineBytes: 0, currentBytes: 16_384, byteGrowth: 16_384 },
+      { name: 'removed_idx', kind: 'index', baselinePages: 2, currentPages: 0, pageGrowth: -2, baselineBytes: 8_192, currentBytes: 0, byteGrowth: -8_192 },
+    ]);
+  });
+
+  it('uses a previous recorded release and has deterministic report ordering', () => {
+    const current = measurement(16_384, [
+      { name: 'alpha', kind: 'table', pages: 2, bytes: 8_192 },
+      { name: 'beta', kind: 'index', pages: 2, bytes: 8_192 },
+    ]);
+    const prior = baseline(measurement(8_192, [
+      { name: 'alpha', kind: 'table', pages: 1, bytes: 4_096 },
+      { name: 'legacy', kind: 'table', pages: 1, bytes: 4_096 },
+    ]));
+    const report = buildReleaseCorpusCapacityReport('a'.repeat(64), current, current, prior);
+    expect(report.baseline).toMatchObject({ id: 'fixture', preVacuumBytes: 8_192 });
+    expect(report.growthSinceBaseline.databaseBytes).toBe(8_192);
+    expect(report.growthSinceBaseline.databaseBasisPoints).toBe(10_000);
+    expect(report.growthSinceBaseline.dbstat.map(row => row.name)).toEqual(['alpha', 'beta', 'legacy']);
+    expect(JSON.stringify(report)).toBe(JSON.stringify(buildReleaseCorpusCapacityReport('a'.repeat(64), current, current, prior)));
+  });
+
+  it('reads the checked-in Transform 9 baseline and refuses public arguments', () => {
+    const prior = readRecordedCapacityBaseline(ROOT);
+    expect(prior.release.id).toBe('transform-9');
+    expect(prior.measurement.fileBytes).toBeGreaterThan(0);
+    expect(prior.measurement.dbstat).not.toEqual([]);
+    expect(() => parseReleaseCorpusCapacityArguments([])).not.toThrow();
+    expect(() => parseReleaseCorpusCapacityArguments(['--database', 'data/theologai.db'])).toThrow('accepts no arguments');
+  });
+
+  it('builds only a disposable fresh fixture when dependencies are injected for tests', () => {
+    const corpusIdentity = computeD1CorpusIdentity(parseDataManifest(readFileSync(join(ROOT, 'data', 'data-manifest.json'))));
+    const report = runReleaseCorpusCapacityReport(ROOT, {
+      buildDatabase: ({ outputPath }) => fixtureDatabase(outputPath, corpusIdentity),
+      baseline: baseline(measurement(4_096, [{ name: 'sqlite_schema', kind: 'internal', pages: 1, bytes: 4_096 }])),
+    });
+    expect(report.corpus).toMatchObject({ storage: 'sqlite_d1_materialized', freshBuildVerified: true });
+    expect(report.current.preVacuum.fileBytes).toBeGreaterThan(0);
+    expect(report.capacity.withinLimit).toBe(true);
+  });
+});

--- a/test/unit/scripts/releaseCorpusCapacity.test.ts
+++ b/test/unit/scripts/releaseCorpusCapacity.test.ts
@@ -8,11 +8,13 @@ import {
   D1_CORPUS_CAPACITY_WARNING_BYTES,
   assessCorpusCapacity,
   assertCorpusCapacity,
+  assertDatabaseCapacityMeasurement,
   buildReleaseCorpusCapacityReport,
   compareDbstatGrowth,
   measurePreVacuumDatabase,
   parseReleaseCorpusCapacityArguments,
   readRecordedCapacityBaseline,
+  releaseCorpusCapacityExitCode,
   runReleaseCorpusCapacityReport,
   type DatabaseCapacityMeasurement,
   type RecordedCapacityBaseline,
@@ -89,16 +91,38 @@ describe('release-wide SQLite/D1 corpus capacity report', () => {
     expect(() => assertCorpusCapacity(D1_CORPUS_CAPACITY_LIMIT_BYTES + 1)).toThrow('350 MiB');
   });
 
-  it('includes new and removed dbstat objects with zero-sided growth, in lexical order', () => {
+  it('includes new and removed dbstat objects with zero-sided growth, largest growth first', () => {
     const growth = compareDbstatGrowth(
       [{ name: 'alpha', kind: 'table', pages: 3, bytes: 12_288 }, { name: 'removed_idx', kind: 'index', pages: 2, bytes: 8_192 }],
       [{ name: 'alpha', kind: 'table', pages: 5, bytes: 20_480 }, { name: 'new_fts_data', kind: 'table', pages: 4, bytes: 16_384 }],
     );
     expect(growth).toEqual([
-      { name: 'alpha', kind: 'table', baselinePages: 3, currentPages: 5, pageGrowth: 2, baselineBytes: 12_288, currentBytes: 20_480, byteGrowth: 8_192 },
       { name: 'new_fts_data', kind: 'table', baselinePages: 0, currentPages: 4, pageGrowth: 4, baselineBytes: 0, currentBytes: 16_384, byteGrowth: 16_384 },
+      { name: 'alpha', kind: 'table', baselinePages: 3, currentPages: 5, pageGrowth: 2, baselineBytes: 12_288, currentBytes: 20_480, byteGrowth: 8_192 },
       { name: 'removed_idx', kind: 'index', baselinePages: 2, currentPages: 0, pageGrowth: -2, baselineBytes: 8_192, currentBytes: 0, byteGrowth: -8_192 },
     ]);
+  });
+
+  it('rejects tampered object bytes and incomplete total-page accounting', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'theologai-release-capacity-tamper-'));
+    const path = join(directory, 'fixture.sqlite');
+    try {
+      fixtureDatabase(path);
+      const measured = measurePreVacuumDatabase(path);
+      const baselineTamper = structuredClone(measured);
+      baselineTamper.dbstat[0]!.bytes += baselineTamper.pageSize;
+      expect(() => assertDatabaseCapacityMeasurement(baselineTamper, 'tampered baseline'))
+        .toThrow('bytes must equal pages multiplied by pageSize');
+
+      const currentTamper = structuredClone(measured);
+      currentTamper.pageCount += 1;
+      currentTamper.pageCountBytes += currentTamper.pageSize;
+      currentTamper.fileBytes += currentTamper.pageSize;
+      expect(() => assertDatabaseCapacityMeasurement(currentTamper, 'tampered current'))
+        .toThrow('dbstat allocations plus freelist pages must conserve');
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 
   it('uses a previous recorded release and has deterministic report ordering', () => {
@@ -114,15 +138,36 @@ describe('release-wide SQLite/D1 corpus capacity report', () => {
     expect(report.baseline).toMatchObject({ id: 'fixture', preVacuumBytes: 8_192 });
     expect(report.growthSinceBaseline.databaseBytes).toBe(8_192);
     expect(report.growthSinceBaseline.databaseBasisPoints).toBe(10_000);
-    expect(report.growthSinceBaseline.dbstat.map(row => row.name)).toEqual(['alpha', 'beta', 'legacy']);
+    expect(report.growthSinceBaseline.dbstat.map(row => row.name)).toEqual(['beta', 'alpha', 'legacy']);
     expect(JSON.stringify(report)).toBe(JSON.stringify(buildReleaseCorpusCapacityReport('a'.repeat(64), current, current, prior)));
+  });
+
+  it('keeps the structured report reachable before returning a hard-failure exit code', () => {
+    const overLimitBytes = D1_CORPUS_CAPACITY_LIMIT_BYTES + 4_096;
+    const current = measurement(overLimitBytes, [
+      { name: 'all_pages', kind: 'table', pages: overLimitBytes / 4_096, bytes: overLimitBytes },
+    ]);
+    const prior = baseline(measurement(4_096, [
+      { name: 'all_pages', kind: 'table', pages: 1, bytes: 4_096 },
+    ]));
+    const report = buildReleaseCorpusCapacityReport('a'.repeat(64), current, current, prior);
+    expect(report.capacity).toMatchObject({
+      status: 'exceeds_350_mib', preVacuumBytes: overLimitBytes, withinLimit: false,
+    });
+    expect(report.growthSinceBaseline.dbstat).toHaveLength(1);
+    expect(JSON.parse(JSON.stringify(report))).toMatchObject({ baseline: { id: 'fixture' } });
+    expect(releaseCorpusCapacityExitCode(report)).toBe(1);
   });
 
   it('reads the checked-in Transform 9 baseline and refuses public arguments', () => {
     const prior = readRecordedCapacityBaseline(ROOT);
-    expect(prior.release.id).toBe('transform-9');
-    expect(prior.measurement.fileBytes).toBeGreaterThan(0);
-    expect(prior.measurement.dbstat).not.toEqual([]);
+    expect(prior.release).toMatchObject({
+      id: 'transform-9-reviewed-pre-transform-10',
+      commit: '9f8c2f16ae81bcdcf684840b91e920481c18430c',
+      corpusIdentity: '4e182bfd2953fe06e7c8d7e13a705988e85b5a58001e7fe72440333d34f6d442',
+    });
+    expect(prior.measurement.fileBytes).toBe(315_211_776);
+    expect(prior.measurement.dbstat).toHaveLength(117);
     expect(() => parseReleaseCorpusCapacityArguments([])).not.toThrow();
     expect(() => parseReleaseCorpusCapacityArguments(['--database', 'data/theologai.db'])).toThrow('accepts no arguments');
   });

--- a/test/unit/scripts/releaseCorpusCapacity.test.ts
+++ b/test/unit/scripts/releaseCorpusCapacity.test.ts
@@ -11,6 +11,7 @@ import {
   assertDatabaseCapacityMeasurement,
   buildReleaseCorpusCapacityReport,
   compareDbstatGrowth,
+  emitReleaseCorpusCapacityReport,
   measurePreVacuumDatabase,
   parseReleaseCorpusCapacityArguments,
   readRecordedCapacityBaseline,
@@ -20,6 +21,7 @@ import {
   type RecordedCapacityBaseline,
 } from '../../../scripts/release-corpus-capacity.js';
 import { computeD1CorpusIdentity, parseDataManifest } from '../../../scripts/d1-corpus-identity.js';
+import { VERIFY_DATABASE_DEFER_CAPACITY_FLAG } from '../../../scripts/release-corpus-capacity-policy.js';
 
 const ROOT = process.cwd();
 
@@ -157,6 +159,41 @@ describe('release-wide SQLite/D1 corpus capacity report', () => {
     expect(report.growthSinceBaseline.dbstat).toHaveLength(1);
     expect(JSON.parse(JSON.stringify(report))).toMatchObject({ baseline: { id: 'fixture' } });
     expect(releaseCorpusCapacityExitCode(report)).toBe(1);
+  });
+
+  it('defers only the default verifier size abort, emits over-limit JSON, then exits 1', () => {
+    const corpusIdentity = computeD1CorpusIdentity(parseDataManifest(readFileSync(join(ROOT, 'data', 'data-manifest.json'))));
+    const overLimitBytes = D1_CORPUS_CAPACITY_LIMIT_BYTES + 4_096;
+    const overLimitMeasurement = measurement(overLimitBytes, [
+      { name: 'all_pages', kind: 'table', pages: overLimitBytes / 4_096, bytes: overLimitBytes },
+    ]);
+    const commands: Array<{ script: string; args: string[] }> = [];
+    const report = runReleaseCorpusCapacityReport(ROOT, {
+      commandRunner: (_root, script, args) => {
+        commands.push({ script, args: [...args] });
+        if (script === 'scripts/build-database.ts') fixtureDatabase(args[1]!, corpusIdentity);
+      },
+      measurePreVacuum: () => structuredClone(overLimitMeasurement),
+      measurePostVacuum: () => structuredClone(overLimitMeasurement),
+      baseline: baseline(measurement(4_096, [
+        { name: 'all_pages', kind: 'table', pages: 1, bytes: 4_096 },
+      ])),
+    });
+    expect(commands).toHaveLength(2);
+    expect(commands[0]).toMatchObject({ script: 'scripts/build-database.ts', args: ['--output', expect.any(String)] });
+    expect(commands[1]).toMatchObject({
+      script: 'scripts/verify-database.ts',
+      args: ['--database', expect.any(String), VERIFY_DATABASE_DEFER_CAPACITY_FLAG],
+    });
+
+    let stdout = '';
+    const exitCode = emitReleaseCorpusCapacityReport(report, value => { stdout += value; });
+    expect(JSON.parse(stdout)).toMatchObject({
+      schemaVersion: 'theologai-release-corpus-capacity-report.v1',
+      capacity: { status: 'exceeds_350_mib', withinLimit: false },
+      growthSinceBaseline: { dbstat: [expect.objectContaining({ name: 'all_pages' })] },
+    });
+    expect(exitCode).toBe(1);
   });
 
   it('reads the checked-in Transform 9 baseline and refuses public arguments', () => {

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -14,6 +14,7 @@
     "scripts/audit-original-language-v2-preview.ts",
     "scripts/audit-original-language-v2-production.ts",
     "scripts/audit-historical-core-preview.ts",
-    "scripts/audit-historical-core-production.ts"
+    "scripts/audit-historical-core-production.ts",
+    "scripts/release-corpus-capacity.ts"
   ]
 }

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -15,6 +15,8 @@
     "scripts/audit-original-language-v2-production.ts",
     "scripts/audit-historical-core-preview.ts",
     "scripts/audit-historical-core-production.ts",
-    "scripts/release-corpus-capacity.ts"
+    "scripts/release-corpus-capacity-policy.ts",
+    "scripts/release-corpus-capacity.ts",
+    "scripts/verify-database.ts"
   ]
 }


### PR DESCRIPTION
## What changed

- adds a generic release-wide SQLite/D1 corpus capacity report
- records the exact reviewed pre-Transform-10 physical baseline
- reports authoritative pre-VACUUM size, headroom, and per-object growth
- warns at 90% of the conservative 350 MiB limit and fails above that limit
- validates complete page and freelist conservation
- preserves structured over-limit evidence before returning a failing status
- runs the capacity check during fresh-checkout CI

## Current result

- pre-VACUUM size: 339,603,456 bytes
- headroom: 27,398,144 bytes
- growth from the reviewed Transform-9 baseline: 24,391,680 bytes
- status: warning, within limit

## Verification

- Node 22 focused tests: 9/9
- Node and release-script typechecks
- fresh database build and complete semantic verification
- exact baseline and tamper checks
- public over-limit JSON/exit-code regression test
- independent Sol review: GO, no P0-P3 findings

This PR changes capacity tooling, tests, CI, and policy documentation only. It does not alter schema, corpus content, MCP behavior, bindings, CCEL, historical search, or deployments.
