### PR TITLE
docs: record PR108 production release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,18 +174,23 @@ The SQLite database (`data/theologai.db`) is a derived artifact. Cross-reference
 
 ## Release-state boundary
 
-PR #101 is the current production release record. It merged as source commit
-`e2d351a11fce9c2cb1f72add0bcf365332737f3c` with exact tree
-`b9807ea1980326b5faf0a8a595c9606c67abfce5`. At the canonical endpoint
-`https://mcp.theologai.xyz/mcp`, protected workflow `30401732957` observed
-server version `3.6.0` and, before and after testing, the same sole 100%
-Cloudflare production assignment: deployment
-`71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+PR #108 is the current production release record. It merged as source commit
+`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`. At the canonical endpoint
+`https://mcp.theologai.xyz/mcp`, protected workflow `30496350408` proved the
+same sole 100% Cloudflare production assignment before and after testing:
+deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). The historical core passed 8/8,
+Transform-11 spine passed 10/10, `original_language_study` v2 passed 11/11,
+primary-source edge stabilization matched on attempt 4 and remained stable,
+and the independent post-release review returned `SHIP`.
+
+PR #101 is the matched rollback record—not the active production binding:
+deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Primary-source stabilization passed
-on attempt 1, `original_language_study` v2 passed 11/11 cases, and the eight
-reviewed Transform-9 historical works passed.
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`).
 
 The stateless `original_language_study` v2 production audit passed 11/11 cases
 in 14 exchanges (initialization, initialized notification, `tools/list`, and
@@ -237,9 +242,8 @@ remains direct.
 > `a6959d24fb7f50a9848fe2d011f425894718471b8a0609e7833780a291721a44`.
 
 Transform 11 activates 18 reviewed sectioned-only source-pack editions in the
-checked-out local corpus and the current preview 35-work catalog. Production
-remains on the 25-work PR #101 baseline until its separately protected D1
-cutover completes. Norton and Aquinas assets remain inactive; the incomplete
+checked-out local corpus and both deployed 35-work catalogs. Norton and Aquinas
+assets remain inactive; the incomplete
 Aquinas hierarchy has no document, catalog, search, resource, runtime, or D1
 projection.
 `package.json` is private: npm distribution is unsupported.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ locally over stdio or Streamable HTTP and on Cloudflare Workers with D1.
 The checked-out local registry contains eleven tools, six guided prompts, eight
 English Bible translations, six commentary sources, 35 locally indexed
 historical works, Strong's dictionaries, and Greek/Hebrew morphology. The
-checked-out Transform 11 release adds ten reviewed editions to the 25-work
-production baseline. Preview serves the 35-work catalog; production remains on
-the 25-work baseline until its separately protected D1 release proves cutover.
+checked-out Transform 11 release adds ten reviewed editions to the former
+25-work production baseline. Preview and production now serve the 35-work
+catalog after the separately protected PR #108 D1 cutover.
 
 The integrated Transform 10 candidate is local-only and unpublished. Its
 Aquinas packet, schema, and standalone materializer are retained for future
@@ -54,17 +54,17 @@ Remote MCP client configuration:
 ```
 
 Use the preview URL only for explicitly authorized release testing. The current
-live production baseline is PR #101 merge
-`e2d351a11fce9c2cb1f72add0bcf365332737f3c` with exact tree
-`b9807ea1980326b5faf0a8a595c9606c67abfce5`: Cloudflare deployment
-`71b76d24-bf5f-490e-adc4-31cf63fb046e` serves Worker
-`bae58cd3-cad7-4663-879d-408accf061b0` (#96) as the sole 100% assignment,
-bound to D1 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Protected production workflow
-`30401732957` passed candidate readiness, Transform-8/9 authority checks,
-Transform-10 normal-corpus exclusion predicates, and all post-deployment
-audits. The PR #96 identity and audit record below is historical evidence, not
-the current production binding.
+live production baseline is PR #108 merge
+`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`: protected workflow
+`30496350408` deployed Cloudflare deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, serving Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98) as the sole 100% assignment,
+bound to D1 `theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). The historical-core audit passed
+8/8, the Transform-11 spine audit passed 10/10, the original-language audit
+passed 11/11, primary-source edge stabilization matched on attempt 4 and
+remained stable, and the independent post-release review returned `SHIP`.
+The PR #101 production assignment is retained as the matched rollback pair.
 
 The historical PR #96 `original_language_study` schema-v2 audit passed 11/11
 cases.
@@ -143,10 +143,12 @@ Primary readiness, Transform-8 authority (`1/12/12` pages), and the complete
 Transform-11 source-pack authority audit (`1/1/1/1/1/1/133/17` pages) passed.
 Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550` now
 serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact
-D1. Production is unchanged. Transform-10 hierarchy, publication, and Aquinas
-material remain excluded.
+D1. Production was unchanged by that preview release. Transform-10 hierarchy,
+publication, and Aquinas material remain excluded.
 
