### PR TITLE
Prepare Transform 11 production D1 cutover

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,8 +237,9 @@ remains direct.
 > `a6959d24fb7f50a9848fe2d011f425894718471b8a0609e7833780a291721a44`.
 
 Transform 11 activates 18 reviewed sectioned-only source-pack editions in the
-checked-out local corpus. Until its protected preview release completes, both
-deployed environments remain on the 25-work PR #101 baseline. Norton and
-Aquinas assets remain inactive; the incomplete Aquinas hierarchy has no
-document, catalog, search, resource, runtime, or D1 projection.
+checked-out local corpus and the current preview 35-work catalog. Production
+remains on the 25-work PR #101 baseline until its separately protected D1
+cutover completes. Norton and Aquinas assets remain inactive; the incomplete
+Aquinas hierarchy has no document, catalog, search, resource, runtime, or D1
+projection.
 `package.json` is private: npm distribution is unsupported.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ locally over stdio or Streamable HTTP and on Cloudflare Workers with D1.
 The checked-out local registry contains eleven tools, six guided prompts, eight
 English Bible translations, six commentary sources, 35 locally indexed
 historical works, Strong's dictionaries, and Greek/Hebrew morphology. The
-checked-out Transform 11 candidate adds ten reviewed editions to the 25-work
-deployed baseline; preview and production remain unchanged until separately
-protected D1 releases.
+checked-out Transform 11 release adds ten reviewed editions to the 25-work
+production baseline. Preview serves the 35-work catalog; production remains on
+the 25-work baseline until its separately protected D1 release proves cutover.
 
 The integrated Transform 10 candidate is local-only and unpublished. Its
 Aquinas packet, schema, and standalone materializer are retained for future
@@ -132,22 +132,21 @@ reviewed 49-file, 1,627,474-row deterministic seed for schema `0008`; remote
 readiness passed, Transform-8/9 authority audits passed, and Transform-10
 normal-corpus exclusion predicates proved hierarchy, publication, and
 Aquinas-lineage rows empty. The protected release subsequently proved this
-exact binding; it is the current preview baseline and makes no production
-claim.
+exact binding; it is the retained compatible preview predecessor and makes no
+production claim.
 
-PR #107's checked-in preview target is the separately prepared, currently
-unbound Transform-11 candidate `theologai-preview-20260728-transform11-a`
+PR #107's preview candidate `theologai-preview-20260728-transform11-a`
 (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). Its one-use schema-`0008` import
 applied the exact reviewed 49-file, 1,630,259-row seed with corpus identity
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and the complete
 Transform-11 source-pack authority audit (`1/1/1/1/1/1/133/17` pages) passed.
