### PR TITLE
docs: record PR101 production release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,15 +174,18 @@ The SQLite database (`data/theologai.db`) is a derived artifact. Cross-reference
 
 ## Release-state boundary
 
-PR #96 is the current production release record. The audit checked out source
-commit `ac4b5ed774302fbfc86bf846b6ee77a07beed456` with exact tree
-`adf08edbf6bfcb14b9613354b2b8fb9f62ec8c16`. At the canonical endpoint
-`https://mcp.theologai.xyz/mcp`, it observed server version `3.6.0` and, before
-and after testing, the same sole 100% Cloudflare production assignment:
-deployment `2d10d693-958e-47a6-ae24-81647679c2f6`, Worker
-`7a3f5078-37bc-453e-bac7-a0743afd508a`, and D1
-`theologai-production-20260723-a`
-(`3f7faa0e-689f-47aa-a601-dc662db9a6cf`).
+PR #101 is the current production release record. It merged as source commit
+`e2d351a11fce9c2cb1f72add0bcf365332737f3c` with exact tree
+`b9807ea1980326b5faf0a8a595c9606c67abfce5`. At the canonical endpoint
+`https://mcp.theologai.xyz/mcp`, protected workflow `30401732957` observed
+server version `3.6.0` and, before and after testing, the same sole 100%
+Cloudflare production assignment: deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
+`theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Primary-source stabilization passed
+on attempt 1, `original_language_study` v2 passed 11/11 cases, and the eight
+reviewed Transform-9 historical works passed.
 
 The stateless `original_language_study` v2 production audit passed 11/11 cases
 in 14 exchanges (initialization, initialized notification, `tools/list`, and

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ locally over stdio or Streamable HTTP and on Cloudflare Workers with D1.
 The checked-out local registry contains eleven tools, six guided prompts, eight
 English Bible translations, six commentary sources, 25 locally indexed
 historical works, Strong's dictionaries, and Greek/Hebrew morphology. Preview
-serves the 25-work Transform 9 catalog; production's PR #104 normal D1 baseline
-also serves the 25-work catalog.
+and production both serve the 25-work Transform 9 catalog from separate
+schema-`0008` D1 databases.
 
 The integrated Transform 10 candidate is local-only and unpublished. Its
 Aquinas packet, schema, and standalone materializer are retained for future
@@ -52,13 +52,18 @@ Remote MCP client configuration:
 }
 ```
 
-Use the preview URL only for explicitly authorized release testing. Before the
-proposed production cutover, the current live production baseline is PR #104:
-Cloudflare deployment `07bbd8aa-5c69-4b0c-a9df-c756f537bb97`, serving Worker
-`09fa6471-eb50-480e-85b2-bc04b742dcb3` (#94), bound to D1
-`theologai-production-20260728-normal-a`
-(`a3d26bba-7adc-44b0-86d0-562b2ced6bd3`). The PR #96 identity and audit record
-below is historical evidence, not the current production binding.
+Use the preview URL only for explicitly authorized release testing. The current
+live production baseline is PR #101 merge
+`e2d351a11fce9c2cb1f72add0bcf365332737f3c` with exact tree
+`b9807ea1980326b5faf0a8a595c9606c67abfce5`: Cloudflare deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e` serves Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96) as the sole 100% assignment,
+bound to D1 `theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Protected production workflow
+`30401732957` passed candidate readiness, Transform-8/9 authority checks,
+Transform-10 normal-corpus exclusion predicates, and all post-deployment
+audits. The PR #96 identity and audit record below is historical evidence, not
+the current production binding.
 
 The historical PR #96 `original_language_study` schema-v2 audit passed 11/11
 cases.
@@ -129,23 +134,25 @@ Aquinas-lineage rows empty. The protected release subsequently proved this
 exact binding; it is the current preview baseline and makes no production
 claim.
 
-PR #101's checked-in production target is
+PR #101's current production target is
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). It was unbound when its reviewed
 49-file, 1,627,474-row schema-`0008` preparation completed: remote readiness
 passed, Transform-8/9 authority audits passed, and Transform-10 normal-corpus
 exclusion predicates proved hierarchy, publication, and Aquinas-lineage rows
