### PR TITLE
fix: make historical release audit profile aware

### DIFF
--- a/scripts/audit-historical-core-preview.ts
+++ b/scripts/audit-historical-core-preview.ts
@@ -9,11 +9,105 @@ import { link, lstat, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from 'no
 import { basename, dirname, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { HISTORICAL_SECTIONED_ONLY_LANDING_MAX_BYTES } from '../src/kernel/historicalSectionedDelivery.js';
+import { buildLocalDocumentResourceUri } from '../src/kernel/documentResource.js';
 import { classicTextsOutputSchema } from '../src/mcp/schemas/classicTexts.js';
-import { primarySourceSearchV7OutputSchema } from '../src/mcp/schemas/primarySourceSearchV4.js';
+import { primarySourceSearchV6OutputSchema, primarySourceSearchV7OutputSchema } from '../src/mcp/schemas/primarySourceSearchV4.js';
+import { createPrimarySourceSearchHandler } from '../src/tools/v2/primarySourceSearch.js';
 
 const PREVIEW_ENDPOINT = 'https://preview-mcp.theologai.xyz/mcp';
 const PRODUCTION_ENDPOINT = 'https://mcp.theologai.xyz/mcp';
+
+/**
+ * The Transform-9 fixture is shared, but primary-source search has two
+ * intentionally different public contracts. Keep every difference explicit
+ * here so an audit cannot accidentally project the preview discovery shape on
+ * to the production local-only release (or vice versa).
+ */
+type PrimarySourceAuditContract = Readonly<{
+  contractVersion: '6' | '7';
+  schemaVersion: '6' | '7';
+  openWorldHint: boolean;
+  providerEnum: readonly ('local' | 'ccel')[];
+  providerMaximum: 1 | 2;
+  inputSchema: ObjectRecord;
+  outputSchema: ObjectRecord;
+  inputSchemaSha256: string;
+  outputSchemaSha256: string;
+  primarySourceResearchPrompt: Readonly<{ required: readonly string[]; absent: readonly string[] }>;
+  confessionStudyPrompt: Readonly<{ required: readonly string[]; absent: readonly string[] }>;
+  /** Preview owns a disabled structured CCEL probe; production rejects CCEL at input validation. */
+  externalDiscoveryBoundary: 'disabled_structured_ccel' | 'rejected_at_input_schema';
+}>;
+
+function primaryInputSchemaFor(contractVersion: '6' | '7'): ObjectRecord {
+  const contract = contractVersion === '7'
+    ? { exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false, contractVersion: '7' as const, liveCcelEnabled: false }
+    : { exposeCcelDiscovery: false, ccelLiveSearch: false, ccelCoordinator: false, contractVersion: '6' as const, liveCcelEnabled: false };
+  const schema = createPrimarySourceSearchHandler({} as never, contract).inputSchema;
+  const record = schema !== null && typeof schema === 'object' && !Array.isArray(schema) ? schema as ObjectRecord : undefined;
+  if (!record) throw new Error(`primary-source v${contractVersion} input schema is not an object`);
+  return record;
+}
+
+const PRIMARY_SOURCE_V7_AUDIT_CONTRACT: PrimarySourceAuditContract = {
+  contractVersion: '7', schemaVersion: '7', openWorldHint: true,
+  providerEnum: ['local', 'ccel'], providerMaximum: 2,
+  inputSchema: primaryInputSchemaFor('7'), outputSchema: primarySourceSearchV7OutputSchema as ObjectRecord,
+  inputSchemaSha256: '5ee3fbbcee8ae6956d154c1b84eccbf0a984011fed7076e2bf3e9c6d03c74d90',
+  outputSchemaSha256: '005977f15f3db2d661314055f61ee61d27aee1ae153c86f3a844d199bb477cef',
+  primarySourceResearchPrompt: {
+    required: [
+      'Search local evidence', 'Search one external scope now', 'Use the v7 contract',
+      '"providers":["local"]', '"providers":["ccel"]',
+      'This prompt authorizes at most one CCEL-bearing call.',
+      'The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range.',
+      'Use MCP `resources/read` only for local `mcp_resource` URIs.',
+      'Open external `external_url` pages directly', 'name disabled, unavailable, or unsupported searches',
+    ],
+    absent: [
+      'This workflow is local-only', 'Use the v6 structured result',
+      'This workflow supports a topic survey',
+    ],
+  },
+  confessionStudyPrompt: {
+    required: [
+      '"providers":["local","ccel"]', 'external `external_url` locator',
+      'it is not an MCP resource', 'rights status is not determined',
+      'Name any disabled, unavailable, or unsupported provider',
+    ],
+    absent: ['Run bounded local discovery', 'canonical `resource_link` blocks'],
+  },
+  externalDiscoveryBoundary: 'disabled_structured_ccel',
+};
+
+const PRIMARY_SOURCE_V6_AUDIT_CONTRACT: PrimarySourceAuditContract = {
+  contractVersion: '6', schemaVersion: '6', openWorldHint: false,
+  providerEnum: ['local'], providerMaximum: 1,
+  inputSchema: primaryInputSchemaFor('6'), outputSchema: primarySourceSearchV6OutputSchema as ObjectRecord,
+  inputSchemaSha256: '37849624bac2e884106050fcff39851e40cac31969b4f7511f516f78348fea87',
+  outputSchemaSha256: '25758f8d06c43c3f2961fa7b35ba1d62a548df923589b391c65204813a6511b8',
+  primarySourceResearchPrompt: {
+    required: [
+      'Run bounded discovery', 'This workflow is local-only', 'Use the v6 structured result',
+      'exact MCP resource', 'This workflow supports a topic survey',
+    ],
+    absent: [
+      'Search one external scope now', 'Use the v7 contract', '"providers":["ccel"]',
+      'This prompt authorizes at most one CCEL-bearing call.', 'external `external_url` pages',
+    ],
+  },
+  confessionStudyPrompt: {
+    required: [
+      'Run bounded local discovery', 'hosted collection', 'canonical `resource_link` blocks', 'resources/read',
+    ],
+    absent: [
+      '"providers":["local","ccel"]', 'external `external_url` locator',
+      'rights status is not determined', 'Name any disabled, unavailable, or unsupported provider',
+    ],
+  },
+  externalDiscoveryBoundary: 'rejected_at_input_schema',
+};
+
 export type HistoricalCoreAuditProfile = {
   endpoint: string;
   hostname: string;
@@ -21,14 +115,15 @@ export type HistoricalCoreAuditProfile = {
   audit: 'historical-core-preview' | 'historical-core-production';
   endpointClass: 'preview-custom' | 'production-custom';
   label: 'preview' | 'production';
+  primarySource: PrimarySourceAuditContract;
 };
-const PREVIEW_PROFILE: HistoricalCoreAuditProfile = {
+export const PREVIEW_PROFILE: HistoricalCoreAuditProfile = {
   endpoint: PREVIEW_ENDPOINT, hostname: 'preview-mcp.theologai.xyz', serverVersion: '3.6.0-preview',
-  audit: 'historical-core-preview', endpointClass: 'preview-custom', label: 'preview',
+  audit: 'historical-core-preview', endpointClass: 'preview-custom', label: 'preview', primarySource: PRIMARY_SOURCE_V7_AUDIT_CONTRACT,
 };
 export const PRODUCTION_PROFILE: HistoricalCoreAuditProfile = {
   endpoint: PRODUCTION_ENDPOINT, hostname: 'mcp.theologai.xyz', serverVersion: '3.6.0',
-  audit: 'historical-core-production', endpointClass: 'production-custom', label: 'production',
+  audit: 'historical-core-production', endpointClass: 'production-custom', label: 'production', primarySource: PRIMARY_SOURCE_V6_AUDIT_CONTRACT,
 };
 const PROTOCOL_VERSION = '2025-11-25';
 const MAX_LOGICAL_OPERATIONS = 54;
@@ -58,8 +153,6 @@ const LEGACY_WORK_IDS = [
 ] as const;
 const EXPECTED_CLASSIC_INPUT_SCHEMA_SHA256 = '45124e704b5e0009b5bc3672c52b0d7ed6e8193063b621a7ccf766d1d2ad00d4';
 const EXPECTED_CLASSIC_OUTPUT_SCHEMA_SHA256 = 'b8a6af9dff44cf8ad9d964661ca76cbe4ab9bcbdc97d9aca85df4edea73a9a7c';
-const EXPECTED_PRIMARY_INPUT_SCHEMA_SHA256 = '5ee3fbbcee8ae6956d154c1b84eccbf0a984011fed7076e2bf3e9c6d03c74d90';
-const EXPECTED_PRIMARY_OUTPUT_SCHEMA_SHA256 = '005977f15f3db2d661314055f61ee61d27aee1ae153c86f3a844d199bb477cef';
 
 const EXPECTED_FIXTURE = {
   schemaVersion: 1,
@@ -317,13 +410,13 @@ function assertInitialize(message: ObjectRecord, profile: HistoricalCoreAuditPro
   return { protocolVersion: PROTOCOL_VERSION, serverName: 'theologai-bible-server', serverVersion: profile.serverVersion };
 }
 
-function assertToolRegistration(message: ObjectRecord): ObjectRecord {
+function assertToolRegistration(message: ObjectRecord, profile: HistoricalCoreAuditProfile): ObjectRecord {
   const listed = array(result(message, 'tools/list').tools, 'tools/list.tools').map(object);
   assert(listed.every(Boolean) && JSON.stringify(listed.map(tool => tool!.name)) === JSON.stringify(TOOL_NAMES), 'exact 11-tool registration/order drifted');
   for (const tool of listed) {
     const annotations = object(tool!.annotations);
     assert(annotations?.readOnlyHint === true && annotations.destructiveHint === false && annotations.idempotentHint === true, `${tool!.name} annotations drifted`);
-    const expectedOpenWorld = tool!.name === 'primary_source_search' ? true : tool!.name === 'classic_text_lookup' ? false : undefined;
+    const expectedOpenWorld = tool!.name === 'primary_source_search' ? profile.primarySource.openWorldHint : tool!.name === 'classic_text_lookup' ? false : undefined;
     assert(annotations?.openWorldHint === expectedOpenWorld
       && (expectedOpenWorld === undefined ? !Object.hasOwn(annotations!, 'openWorldHint') : Object.hasOwn(annotations!, 'openWorldHint')),
     `${tool!.name} open-world annotation drifted`);
@@ -351,16 +444,23 @@ function assertToolRegistration(message: ObjectRecord): ObjectRecord {
     && queries?.minItems === 1 && queries.maxItems === 4 && queryItem?.additionalProperties === false
     && JSON.stringify(Object.keys(properties ?? {})) === JSON.stringify(['id', 'text', 'providers', 'match', 'selection', 'author', 'work', 'startYear', 'endYear', 'page', 'limit']), 'primary-source input contract drifted');
   const providers = object(properties?.providers); const providerItems = object(providers?.items);
-  assert(providers?.minItems === 1 && providers?.maxItems === 2 && JSON.stringify(providerItems?.enum) === JSON.stringify(['local', 'ccel']), 'primary-source provider contract drifted');
-  assert(sha256(canonicalJson(primaryInput)) === EXPECTED_PRIMARY_INPUT_SCHEMA_SHA256, 'primary-source input schema hash drifted');
-  assert(canonicalJson(primaryOutput) === canonicalJson(primarySourceSearchV7OutputSchema), 'advertised primary-source output schema differs from the checked-out contract');
-  assert(sha256(canonicalJson(primarySourceSearchV7OutputSchema)) === EXPECTED_PRIMARY_OUTPUT_SCHEMA_SHA256
-    && sha256(canonicalJson(primaryOutput)) === EXPECTED_PRIMARY_OUTPUT_SCHEMA_SHA256, 'primary-source output schema hash drifted');
+  assert(providers?.minItems === 1 && providers?.maxItems === profile.primarySource.providerMaximum
+    && JSON.stringify(providerItems?.enum) === JSON.stringify(profile.primarySource.providerEnum), 'primary-source provider contract drifted');
+  assert(canonicalJson(primaryInput) === canonicalJson(profile.primarySource.inputSchema), 'advertised primary-source input schema differs from the checked-out contract');
+  assert(sha256(canonicalJson(profile.primarySource.inputSchema)) === profile.primarySource.inputSchemaSha256
+    && sha256(canonicalJson(primaryInput)) === profile.primarySource.inputSchemaSha256, 'primary-source input schema hash drifted');
+  assert(canonicalJson(primaryOutput) === canonicalJson(profile.primarySource.outputSchema), 'advertised primary-source output schema differs from the checked-out contract');
+  assert(sha256(canonicalJson(profile.primarySource.outputSchema)) === profile.primarySource.outputSchemaSha256
+    && sha256(canonicalJson(primaryOutput)) === profile.primarySource.outputSchemaSha256, 'primary-source output schema hash drifted');
   return {
     classicTextInputSchemaSha256: EXPECTED_CLASSIC_INPUT_SCHEMA_SHA256,
     classicTextOutputSchemaSha256: EXPECTED_CLASSIC_OUTPUT_SCHEMA_SHA256,
-    primarySourceInputSchemaSha256: EXPECTED_PRIMARY_INPUT_SCHEMA_SHA256,
-    primarySourceOutputSchemaSha256: EXPECTED_PRIMARY_OUTPUT_SCHEMA_SHA256,
+    primarySourceContractVersion: profile.primarySource.contractVersion,
+    primarySourceOpenWorldHint: profile.primarySource.openWorldHint,
+    primarySourceProviderMaximum: profile.primarySource.providerMaximum,
+    primarySourceExternalDiscoveryBoundary: profile.primarySource.externalDiscoveryBoundary,
+    primarySourceInputSchemaSha256: profile.primarySource.inputSchemaSha256,
+    primarySourceOutputSchemaSha256: profile.primarySource.outputSchemaSha256,
   };
 }
 
@@ -377,22 +477,27 @@ function promptText(message: ObjectRecord, label: string): string {
   return requireString(content.text, `${label} content text`);
 }
 
-function assertPrimarySourceResearchPrompt(message: ObjectRecord): void {
-  const text = promptText(message, 'primary-source-research prompt');
-  assert(text.includes('Search local evidence') && text.includes('Search one external scope now') && text.includes('Use the v7 contract')
-    && text.includes('"providers":["local"]') && text.includes('"providers":["ccel"]')
-    && text.includes('This prompt authorizes at most one CCEL-bearing call.')
-    && text.includes('The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range.')
-    && text.includes('Use MCP `resources/read` only for local `mcp_resource` URIs.')
-    && text.includes('Open external `external_url` pages directly')
-    && text.includes('name disabled, unavailable, or unsupported searches'), 'primary-source-research current v7 prompt behavior drifted');
+function assertPromptContract(
+  message: ObjectRecord,
+  label: string,
+  expected: PrimarySourceAuditContract['primarySourceResearchPrompt'],
+  profile: HistoricalCoreAuditProfile,
+): void {
+  const text = promptText(message, label);
+  for (const required of expected.required) {
+    assert(text.includes(required), `${profile.label} ${label} required behavior drifted`);
+  }
+  for (const absent of expected.absent) {
+    assert(!text.includes(absent), `${profile.label} ${label} local-only boundary drifted`);
+  }
 }
 
-function assertConfessionStudyPrompt(message: ObjectRecord): void {
-  const text = promptText(message, 'confession-study prompt');
-  assert(text.includes('"providers":["local","ccel"]') && text.includes('external `external_url` locator')
-    && text.includes('it is not an MCP resource') && text.includes('rights status is not determined')
-    && text.includes('Name any disabled, unavailable, or unsupported provider'), 'confession-study current v7 prompt behavior drifted');
+function assertPrimarySourceResearchPrompt(message: ObjectRecord, profile: HistoricalCoreAuditProfile): void {
+  assertPromptContract(message, 'primary-source-research prompt', profile.primarySource.primarySourceResearchPrompt, profile);
+}
+
+function assertConfessionStudyPrompt(message: ObjectRecord, profile: HistoricalCoreAuditProfile): void {
+  assertPromptContract(message, 'confession-study prompt', profile.primarySource.confessionStudyPrompt, profile);
 }
 
 function expectedResourceUris(fixture: AuditFixture): string[] {
@@ -537,27 +642,84 @@ function assertClassicSearch(raw: RawToolResult, workId: string): ObjectRecord {
   return { returnedHitCount: hits.length, matchingWorkObserved: true, snippetsDiscoveryOnly: true };
 }
 
-function assertPrimarySearch(raw: RawToolResult, probe: AuditFixture['probes'][number]): { uri: string; evidence: ObjectRecord } {
+function assertPrimarySearch(
+  raw: RawToolResult,
+  probe: AuditFixture['probes'][number],
+  profile: HistoricalCoreAuditProfile,
+): { uri: string; evidence: ObjectRecord } {
   const { workId } = probe;
   const output = structured(raw, `${workId} primary search`);
   const queries = array(output.queries, `${workId} primary queries`).map(object);
-  assert(output.schemaVersion === '7' && output.kind === 'primary_source_search' && output.planStatus === 'complete' && queries.length === 1 && queries[0] !== undefined, `${workId} primary envelope drifted`);
+  assert(output.schemaVersion === profile.primarySource.schemaVersion && output.kind === 'primary_source_search'
+    && output.planStatus === 'complete' && queries.length === 1 && queries[0] !== undefined,
+  `${workId} primary v${profile.primarySource.contractVersion} envelope drifted`);
+  const responseWindow = object(output.responseWindow);
+  assert(responseWindow?.unit === 'utf8_bytes' && responseWindow.maximum === 32768 && typeof responseWindow.truncated === 'boolean',
+    `${workId} primary response-window evidence drifted`);
+  assert(queries[0]!.normalizedMode === 'all_terms' && queries[0]!.normalizedSelection === 'relevance',
+    `${workId} primary local query-normalization drifted`);
   const providers = array(queries[0]!.providers, `${workId} primary providers`).map(object);
-  assert(providers.length === 1 && providers[0]?.provider === 'local' && providers[0]?.status === 'ok' && providers[0]?.searched === true, `${workId} local provider execution drifted`);
+  assert(providers.length === 1 && providers[0]?.provider === 'local' && providers[0]?.status === 'ok'
+    && providers[0]?.searched === true && providers[0]?.page === 1 && Array.isArray(providers[0]?.notices),
+  `${workId} local provider execution drifted`);
+  const resultWindow = object(providers[0]?.resultWindow);
+  assert(resultWindow !== undefined && typeof resultWindow.returnedHitCount === 'number'
+    && ['additional_match_observed', 'no_additional_match_observed', 'not_evaluated'].includes(resultWindow.additionalMatchStatus as string),
+  `${workId} local provider result-window evidence drifted`);
   const hits = array(providers[0]!.hits, `${workId} local hits`).map(object);
   const hit = hits[0];
   assert(hit !== undefined, `${workId} natural local query returned no relevance-ranked hit`);
+  for (const candidate of hits) {
+    const candidateLocator = object(candidate?.locator);
+    assert(candidate?.provider === 'local' && candidateLocator?.kind === 'mcp_resource'
+      && typeof candidateLocator.uri === 'string' && candidateLocator.uri.startsWith('theologai://documents/'),
+    `${workId} primary local provider hit-scope drifted`);
+    const documentId = candidateLocator.documentId;
+    const sectionKey = candidateLocator.sectionKey;
+    const canonicalUri = typeof documentId === 'string' && typeof sectionKey === 'string'
+      ? buildLocalDocumentResourceUri(documentId, sectionKey)
+      : undefined;
+    assert(canonicalUri !== undefined && candidateLocator.uri === canonicalUri,
+      `${workId} primary local provider canonical locator drifted`);
+  }
   const locator = object(hit.locator); const readiness = object(hit.editionReadiness);
   assert(locator?.kind === 'mcp_resource' && locator.documentId === workId
     && locator.sectionKey === probe.primarySearch.sectionKey && locator.sourceOrdinal === probe.primarySearch.sourceOrdinal
     && locator.uri === probe.primarySearch.resourceUri
     && readiness?.editionIdentity === 'established' && readiness.normalizedTextRights === 'no_known_conflict', `${workId} primary local evidence identity/readiness drifted`);
   const policy = object(output.evidencePolicy); const coverage = object(output.coverage);
+  const serverObserved = object(coverage?.serverObserved);
+  const searched = array(serverObserved?.searched, `${workId} primary searched ledger`).map(object);
+  const notSearched = array(serverObserved?.notSearched, `${workId} primary not-searched ledger`).map(object);
   assert(policy?.snippetUse === 'discovery_only' && policy.localSectionAccess === 'mcp_resource_read'
-    && policy.externalSectionAccess === 'direct_url_only' && coverage?.localAttempted === true
-    && typeof coverage.localHitCount === 'number' && Number.isSafeInteger(coverage.localHitCount) && coverage.localHitCount >= 1,
+    && policy.coverageScope === 'bounded_non_exhaustive'
+    && policy.lookupAliasUse === 'exact_routing_only_not_metadata_evidence'
+    && coverage?.localAttempted === true && coverage.localStatus === 'ok'
+    && typeof coverage.localHitCount === 'number' && Number.isSafeInteger(coverage.localHitCount) && coverage.localHitCount >= 1
+    && Array.isArray(coverage.notices)
+    && searched.length === 1 && searched[0]?.provider === 'local' && searched[0]?.status === 'ok'
+    && typeof searched[0]?.returnedHitCount === 'number' && notSearched.length === 0,
   `${workId} primary evidence policy drifted`);
-  return { uri: locator.uri as string, evidence: { localHitCount: coverage.localHitCount as number, exactWorkObserved: true, localReadiness: 'established' } };
+  if (profile.primarySource.contractVersion === '7') {
+    assert(policy.externalSectionAccess === 'direct_url_only' && policy.externalRightsStatus === 'not_determined'
+      && coverage.ccelAttempted === false && coverage.ccelHitCount === 0 && !Object.hasOwn(coverage, 'ccelStatus')
+      && searched.every(entry => entry?.provider === 'local') && notSearched.every(entry => entry?.provider === 'local'),
+    `${workId} preview external-discovery evidence boundary drifted`);
+  } else {
+    assert(!Object.hasOwn(policy, 'externalSectionAccess') && !Object.hasOwn(policy, 'externalRightsStatus')
+      && !Object.hasOwn(coverage, 'ccelAttempted') && !Object.hasOwn(coverage, 'ccelHitCount') && !Object.hasOwn(coverage, 'ccelStatus')
+      && searched.every(entry => entry?.provider === 'local') && notSearched.every(entry => entry?.provider === 'local'),
+    `${workId} production local-only evidence boundary drifted`);
+  }
+  return {
+    uri: locator.uri as string,
+    evidence: {
+      localHitCount: coverage.localHitCount as number,
+      exactWorkObserved: true,
+      localReadiness: 'established',
+      primarySourceContractVersion: profile.primarySource.contractVersion,
+    },
+  };
 }
 
 function assertExactSection(message: ObjectRecord, expectedUri: string, workId: string): ObjectRecord {
@@ -583,6 +745,19 @@ function assertCcelDisabled(raw: RawToolResult, profile: HistoricalCoreAuditProf
     && provider.status === 'disabled' && provider.searched === false && provider.hitCount === 0 && Array.isArray(provider.hits) && provider.hits.length === 0
     && coverage?.localAttempted === false && coverage.ccelAttempted === false && coverage.ccelStatus === 'disabled' && coverage.ccelHitCount === 0, `${profile.label} CCEL-disabled/local-only execution invariant drifted`);
   return { provider: 'ccel_live', status: 'disabled', searched: false, hitCount: 0 };
+}
+
+/** Production must reject an external provider in JSON Schema before any provider can execute. */
+function assertCcelRejectedAtInputSchema(raw: RawToolResult, profile: HistoricalCoreAuditProfile): ObjectRecord {
+  assert(raw.isError === true && raw.structuredContent === undefined,
+    `${profile.label} CCEL input-boundary regression must be a safe unstructured validation error`);
+  assert(raw.text.length === 1 && raw.text[0]!.startsWith('Invalid arguments for primary_source_search:'),
+    `${profile.label} CCEL input-boundary regression must be classified by schema validation`);
+  const serialized = JSON.stringify(raw.raw);
+  assertNoSensitiveErrorText(serialized, `${profile.label} CCEL input-boundary regression`);
+  assert(!serialized.includes('ccel_live') && !serialized.includes('"searched"') && !serialized.includes('"providers"'),
+    `${profile.label} CCEL input-boundary regression exposed provider execution`);
+  return { provider: 'ccel', status: 'rejected_at_input_schema', searched: false, hitCount: 0 };
 }
 
 function assertNoSensitiveErrorText(value: string, label: string): void {
@@ -628,6 +803,7 @@ function evidenceTextIsSafe(value: unknown): void {
     'schemaVersion', 'audit', 'endpointClass', 'fixtureSha256', 'durationMs', 'negotiated', 'schemas', 'budgets', 'catalog', 'classicCatalog', 'records', 'regressions',
     'protocolVersion', 'serverName', 'serverVersion',
     'classicTextInputSchemaSha256', 'classicTextOutputSchemaSha256', 'primarySourceInputSchemaSha256', 'primarySourceOutputSchemaSha256',
+    'primarySourceContractVersion', 'primarySourceOpenWorldHint', 'primarySourceProviderMaximum', 'primarySourceExternalDiscoveryBoundary',
     'logicalOperations', 'maximumLogicalOperations', 'httpExchanges', 'maximumHttpExchanges', 'retryCount', 'perRequestMaximumDurationMs', 'maximumDurationMs', 'maximumMcpResponseBytes', 'aggregateMcpResponseBytes', 'maximumAggregateMcpResponseBytes',
     'workCount', 'legacyWorkCount', 'coreWorkCount', 'sourcePackId', 'coreSectionCount', 'reviewedSectionedWorkCount', 'legacyCompleteWorkCount',
     'workId', 'editionId', 'passed', 'landing', 'directory', 'classicSearch', 'primary', 'section',
@@ -663,14 +839,14 @@ export async function runHistoricalCoreAudit(
   const client = new FixedAuditMcp(fetchImpl, deadline, profile);
   const negotiated = assertInitialize(await client.initialize(), profile);
   await client.initialized();
-  const schemas = assertToolRegistration(await client.toolsList());
+  const schemas = assertToolRegistration(await client.toolsList(), profile);
   assertPrompts(await client.promptsList());
   assertResources(await client.resourcesList(), fixture);
   assertResourceTemplates(await client.resourceTemplatesList());
   assertPrimarySourceResearchPrompt(await client.getPrompt('primary-source-research', {
     topic: 'eucharist', authors: 'Erasmus of Rotterdam,Martin Luther', startYear: '500', endYear: '1500', maxSections: '2',
-  }));
-  assertConfessionStudyPrompt(await client.getPrompt('confession-study', { topic: 'justification' }));
+  }), profile);
+  assertConfessionStudyPrompt(await client.getPrompt('confession-study', { topic: 'justification' }), profile);
   const catalog = assertCatalog(await client.readResource('theologai://primary-sources/catalog'), fixture);
   const classicCatalog = assertClassicCatalog(await client.callTool('classic_text_lookup', { listWorks: true }), fixture);
   const directLandingResourceBytes = assertDirectLandingResource(
@@ -687,13 +863,18 @@ export async function runHistoricalCoreAudit(
     const classicSearch = assertClassicSearch(await client.callTool('classic_text_lookup', { query: probe.query }), probe.workId);
     const primary = assertPrimarySearch(await client.callTool('primary_source_search', { queries: [{
       id: `core-${probe.workId}`, text: probe.query, providers: ['local'], work: probe.workId, match: 'all_terms', selection: 'relevance', limit: 5,
-    }] }), probe);
+    }] }), probe, profile);
     const section = assertExactSection(await client.readResource(primary.uri), primary.uri, probe.workId);
     records.push({ workId: probe.workId, editionId: probe.editionId, passed: true, durationMs: Date.now() - started, landing, directory, classicSearch, primary: primary.evidence, section });
   }
   assert(observedCoreSectionCount === fixture.baseline.expectedCatalogIdentity.coreSectionCount, 'reviewed core section-count identity drifted');
   const legacy = assertLegacyRegression(await client.callTool('classic_text_lookup', { work: fixture.legacyRegression.workId }), fixture);
-  const ccel = assertCcelDisabled(await client.callTool('primary_source_search', { queries: [{ id: 'ccel-disabled', text: 'Lord Supper', providers: ['ccel'], match: 'all_terms', selection: 'relevance', limit: 1 }] }), profile);
+  const ccelRaw = await client.callTool('primary_source_search', {
+    queries: [{ id: 'ccel-disabled', text: 'Lord Supper', providers: ['ccel'], match: 'all_terms', selection: 'relevance', limit: 1 }],
+  });
+  const ccel = profile.primarySource.externalDiscoveryBoundary === 'disabled_structured_ccel'
+    ? assertCcelDisabled(ccelRaw, profile)
+    : assertCcelRejectedAtInputSchema(ccelRaw, profile);
   const invalidResourceUri = 'theologai://documents/does-not-exist#section-not-real';
   assertResourceNotFound(await client.readResource(invalidResourceUri), invalidResourceUri);
   const invalidCursor = 'not-a-valid-cursor';

--- a/test/unit/scripts/historicalCorePreviewAudit.test.ts
+++ b/test/unit/scripts/historicalCorePreviewAudit.test.ts
@@ -2,18 +2,25 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSy
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   AuditDeadline,
   MAX_MCP_RESPONSE_BYTES,
+  PREVIEW_PROFILE,
+  PRODUCTION_PROFILE,
   publishAuditEvidence,
   readBoundedResponseBody,
   runAuditCli,
   runPreviewAudit,
+  runProductionAudit,
   validateFixture,
 } from '../../../scripts/audit-historical-core-preview.js';
 import { classicTextsOutputSchema } from '../../../src/mcp/schemas/classicTexts.js';
-import { primarySourceSearchV7OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
+import { primarySourceSearchV6OutputSchema, primarySourceSearchV7OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
+import { registerToolHandlers } from '../../../src/mcp/tools.js';
 import { createClassicTextsHandler } from '../../../src/tools/v2/classicTexts.js';
 import { createPrimarySourceSearchHandler } from '../../../src/tools/v2/primarySourceSearch.js';
 
@@ -36,6 +43,8 @@ type FakeOptions = {
   directLandingText?: string;
   truncateClassicCatalog?: boolean;
   primaryLocatorDrift?: boolean;
+  laterExternalPrimaryHit?: boolean;
+  laterNoncanonicalPrimaryHit?: boolean;
   catalogProvenanceStatus?: string | null;
   landingResourceSizeBytes?: number | null;
   ccelIsError?: boolean;
@@ -43,14 +52,6 @@ type FakeOptions = {
 };
 
 const FAKE_LANDING_TEXT = '# Work record\nMetadata only.';
-
-const V7_CONTRACT = {
-  exposeCcelDiscovery: true,
-  ccelLiveSearch: false,
-  ccelCoordinator: false,
-  contractVersion: '7' as const,
-  liveCcelEnabled: false,
-};
 
 async function fixture(): Promise<RecordValue> {
   return JSON.parse(await readFile(fixtureUrl, 'utf8')) as RecordValue;
@@ -190,15 +191,141 @@ describe('historical core preview audit contract', () => {
     expect(relevanceReads.filter((uri, index) => uri !== parsed.probes[index]!.firstSection.resourceUri)).toHaveLength(5);
   });
 
+  it('runs the same exact 55-exchange inventory against the production v6 profile and retains only local-only evidence', async () => {
+    const parsed = validateFixture(await fixture());
+    const calls: Array<{ url: string; body: RecordValue }> = [];
+    const fakeFetch: typeof fetch = async (input, init) => {
+      const body = JSON.parse(String(init?.body)) as RecordValue;
+      calls.push({ url: String(input), body });
+      return responseFor(body, parsed, {}, PRODUCTION_PROFILE);
+    };
+
+    const evidence = await runProductionAudit(parsed, fakeFetch);
+    expect(calls).toHaveLength(55);
+    expect(calls.every(call => call.url === 'https://mcp.theologai.xyz/mcp')).toBe(true);
+    expect(evidence.schemas).toMatchObject({
+      primarySourceContractVersion: '6', primarySourceOpenWorldHint: false,
+      primarySourceProviderMaximum: 1, primarySourceExternalDiscoveryBoundary: 'rejected_at_input_schema',
+      primarySourceInputSchemaSha256: '37849624bac2e884106050fcff39851e40cac31969b4f7511f516f78348fea87',
+      primarySourceOutputSchemaSha256: '25758f8d06c43c3f2961fa7b35ba1d62a548df923589b391c65204813a6511b8',
+    });
+    expect((evidence.regressions as RecordValue).ccel).toEqual({
+      provider: 'ccel', status: 'rejected_at_input_schema', searched: false, hitCount: 0,
+    });
+    const serialized = JSON.stringify(evidence);
+    expect(serialized).not.toContain('ccel_live');
+    expect(serialized).not.toContain('external_url');
+    expect(serialized).not.toContain('theologai://documents/');
+    expect(calls.filter(call => call.body.method === 'tools/call'
+      && (call.body.params as RecordValue).name === 'primary_source_search')).toHaveLength(9);
+  });
+
+  it('fails closed when production v6 registration, prompts, or local-only evidence drift toward preview discovery behavior', async () => {
+    const parsed = validateFixture(await fixture());
+    await expect(runProductionAudit(parsed, fakeFetchWith(parsed, {
+      mutate: (body, response) => {
+        if (body.method === 'tools/list') {
+          const primary = ((response.result as RecordValue).tools as RecordValue[])
+            .find(tool => tool.name === 'primary_source_search')!;
+          (primary.annotations as RecordValue).openWorldHint = true;
+        }
+        return response;
+      },
+    }, PRODUCTION_PROFILE))).rejects.toThrow('open-world annotation drifted');
+
+    await expect(runProductionAudit(parsed, fakeFetchWith(parsed, {
+      mutate: (body, response) => {
+        if (body.method === 'tools/list') {
+          const primary = ((response.result as RecordValue).tools as RecordValue[])
+            .find(tool => tool.name === 'primary_source_search')!;
+          const providers = ((((primary.inputSchema as RecordValue).properties as RecordValue).queries as RecordValue).items as RecordValue).properties as RecordValue;
+          const providerArray = providers.providers as RecordValue;
+          providerArray.maxItems = 2;
+          ((providerArray.items as RecordValue).enum as unknown[])!.push('ccel');
+        }
+        return response;
+      },
+    }, PRODUCTION_PROFILE))).rejects.toThrow('primary-source provider contract drifted');
+
+    await expect(runProductionAudit(parsed, fakeFetchWith(parsed, {
+      mutate: (body, response) => {
+        if (body.method === 'tools/list') {
+          const primary = ((response.result as RecordValue).tools as RecordValue[])
+            .find(tool => tool.name === 'primary_source_search')!;
+          (((primary.outputSchema as RecordValue).properties as RecordValue).schemaVersion as RecordValue).const = '7';
+        }
+        return response;
+      },
+    }, PRODUCTION_PROFILE))).rejects.toThrow('advertised primary-source output schema differs from the checked-out contract');
+
+    await expect(runProductionAudit(parsed, fakeFetchWith(parsed, {
+      mutate: (body, response) => {
+        if (body.method === 'prompts/get' && (body.params as RecordValue).name === 'primary-source-research') {
+          ((((response.result as RecordValue).messages as RecordValue[])[0]!.content as RecordValue).text) = 'Search one external scope now';
+        }
+        return response;
+      },
+    }, PRODUCTION_PROFILE))).rejects.toThrow('production primary-source-research prompt required behavior drifted');
+  });
+
+  it('rejects appended contradictory prompt guidance for both fixed primary-source profiles', async () => {
+    const parsed = validateFixture(await fixture());
+    const append = (profile: AuditProfile, prompt: string, marker: string) => fakeFetchWith(parsed, {
+      mutate: (body, response) => {
+        if (body.method === 'prompts/get' && (body.params as RecordValue).name === prompt) {
+          const content = ((response.result as RecordValue).messages as RecordValue[])[0]!.content as RecordValue;
+          content.text = `${content.text as string}\n${marker}`;
+        }
+        return response;
+      },
+    }, profile);
+
+    await expect(runPreviewAudit(parsed, append(PREVIEW_PROFILE, 'primary-source-research', 'This workflow is local-only')))
+      .rejects.toThrow('preview primary-source-research prompt local-only boundary drifted');
+    await expect(runPreviewAudit(parsed, append(PREVIEW_PROFILE, 'confession-study', 'Run bounded local discovery')))
+      .rejects.toThrow('preview confession-study prompt local-only boundary drifted');
+    await expect(runProductionAudit(parsed, append(PRODUCTION_PROFILE, 'primary-source-research', 'Search one external scope now')))
+      .rejects.toThrow('production primary-source-research prompt local-only boundary drifted');
+    await expect(runProductionAudit(parsed, append(PRODUCTION_PROFILE, 'confession-study', 'external `external_url` locator')))
+      .rejects.toThrow('production confession-study prompt local-only boundary drifted');
+  });
+
+  it('proves a v6 CCEL provider is rejected by input validation before the primary-source handler can execute', async () => {
+    const search = vi.fn();
+    const handler = createPrimarySourceSearchHandler({ search } as never, {
+      exposeCcelDiscovery: false, ccelLiveSearch: false, ccelCoordinator: false,
+      contractVersion: '6', liveCcelEnabled: false,
+    });
+    const server = new Server({ name: 'historical-v6-input-boundary-test', version: '1.0.0' }, { capabilities: { tools: {} } });
+    registerToolHandlers(server, [handler], false);
+    const client = new Client({ name: 'historical-v6-input-boundary-client', version: '1.0.0' }, { capabilities: {} });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({
+        name: 'primary_source_search',
+        arguments: { queries: [{ id: 'ccel-boundary', text: 'Lord Supper', providers: ['ccel'] }] },
+      });
+      expect(result).toMatchObject({ isError: true, content: [{ type: 'text', text: expect.stringContaining('Invalid arguments for primary_source_search:') }] });
+      expect(result).not.toHaveProperty('structuredContent');
+      expect(JSON.stringify(result)).not.toContain('ccel_live');
+      expect(search).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
   it('fails before probes when a pinned advertised schema or open-world annotation drifts', async () => {
     const parsed = validateFixture(await fixture());
     let calls = 0;
     const schemaDrift: typeof fetch = async (_input, init) => {
       calls += 1;
       const body = JSON.parse(String(init?.body)) as RecordValue;
-      if (body.method === 'initialize') return jsonResponse(initialize(body));
+      if (body.method === 'initialize') return jsonResponse(initialize(body, PREVIEW_PROFILE));
       if (body.method === 'notifications/initialized') return new Response('', { status: 202 });
-      const tools = fakeTools();
+      const tools = fakeTools(PREVIEW_PROFILE);
       ((tools.find(tool => tool.name === 'classic_text_lookup')!.outputSchema as RecordValue).properties as RecordValue).schemaVersion = { const: 'wrong' };
       return jsonResponse({ jsonrpc: '2.0', id: body.id, result: { tools } });
     };
@@ -231,12 +358,16 @@ describe('historical core preview audit contract', () => {
         ((((response.result as RecordValue).messages as RecordValue[])[0]!.content as RecordValue).text) = 'old prompt';
       }
       return response;
-    } }))).rejects.toThrow('current v7 prompt behavior drifted');
+    } }))).rejects.toThrow('preview primary-source-research prompt required behavior drifted');
     await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { truncateClassicCatalog: true })))
       .rejects.toThrow('reviewed registration inventory drifted');
     await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { directLandingText: '<img src="scan.png">' }))).rejects.toThrow('direct landing resource is not bounded normalized metadata');
     await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { primaryLocatorDrift: true })))