-The checked-in declaration is not a live binding or deployment; preview remains
-on the PR #101 baseline until the protected workflow proves the exact cutover.
-Production is unchanged. Transform-10 hierarchy, publication, and Aquinas
+Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550` now
+serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact
+D1. Production is unchanged. Transform-10 hierarchy, publication, and Aquinas
 material remain excluded.
 
-PR #101's current production target is
+PR #101's live production D1 is
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). It was unbound when its reviewed
 49-file, 1,627,474-row schema-`0008` preparation completed: remote readiness
@@ -158,6 +157,19 @@ before and after its black-box audits. Production primary-source stabilization
 matched on attempt 1, `original_language_study` v2 passed 11/11 cases, and all
 eight reviewed Transform-9 core works passed. This release activates no
 Transform-10 hierarchy or publication rows.
+
+The checked-in production target is the separately prepared, still unbound
+Transform-11 candidate `theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
+merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
+`dec0f2d66779e6126b3ddb02e74304b97293c67f`, and the reviewed 49-file,
+1,630,259-row seed with corpus identity
+`29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
+Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
+configuration selection alone is not a production binding or deployment; the
+PR #101 production D1 above is retained as the rollback pair until the
+protected release proves the new Worker/D1 assignment and audits.
 For a preview-client rollback without changing server state, use the direct preview
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
@@ -192,7 +204,7 @@ fresh server and transport.
 | `bible_cross_references` | Query locally indexed OpenBible.info cross references with raw vote ranking, explicit discovery-only semantics, threshold-scoped result windows, and pinned snapshot provenance. |
 | `parallel_passages` | Return complete UBS source-attested parallel groups by default; legacy curated edges and OpenBible.info cross references require explicit selectors and remain separate. |
 | `commentary_lookup` | Retrieve Matthew Henry, JFB, Adam Clarke, John Gill, Keil-Delitzsch (OT), or Tyndale notes. |
-| `classic_text_lookup` | The checked-out Transform 11 catalog searches and browses 35 historical works with canonical source-first section keys; 18 reviewed source-pack editions use bounded sectioned delivery. The deployed preview and production baselines remain the prior 25-work catalog until separately protected releases. Exact sections are the only body route, and remote CCEL document bodies are not retrieved or republished. |
+| `classic_text_lookup` | The checked-out Transform 11 catalog searches and browses 35 historical works with canonical source-first section keys; 18 reviewed source-pack editions use bounded sectioned delivery. Preview serves the 35-work Transform-11 catalog; production remains on the 25-work baseline until its separately protected release proves cutover. Exact sections are the only body route, and remote CCEL document bodies are not retrieved or republished. |
 | `primary_source_search` | Execute bounded primary-source query plans. Production v6/local-only is deployed; preview runs the audited v7/discovery-only contract with CCEL execution disabled before adapter, coordinator, or fetch. The Transform-9 preview corpus release does not change that CCEL policy. Local locators use canonical section keys plus source ordinals; snippets remain discovery-only and research workflows maintain explicit searched/read/deferred/not-searched coverage ledgers. |
 | `original_language_lookup` | Look up or search Strong's entries, with opt-in rights-reviewed STEPBible metadata, exact corrected-corpus usage, and bounded occurrence pages for exact identities. The Online-Bible-derived TBESH Hebrew `Meaning` field is withheld. |
 | `bible_verse_morphology` | Return bounded word-by-word morphology for one exact verse, with raw codes, nullable expansions, and separate pinned STEPBible morphology/lemma provenance. |
@@ -364,9 +376,10 @@ adds Augustine's *On Christian Doctrine*, Basil, both Gregories, Justin Martyr,
 Origen, Hooker Book I, Julian of Norwich, *The Imitation of Christ*, and
 Pascal's *Pensées*. The three packs are sectioned-only, contribute 1,057
 canonical sections, and add no legacy aliases; exact resources disclose the
-reviewed edition and normalized-text rights boundary. The deployed preview and
-production baselines remain the 25-work PR #101 corpus until protected release.
-The exact checked-out count is enforced by `data/data-manifest.json`.
+reviewed edition and normalized-text rights boundary. Preview serves the
+35-work Transform-11 catalog; production remains on the 25-work PR #101 corpus
+until its protected release proves cutover. The exact checked-out count is
+enforced by `data/data-manifest.json`.
 
 Approved UBS Hebrew artifacts plus the separately acquired Norton and Aquinas
 public-domain packets are checked into the repository for deterministic
@@ -387,9 +400,10 @@ catalogs. Norton and Aquinas assets remain inactive. Norton is a future successo
 `sectioned_only` candidate. Cyril remains blocked with zero output pending
 reliable translator attribution.
 
-Production v6/local-only and preview v7/discovery-only both currently search
-and retrieve the deployed 25-work Transform 9 collection. Both deployed
-environments do **not** currently fetch CCEL search results or document bodies.
+Production v6/local-only currently searches and retrieves the 25-work PR #101
+collection. Preview v7/discovery-only currently serves the 35-work Transform-11
+collection. Both deployed environments do **not** currently fetch CCEL search
+results or document bodies.
 Preview's existing `classic_text_lookup` provides the Baltimore hard cut and
 canonical/legacy resolution without adding a tool. Its deployed v7
 CCEL-discovery profile returns a disabled provider result before adapter

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -287,7 +287,8 @@ This preparer does not change `wrangler.toml`, a Worker binding, deployment,
 or database inventory. It does mutate only the separately named, unbound
 production candidate corpus: migrations and deterministic seed files are
 applied there after the pristine-target guard passes. It never mutates the
-active/bound production corpus. The current candidate
+active/bound production corpus. The PR #101 candidate, now the live production
+baseline,
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`) was unbound when its one-use operation
 completed with 49/49 seed files, 1,627,474 rows, schema `0008`, corpus identity
@@ -302,11 +303,15 @@ audits. The current production baseline is deployment
 `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The current preview baseline is PR
-#101 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The retained PR #101 preview
+predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The checked-out Transform-10 Aquinas
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is
+deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+`06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
+`theologai-preview-20260728-transform11-a`
+(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). The checked-out Transform-10 Aquinas
 hierarchy remains local-only and unpublished, with no catalog, runtime, or MCP
 projection. Future production workflows retain the same reconciliation
 contract: re-resolve the checked-in candidate name/UUID, rerun readiness by
@@ -323,8 +328,31 @@ Primary readiness, Transform-8 authority (`1/12/12` pages), and the complete
 Transform-11 source-pack authority audit (`1/1/1/1/1/1/133/17` pages) passed.
 An authorized read-only audit rerun followed one transient Cloudflare
 authentication failure; migration and seed application were not retried,