-empty. The checked-in target alone does not establish a current live Worker
-binding or activate that runtime; the protected production workflow must prove
-the exact binding before its audits become release evidence.
+empty. The protected production workflow subsequently proved the exact binding
+before and after its black-box audits. Production primary-source stabilization
+matched on attempt 1, `original_language_study` v2 passed 11/11 cases, and all
+eight reviewed Transform-9 core works passed. This release activates no
+Transform-10 hierarchy or publication rows.
 For a preview-client rollback without changing server state, use the direct preview
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
 
-The preview data layer now includes schema `0008`; its earlier local-only and
-preview-only activation statements are historical. PR #104 binds
-`theologai-production-20260728-normal-a` in production, while PR #101 is the
-current preview binding recorded above. The historical PR #96 public
+The preview and production data layers now include schema `0008`; earlier
+local-only and preview-only activation statements are historical. PR #101
+binds the separate preview and production D1 databases recorded above. The
+historical PR #96 public
 `original_language_study` v2 audit does not independently establish the runtime
 path for every later historical transform. The pinned packet's `SOURCE.json`
 remains a historical acquisition-gate snapshot, not deployment evidence.
@@ -172,7 +179,7 @@ fresh server and transport.
 | `bible_cross_references` | Query locally indexed OpenBible.info cross references with raw vote ranking, explicit discovery-only semantics, threshold-scoped result windows, and pinned snapshot provenance. |
 | `parallel_passages` | Return complete UBS source-attested parallel groups by default; legacy curated edges and OpenBible.info cross references require explicit selectors and remain separate. |
 | `commentary_lookup` | Retrieve Matthew Henry, JFB, Adam Clarke, John Gill, Keil-Delitzsch (OT), or Tyndale notes. |
-| `classic_text_lookup` | The checked-out local catalog searches and browses 25 historical works with canonical source-first section keys; eight reviewed source-pack editions use bounded sectioned delivery. Preview serves the schema-`0008` Transform-9 catalog and production's PR #104 normal D1 baseline serves the 25-work catalog. Exact sections are the only body route, and remote CCEL document bodies are not retrieved or republished. |
+| `classic_text_lookup` | The checked-out local catalog searches and browses 25 historical works with canonical source-first section keys; eight reviewed source-pack editions use bounded sectioned delivery. Preview and production serve separate schema-`0008` D1 databases containing the same 25-work Transform-9 catalog. Exact sections are the only body route, and remote CCEL document bodies are not retrieved or republished. |
 | `primary_source_search` | Execute bounded primary-source query plans. Production v6/local-only is deployed; preview runs the audited v7/discovery-only contract with CCEL execution disabled before adapter, coordinator, or fetch. The Transform-9 preview corpus release does not change that CCEL policy. Local locators use canonical section keys plus source ordinals; snippets remain discovery-only and research workflows maintain explicit searched/read/deferred/not-searched coverage ledgers. |
 | `original_language_lookup` | Look up or search Strong's entries, with opt-in rights-reviewed STEPBible metadata, exact corrected-corpus usage, and bounded occurrence pages for exact identities. The Online-Bible-derived TBESH Hebrew `Meaning` field is withheld. |
 | `bible_verse_morphology` | Return bounded word-by-word morphology for one exact verse, with raw codes, nullable expansions, and separate pinned STEPBible morphology/lemma provenance. |
@@ -343,7 +350,7 @@ public-domain source-pack editions (Anselm, Athanasius, Augustine, Bunyan,
 Calvin, Irenaeus, John of Damascus, and Wesley). The core-eight is
 sectioned-only, contributes 512 canonical sections, and adds no legacy aliases;
 exact resources disclose the reviewed edition and normalized-text rights
-boundary. Preview and the current PR #104 production baseline both serve the
+boundary. Preview and the current PR #101 production baseline both serve the
 25-work Transform 9 catalog. The exact local count is enforced by
 `data/data-manifest.json`.
 
@@ -567,7 +574,7 @@ per-request D1 repositories. Both targets share one MCP registry.
 
 - The current tracked roadmap is [docs/ROADMAP.md](docs/ROADMAP.md), beginning
   after the PR #10 production baseline.
-- Live CCEL discovery and search remain gated future work. PR #104 production
+- Live CCEL discovery and search remain gated future work. PR #101 production
   is deployed v6/local-only, and preview is deployed v7/discovery-only with
   CCEL execution disabled before adapter, coordinator, or fetch. The
   Transform-9 preview corpus release does not change that policy.

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -295,21 +295,24 @@ completed with 49/49 seed files, 1,627,474 rows, schema `0008`, corpus identity
 remote readiness `ready`, passed Transform-8/9 authority audits, and satisfied
 Transform-10 normal-corpus exclusion predicates proving hierarchy, publication,
 and Aquinas-lineage rows empty. The preparer ran from the predecessor-bound