-      .rejects.toThrow('primary local evidence identity/readiness drifted');
+      .rejects.toThrow('primary local provider canonical locator drifted');
+    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { laterExternalPrimaryHit: true })))
+      .rejects.toThrow('primary local provider hit-scope drifted');
+    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { laterNoncanonicalPrimaryHit: true })))
+      .rejects.toThrow('primary local provider canonical locator drifted');
   });
 
   it('requires the reviewed core-eight provenance status, rather than treating a stronger-looking status as interchangeable', async () => {
@@ -448,33 +579,44 @@ describe('historical core preview audit contract', () => {
   });
 });
 
-function fakeFetchWith(fixtureValue: Audit, options: FakeOptions): typeof fetch {
-  return async (_input, init) => responseFor(JSON.parse(String(init?.body)) as RecordValue, fixtureValue, options);
+type AuditProfile = typeof PREVIEW_PROFILE;
+
+function fakeFetchWith(
+  fixtureValue: Audit,
+  options: FakeOptions = {},
+  profile: AuditProfile = PREVIEW_PROFILE,
+): typeof fetch {
+  return async (_input, init) => responseFor(JSON.parse(String(init?.body)) as RecordValue, fixtureValue, options, profile);
 }
 
-function responseFor(body: RecordValue, fixtureValue: Audit, options: FakeOptions = {}): Response {
+function responseFor(
+  body: RecordValue,
+  fixtureValue: Audit,
+  options: FakeOptions = {},
+  profile: AuditProfile = PREVIEW_PROFILE,
+): Response {
   let payload: RecordValue;
-  if (body.method === 'initialize') return jsonResponse(initialize(body));
+  if (body.method === 'initialize') return jsonResponse(initialize(body, profile));
   if (body.method === 'notifications/initialized') return new Response('', { status: 202 });
-  if (body.method === 'tools/list') payload = { jsonrpc: '2.0', id: body.id, result: { tools: fakeTools() } };
+  if (body.method === 'tools/list') payload = { jsonrpc: '2.0', id: body.id, result: { tools: fakeTools(profile) } };
   else if (body.method === 'prompts/list') payload = { jsonrpc: '2.0', id: body.id, result: { prompts: fakePrompts() } };
-  else if (body.method === 'prompts/get') payload = promptResponse(body);
+  else if (body.method === 'prompts/get') payload = promptResponse(body, profile);
   else if (body.method === 'resources/list') payload = { jsonrpc: '2.0', id: body.id, result: { resources: fakeResources(fixtureValue) } };
   else if (body.method === 'resources/templates/list') payload = { jsonrpc: '2.0', id: body.id, result: { resourceTemplates: fakeResourceTemplates() } };
   else if (body.method === 'resources/read') return resourceResponse(body, fixtureValue, options);
-  else if (body.method === 'tools/call') return toolResponse(body, fixtureValue, options);
+  else if (body.method === 'tools/call') return toolResponse(body, fixtureValue, options, profile);
   else throw new Error(`unexpected fake method ${body.method}`);
   return jsonResponse(options.mutate ? options.mutate(body, payload) : payload);
 }
 
-function initialize(body: RecordValue): RecordValue {
+function initialize(body: RecordValue, profile: AuditProfile): RecordValue {
   return { jsonrpc: '2.0', id: body.id, result: {
     protocolVersion: '2025-11-25', capabilities: { tools: {}, resources: {}, prompts: {} },
-    serverInfo: { name: 'theologai-bible-server', version: '3.6.0-preview' },
+    serverInfo: { name: 'theologai-bible-server', version: profile.serverVersion },
   } };
 }
 
-function fakeTools(): RecordValue[] {
+function fakeTools(profile: AuditProfile): RecordValue[] {
   const base = { readOnlyHint: true, destructiveHint: false, idempotentHint: true };
   return [
     'bible_lookup', 'bible_cross_references', 'parallel_passages', 'commentary_lookup',
@@ -482,7 +624,11 @@ function fakeTools(): RecordValue[] {
     'bible_verse_morphology', 'original_language_study', 'donation_config', 'verify_donation',
   ].map(name => {
     if (name === 'classic_text_lookup') return { name, annotations: { ...base, openWorldHint: false }, inputSchema: classicInput(), outputSchema: structuredClone(classicTextsOutputSchema) };
-    if (name === 'primary_source_search') return { name, annotations: { ...base, openWorldHint: true }, inputSchema: primaryInput(), outputSchema: structuredClone(primarySourceSearchV7OutputSchema) };
+    if (name === 'primary_source_search') return {
+      name, annotations: { ...base, openWorldHint: profile.primarySource.openWorldHint },
+      inputSchema: primaryInput(profile),
+      outputSchema: structuredClone(profile.primarySource.contractVersion === '7' ? primarySourceSearchV7OutputSchema : primarySourceSearchV6OutputSchema),
+    };
     return { name, annotations: { ...base } };
   });
 }
@@ -491,19 +637,23 @@ function classicInput(): RecordValue {
   return structuredClone(createClassicTextsHandler({} as never).inputSchema) as RecordValue;
 }
 
-function primaryInput(): RecordValue {
-  return structuredClone(createPrimarySourceSearchHandler({} as never, V7_CONTRACT).inputSchema) as RecordValue;
+function primaryInput(profile: AuditProfile): RecordValue {
+  return structuredClone(profile.primarySource.inputSchema) as RecordValue;
 }
 
 function fakePrompts(): RecordValue[] {
   return ['word-study', 'passage-exegesis', 'compare-translations', 'confession-study', 'primary-source-research', 'donate'].map(name => ({ name }));
 }
 
-function promptResponse(body: RecordValue): RecordValue {
+function promptResponse(body: RecordValue, profile: AuditProfile): RecordValue {
   const name = (body.params as RecordValue).name;
-  const text = name === 'primary-source-research'
-    ? 'Search local evidence. Search one external scope now. Use the v7 contract. {"providers":["local"]} {"providers":["ccel"]}. This prompt authorizes at most one CCEL-bearing call. The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range. Use MCP `resources/read` only for local `mcp_resource` URIs. Open external `external_url` pages directly and name disabled, unavailable, or unsupported searches.'
-    : 'Use {"providers":["local","ccel"]}. An external `external_url` locator exists; it is not an MCP resource and rights status is not determined. Name any disabled, unavailable, or unsupported provider.';
+  const text = profile.primarySource.contractVersion === '7'
+    ? name === 'primary-source-research'
+      ? 'Search local evidence. Search one external scope now. Use the v7 contract. {"providers":["local"]} {"providers":["ccel"]}. This prompt authorizes at most one CCEL-bearing call. The external CCEL call deliberately omits the requested local composition-year bounds; any returned CCEL hit cannot establish membership in that requested local range. Use MCP `resources/read` only for local `mcp_resource` URIs. Open external `external_url` pages directly and name disabled, unavailable, or unsupported searches.'
+      : 'Use {"providers":["local","ccel"]}. An external `external_url` locator exists; it is not an MCP resource and rights status is not determined. Name any disabled, unavailable, or unsupported provider.'
+    : name === 'primary-source-research'
+      ? 'Run bounded discovery. This workflow is local-only. Use the v6 structured result. Read an exact MCP resource before quotation. This workflow supports a topic survey.'
+      : 'Run bounded local discovery across the hosted collection. Follow canonical `resource_link` blocks with resources/read.';
   return { jsonrpc: '2.0', id: body.id, result: { messages: [{ role: 'user', content: { type: 'text', text } }] } };
 }
 
@@ -564,12 +714,12 @@ function fakeCatalog(fixtureValue: Audit, options: FakeOptions = {}): RecordValu
     policies: { scope: 'hosted_collection_only', editionProvenance: 'mixed_legacy_and_reviewed_source_packs', rightsStatus: 'mixed_not_established_and_no_known_conflict' } };
 }
 
-function toolResponse(body: RecordValue, fixtureValue: Audit, options: FakeOptions): Response {
+function toolResponse(body: RecordValue, fixtureValue: Audit, options: FakeOptions, profile: AuditProfile): Response {
   const params = body.params as RecordValue;
   const name = params.name as string;
   const args = params.arguments as RecordValue;
   if (name === 'classic_text_lookup') return classicTool(body, args, fixtureValue, options);
-  if (name === 'primary_source_search') return primaryTool(body, args, fixtureValue, options);
+  if (name === 'primary_source_search') return primaryTool(body, args, fixtureValue, options, profile);
   throw new Error(`unexpected fake tool ${name}`);
 }
 
@@ -605,34 +755,88 @@ function directory(probe: Audit['probes'][number]): RecordValue {
   return { schemaVersion: '2', kind: 'classic_text_lookup', mode: 'browse_sections', directory: { work: { id: probe.workId }, coverage: 'bounded_section_directory', pagination: { pageSize: 32 }, sections: [{ sectionKey: probe.firstSection.sectionKey, sourceOrdinal: probe.firstSection.sourceOrdinal, resource: { kind: 'mcp_resource', uri: probe.firstSection.resourceUri } }] } };
 }
 
-function primaryTool(body: RecordValue, args: RecordValue, fixtureValue: Audit, options: FakeOptions): Response {
+function primaryTool(
+  body: RecordValue,
+  args: RecordValue,
+  fixtureValue: Audit,
+  options: FakeOptions,
+  profile: AuditProfile,
+): Response {
   const query = ((args.queries as RecordValue[])[0])!;
-  if ((query.providers as string[])[0] === 'ccel') return toolResult(body, {
-    isError: options.ccelIsError ?? true,
-    ...(options.ccelStructuredContent === false ? {} : { structuredContent: {
-      schemaVersion: '7', kind: 'primary_source_search', planStatus: 'unavailable',
-      queries: [{ providers: [{ provider: 'ccel_live', status: 'disabled', searched: false, hitCount: 0, hits: [] }] }],
-      coverage: { localAttempted: false, ccelAttempted: false, ccelStatus: 'disabled', ccelHitCount: 0 },
-    } }),
-  });
+  if ((query.providers as string[])[0] === 'ccel') {
+    if (profile.primarySource.externalDiscoveryBoundary === 'rejected_at_input_schema') {
+      return toolResult(body, {
+        isError: true,
+        content: [{ type: 'text', text: 'Invalid arguments for primary_source_search: argument "queries.0.providers.0" must be equal to "local"' }],
+      });
+    }
+    return toolResult(body, {
+      isError: options.ccelIsError ?? true,
+      ...(options.ccelStructuredContent === false ? {} : { structuredContent: {
+        schemaVersion: '7', kind: 'primary_source_search', planStatus: 'unavailable',
+        queries: [{ id: 'ccel-disabled', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [{
+          provider: 'ccel_live', status: 'disabled', searched: false, page: 1, hitCount: 0,
+          resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'not_evaluated' }, hits: [], notices: [],
+        }] }],
+        responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
+        coverage: { localAttempted: false, localHitCount: 0, ccelAttempted: false, ccelStatus: 'disabled', ccelHitCount: 0, notices: [], serverObserved: { searched: [], notSearched: [{ queryId: 'ccel-disabled', provider: 'ccel_live', status: 'disabled' }] } },
+        evidencePolicy: { snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', externalSectionAccess: 'direct_url_only', coverageScope: 'bounded_non_exhaustive', externalRightsStatus: 'not_determined', lookupAliasUse: 'exact_routing_only_not_metadata_evidence', coverageLedger: { searched: 'server_observed_provider_execution', read: 'host_observed_successful_exact_resource_or_page_read', deferred: 'host_recorded_intentional_deferral', notSearched: 'server_observed_provider_non_execution' } },
+      } }),
+    });
+  }
   const workId = query.work as string;
   const probe = fixtureValue.probes.find(item => item.workId === workId)!;
   const uri = options.primaryLocatorDrift
     ? `${probe.landingResourceUri}#section-noncanonical`
     : probe.primarySearch.resourceUri;
-  const relevanceHit = { locator: {
+  const relevanceHit = { queryId: query.id, title: workId, snippet: 'discovery snippet', rankWithinProvider: 1, page: 1, snippetOnly: true, attribution: 'TheologAI local historical-document collection', provider: 'local', resourceSizeBytes: 42, locator: {
     kind: 'mcp_resource', uri, documentId: workId,
     sectionKey: probe.primarySearch.sectionKey, sourceOrdinal: probe.primarySearch.sourceOrdinal,
-  }, editionReadiness: { editionIdentity: 'established', normalizedTextRights: 'no_known_conflict' } };
+  }, editionReadiness: { foundation: 'edition-provenance-foundation.v1', editionIdentity: 'established', provenance: 'verified_with_uncertainty', exactArtifactRights: 'not_claimed_for_scan_artifacts', normalizedTextRights: 'no_known_conflict' } };
   // Real relevance results need not be the directory's first source section.
   // Keep a lower-ranked first section when different to prove this gate reads
   // the pinned relevance hit, not a directory-order surrogate.
-  const lowerRankedDirectoryHit = probe.primarySearch.resourceUri === probe.firstSection.resourceUri ? [] : [{ locator: {
+  const lowerRankedDirectoryHit = probe.primarySearch.resourceUri === probe.firstSection.resourceUri ? [] : [{ queryId: query.id, title: workId, snippet: 'discovery snippet', rankWithinProvider: 2, page: 1, snippetOnly: true, attribution: 'TheologAI local historical-document collection', provider: 'local', resourceSizeBytes: 42, locator: {
     kind: 'mcp_resource', uri: probe.firstSection.resourceUri, documentId: workId,
     sectionKey: probe.firstSection.sectionKey, sourceOrdinal: probe.firstSection.sourceOrdinal,
-  }, editionReadiness: { editionIdentity: 'established', normalizedTextRights: 'no_known_conflict' } }];
-  const hits = [relevanceHit, ...lowerRankedDirectoryHit];
-  return toolResult(body, { structuredContent: { schemaVersion: '7', kind: 'primary_source_search', planStatus: 'complete', queries: [{ providers: [{ provider: 'local', status: 'ok', searched: true, hitCount: hits.length, hits }] }], coverage: { localAttempted: true, localHitCount: hits.length }, evidencePolicy: { snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', externalSectionAccess: 'direct_url_only' } } });
+  }, editionReadiness: { foundation: 'edition-provenance-foundation.v1', editionIdentity: 'established', provenance: 'verified_with_uncertainty', exactArtifactRights: 'not_claimed_for_scan_artifacts', normalizedTextRights: 'no_known_conflict' } }];
+  const laterExternalHit = options.laterExternalPrimaryHit ? [{
+    queryId: query.id, title: 'Unreviewed external result', snippet: 'discovery snippet', rankWithinProvider: 3, page: 1,
+    snippetOnly: true, attribution: 'Unreviewed provider', provider: 'ccel_live',
+    locator: { kind: 'external_url', url: 'https://ccel.org/ccel/example/work.html' },
+    editionReadiness: { editionIdentity: 'provider_unreviewed', provenance: 'provider_unreviewed', exactArtifactRights: 'not_determined' },
+  }] : [];
+  const laterNoncanonicalLocalHit = options.laterNoncanonicalPrimaryHit ? [{
+    queryId: query.id, title: workId, snippet: 'discovery snippet', rankWithinProvider: 4, page: 1,
+    snippetOnly: true, attribution: 'TheologAI local historical-document collection', provider: 'local', resourceSizeBytes: 42,
+    locator: {
+      kind: 'mcp_resource', uri: `${probe.landingResourceUri}#section-not-the-returned-section`, documentId: workId,
+      sectionKey: probe.primarySearch.sectionKey, sourceOrdinal: probe.primarySearch.sourceOrdinal,
+    },
+    editionReadiness: { foundation: 'edition-provenance-foundation.v1', editionIdentity: 'established', provenance: 'verified_with_uncertainty', exactArtifactRights: 'not_claimed_for_scan_artifacts', normalizedTextRights: 'no_known_conflict' },
+  }] : [];
+  const hits = [relevanceHit, ...lowerRankedDirectoryHit, ...laterExternalHit, ...laterNoncanonicalLocalHit];
+  const provider = {
+    provider: 'local', status: 'ok', searched: true, page: 1, hitCount: hits.length,
+    resultWindow: { returnedHitCount: hits.length, additionalMatchStatus: 'no_additional_match_observed' }, hits, notices: [],
+    scope: { status: 'matched', requested: { work: workId }, eligibleDocumentCount: 1, eligibleDocuments: [], eligibleDocumentsTruncated: false },
+  };
+  const output = profile.primarySource.contractVersion === '7'
+    ? {
+      schemaVersion: '7', kind: 'primary_source_search', planStatus: 'complete',
+      responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
+      queries: [{ id: query.id, normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [provider] }],
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: hits.length, ccelAttempted: false, ccelHitCount: 0, notices: [], serverObserved: { searched: [{ queryId: query.id, provider: 'local', status: 'ok', returnedHitCount: hits.length }], notSearched: [] } },
+      evidencePolicy: { snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', externalSectionAccess: 'direct_url_only', coverageScope: 'bounded_non_exhaustive', externalRightsStatus: 'not_determined', lookupAliasUse: 'exact_routing_only_not_metadata_evidence', coverageLedger: { searched: 'server_observed_provider_execution', read: 'host_observed_successful_exact_resource_or_page_read', deferred: 'host_recorded_intentional_deferral', notSearched: 'server_observed_provider_non_execution' } },
+    }
+    : {
+      schemaVersion: '6', kind: 'primary_source_search', planStatus: 'complete',
+      responseWindow: { unit: 'utf8_bytes', maximum: 32768, truncated: false },
+      queries: [{ id: query.id, normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [provider] }],
+      coverage: { localAttempted: true, localStatus: 'ok', localHitCount: hits.length, notices: [], serverObserved: { searched: [{ queryId: query.id, provider: 'local', status: 'ok', returnedHitCount: hits.length }], notSearched: [] } },
+      evidencePolicy: { snippetUse: 'discovery_only', localSectionAccess: 'mcp_resource_read', coverageScope: 'bounded_non_exhaustive', lookupAliasUse: 'exact_routing_only_not_metadata_evidence', coverageLedger: { searched: 'server_observed_provider_execution', read: 'host_observed_successful_exact_resource_or_page_read', deferred: 'host_recorded_intentional_deferral', notSearched: 'server_observed_provider_non_execution' } },
+    };
+  return toolResult(body, { structuredContent: output });
 }
 
 function toolResult(body: RecordValue, result: RecordValue): Response { return jsonResponse({ jsonrpc: '2.0', id: body.id, result }); }

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -11,9 +11,16 @@ describe('production release guards', () => {
       endpoint: 'https://mcp.theologai.xyz/mcp', hostname: 'mcp.theologai.xyz', serverVersion: '3.6.0',
       audit: 'original-language-v2-production', endpointClass: 'production-custom', label: 'production',
     });
-    expect(historicalProfile).toEqual({
+    expect(historicalProfile).toMatchObject({
       endpoint: 'https://mcp.theologai.xyz/mcp', hostname: 'mcp.theologai.xyz', serverVersion: '3.6.0',
       audit: 'historical-core-production', endpointClass: 'production-custom', label: 'production',
+      primarySource: {
+        contractVersion: '6', schemaVersion: '6', openWorldHint: false,
+        providerEnum: ['local'], providerMaximum: 1,
+        inputSchemaSha256: '37849624bac2e884106050fcff39851e40cac31969b4f7511f516f78348fea87',
+        outputSchemaSha256: '25758f8d06c43c3f2961fa7b35ba1d62a548df923589b391c65204813a6511b8',
+        externalDiscoveryBoundary: 'rejected_at_input_schema',
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- pin the historical release audit to the intentional preview v7 and production v6 primary-source contracts
- preserve preview disabled-CCEL verification while proving production rejects CCEL at input validation
- verify profile-specific schemas, annotations, guided prompts, local-only result isolation, and canonical resource locators
- add full production-profile and cross-profile drift coverage

## Scope
Audit harness and tests only. No runtime, corpus, configuration, workflow, database, or feature behavior changes.

## Verification
- Node 22 focused tests: 23/23
- Node 22 full unit suite: 2,359 passed, 2 skipped
- release-script, Node, and Worker typechecks
- independent Sol review: no P0-P3 findings, GO

## Release intent
After full CI: exact-head preview deployment/audit/revocation, then merge and a fresh protected same-D1 production release to close the incomplete PR #102 production release record.