-PR #101's live production D1 is
+PR #101's former production assignment, retained as the rollback pair, is
+deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). It was unbound when its reviewed
 49-file, 1,627,474-row schema-`0008` preparation completed: remote readiness
@@ -158,7 +160,7 @@ matched on attempt 1, `original_language_study` v2 passed 11/11 cases, and all
 eight reviewed Transform-9 core works passed. This release activates no
 Transform-10 hierarchy or publication rows.
 
-The checked-in production target is the separately prepared, still unbound
+The protected PR #108 production release activated the separately prepared
 Transform-11 candidate `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
 merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
@@ -166,17 +168,22 @@ merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
 1,630,259-row seed with corpus identity
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
-Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
-configuration selection alone is not a production binding or deployment; the
-PR #101 production D1 above is retained as the rollback pair until the
-protected release proves the new Worker/D1 assignment and audits.
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed.
+Protected workflow `30496350408` then deployed
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), from merge
+`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` and bound it to that exact D1.
+Historical core passed 8/8, Transform-11 spine passed 10/10,
+`original_language_study` passed 11/11, primary-source edge stabilization
+matched on attempt 4 and remained stable, and independent post-release review
+returned `SHIP`. The PR #101 Worker/D1 pair above remains the rollback record.
 For a preview-client rollback without changing server state, use the direct preview
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
 
 The preview and production data layers now include schema `0008`; earlier
 local-only and preview-only activation statements are historical. PR #101
-binds the separate preview and production D1 databases recorded above. The
+bound the separate preview and production D1 databases recorded above. The
 historical PR #96 public
 `original_language_study` v2 audit does not independently establish the runtime
 path for every later historical transform. The pinned packet's `SOURCE.json`
@@ -204,7 +211,7 @@ fresh server and transport.
 | `bible_cross_references` | Query locally indexed OpenBible.info cross references with raw vote ranking, explicit discovery-only semantics, threshold-scoped result windows, and pinned snapshot provenance. |
 | `parallel_passages` | Return complete UBS source-attested parallel groups by default; legacy curated edges and OpenBible.info cross references require explicit selectors and remain separate. |
 | `commentary_lookup` | Retrieve Matthew Henry, JFB, Adam Clarke, John Gill, Keil-Delitzsch (OT), or Tyndale notes. |
-| `classic_text_lookup` | The checked-out Transform 11 catalog searches and browses 35 historical works with canonical source-first section keys; 18 reviewed source-pack editions use bounded sectioned delivery. Preview serves the 35-work Transform-11 catalog; production remains on the 25-work baseline until its separately protected release proves cutover. Exact sections are the only body route, and remote CCEL document bodies are not retrieved or republished. |
+| `classic_text_lookup` | The checked-out Transform 11 catalog searches and browses 35 historical works with canonical source-first section keys; 18 reviewed source-pack editions use bounded sectioned delivery. Preview and production serve the 35-work Transform-11 catalog. Exact sections are the only body route, and remote CCEL document bodies are not retrieved or republished. |
 | `primary_source_search` | Execute bounded primary-source query plans. Production v6/local-only is deployed; preview runs the audited v7/discovery-only contract with CCEL execution disabled before adapter, coordinator, or fetch. The Transform-9 preview corpus release does not change that CCEL policy. Local locators use canonical section keys plus source ordinals; snippets remain discovery-only and research workflows maintain explicit searched/read/deferred/not-searched coverage ledgers. |
 | `original_language_lookup` | Look up or search Strong's entries, with opt-in rights-reviewed STEPBible metadata, exact corrected-corpus usage, and bounded occurrence pages for exact identities. The Online-Bible-derived TBESH Hebrew `Meaning` field is withheld. |
 | `bible_verse_morphology` | Return bounded word-by-word morphology for one exact verse, with raw codes, nullable expansions, and separate pinned STEPBible morphology/lemma provenance. |
@@ -377,14 +384,14 @@ Origen, Hooker Book I, Julian of Norwich, *The Imitation of Christ*, and
 Pascal's *Pensées*. The three packs are sectioned-only, contribute 1,057
 canonical sections, and add no legacy aliases; exact resources disclose the
 reviewed edition and normalized-text rights boundary. Preview serves the
-35-work Transform-11 catalog; production remains on the 25-work PR #101 corpus
-until its protected release proves cutover. The exact checked-out count is
+35-work Transform-11 catalog, and production now serves the same corpus after
+the protected PR #108 cutover. The exact checked-out count is
 enforced by `data/data-manifest.json`.
 
 Approved UBS Hebrew artifacts plus the separately acquired Norton and Aquinas
 public-domain packets are checked into the repository for deterministic
 verification and release work. Those acquisition packets remain outside the
-deployed 25-work catalog. Transform 10 retains an Aquinas packet, schema, and
+deployed catalog. Transform 10 retains an Aquinas packet, schema, and
 standalone materializer only; normal builds exclude its hierarchy and lineage,
 and it adds neither a document/catalog projection nor a runtime or MCP surface.
 The reviewed PR95 core-eight remains part of both deployed baselines and the
@@ -400,10 +407,9 @@ catalogs. Norton and Aquinas assets remain inactive. Norton is a future successo
 `sectioned_only` candidate. Cyril remains blocked with zero output pending
 reliable translator attribution.
 
-Production v6/local-only currently searches and retrieves the 25-work PR #101
-collection. Preview v7/discovery-only currently serves the 35-work Transform-11
-collection. Both deployed environments do **not** currently fetch CCEL search
-results or document bodies.
+Production v6/local-only and preview v7/discovery-only currently search and
+retrieve the 35-work Transform-11 collection.
+Both deployed environments do **not** currently fetch CCEL search results or document bodies.
 Preview's existing `classic_text_lookup` provides the Baltimore hard cut and
 canonical/legacy resolution without adding a tool. Its deployed v7
 CCEL-discovery profile returns a disabled provider result before adapter
@@ -601,7 +607,7 @@ per-request D1 repositories. Both targets share one MCP registry.
 
 - The current tracked roadmap is [docs/ROADMAP.md](docs/ROADMAP.md), beginning
   after the PR #10 production baseline.
-- Live CCEL discovery and search remain gated future work. PR #101 production
+- Live CCEL discovery and search remain gated future work. PR #108 production
   is deployed v6/local-only, and preview is deployed v7/discovery-only with
   CCEL execution disabled before adapter, coordinator, or fetch. The
   Transform-9 preview corpus release does not change that policy.

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -287,8 +287,8 @@ This preparer does not change `wrangler.toml`, a Worker binding, deployment,
 or database inventory. It does mutate only the separately named, unbound
 production candidate corpus: migrations and deterministic seed files are
 applied there after the pristine-target guard passes. It never mutates the
-active/bound production corpus. The PR #101 candidate, now the live production
-baseline,
+active/bound production corpus. The PR #101 candidate, now the retained
+production rollback,
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`) was unbound when its one-use operation
 completed with 49/49 seed files, 1,627,474 rows, schema `0008`, corpus identity