-revision; the later reviewed root target names this candidate but does not
-itself bind or deploy it. Before that production cutover, the current live
-production baseline is PR #104 deployment `07bbd8aa-5c69-4b0c-a9df-c756f537bb97`,
-Worker `09fa6471-eb50-480e-85b2-bc04b742dcb3` (#94), and D1
-`theologai-production-20260728-normal-a`
-(`a3d26bba-7adc-44b0-86d0-562b2ced6bd3`). The current preview baseline is PR
+revision. PR #101 subsequently merged as
+`e2d351a11fce9c2cb1f72add0bcf365332737f3c`, and protected production workflow
+`30401732957` proved the candidate binding before and after its black-box
+audits. The current production baseline is deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
+`theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The current preview baseline is PR
 #101 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
 (`51890e12-1c3f-421f-b661-9a5ea9637e43`). The checked-out Transform-10 Aquinas
 hierarchy remains local-only and unpublished, with no catalog, runtime, or MCP
-projection. The protected production workflow later re-resolves the checked-in
-candidate name/UUID, reruns readiness by exact name, records the predecessor
-Worker/D1 identity, and refuses to start either black-box audit unless the sole
-active deployed Worker is bound to that readiness-tested candidate.
+projection. Future production workflows retain the same reconciliation
+contract: re-resolve the checked-in candidate name/UUID, rerun readiness by
+exact name, record the predecessor Worker/D1 identity, and refuse to start
+black-box audits unless the sole active deployed Worker is bound to the
+readiness-tested candidate.
 
 Approved deploy jobs perform the last compatibility check read-only against
 the candidate name resolved from the checked-in name/UUID pair:

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -34,19 +34,17 @@ PR95's Transform-9 normal preview release is historical, having used
 #101 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). Before the proposed cutover, the
-current production baseline is PR #104 deployment
-`07bbd8aa-5c69-4b0c-a9df-c756f537bb97`, Worker
-`09fa6471-eb50-480e-85b2-bc04b742dcb3` (#94), and D1
-`theologai-production-20260728-normal-a`
-(`a3d26bba-7adc-44b0-86d0-562b2ced6bd3`). The separately prepared schema-`0008` production candidate
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current production baseline is
+PR #101 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`) was unbound when remote readiness and
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). This schema-`0008` database was
+unbound when remote readiness and
 Transform-8/9 authority audits passed and Transform-10 normal-corpus exclusion
 predicates proved hierarchy, publication, and Aquinas-lineage rows empty. The
-checked-in root target names it for protected verification, not as evidence of
-a current live Worker binding or hierarchy/publication activation. Production
-release remains separately gated.
+protected workflow subsequently proved it as the sole active production
+binding before and after bounded black-box audits. No hierarchy or publication
+activation occurred.
 
 PR #101's checked-in preview target is the schema-`0008` candidate
 `theologai-preview-20260728-hierarchy-a`

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -1,10 +1,9 @@
 # Production Release Reconciliation
 
-This document describes a future protected production cutover. It records
-release safeguards only; it does not claim that PR95's 25-work Transform-9
-materialization is deployed to production. At this revision, the checked-out
-local catalog and deployed preview corpus have 25 works (the legacy 17 plus the
-reviewed core eight). The Transform-10 Aquinas packet is local-only and
+This document records the completed PR #101 protected production cutover and
+the safeguards required for later releases. The checked-out local catalog,
+preview, and production each have 25 works (the legacy 17 plus the reviewed
+core eight). The Transform-10 Aquinas packet remains local-only and
 unpublished; normal D1 corpora prove that its hierarchy rows and shared lineage
 are absent. It has no document/catalog, runtime, or MCP projection.
 