-resumed, or repaired. The candidate is not a live preview binding until the
-protected workflow proves it; production remains unchanged.
+resumed, or repaired. Protected preview deployment
+`5e812152-355b-4a5f-a123-2485e89f1550` now serves Worker
+`06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact D1; production
+remains unchanged.
+
+The checked-in root production binding now selects the separately prepared,
+unbound Transform-11 candidate
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
+merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
+`dec0f2d66779e6126b3ddb02e74304b97293c67f`, and the exact reviewed 49-file,
+1,630,259-row seed with corpus identity
+`29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
+Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. Do not
+retry, resume, repair, re-seed, or directly mutate this prepared candidate. Its
+single intended binding is the protected deployment after that deployment
+re-proves the exact readiness-tested assignment and completes its audits. The
+checked-in name/UUID pair is a release target, not a live binding claim:
+production remains on Worker `bae58cd3-cad7-4663-879d-408accf061b0`, deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
+`theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`) until the protected release proves
+the new assignment and audits. Retain the latter matched Worker/D1 pair for
+rollback.
 
 Approved deploy jobs perform the last compatibility check read-only against
 the candidate name resolved from the checked-in name/UUID pair:

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -45,12 +45,13 @@ the exact `candidateD1` binding as deployment
 `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). This is the current preview binding;
-the checked-in target alone would not establish it or activate the dormant
-hierarchy/publication runtime. Its protected release evidence is authoritative.
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). This is the retained compatible
+preview predecessor; the checked-in target alone did not establish it or
+activate the dormant hierarchy/publication runtime. Its protected release
+evidence remains authoritative for that predecessor.
 
-PR #107's checked-in preview target is instead the unbound Transform-11
-candidate `theologai-preview-20260728-transform11-a`
+PR #107's Transform-11 candidate
+`theologai-preview-20260728-transform11-a`
 (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). Its one-use schema-`0008` import
 applied all 49 reviewed seed files and 1,630,259 rows with corpus identity
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
@@ -59,9 +60,11 @@ transient Cloudflare authentication failure interrupted the first
 Transform-11 authority read; an explicitly authorized read-only rerun then
 passed primary readiness, Transform-8 (`1/12/12` pages), and the complete
 Transform-11 audit (`1/1/1/1/1/1/133/17` pages). No seed, migration, repair, or
-resume was repeated. This record neither binds nor deploys the candidate; the
-PR #101 deployment above remains live until a protected release proves this
-exact candidate binding. Production remains unchanged.
+resume was repeated. The candidate was unbound during that preparation.
+Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550` now
+serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) as the sole active
+preview assignment bound to that exact candidate D1. Production remains
+unchanged.
 
 The candidate-binding observation is written before the strict gate and is uploaded through `always()` handling. It contains only version/deployment IDs, predecessor/active/candidate D1 IDs, the `d1Changed` value, and boolean configuration/binding verdicts; it excludes raw Wrangler JSON, headers, requests, sessions, and secrets. The final post-mutation observation is likewise retained and hashed even if the strict candidate-binding gate blocks both audits.
 

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -14,8 +14,9 @@ edition-scoped authority hierarchy packet and standalone materializer. Normal
 release builds deliberately exclude its hierarchy rows and shared lineage. It
 is unpublished and has no document or catalog projection, runtime composition
 dependency, or MCP surface. It leaves the active historical catalog boundary
-unchanged in deployed environments: preview and production remain on the
-Transform-9 25-work corpus until a protected Transform 11 preview release.
+unchanged in production: preview serves the Transform-11 35-work corpus while
+production remains on the Transform-9 25-work corpus until its protected D1
+release proves cutover.
 
 Transform 11 retains migration `0006_historical_source_packs` and schema
 `0008`, but expands the manifest allowlist to three checked-in packs, 18 works,
@@ -33,11 +34,15 @@ deployment identifiers.
 
 PR95's Transform-9 normal preview release is historical, having used
 `theologai-preview-20260727-normal-a`
-(`776944d4-60d1-457f-b13e-b4e7898971ca`). The current preview baseline is PR
-#101 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
+(`776944d4-60d1-457f-b13e-b4e7898971ca`). The retained PR #101 preview
+predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current production baseline is
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is
+deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+`06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
+`theologai-preview-20260728-transform11-a`
+(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). The current production baseline is
 PR #101 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
@@ -57,19 +62,32 @@ unbound when its one-time 49-file, 1,627,474-row preparation completed: remote
 readiness and Transform-8/9 authority audits passed, and Transform-10
 normal-corpus exclusion predicates proved hierarchy, publication, and
 Aquinas-lineage rows empty. Protected PR #101 release evidence subsequently
-proved the exact current preview binding; dormant hierarchy/publication runtime
-activation remains absent.
+proved the exact retained preview predecessor binding; dormant
+hierarchy/publication runtime activation remained absent.
 
-PR #107's checked-in preview target is now the separately prepared Transform-11
-candidate `theologai-preview-20260728-transform11-a`
+PR #107's Transform-11 preview candidate
+`theologai-preview-20260728-transform11-a`
 (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). Its exact reviewed 49-file,
 1,630,259-row seed has corpus identity
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
-Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
-candidate remains unbound: preview still serves the PR #101 25-work baseline,
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed while
+unbound. Protected preview deployment now proves the current binding above;
 production is unchanged, and Transform-10 hierarchy/publication/Aquinas rows
 remain excluded.
+
+The checked-in root production target is the prepared but unbound Transform-11
+candidate `theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). Its one-use ENAM preparation from
+merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
+`dec0f2d66779e6126b3ddb02e74304b97293c67f`, imported the exact 49-file,
+1,630,259-row seed with corpus identity
+`29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
+Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
+configuration declaration is not a production binding or deployment; retain
+the PR #101 Worker/D1 baseline above until the protected release proves the
+candidate assignment and audits.
 
 ## Source and materialization
 

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -1,9 +1,10 @@
 # Production Release Reconciliation
 
-This document records the completed PR #101 protected production cutover and
-the safeguards required for later releases. The checked-out local catalog,
-preview, and production each have 25 works (the legacy 17 plus the reviewed
-core eight). The Transform-10 Aquinas packet remains local-only and
+This document records the completed PR #101 protected production cutover, the
+prepared PR #107 successor, and the safeguards required for later releases.
+The checked-out local catalog and preview have 35 works (the legacy 17 plus 18
+reviewed editions); production remains on 25 works (the legacy 17 plus the
+reviewed core eight) until the successor release proves cutover. The Transform-10 Aquinas packet remains local-only and
 unpublished; normal D1 corpora prove that its hierarchy rows and shared lineage
 are absent. It has no document/catalog, runtime, or MCP projection.
 
@@ -24,11 +25,33 @@ workflow re-resolve and verify that candidate. PR #101 merged as
 bound to the candidate D1 above. Candidate readiness, Transform-8/9 authority
 audits, Transform-10 normal-corpus exclusion predicates, primary-source edge
 stabilization, 11/11 original-language cases, and the reviewed historical core
-audit all passed. The current preview baseline is PR
-#101 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
+audit all passed. The retained PR #101 preview predecessor was
+deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`).
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is
+deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+`06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
+`theologai-preview-20260728-transform11-a`
+(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`).
+
+The checked-in root production target is the separately prepared, unbound
+Transform-11 candidate `theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
+merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f` with exact tree
+`dec0f2d66779e6126b3ddb02e74304b97293c67f`. Its one-use schema-`0008`
+preparation imported the exact reviewed 49-file, 1,630,259-row deterministic
+seed with corpus identity
+`29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
+Primary readiness, Transform-8 authority (`1/12/12` pages), and the complete
+Transform-11 source-pack authority audit (`1/1/1/1/1/1/133/17` pages) passed.
+The declaration is not live traffic evidence: production remains Worker
+`bae58cd3-cad7-4663-879d-408accf061b0`, deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
+`theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Preserve that matched pair as the
+rollback record until the protected release proves the candidate binding and
+completes all post-deployment audits.
 
 The retained sanitized production evidence has these exact SHA-256 identities:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -660,11 +660,15 @@ Code readiness and operational readiness are deliberately separate:
   `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
   `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
   `theologai-production-20260728-hierarchy-a`