@@ -299,11 +299,12 @@ and Aquinas-lineage rows empty. The preparer ran from the predecessor-bound
 revision. PR #101 subsequently merged as
 `e2d351a11fce9c2cb1f72add0bcf365332737f3c`, and protected production workflow
 `30401732957` proved the candidate binding before and after its black-box
-audits. The current production baseline is deployment
+audits. That PR #101 production assignment—deployment
 `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The retained PR #101 preview
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`)—is now the matched rollback pair.
+The retained PR #101 preview
 predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
@@ -330,11 +331,11 @@ An authorized read-only audit rerun followed one transient Cloudflare
 authentication failure; migration and seed application were not retried,
 resumed, or repaired. Protected preview deployment
 `5e812152-355b-4a5f-a123-2485e89f1550` now serves Worker
-`06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact D1; production
-remains unchanged.
+`06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact D1; this preview
+assignment remained unchanged during the later PR #108 production release.
 
-The checked-in root production binding now selects the separately prepared,
-unbound Transform-11 candidate
+The checked-in root production binding selected the separately prepared,
+initially unbound Transform-11 candidate
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
 merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
@@ -343,16 +344,15 @@ merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. Do not
-retry, resume, repair, re-seed, or directly mutate this prepared candidate. Its
-single intended binding is the protected deployment after that deployment
-re-proves the exact readiness-tested assignment and completes its audits. The
-checked-in name/UUID pair is a release target, not a live binding claim:
-production remains on Worker `bae58cd3-cad7-4663-879d-408accf061b0`, deployment
-`71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
-`theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`) until the protected release proves
-the new assignment and audits. Retain the latter matched Worker/D1 pair for
-rollback.
+retry, resume, repair, re-seed, or directly mutate this prepared database.
+Protected workflow `30496350408` later deployed merge
+`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` as deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), bound to that exact D1.
+Historical core passed 8/8, Transform-11 spine passed 10/10,
+original-language passed 11/11, primary-source edge stabilization matched on
+attempt 4 and remained stable, and independent post-release review returned
+`SHIP`. Retain the PR #101 matched Worker/D1 pair above for rollback.
 
 Approved deploy jobs perform the last compatibility check read-only against
 the candidate name resolved from the checked-in name/UUID pair:

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -14,9 +14,8 @@ edition-scoped authority hierarchy packet and standalone materializer. Normal
 release builds deliberately exclude its hierarchy rows and shared lineage. It
 is unpublished and has no document or catalog projection, runtime composition
 dependency, or MCP surface. It leaves the active historical catalog boundary
-unchanged in production: preview serves the Transform-11 35-work corpus while
-production remains on the Transform-9 25-work corpus until its protected D1
-release proves cutover.
+unchanged through preparation: preview and production now serve the
+Transform-11 35-work corpus after the protected PR #108 D1 cutover.
 
 Transform 11 retains migration `0006_historical_source_packs` and schema
 `0008`, but expands the manifest allowlist to three checked-in packs, 18 works,
@@ -42,8 +41,8 @@ predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
 `06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
 `theologai-preview-20260728-transform11-a`