@@ -16,17 +15,33 @@ has corpus identity `c43bfa2f5e7ff04c3641a228092bdc91d597edc60dc7d596507e8ca6c0a
 remote readiness and Transform-8/9 authority audits passed, and Transform-10
 normal-corpus exclusion predicates proved hierarchy, publication, and
 Aquinas-lineage rows empty. The checked-in root target lets the protected
-workflow re-resolve and verify that candidate, but it alone is not evidence of
-a current live Worker binding or hierarchy/publication activation. Before a
-separately authorized merge, deployment, and audit complete, live production
-is PR #104 deployment `07bbd8aa-5c69-4b0c-a9df-c756f537bb97`, serving Worker
-`09fa6471-eb50-480e-85b2-bc04b742dcb3` (#94), bound to D1
-`theologai-production-20260728-normal-a`
-(`a3d26bba-7adc-44b0-86d0-562b2ced6bd3`). The current preview baseline is PR
+workflow re-resolve and verify that candidate. PR #101 merged as
+`e2d351a11fce9c2cb1f72add0bcf365332737f3c` with exact tree
+`b9807ea1980326b5faf0a8a595c9606c67abfce5`. Protected production workflow
+`30401732957` then deployed Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96) through deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e` as the sole 100% production assignment,
+bound to the candidate D1 above. Candidate readiness, Transform-8/9 authority
+audits, Transform-10 normal-corpus exclusion predicates, primary-source edge
+stabilization, 11/11 original-language cases, and the reviewed historical core
+audit all passed. The current preview baseline is PR
 #101 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
 (`51890e12-1c3f-421f-b661-9a5ea9637e43`).
+
+The retained sanitized production evidence has these exact SHA-256 identities:
+
+- deployment identity:
+  `54394f19fd5e1e933d6a5e3324abe36ba75f5a1c0d346d56335cc15e47798492`;
+- final routing/binding observation:
+  `c68c3dd65c40968250426bdb2c5e38917c10a32c11380ad3f00ec8b9be24e2f4`;
+- primary-source edge stabilization:
+  `59926f62bc375d47e1d12efca4ce5f229a7c14a7fd02268a4df2cc52f7a73893`;
+- original-language v2 audit:
+  `cf4aae7baccaed3334308d8056008da165f00706c080885f0ffb4290ceef5037`;
+- Transform-9 historical-core audit:
+  `c60f98020b555b748e2d5c80e8b18e004841e9ccf5813f4562e658c8783ea2b`.
 
 The production workflow is intentionally derived from checked-in identity:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -655,22 +655,24 @@ Code readiness and operational readiness are deliberately separate:
   controls when a cursor is present, and retains `includeText: false` as the
   existing default. Any future workflow or prompt change remains a separate
   slice rather than another cursor implementation.