-  (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Preview is deployed in PR #101 as
-  deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
+  (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The retained PR #101 preview
+  predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
   `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
   `theologai-preview-20260728-hierarchy-a`
-  (`51890e12-1c3f-421f-b661-9a5ea9637e43`) with the v7/discovery-only
+  (`51890e12-1c3f-421f-b661-9a5ea9637e43`). Preview now serves deployment
+  `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+  `06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
+  `theologai-preview-20260728-transform11-a`
+  (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`) with the v7/discovery-only
   contract; CCEL execution remains disabled before adapter, coordinator, or
   fetch. The schema-`0008` production database was
   unbound when remote readiness and Transform-8/9 authority audits passed and
@@ -736,11 +740,19 @@ Code readiness and operational readiness are deliberately separate:
   `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
   `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
   `theologai-production-20260728-hierarchy-a`
-  (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Local-only hardening commit
-  `5346be93237086a541d7bb1982b96752807878be` and the subsequent durable
-  historical-spine audit work are unpublished; they require fresh push, CI,
-  and a protected same-D1 preview release before production preparation. The
-  integrated Transform 10 Aquinas
+  (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The checked-in root production
+  binding now selects the prepared but unbound ENAM Transform-11 candidate
+  `theologai-production-20260729-transform11-a`
+  (`53211f50-a893-4b4c-be1e-bc625a595dc7`), prepared once from merge
+  `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
+  `dec0f2d66779e6126b3ddb02e74304b97293c67f`, and the exact reviewed 49-file,
+  1,630,259-row seed with corpus identity
+  `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
+  Primary readiness, Transform-8 authority (`1/12/12` pages), and full
+  Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
+  binding declaration alone is not a release or live-traffic claim; preserve
+  the PR #101 Worker/D1 pair for rollback until protected deployment and
+  audits prove the successor. The integrated Transform 10 Aquinas
   hierarchy is local-only and unpublished. Its present packet ends at Tertia
   question 90 and contains no Supplement, so Transform 11 gives it no
   document/catalog/search/resource/runtime/D1 projection. A future Aquinas

--- a/docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md
+++ b/docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md
@@ -69,6 +69,12 @@ historical-core audits passed. Preview authorization was then removed; the
 revocation workflow `30420256210` passed and PR #107 has no `deploy-preview`
 label.
 
+The retained deployment above is historical release evidence. The current
+preview baseline is deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+`06b9a603-8339-42b6-a246-ef9238563043` (#140), and the same
+`theologai-preview-20260728-transform11-a`
+(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`) D1.
+
 A separate, zero-retry targeted audit of the ten newly activated works also
 passed. Its 84-exchange main audit checked landing, browse, natural search,
 scoped local primary-source search, and direct reads; its separate 12-exchange
@@ -77,11 +83,22 @@ pagination/cursor audit also passed. Sanitized evidence hashes are
 `aedef2ffffe6d3de04a5c341a09f137df7abc0d90cee11929ee988fb90f95080`.
 
 Production did not change: it remains the PR #101 production baseline on
-Worker #96 and D1 `f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`. The later local-only convergence
-hardening commit `5346be93237086a541d7bb1982b96752807878be` and the current
-durable historical-spine audit work are unpublished. They require a fresh
-push, exact-head CI, and protected same-D1 preview release before any
-production-D1 preparation, merge, or production deployment is considered.
+Worker `bae58cd3-cad7-4663-879d-408accf061b0` (#96), deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
+`theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The checked-in root binding selects
+the separately prepared but unbound ENAM candidate
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`), prepared once from merge
+`501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
+`dec0f2d66779e6126b3ddb02e74304b97293c67f`, and the exact 49-file,
+1,630,259-row seed with corpus identity
+`29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
+Primary readiness, Transform-8 authority (`1/12/12` pages), and full
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
+configuration choice is not a deployment claim: preserve the current PR #101
+Worker/D1 pair for rollback until a protected release proves the new binding
+and completes production audits.
 
 The exact ten-work audit added after this activation is documented in
 [Transform-11 Historical-Spine Release Audit](HISTORICAL-SPINE-RELEASE-AUDIT.md).

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -17,27 +17,39 @@ and Aquinas-lineage rows empty. Protected workflow `30401732957` subsequently
 proved the exact binding before and after its bounded black-box audits. This is
 not a hierarchy/publication activation.
 
-The current preview baseline is PR #101 deployment
+The retained PR #101 preview predecessor was deployment
 `070b292b-0bae-400a-b983-3d72157b5a96`, serving Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), bound to
 `theologai-preview-20260728-hierarchy-a`
 (`51890e12-1c3f-421f-b661-9a5ea9637e43`). It was unbound when seeded once
 through schema `0008`: remote readiness and Transform-8/9 authority audits
 passed, and Transform-10 normal-corpus exclusion predicates proved hierarchy,
-publication, and Aquinas-lineage rows empty. Protected release evidence proves
-this exact current binding; dormant hierarchy/publication runtime activation
-remains absent.
+publication, and Aquinas-lineage rows empty. Its release evidence remains the
+compatible predecessor record; dormant hierarchy/publication runtime activation
+remained absent.
 
-PR #107's checked-in preview target is the prepared but unbound Transform-11
-candidate `theologai-preview-20260728-transform11-a`
+PR #107's Transform-11 candidate `theologai-preview-20260728-transform11-a`
 (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). Its one-use schema-`0008` operation
 applied the reviewed 49-file, 1,630,259-row deterministic seed with corpus
 identity `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed while
+unbound. Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550`
+now serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) as the sole
+active preview assignment bound to that exact D1. Production remains unchanged.
+
+The checked-in root production target is the prepared but unbound Transform-11
+candidate `theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
+merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
+`dec0f2d66779e6126b3ddb02e74304b97293c67f`, and the reviewed 49-file,
+1,630,259-row seed with corpus identity
+`29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
+Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
-configuration change alone is not a remote binding: the PR #101 preview
-deployment above remains live until the protected workflow proves this exact
-candidate, and production remains unchanged.
+checked-in declaration is not a live production binding or deployment; retain
+the PR #101 Worker/D1 pair above as the current production baseline and rollback
+pair until the protected release proves the new assignment and audits.
 
 Historical PR #96 production evidence is source-attested to checked-out commit
 `ac4b5ed774302fbfc86bf846b6ee77a07beed456` and exact tree
@@ -636,15 +648,14 @@ readiness query that checks integrity, exact manifest row counts, and required
 indexes, column signatures, foreign keys, and schema/corpus identity markers. A
 missing, stale, partial, or incompatible corpus stops deployment.
 
-The deployed preview Transform 9 / 25-work release runs the same gate's bounded
-source-pack authority audit: direct eight-row normalized-section pages plus
-compact identity/document/edition-FTS/runtime-FTS parity pages. The audit is
-read-only and catches an orphan or extra normalized section that a
-delivery-profile join alone would miss. The current PR #101 preview and
-production D1 databases both contain the 25-work corpus and exclude inactive
-Aquinas hierarchy and publication rows. This does not authorize Aquinas
-activation. Any later corpus cutover must rerun this gate and audit against its
-exact candidate.
+The current preview Transform-11 / 35-work release ran the same gate's complete
+source-pack authority audit, including direct normalized-section pages and
+identity/document/edition-FTS/runtime-FTS parity pages. The audit is read-only
+and catches an orphan or extra normalized section that a delivery-profile join
+alone would miss. Production remains on the PR #101 25-work D1, which excludes
+inactive Aquinas hierarchy and publication rows; its separately prepared
+Transform-11 candidate must pass its protected cutover and audits before that
+state changes. This does not authorize Aquinas activation.
 
 The corpus marker is the scoped D1 materialization identity derived from
 `data/data-manifest.json` `materializations.d1`, not the hash of the complete

--- a/scripts/ccel-operator-secret-release.ts
+++ b/scripts/ccel-operator-secret-release.ts
@@ -4,9 +4,9 @@ import { parse as parseToml } from 'smol-toml';
 
 export const CCEL_OPERATOR_SECRET = 'THEOLOGAI_CCEL_OPERATOR_TOKEN';
 export const PRODUCTION_WORKER = 'theologai';
-/** Prepared schema-0008 candidate; it was unbound during readiness and config alone does not prove live traffic. */
-export const PRODUCTION_D1_NAME = 'theologai-production-20260728-hierarchy-a';
-export const PRODUCTION_D1_ID = 'f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395';
+/** Prepared Transform-11 candidate; it was unbound during readiness and config alone does not prove live traffic. */
+export const PRODUCTION_D1_NAME = 'theologai-production-20260729-transform11-a';
+export const PRODUCTION_D1_ID = '53211f50-a893-4b4c-be1e-bc625a595dc7';
 /** The reviewed, prepared preview candidate; config alone does not bind it. */
 export const PREVIEW_D1_NAME = 'theologai-preview-20260728-transform11-a';
 export const PREVIEW_D1_ID = '62b871a6-5b4d-4d9b-8f52-301f6c878f48';

--- a/test/fixtures/wrangler/baseline-version-view.json
+++ b/test/fixtures/wrangler/baseline-version-view.json
@@ -20,7 +20,7 @@
       "compatibility_flags": ["nodejs_compat"]
     },
     "bindings": [
-      { "name": "THEOLOGAI_DB", "type": "d1", "id": "f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395" },
+      { "name": "THEOLOGAI_DB", "type": "d1", "id": "53211f50-a893-4b4c-be1e-bc625a595dc7" },
       { "name": "THEOLOGAI_CCEL_COORDINATOR", "type": "durable_object_namespace", "class_name": "CcelGlobalCoordinator", "script_name": "theologai-ccel-coordinator" },
       { "name": "THEOLOGAI_RATE_LIMITER", "type": "ratelimit", "namespace_id": "361201", "simple": { "limit": 120, "period": 60 } },
       { "name": "THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER", "type": "ratelimit", "namespace_id": "361203", "simple": { "limit": 12, "period": 60 } },

--- a/test/fixtures/wrangler/staged-version-view.json
+++ b/test/fixtures/wrangler/staged-version-view.json
@@ -21,7 +21,7 @@
       "compatibility_flags": ["nodejs_compat"]
     },
     "bindings": [
-      { "name": "THEOLOGAI_DB", "type": "d1", "id": "f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395" },
+      { "name": "THEOLOGAI_DB", "type": "d1", "id": "53211f50-a893-4b4c-be1e-bc625a595dc7" },
       { "name": "THEOLOGAI_CCEL_COORDINATOR", "type": "durable_object_namespace", "class_name": "CcelGlobalCoordinator", "script_name": "theologai-ccel-coordinator" },
       { "name": "THEOLOGAI_RATE_LIMITER", "type": "ratelimit", "namespace_id": "361201", "simple": { "limit": 120, "period": 60 } },
       { "name": "THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER", "type": "ratelimit", "namespace_id": "361203", "simple": { "limit": 12, "period": 60 } },

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -19,8 +19,8 @@ describe('custom-domain infrastructure contract', () => {
     expect(production).toContain('workers_dev = true');
     expect(production).toContain('{ pattern = "mcp.theologai.xyz", custom_domain = true }');
     expect(production).not.toContain('preview-mcp.theologai.xyz');
-    expect(production).toContain('database_name = "theologai-production-20260728-hierarchy-a"');
-    expect(production).toContain('database_id = "f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395"');
+    expect(production).toContain('database_name = "theologai-production-20260729-transform11-a"');
+    expect(production).toContain('database_id = "53211f50-a893-4b4c-be1e-bc625a595dc7"');
     expect(production).toContain('namespace_id = "361201"');
 
     expect(preview).toContain('workers_dev = true');

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -170,6 +170,21 @@ describe('published project contract', () => {
     expect(`${developerGuide}\n${confessionSkill}`).not.toMatch(/18 historical documents/i);
   });
 
+  it('keeps current Transform 11 preview and PR #101 production release states distinct', async () => {
+    const [readme, operations, developerGuide] = await Promise.all([
+      readProjectFile('README.md'),
+      readProjectFile('docs/worker-operations.md'),
+      readProjectFile('CLAUDE.md'),
+    ]);
+
+    expect(readme).toContain('Preview v7/discovery-only currently serves the 35-work Transform-11\ncollection');
+    expect(readme).toContain('Production v6/local-only currently searches and retrieves the 25-work PR #101\ncollection');
+    expect(operations).toContain('current preview Transform-11 / 35-work release');
+    expect(operations).toContain('Production remains on the PR #101 25-work D1');
+    expect(developerGuide).toContain('current preview 35-work catalog');
+    expect(developerGuide).toContain('Production\nremains on the 25-work PR #101 baseline');
+  });
+
   it('does not reintroduce retired scope claims', async () => {
     const [readme, historicalTestReport, historicalArchitecture, historicalDevelopment, workerConfig, coordinatorGuide, roadmap] = await Promise.all([
       readProjectFile('README.md'),
@@ -184,10 +199,10 @@ describe('published project contract', () => {
     expect(readme).not.toMatch(/1,000\+.*CCEL/i);
     expect(readme).not.toMatch(/eighteen locally indexed|18 locally indexed/i);
     expect(readme).not.toMatch(/six public-domain commentar/i);
-    expect(readme).toContain('do **not** currently fetch CCEL search results or document bodies');
+    expect(readme).toMatch(/Both deployed environments do \*\*not\*\* currently fetch CCEL search\s+results or document bodies/);
     expect(readme).toContain('Production v6/local-only is deployed');
     expect(readme).toContain('preview runs the audited v7/discovery-only contract with CCEL execution disabled');
-    expect(readme).toMatch(/deployed preview and production baselines remain the prior 25-work catalog/);
+    expect(readme).toMatch(/Preview serves the 35-work catalog; production remains on\s+the 25-work baseline/);
     expect(readme).toContain('35 locally indexed');
     expect(readme).toContain('18 reviewed source-pack editions');
     expect(readme).toContain('The integrated Transform 10 candidate is local-only and unpublished');
@@ -220,7 +235,7 @@ describe('published project contract', () => {
     expect(historicalDevelopment.slice(0, 700)).toContain('Historical development plan');
   });
 
-  it('keeps the current PR #101 preview baseline distinct from historical preview releases', async () => {
+  it('keeps the current Transform 11 preview baseline distinct from historical preview releases', async () => {
     const [reconciliation, operations] = await Promise.all([
       readProjectFile('docs/PREVIEW-RELEASE-RECONCILIATION.md'),
       readProjectFile('docs/worker-operations.md'),
@@ -234,8 +249,8 @@ describe('published project contract', () => {
     const deployedPreviewD1Id = '776944d4-60d1-457f-b13e-b4e7898971ca';
     const preparedCandidateD1 = 'theologai-preview-20260728-hierarchy-a';
     const preparedCandidateD1Id = '51890e12-1c3f-421f-b661-9a5ea9637e43';
-    const currentPreviewDeployment = '070b292b-0bae-400a-b983-3d72157b5a96';
-    const currentPreviewWorker = 'bd722b69-2e2c-4d8d-b42b-617e8caba13d';
+    const currentPreviewDeployment = '5e812152-355b-4a5f-a123-2485e89f1550';
+    const currentPreviewWorker = '06b9a603-8339-42b6-a246-ef9238563043';
     const predecessorDeployment = '7f00a94b-4ff4-47d6-9bee-2efb99673718';
     const predecessorVersion = 'f78d66f1-cefe-46ba-88ba-9ddec259cda4';
     const predecessorD1 = 'theologai-preview-20260722-b';
@@ -264,16 +279,16 @@ describe('published project contract', () => {
     expect(operations).toContain('protected PR95 preview release deployed Cloudflare deployment');
     expect(operations).toContain('black-box audit passed with no P0-P3 findings');
     expect(operations).toContain('Transform-10 Aquinas\nhierarchy from all normal D1 corpora');
-    expect(operations).toContain('both contain the 25-work corpus and exclude inactive\nAquinas');
+    expect(operations).toContain('Production remains on the PR #101 25-work D1, which excludes\ninactive Aquinas');
     expect(operations).not.toContain('prepared but unbound preview\ncandidate retains that inactive authority data');
     expect(operations).toContain(`Its historical Cloudflare deployment\n\`${historicalDeployment}\` served Worker`);
     expect(operations).toContain('This historical release is neither\nthe current preview identity nor the immediate retained predecessor');
     expect(reconciliation).toContain('it makes no production claim');
     expect(reconciliation).toContain('PR #101\'s checked-in preview candidate was unbound when prepared');
-    expect(reconciliation).toContain('This is the current preview binding');
-    expect(reconciliation).toContain('protected release evidence is authoritative');
-    expect(operations).toContain('The current preview baseline is PR #101 deployment');
-    expect(operations).toContain('Protected release evidence proves\nthis exact current binding');
+    expect(reconciliation).toContain('This is the retained compatible\npreview predecessor');
+    expect(reconciliation).toContain('evidence remains authoritative for that predecessor');
+    expect(operations).toContain('The retained PR #101 preview predecessor was deployment');
+    expect(operations).toContain('active preview assignment bound to that exact D1');
   });
 
   it('records the completed Transform 11 preview release and unpublished hardening boundary', async () => {
@@ -301,12 +316,12 @@ describe('published project contract', () => {
     expect(documents[4]).toContain('f5ef7a40-1b4b-4120-a1bb-70b33630b4a6');
     expect(documents[4]).toContain('30420256210');
     expect(documents[4]).toContain('no `deploy-preview`\nlabel');
-    expect(documents[4]).toContain('PR #101 production baseline on\nWorker #96');
-    expect(documents[4]).toContain('5346be93237086a541d7bb1982b96752807878be');
+    expect(documents[4]).toContain('theologai-production-20260728-hierarchy-a');
+    expect(documents[4]).toContain('theologai-production-20260729-transform11-a');
     expect(documents[6]).toContain('30419373527');
     expect(documents[6]).toContain('30420256210');
     expect(documents[6]).toContain('PR #101 production baseline remains unchanged');
-    expect(documents[5]).toContain('production remains unchanged');
+    expect(documents[5]).toContain('Production remains unchanged');
   });
 
   it('documents the completed PR #101 production cutover without implying hierarchy activation', async () => {
@@ -318,8 +333,8 @@ describe('published project contract', () => {
       readProjectFile('docs/worker-operations.md'),
       readProjectFile('docs/ROADMAP.md'),
     ]);
-    const candidateD1 = 'theologai-production-20260728-hierarchy-a';
-    const candidateD1Id = 'f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395';
+    const preparedCandidateD1 = 'theologai-production-20260729-transform11-a';
+    const preparedCandidateD1Id = '53211f50-a893-4b4c-be1e-bc625a595dc7';
     const liveProduction = {
       deployment: '71b76d24-bf5f-490e-adc4-31cf63fb046e',
       worker: 'bae58cd3-cad7-4663-879d-408accf061b0',
@@ -333,9 +348,9 @@ describe('published project contract', () => {
       d1Id: '51890e12-1c3f-421f-b661-9a5ea9637e43',
     };
 
-    for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations]) {
-      expect(document).toContain(candidateD1);
-      expect(document).toContain(candidateD1Id);
+    for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
+      expect(document).toContain(preparedCandidateD1);
+      expect(document).toContain(preparedCandidateD1Id);
     }
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
       for (const value of Object.values(liveProduction)) expect(document).toContain(value);

--- a/test/unit/scripts/previewReleaseReconciliation.test.ts
+++ b/test/unit/scripts/previewReleaseReconciliation.test.ts
@@ -20,8 +20,8 @@ const candidateDeployment = '423e4567-e89b-42d3-a456-426614174000';
 const predecessorD1Id = '94c4938b-7800-4d68-9097-0df33c31fdc1';
 const candidateD1Id = '62b871a6-5b4d-4d9b-8f52-301f6c878f48';
 const candidateD1Name = 'theologai-preview-20260728-transform11-a';
-const productionCandidateD1Id = 'f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395';
-const productionCandidateD1Name = 'theologai-production-20260728-hierarchy-a';
+const productionCandidateD1Id = '53211f50-a893-4b4c-be1e-bc625a595dc7';
+const productionCandidateD1Name = 'theologai-production-20260729-transform11-a';
 
 function deployments(id = predecessorDeployment, version = predecessorVersion): string {
   return JSON.stringify([{

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,11 +45,11 @@ script_name = "theologai-ccel-coordinator"
 # For multi-environment setups, use [env.staging] / [env.production] sections.
 [[d1_databases]]
 binding = "THEOLOGAI_DB"
-# PR #101's prepared schema-0008 candidate. This declaration selects the
+# PR #107's prepared Transform-11 candidate. This declaration selects the
 # release target only; the protected production workflow must prove the active
 # Worker binding before audits establish any live-state claim.
-database_name = "theologai-production-20260728-hierarchy-a"
-database_id = "f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395"
+database_name = "theologai-production-20260729-transform11-a"
+database_id = "53211f50-a893-4b4c-be1e-bc625a595dc7"
 migrations_dir = "migrations"
 
 # Anonymous abuse control. Counters are intentionally local to each Cloudflare


### PR DESCRIPTION
## What changed

- Point the checked-in production `THEOLOGAI_DB` binding at the separately prepared Transform-11 production candidate:
  - `theologai-production-20260729-transform11-a`
  - `53211f50-a893-4b4c-be1e-bc625a595dc7`
- Keep the preview binding unchanged on its audited Transform-11 D1.
- Reconcile release documentation and invariant fixtures with the actual live split: preview serves 35 works; production remains on the PR #101 25-work baseline until the protected deployment proves cutover.

## Why

PR #107 merged application and corpus expectations for 35 historical works, but its first production workflow correctly failed closed before deployment because the active PR #101 D1 contains the earlier 25-work corpus. The replacement candidate was therefore created and prepared separately rather than mutating the active database.

The candidate was prepared once in ENAM from merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, tree `dec0f2d66779e6126b3ddb02e74304b97293c67f`, and the exact reviewed 49-file / 1,630,259-row seed with corpus identity `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.

Preparation passed:

- primary D1 readiness
- Transform-8 authority: `1/12/12` pages
- complete Transform-11 source-pack authority: `1/1/1/1/1/1/133/17` pages

## Release safety

- This PR does not deploy or mutate either Worker.
- The candidate was unbound during preparation.
- Current production remains Worker `bae58cd3-cad7-4663-879d-408accf061b0`, deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, D1 `f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`.
- Current preview remains Worker `06b9a603-8339-42b6-a246-ef9238563043`, deployment `5e812152-355b-4a5f-a123-2485e89f1550`, D1 `62b871a6-5b4d-4d9b-8f52-301f6c878f48`.
- The current production Worker/D1 pair is retained for rollback.
- No application behavior, schema, migration, corpus, CCEL policy, preview binding, or workflow behavior changes are included.

## Validation

- Independent Sol release review: SHIP, no findings after two repair rounds
- Documentation contracts: 10/10
- Targeted release/config/reconciliation tests: 37/37
- Release-script typecheck
- Generated Worker binding types check
- Production and preview Wrangler dry-run validation
- `git diff --check`