-(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). The current production baseline is
-PR #101 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). The retained PR #101 production
+rollback is deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). This schema-`0008` database was
@@ -73,10 +72,10 @@ PR #107's Transform-11 preview candidate
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed while
 unbound. Protected preview deployment now proves the current binding above;
-production is unchanged, and Transform-10 hierarchy/publication/Aquinas rows
-remain excluded.
+production was unchanged by that preview release, and Transform-10
+hierarchy/publication/Aquinas rows remain excluded.
 
-The checked-in root production target is the prepared but unbound Transform-11
+The checked-in root production target was prepared unbound as Transform-11
 candidate `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). Its one-use ENAM preparation from
 merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
@@ -85,9 +84,14 @@ merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
-configuration declaration is not a production binding or deployment; retain
-the PR #101 Worker/D1 baseline above until the protected release proves the
-candidate assignment and audits.
+protected workflow `30496350408` subsequently deployed merge
+`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` as deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), bound to this D1. Historical
+core passed 8/8, Transform-11 spine passed 10/10, original-language passed
+11/11, edge stabilization matched attempt 4 and remained stable, and the
+independent post-release review returned `SHIP`. Retain the PR #101 Worker/D1
+pair above as rollback.
 
 ## Source and materialization
 

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -1,10 +1,10 @@
 # Production Release Reconciliation
 
-This document records the completed PR #101 protected production cutover, the
-prepared PR #107 successor, and the safeguards required for later releases.
+This document records the completed PR #108 protected production cutover, its
+PR #101 rollback pair, and the safeguards required for later releases.
 The checked-out local catalog and preview have 35 works (the legacy 17 plus 18
-reviewed editions); production remains on 25 works (the legacy 17 plus the
-reviewed core eight) until the successor release proves cutover. The Transform-10 Aquinas packet remains local-only and
+reviewed editions); production now serves the same 35-work Transform-11
+catalog after the successor cutover. The Transform-10 Aquinas packet remains local-only and
 unpublished; normal D1 corpora prove that its hierarchy rows and shared lineage
 are absent. It has no document/catalog, runtime, or MCP projection.
 
@@ -35,7 +35,7 @@ deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
 `theologai-preview-20260728-transform11-a`
 (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`).
 
-The checked-in root production target is the separately prepared, unbound
+The checked-in root production target was separately prepared unbound as
 Transform-11 candidate `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
 merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f` with exact tree
@@ -45,15 +45,42 @@ seed with corpus identity
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and the complete
 Transform-11 source-pack authority audit (`1/1/1/1/1/1/133/17` pages) passed.
-The declaration is not live traffic evidence: production remains Worker
-`bae58cd3-cad7-4663-879d-408accf061b0`, deployment
-`71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
-`theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Preserve that matched pair as the
-rollback record until the protected release proves the candidate binding and
-completes all post-deployment audits.
+PR #108 merged as `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` with exact tree
+`a59d9a062b2e6c7884de97fd97309878e1cbdc23`. Protected workflow
+`30496350408` then deployed `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), as the sole 100% production
+assignment bound to the candidate D1. Historical core passed 8/8,
+Transform-11 spine passed 10/10, original-language passed 11/11,
+primary-source edge stabilization matched on attempt 4 and remained stable,
+and the independent post-release review returned `SHIP`.
 
-The retained sanitized production evidence has these exact SHA-256 identities:
+The previous PR #101 assignment is retained as the matched rollback record:
+deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
+`theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). Preview remained unchanged at
+deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+`06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
+`theologai-preview-20260728-transform11-a`
+(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`).
+
+GitHub deployment record `5665940735` and protected audit artifact
+`8742223883` link that release to the following sanitized PR #108 evidence:
+
+- deployment identity:
+  `f7bb0275e53a9fe8801ecb3af68f9b74f5df44cab6f20c19cba9b1357d72afd5`;
+- final routing/binding observation:
+  `b1ceb8f02ef210b5fb2212a9b212108411630efcc28ad3248a51c19c7bb0e1c0`;
+- primary-source edge stabilization:
+  `604ce2dee6e14559a1a26c7d0d42e572469ce0e7cf4595be22f1085b9bc9ea05`;
+- original-language v2 audit:
+  `e74999ea97a78a4fe4a6233be18b6a71cb03a9e2207f5b0fe34f71db09fafb0f`;
+- historical-core audit:
+  `636b09fcd9bb41add56e99b001c41d7ad878594f2d77df8f7b41b51621c32c97`;
+- Transform-11 historical-spine audit:
+  `77da8832ab4139a769aae7d87716a3d581407cc2d036b6f7939e306d9b865de5`.
+
+The retained historical PR #101 evidence has these exact SHA-256 identities:
 
 - deployment identity:
   `54394f19fd5e1e933d6a5e3324abe36ba75f5a1c0d346d56335cc15e47798492`;