-- Production v6/local-only is deployed in PR #104 as deployment
-  `07bbd8aa-5c69-4b0c-a9df-c756f537bb97`, Worker
-  `09fa6471-eb50-480e-85b2-bc04b742dcb3` (#94), and D1
-  `theologai-production-20260728-normal-a`
-  (`a3d26bba-7adc-44b0-86d0-562b2ced6bd3`). Preview is deployed in PR #101 as
+- Production v6/local-only is deployed from PR #101 merge
+  `e2d351a11fce9c2cb1f72add0bcf365332737f3c` as deployment
+  `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+  `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
+  `theologai-production-20260728-hierarchy-a`
+  (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Preview is deployed in PR #101 as
   deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
   `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
   `theologai-preview-20260728-hierarchy-a`
   (`51890e12-1c3f-421f-b661-9a5ea9637e43`) with the v7/discovery-only
   contract; CCEL execution remains disabled before adapter, coordinator, or
-  fetch. The separately prepared schema-`0008` production candidate was
+  fetch. The schema-`0008` production database was
   unbound when remote readiness and Transform-8/9 authority audits passed and
   Transform-10 normal-corpus exclusion predicates proved hierarchy,
-  publication, and Aquinas-lineage rows empty. Its checked-in root target is a
-  future-candidate selector rather than evidence of a current live Worker
-  binding or hierarchy/publication activation.
+  publication, and Aquinas-lineage rows empty. Protected workflow
+  `30401732957` later proved that exact binding and passed the production
+  primary-source, original-language, and historical-core audits. This is not
+  hierarchy/publication activation.
   Prospective corpus work remains limited to
   explicit searched/read/deferred coverage semantics and future
   edition/provenance fields; it is not a rollout of evidence already present
@@ -711,12 +713,12 @@ Code readiness and operational readiness are deliberately separate:
 - Expand the local primary-source corpus with rights-reviewed, freely
   redistributable editions and explicit edition provenance. The deployed
   Transform 9 core-eight makes the checked-out local catalog and preview
-  collection 25 works, and the current PR #104 normal D1 baseline is likewise
-  the 25-work production corpus: deployment
-  `07bbd8aa-5c69-4b0c-a9df-c756f537bb97`, Worker
-  `09fa6471-eb50-480e-85b2-bc04b742dcb3` (#94), and D1
-  `theologai-production-20260728-normal-a`
-  (`a3d26bba-7adc-44b0-86d0-562b2ced6bd3`). The integrated Transform 10 Aquinas
+  collection 25 works, and the current PR #101 schema-`0008` D1 baseline is
+  likewise the 25-work production corpus: deployment
+  `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+  `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
+  `theologai-production-20260728-hierarchy-a`
+  (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The integrated Transform 10 Aquinas
   hierarchy is local-only and unpublished, with no catalog/runtime/MCP
   activation; normal candidate D1 corpora exclude its hierarchy and shared
   lineage. Any successor catalog projection still requires separately reviewed

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -1,21 +1,21 @@
 # Worker operations
 
-## Current live baseline before the proposed production cutover
+## Current live baseline
 
 The integrated checked-out normal build excludes the Transform-10 Aquinas
 hierarchy from all normal D1 corpora: it has no catalog, runtime, or MCP
-projection. Before the proposed cutover, production is PR #104 deployment
-`07bbd8aa-5c69-4b0c-a9df-c756f537bb97`, serving Worker
-`09fa6471-eb50-480e-85b2-bc04b742dcb3` (#94), bound to
-`theologai-production-20260728-normal-a`
-(`a3d26bba-7adc-44b0-86d0-562b2ced6bd3`). The checked-in root production target
-is the separately prepared schema-`0008` candidate
+projection. Production is PR #101 merge
+`e2d351a11fce9c2cb1f72add0bcf365332737f3c`, deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e`, serving Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96) as the sole 100% assignment,
+bound to
 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`), which was unbound when preparation,
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). That database was unbound when preparation,
 remote readiness, and Transform-8/9 authority audits completed, and whose
 Transform-10 normal-corpus exclusion predicates proved hierarchy, publication,
-and Aquinas-lineage rows empty. That target is not evidence of a current live
-production binding or hierarchy/publication activation.
+and Aquinas-lineage rows empty. Protected workflow `30401732957` subsequently
+proved the exact binding before and after its bounded black-box audits. This is
+not a hierarchy/publication activation.
 
 The current preview baseline is PR #101 deployment
 `070b292b-0bae-400a-b983-3d72157b5a96`, serving Worker
@@ -629,11 +629,11 @@ The deployed preview Transform 9 / 25-work release runs the same gate's bounded
 source-pack authority audit: direct eight-row normalized-section pages plus
 compact identity/document/edition-FTS/runtime-FTS parity pages. The audit is
 read-only and catches an orphan or extra normalized section that a
-delivery-profile join alone would miss. The current PR #104 normal production
-D1 is the 25-work corpus. The deployed normal-build preview D1 excludes inactive Aquinas
-hierarchy rows and does not authorize production activation. Any separately
-authorized production Transform 9 cutover must rerun this gate and
-audit against its exact candidate.
+delivery-profile join alone would miss. The current PR #101 preview and
+production D1 databases both contain the 25-work corpus and exclude inactive
+Aquinas hierarchy and publication rows. This does not authorize Aquinas
+activation. Any later corpus cutover must rerun this gate and audit against its
+exact candidate.
 
 The corpus marker is the scoped D1 materialization identity derived from
 `data/data-manifest.json` `materializations.d1`, not the hash of the complete

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -187,7 +187,7 @@ describe('published project contract', () => {
     expect(readme).toContain('do **not** currently fetch CCEL search results or document bodies');
     expect(readme).toContain('Production v6/local-only is deployed');
     expect(readme).toContain('preview runs the audited v7/discovery-only contract with CCEL execution disabled');
-    expect(readme).toMatch(/Preview\s+serves the 25-work Transform 9 catalog/);
+    expect(readme).toMatch(/Preview\s+and production both serve the 25-work Transform 9 catalog/);
     expect(readme).toContain('The integrated Transform 10 candidate is local-only and unpublished');
     expect(readme).toContain('not wired into runtime or MCP surfaces');
     expect(readme).toContain('before adapter');
@@ -262,7 +262,7 @@ describe('published project contract', () => {
     expect(operations).toContain('protected PR95 preview release deployed Cloudflare deployment');
     expect(operations).toContain('black-box audit passed with no P0-P3 findings');
     expect(operations).toContain('Transform-10 Aquinas\nhierarchy from all normal D1 corpora');
-    expect(operations).toContain('The deployed normal-build preview D1 excludes inactive Aquinas');
+    expect(operations).toContain('both contain the 25-work corpus and exclude inactive\nAquinas');
     expect(operations).not.toContain('prepared but unbound preview\ncandidate retains that inactive authority data');
     expect(operations).toContain(`Its historical Cloudflare deployment\n\`${historicalDeployment}\` served Worker`);
     expect(operations).toContain('This historical release is neither\nthe current preview identity nor the immediate retained predecessor');