@@ -82,9 +109,11 @@ The production workflow is intentionally derived from checked-in identity:
 5. Before either black-box audit, it proves that the active Worker has exactly
    the readiness-tested candidate D1 UUID. The non-throwing observation is
    retained even if the strict binding gate then fails.
-6. It runs the fixed production original-language-v2 and Transform-9 historical
-   audits, then checks the exact Worker deployment/version remains active and
-   records a final read-only reconciliation observation.
+6. It runs primary-source edge stabilization, the fixed production
+   original-language-v2 audit, the Transform-9 historical-core audit, and the
+   Transform-11 historical-spine audit. It then checks that the exact Worker
+   deployment/version remains active and records a final read-only
+   reconciliation observation.
 
 The production commands accept no URL, environment, Worker, D1, retry,
 rollback, seed, or binding override. They never create or delete a database,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -655,8 +655,17 @@ Code readiness and operational readiness are deliberately separate:
   controls when a cursor is present, and retains `includeText: false` as the
   existing default. Any future workflow or prompt change remains a separate
   slice rather than another cursor implementation.
-- Production v6/local-only is deployed from PR #101 merge
-  `e2d351a11fce9c2cb1f72add0bcf365332737f3c` as deployment
+- Production v6/local-only is deployed from PR #108 merge
+  `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` by protected workflow
+  `30496350408` as deployment
+  `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+  `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), and D1
+  `theologai-production-20260729-transform11-a`
+  (`53211f50-a893-4b4c-be1e-bc625a595dc7`). Historical core passed 8/8,
+  Transform-11 spine passed 10/10, original-language passed 11/11,
+  primary-source edge stabilization matched on attempt 4 and remained stable,
+  and the independent post-release review returned `SHIP`. The PR #101
+  production assignment is retained for rollback: deployment
   `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
   `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
   `theologai-production-20260728-hierarchy-a`
@@ -736,12 +745,9 @@ Code readiness and operational readiness are deliberately separate:
   `1b56d093b298f41a7845b6c328dbf63ade72ca8fdf8cf82bc68004defaa09a05` and
   `aedef2ffffe6d3de04a5c341a09f137df7abc0d90cee11929ee988fb90f95080`.
   Revocation run `30420256210` then passed after removal of the
-  `deploy-preview` label. The PR #101 production baseline remains unchanged:
-  `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
-  `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
-  `theologai-production-20260728-hierarchy-a`
-  (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The checked-in root production
-  binding now selects the prepared but unbound ENAM Transform-11 candidate
+  `deploy-preview` label. Production was unchanged by that preview release.
+  The checked-in root production binding selected the initially unbound ENAM
+  Transform-11 candidate
   `theologai-production-20260729-transform11-a`
   (`53211f50-a893-4b4c-be1e-bc625a595dc7`), prepared once from merge
   `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
@@ -749,10 +755,15 @@ Code readiness and operational readiness are deliberately separate:
   1,630,259-row seed with corpus identity
   `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
   Primary readiness, Transform-8 authority (`1/12/12` pages), and full
-  Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
-  binding declaration alone is not a release or live-traffic claim; preserve
-  the PR #101 Worker/D1 pair for rollback until protected deployment and
-  audits prove the successor. The integrated Transform 10 Aquinas
+  Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed.
+  Protected PR #108 workflow `30496350408` subsequently deployed
+  `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+  `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), bound to that exact D1.
+  Historical core passed 8/8, Transform-11 spine passed 10/10,
+  original-language passed 11/11, edge stabilization matched attempt 4 and
+  remained stable, and independent post-release review returned `SHIP`.
+  Preserve the PR #101 Worker/D1 pair above for rollback. The integrated
+  Transform 10 Aquinas
   hierarchy is local-only and unpublished. Its present packet ends at Tertia
   question 90 and contains no Supplement, so Transform 11 gives it no
   document/catalog/search/resource/runtime/D1 projection. A future Aquinas

--- a/docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md
+++ b/docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md
@@ -82,12 +82,8 @@ pagination/cursor audit also passed. Sanitized evidence hashes are
 `1b56d093b298f41a7845b6c328dbf63ade72ca8fdf8cf82bc68004defaa09a05` and
 `aedef2ffffe6d3de04a5c341a09f137df7abc0d90cee11929ee988fb90f95080`.
 
-Production did not change: it remains the PR #101 production baseline on
-Worker `bae58cd3-cad7-4663-879d-408accf061b0` (#96), deployment
-`71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
-`theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). The checked-in root binding selects
-the separately prepared but unbound ENAM candidate
+Production did not change during the preview release. The checked-in root
+binding selected the separately prepared, initially unbound ENAM candidate
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`), prepared once from merge
 `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
@@ -95,10 +91,19 @@ the separately prepared but unbound ENAM candidate
 1,630,259-row seed with corpus identity
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and full
-Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
-configuration choice is not a deployment claim: preserve the current PR #101
-Worker/D1 pair for rollback until a protected release proves the new binding
-and completes production audits.
+Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed.
+Protected PR #108 workflow `30496350408` then deployed merge
+`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` as deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), bound to that exact D1.
+Historical core passed 8/8, Transform-11 spine passed 10/10,
+original-language passed 11/11, primary-source edge stabilization matched on
+attempt 4 and remained stable, and independent post-release review returned
+`SHIP`. Preserve the former PR #101 assignment for rollback: Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96), deployment
+`71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
+`theologai-production-20260728-hierarchy-a`
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`).
 
 The exact ten-work audit added after this activation is documented in
 [Transform-11 Historical-Spine Release Audit](HISTORICAL-SPINE-RELEASE-AUDIT.md).

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -4,18 +4,23 @@
 
 The integrated checked-out normal build excludes the Transform-10 Aquinas
 hierarchy from all normal D1 corpora: it has no catalog, runtime, or MCP
-projection. Production is PR #101 merge
-`e2d351a11fce9c2cb1f72add0bcf365332737f3c`, deployment
-`71b76d24-bf5f-490e-adc4-31cf63fb046e`, serving Worker
-`bae58cd3-cad7-4663-879d-408accf061b0` (#96) as the sole 100% assignment,
-bound to
+projection. Production is PR #108 merge
+`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`. Protected workflow
+`30496350408` deployed `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, serving
+Worker `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98) as the sole 100%
+assignment, bound to `theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). Historical core passed 8/8,
+Transform-11 spine passed 10/10, original-language passed 11/11,
+primary-source edge stabilization matched on attempt 4 and remained stable,
+and the independent post-release review returned `SHIP`. This is not a
+hierarchy/publication activation; CCEL execution remains disabled and Aquinas
+remains inactive.
+
+The former PR #101 production assignment is the matched rollback pair:
+deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+`bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). That database was unbound when preparation,
-remote readiness, and Transform-8/9 authority audits completed, and whose
-Transform-10 normal-corpus exclusion predicates proved hierarchy, publication,
-and Aquinas-lineage rows empty. Protected workflow `30401732957` subsequently
-proved the exact binding before and after its bounded black-box audits. This is
-not a hierarchy/publication activation.
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`).
 
 The retained PR #101 preview predecessor was deployment
 `070b292b-0bae-400a-b983-3d72157b5a96`, serving Worker
@@ -36,9 +41,10 @@ Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed while
 unbound. Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550`
 now serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) as the sole
-active preview assignment bound to that exact D1. Production remains unchanged.
+active preview assignment bound to that exact D1. This preview assignment
+remained unchanged during the PR #108 production release.
 