@@ -274,7 +274,7 @@ describe('published project contract', () => {
     expect(operations).toContain('Protected release evidence proves\nthis exact current binding');
   });
 
-  it('documents the checked-in production candidate as a release target, not live-state evidence', async () => {
+  it('documents the completed PR #101 production cutover without implying hierarchy activation', async () => {
     const [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('docs/D1-DATA-WORKFLOW.md'),
@@ -286,10 +286,10 @@ describe('published project contract', () => {
     const candidateD1 = 'theologai-production-20260728-hierarchy-a';
     const candidateD1Id = 'f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395';
     const liveProduction = {
-      deployment: '07bbd8aa-5c69-4b0c-a9df-c756f537bb97',
-      worker: '09fa6471-eb50-480e-85b2-bc04b742dcb3',
-      d1: 'theologai-production-20260728-normal-a',
-      d1Id: 'a3d26bba-7adc-44b0-86d0-562b2ced6bd3',
+      deployment: '71b76d24-bf5f-490e-adc4-31cf63fb046e',
+      worker: 'bae58cd3-cad7-4663-879d-408accf061b0',
+      d1: 'theologai-production-20260728-hierarchy-a',
+      d1Id: 'f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395',
     };
     const livePreview = {
       deployment: '070b292b-0bae-400a-b983-3d72157b5a96',
@@ -301,17 +301,16 @@ describe('published project contract', () => {
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations]) {
       expect(document).toContain(candidateD1);
       expect(document).toContain(candidateD1Id);
-      expect(document).toContain('was unbound when');
     }
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
       for (const value of Object.values(liveProduction)) expect(document).toContain(value);
       for (const value of Object.values(livePreview)) expect(document).toContain(value);
     }
-    expect(reconciliation).toContain('not evidence of\na current live Worker binding');
-    expect(dataWorkflow).toContain('does not\nitself bind or deploy it');
-    expect(catalogScope).toContain('not as evidence of\na current live Worker binding');
-    expect(operations).toContain('not evidence of a current live\nproduction binding');
-    expect(roadmap).toContain('future-candidate selector rather than evidence of a current live Worker\n  binding');
+    expect(reconciliation).toContain('completed PR #101 protected production cutover');
+    expect(dataWorkflow).toContain('proved the candidate binding before and after its black-box');
+    expect(catalogScope).toContain('proved it as the sole active production');
+    expect(operations).toContain('proved the exact binding before and after its bounded black-box audits');
+    expect(roadmap).toContain('later proved that exact binding and passed the production');
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
       expect(document).not.toContain('Transform-8/9/10 authority');
       expect(document.replace(/\s+/g, ' ')).toContain('Transform-10 normal-corpus exclusion predicates');


### PR DESCRIPTION
## What changed

- records PR #101 as the current production release across the README, roadmap, D1 workflow, operations guide, release reconciliation record, and repository guidance;
- pins the exact merge/tree, Cloudflare deployment, Worker version, production D1, workflow run, and sanitized evidence hashes;
- replaces the obsolete “future cutover” assertions while preserving the explicit boundary that Transform 10 and Aquinas remain unpublished;
- updates the documentation contract test to enforce the completed release state.

## Verification

- Node 22: `npx vitest run test/unit/docs/publicContract.test.ts` — 8/8 passed.
- `git diff --check` — passed.
- Live Cloudflare identity was independently rechecked before authoring.

This PR changes documentation and its contract test only. It does not change runtime behavior, D1 data, bindings, deployment configuration, or CCEL execution.