-The checked-in root production target is the prepared but unbound Transform-11
+The checked-in root production target was prepared unbound as the Transform-11
 candidate `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
 merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
@@ -47,9 +53,9 @@ merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
-checked-in declaration is not a live production binding or deployment; retain
-the PR #101 Worker/D1 pair above as the current production baseline and rollback
-pair until the protected release proves the new assignment and audits.
+protected PR #108 workflow `30496350408` subsequently proved and activated its
+exact Worker/D1 assignment. The PR #101 Worker/D1 pair above is retained as
+rollback.
 
 Historical PR #96 production evidence is source-attested to checked-out commit
 `ac4b5ed774302fbfc86bf846b6ee77a07beed456` and exact tree
@@ -117,10 +123,12 @@ active.
 > sole 100%; identity SHA-256
 > `a6959d24fb7f50a9848fe2d011f425894718471b8a0609e7833780a291721a44`.
 
-PR95's Transform9 historical source-pack work is deployed to preview only. It
-adds eight reviewed sectioned-only editions to the local catalog and preview
-25-work corpus but has no production Cloudflare migration, binding, deployment,
-or runtime claim. The separate Transform-10 Aquinas hierarchy remains
+At the PR95 cutover, its Transform9 historical source-pack work was deployed to
+preview only. It added eight reviewed sectioned-only editions to the local
+catalog and then-preview 25-work corpus, but PR95 itself made no production
+Cloudflare migration, binding, deployment, or runtime claim. Those editions
+subsequently reached production as part of the PR #108 Transform-11 release.
+The separate Transform-10 Aquinas hierarchy remains
 local-only and inactive; the prepared normal-build candidate excludes its
 hierarchy and lineage, so neither has catalog or runtime activation.
 
@@ -155,9 +163,9 @@ deployment `070b292b-0bae-400a-b983-3d72157b5a96`, serving Worker
 from the reviewed 49-file, 1,627,474-row deterministic seed through schema
 `0008`. Remote readiness and Transform-8/9 authority audits passed, and
 Transform-10 normal-corpus exclusion predicates proved hierarchy, publication,
-and Aquinas-lineage rows empty. Protected release evidence establishes this
-current live binding; dormant hierarchy/publication runtime activation remains
-absent.
+and Aquinas-lineage rows empty. Protected release evidence established that
+then-current binding; later preview releases superseded it. Dormant
+hierarchy/publication runtime activation remains absent.
 
 PR #92 merged as `cd3d1c38fdf0f939a33a41d4b6d5044eb7f44562`; its exact
 reviewed head `3a2b5a57b322dce525f27cfa91c9f667d080bca9` is the separate
@@ -652,10 +660,10 @@ The current preview Transform-11 / 35-work release ran the same gate's complete
 source-pack authority audit, including direct normalized-section pages and
 identity/document/edition-FTS/runtime-FTS parity pages. The audit is read-only
 and catches an orphan or extra normalized section that a delivery-profile join
-alone would miss. Production remains on the PR #101 25-work D1, which excludes
-inactive Aquinas hierarchy and publication rows; its separately prepared
-Transform-11 candidate must pass its protected cutover and audits before that
-state changes. This does not authorize Aquinas activation.
+alone would miss. Production now serves the same Transform-11 35-work corpus
+after its protected PR #108 cutover and audits. The normal corpus continues to
+exclude inactive Aquinas hierarchy and publication rows; this does not
+authorize Aquinas activation.
 
 The corpus marker is the scoped D1 materialization identity derived from
 `data/data-manifest.json` `materializations.d1`, not the hash of the complete

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -170,19 +170,18 @@ describe('published project contract', () => {
     expect(`${developerGuide}\n${confessionSkill}`).not.toMatch(/18 historical documents/i);
   });
 
-  it('keeps current Transform 11 preview and PR #101 production release states distinct', async () => {
+  it('records the current Transform 11 preview and production release states', async () => {
     const [readme, operations, developerGuide] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('docs/worker-operations.md'),
       readProjectFile('CLAUDE.md'),
     ]);
 
-    expect(readme).toContain('Preview v7/discovery-only currently serves the 35-work Transform-11\ncollection');
-    expect(readme).toContain('Production v6/local-only currently searches and retrieves the 25-work PR #101\ncollection');
+    expect(readme).toContain('Production v6/local-only and preview v7/discovery-only currently search and\nretrieve the 35-work Transform-11 collection');
     expect(operations).toContain('current preview Transform-11 / 35-work release');
-    expect(operations).toContain('Production remains on the PR #101 25-work D1');
-    expect(developerGuide).toContain('current preview 35-work catalog');
-    expect(developerGuide).toContain('Production\nremains on the 25-work PR #101 baseline');
+    expect(operations).toContain('Production is PR #108 merge');
+    expect(developerGuide).toContain('both deployed 35-work catalogs');
+    expect(developerGuide).toContain('PR #108 is the current production release record');
   });
 
   it('does not reintroduce retired scope claims', async () => {
@@ -202,7 +201,7 @@ describe('published project contract', () => {
     expect(readme).toMatch(/Both deployed environments do \*\*not\*\* currently fetch CCEL search\s+results or document bodies/);
     expect(readme).toContain('Production v6/local-only is deployed');
     expect(readme).toContain('preview runs the audited v7/discovery-only contract with CCEL execution disabled');
-    expect(readme).toMatch(/Preview serves the 35-work catalog; production remains on\s+the 25-work baseline/);
+    expect(readme).toMatch(/Preview and production now serve the 35-work\s+catalog/);
     expect(readme).toContain('35 locally indexed');
     expect(readme).toContain('18 reviewed source-pack editions');
     expect(readme).toContain('The integrated Transform 10 candidate is local-only and unpublished');
@@ -279,7 +278,7 @@ describe('published project contract', () => {
     expect(operations).toContain('protected PR95 preview release deployed Cloudflare deployment');
     expect(operations).toContain('black-box audit passed with no P0-P3 findings');
     expect(operations).toContain('Transform-10 Aquinas\nhierarchy from all normal D1 corpora');
-    expect(operations).toContain('Production remains on the PR #101 25-work D1, which excludes\ninactive Aquinas');
+    expect(operations).toContain('CCEL execution remains disabled and Aquinas\nremains inactive');
     expect(operations).not.toContain('prepared but unbound preview\ncandidate retains that inactive authority data');
     expect(operations).toContain(`Its historical Cloudflare deployment\n\`${historicalDeployment}\` served Worker`);
     expect(operations).toContain('This historical release is neither\nthe current preview identity nor the immediate retained predecessor');
@@ -320,11 +319,11 @@ describe('published project contract', () => {
     expect(documents[4]).toContain('theologai-production-20260729-transform11-a');
     expect(documents[6]).toContain('30419373527');
     expect(documents[6]).toContain('30420256210');
-    expect(documents[6]).toContain('PR #101 production baseline remains unchanged');
-    expect(documents[5]).toContain('Production remains unchanged');
+    expect(documents[6]).toContain('Production was unchanged by that preview release');
+    expect(documents[5]).toContain('preview assignment\nremained unchanged during the PR #108 production release');
   });
 
-  it('documents the completed PR #101 production cutover without implying hierarchy activation', async () => {
+  it('documents the completed PR #108 Transform 11 production cutover and rollback', async () => {
     const [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('docs/D1-DATA-WORKFLOW.md'),
@@ -333,37 +332,52 @@ describe('published project contract', () => {
       readProjectFile('docs/worker-operations.md'),
       readProjectFile('docs/ROADMAP.md'),
     ]);
-    const preparedCandidateD1 = 'theologai-production-20260729-transform11-a';
-    const preparedCandidateD1Id = '53211f50-a893-4b4c-be1e-bc625a595dc7';
     const liveProduction = {
+      deployment: '3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8',
+      worker: '291f3292-3fa9-44fc-bf6f-b68fd2f4cef6',
+      d1: 'theologai-production-20260729-transform11-a',
+      d1Id: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+    };
+    const rollbackProduction = {
       deployment: '71b76d24-bf5f-490e-adc4-31cf63fb046e',
       worker: 'bae58cd3-cad7-4663-879d-408accf061b0',
       d1: 'theologai-production-20260728-hierarchy-a',
       d1Id: 'f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395',
     };
     const livePreview = {
-      deployment: '070b292b-0bae-400a-b983-3d72157b5a96',
-      worker: 'bd722b69-2e2c-4d8d-b42b-617e8caba13d',
-      d1: 'theologai-preview-20260728-hierarchy-a',
-      d1Id: '51890e12-1c3f-421f-b661-9a5ea9637e43',
+      deployment: '5e812152-355b-4a5f-a123-2485e89f1550',
+      worker: '06b9a603-8339-42b6-a246-ef9238563043',
+      d1: 'theologai-preview-20260728-transform11-a',
+      d1Id: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
     };
 
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
-      expect(document).toContain(preparedCandidateD1);
-      expect(document).toContain(preparedCandidateD1Id);
-    }
-    for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
       for (const value of Object.values(liveProduction)) expect(document).toContain(value);
+      for (const value of Object.values(rollbackProduction)) expect(document).toContain(value);
       for (const value of Object.values(livePreview)) expect(document).toContain(value);
+      expect(document).toContain('30496350408');
+      expect(document).toContain('8da99fd0a161b90a4bd90ab29bde1abf796b3bf6');
     }
-    expect(reconciliation).toContain('completed PR #101 protected production cutover');
-    expect(dataWorkflow).toContain('proved the candidate binding before and after its black-box');
-    expect(catalogScope).toContain('proved it as the sole active production');
-    expect(operations).toContain('proved the exact binding before and after its bounded black-box audits');
-    expect(roadmap).toContain('later proved that exact binding and passed the production');
+    expect(reconciliation).toContain('completed PR #108 protected production cutover');
+    expect(reconciliation).toContain('a59d9a062b2e6c7884de97fd97309878e1cbdc23');
+    expect(reconciliation).toContain('5665940735');
+    expect(reconciliation).toContain('8742223883');
+    expect(reconciliation).toContain('f7bb0275e53a9fe8801ecb3af68f9b74f5df44cab6f20c19cba9b1357d72afd5');
+    expect(reconciliation).toContain('b1ceb8f02ef210b5fb2212a9b212108411630efcc28ad3248a51c19c7bb0e1c0');
+    expect(reconciliation).toContain('604ce2dee6e14559a1a26c7d0d42e572469ce0e7cf4595be22f1085b9bc9ea05');
+    expect(reconciliation).toContain('e74999ea97a78a4fe4a6233be18b6a71cb03a9e2207f5b0fe34f71db09fafb0f');
+    expect(reconciliation).toContain('636b09fcd9bb41add56e99b001c41d7ad878594f2d77df8f7b41b51621c32c97');
+    expect(reconciliation).toContain('77da8832ab4139a769aae7d87716a3d581407cc2d036b6f7939e306d9b865de5');
+    expect(dataWorkflow).toContain('Historical core passed 8/8');
+    expect(catalogScope).toContain('Transform-11 spine passed 10/10');
+    expect(operations).toContain('primary-source edge stabilization matched on attempt 4');
+    expect(roadmap).toContain('independent post-release review returned `SHIP`');
+    expect(reconciliation).toContain('primary-source edge stabilization');
+    expect(reconciliation).toContain('Transform-11 historical-spine audit');
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
       expect(document).not.toContain('Transform-8/9/10 authority');
-      expect(document.replace(/\s+/g, ' ')).toContain('Transform-10 normal-corpus exclusion predicates');
+      expect(document).toContain('Aquinas');
+      expect(document).toMatch(/inactive|local-only|exclusion/);
     }
   });
 


### PR DESCRIPTION
## Summary

- records the completed protected PR #108 Transform 11 production cutover
- pins the exact merge/tree, workflow, deployment, Worker, D1, audit artifact, and sanitized evidence hashes
- preserves the unchanged preview identity, PR #101 rollback pair, CCEL-disabled boundary, and inactive Aquinas boundary
- updates documentation contract coverage for the current 35-work production and preview state

## Verification

- independent Sol review: SHIP after three documentation repairs
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run docs:check` — 10/10
- `git diff --check`

Documentation and tests only. No runtime, binding, workflow, corpus, D1, Cloudflare, CCEL, or deployment mutation.