### PR TITLE
test: align CCEL canary with provider-neutral search

### DIFF
--- a/docs/CCEL-LIVE-PREVIEW-AUDIT.md
+++ b/docs/CCEL-LIVE-PREVIEW-AUDIT.md
@@ -16,7 +16,7 @@ owner separately authorizes a live canary and the current robots/interface
 preflight is recorded. Production remains deployed v6/local-only. Preview is
 deployed and audited on the v7/discovery-only contract, with CCEL execution
 disabled before adapter, coordinator, or fetch. It makes no production MCP tool
-call: production is a `tools/list` v6 local-only schema control. Before either
+call: production is a `tools/list` v6 local-only schema control. Before any
 preview tool call, the canary also uses the already-protected production
 operator route and exact live Worker UUID to read a content-free coordinator
 snapshot. The token is read only from `THEOLOGAI_CCEL_OPERATOR_TOKEN`; it is
@@ -26,12 +26,14 @@ proceeds. These schema observations prove v6 local-only versus v7 CCEL
 exposure; they do not attest exact deployed flag bits. A successful
 origin admission separately proves that the separately authorized canary's live
 execution was effective, which differs from the deployed inert baseline.
-Preview issues exactly two concurrent,
-CCEL-only contenders and requires one bounded discovery result plus one
-structured globally busy result. A separate local-only search verifies usable
-fallback without touching CCEL. A checked audit-side budget refuses any third
-CCEL-bearing call, so isolate/cache changes or elapsed coordinator intervals
-cannot raise the mechanical maximum above two possible CCEL-origin admissions.
+Preview issues exactly two concurrent `searchDepth: "expanded"` contenders.
+Each must retain its curated local result group first; one external group must
+report a bounded discovery result and the other must report structured global
+busy state as a partial, non-error response. A separate
+`searchDepth: "standard"` call verifies usable catalog search without touching
+CCEL. A checked audit-side budget refuses any third expanded call, so
+isolate/cache changes or elapsed coordinator intervals cannot raise the
+mechanical maximum above two possible CCEL-origin admissions.
 
 The pre-snapshot must show a clean closed circuit with every prior admission
 retired. The post-snapshot must show the same operator epoch, exactly one

--- a/scripts/audit-ccel-preview.ts
+++ b/scripts/audit-ccel-preview.ts
@@ -2,6 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { normalizeCcelSectionLocator } from '../src/adapters/commentary/CcelSearchAdapter.js';
 import { CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT, type CcelCoordinatorSnapshot } from '../src/services/historical/CcelUpstreamCoordinator.js';
+import { CCEL_COMPOSITION_DATE_NOTICE } from '../src/services/historical/primarySourceTypes.js';
 import { runOperatorRequest } from './ccel-coordinator-operator.js';
 
 export const LIVE_AUDIT_CONFIRMATION = 'I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS';
@@ -43,6 +44,7 @@ export function parseCcelAuditArgs(argv: string[]): CcelAuditOptions {
 
 type Provider = {
   provider?: string; status?: string; searched?: boolean; retryAfterSeconds?: number; hitCount?: number;
+  notices?: string[];
   scope?: { eligibleDocuments?: Array<{ editionReadiness?: EditionReadiness }> };
   hits?: Array<{
     snippet?: string; metadataStatus?: string; editionReadiness?: EditionReadiness;
@@ -60,6 +62,7 @@ type SearchOutput = {
   responseWindow?: { unit?: string; maximum?: number; truncated?: boolean };
   coverage?: {
     localAttempted?: boolean; localHitCount?: number; ccelAttempted?: boolean; ccelHitCount?: number;
+    notices?: string[];
     serverObserved?: { searched?: CoverageObservation[]; notSearched?: CoverageObservation[] };
   };
   evidencePolicy?: {
@@ -110,8 +113,8 @@ class CcelCallBudget {
   private used = 0;
   constructor(readonly maximum: number) {}
 
-  authorize(providers: string[]): void {
-    if (!providers.includes('ccel')) return;
+  authorize(searchDepth: 'standard' | 'expanded'): void {
+    if (searchDepth !== 'expanded') return;
     if (this.used >= this.maximum) {
       throw new Error(`Audit refused a CCEL-bearing call beyond its hard maximum of ${this.maximum}.`);
     }
@@ -147,25 +150,38 @@ export async function runCcelPreviewAudit(options: CcelAuditOptions, dependencie
     const preSnapshot = await readAuditSnapshot(snapshotCoordinator, 'pre');
     assertCanaryReady(preSnapshot, now());
 
-    // Exactly two concurrent CCEL-only calls exercise the one global Durable
+    // Exactly two concurrent expanded calls exercise the one global Durable
     // Object budget without relying on process-local cache affinity or elapsed
-    // wall time. One may be admitted; the other must receive structured busy.
+    // wall time. Both retain the curated local group first; one external group
+    // may be admitted while the other must report structured busy as partial.
     const runId = crypto.randomUUID().replaceAll('-', '');
     const contenders = await Promise.all([
-      search(preview, ccelBudget, 'audit-contender-a', `theologai audit ${runId} alpha`, ['ccel'], true),
-      search(preview, ccelBudget, 'audit-contender-b', `theologai audit ${runId} beta`, ['ccel'], true),
+      search(preview, ccelBudget, 'audit-contender-a', `theologai audit ${runId} alpha`, 'expanded', {
+        startYear: 1500, endYear: 1700,
+      }),
+      search(preview, ccelBudget, 'audit-contender-b', `theologai audit ${runId} beta`, 'expanded', {
+        startYear: 1500, endYear: 1700,
+      }),
     ]);
+    for (const output of contenders) {
+      assertProviderOrder(output, ['local', 'ccel_live']);
+      assert(['ok', 'no_results', 'catalog_miss'].includes(provider(output, 'local')?.status ?? ''),
+        'expanded search retains a usable curated local group first');
+    }
     const cold = contenders.filter(output => ['ok', 'no_results'].includes(provider(output, 'ccel_live')?.status ?? ''));
     const busy = contenders.filter(output => provider(output, 'ccel_live')?.status === 'rate_limited');
     assert(cold.length === 1 && busy.length === 1, 'one admitted discovery and one globally rate-limited contender');
     for (const output of contenders) assertValidV5Envelope(output);
     assertValidExternalDiscovery(provider(cold[0]!, 'ccel_live')!);
+    assertDateOmissionNotice(cold[0]!);
+    assert(busy[0]!.planStatus === 'partial', 'busy expanded search remains a partial result');
     assertValidRateLimited(provider(busy[0]!, 'ccel_live')!);
     const postSnapshot = await readAuditSnapshot(snapshotCoordinator, 'post');
     const coordinator = assertCanaryDelta(preSnapshot, postSnapshot);
 
     // Local search is deliberately separate and cannot consume an origin slot.
-    const local = await search(preview, ccelBudget, 'audit-local-fallback', 'justification', ['local']);
+    const local = await search(preview, ccelBudget, 'audit-local-fallback', 'justification', 'standard');
+    assertProviderOrder(local, ['local']);
     assert(['ok', 'no_results', 'catalog_miss'].includes(provider(local, 'local')?.status ?? ''), 'usable local fallback independent of CCEL');
     assertValidV5Envelope(local);
     assert(ccelBudget.snapshot() === 2, 'exactly two CCEL-bearing tool calls');
@@ -389,6 +405,13 @@ function assertValidExternalDiscovery(external: Provider): void {
   }
 }
 
+function assertDateOmissionNotice(output: SearchOutput): void {
+  const external = provider(output, 'ccel_live');
+  assert(external?.notices?.[0] === CCEL_COMPOSITION_DATE_NOTICE
+    && output.coverage?.notices?.includes(CCEL_COMPOSITION_DATE_NOTICE),
+  'expanded external discovery discloses omitted composition-date filtering');
+}
+
 async function connect(url: string, name: string): Promise<CcelAuditClient> {
   const client = new Client({ name, version: '1.0.0' }, { capabilities: {} });
   await client.connect(new StreamableHTTPClientTransport(new URL(url)));
@@ -400,29 +423,27 @@ async function search(
   budget: CcelCallBudget,
   id: string,
   text: string,
-  providers: string[],
-  allowRateLimitedError = false,
+  searchDepth: 'standard' | 'expanded',
+  dates: { startYear?: number; endYear?: number } = {},
 ): Promise<SearchOutput> {
-  budget.authorize(providers);
+  budget.authorize(searchDepth);
   const response = await client.callTool({ name: 'primary_source_search', arguments: {
-    queries: [{ id, text, providers, match: 'all_terms', selection: 'relevance', limit: 2 }],
+    queries: [{
+      id, text, searchDepth, match: 'all_terms', selection: 'relevance', limit: 2,
+      ...(searchDepth === 'expanded' ? { expandedLimit: 2 } : {}),
+      ...dates,
+    }],
   } });
+  if (response.isError) throw new Error('Primary-source call returned an unexpected tool error form.');
   const output = (response.structuredContent ?? {}) as SearchOutput;
-  const providersReturned = output.queries?.flatMap(query => query.providers ?? []) ?? [];
-  const ccelOnlyRateLimited = output.planStatus === 'unavailable'
-    && providersReturned.length === 1
-    && providersReturned[0]?.provider === 'ccel_live'
-    && providersReturned[0].status === 'rate_limited';
-  if (!response.isError) {
-    if (allowRateLimitedError && ccelOnlyRateLimited) {
-      throw new Error('Primary-source CCEL-only rate limit was not marked as a tool error.');
-    }
-    return output;
-  }
-  const expectedRateLimit = allowRateLimitedError
-    && ccelOnlyRateLimited;
-  if (!expectedRateLimit) throw new Error('Primary-source call returned an unexpected tool error form.');
   return output;
+}
+
+function assertProviderOrder(output: SearchOutput, expected: string[]): void {
+  const queries = output.queries ?? [];
+  assert(queries.length === 1
+    && JSON.stringify(queries[0]?.providers?.map(item => item.provider)) === JSON.stringify(expected),
+  `provider groups retain ordered ${expected.join(', ')} execution`);
 }
 
 function provider(output: SearchOutput, name: string): Provider | undefined {

--- a/scripts/test-node-http-e2e.ts
+++ b/scripts/test-node-http-e2e.ts
@@ -157,6 +157,24 @@ function resourceText(contents: Array<{ text?: string }>): string {
   return contents.map(item => item.text ?? '').join('\n');
 }
 
+function providerNeutralPrimarySourceArguments(inputSchema: object): Record<string, unknown> {
+  const properties = (inputSchema as {
+    properties?: { queries?: { items?: { properties?: Record<string, unknown> } } };
+  }).properties?.queries?.items?.properties;
+  assert(properties, 'primary_source_search must advertise query properties');
+  const query = {
+    id: 'node-e2e-topic',
+    text: 'justification',
+    match: 'all_terms',
+    selection: 'work_diversity',
+    limit: 2,
+    ...(Object.hasOwn(properties, 'searchDepth')
+      ? { searchDepth: 'standard' }
+      : { providers: ['local'] }),
+  };
+  return { queries: [query] };
+}
+
 async function main(): Promise<void> {
   const nodeMajor = Number(process.versions.node.split('.')[0]);
   assert.equal(nodeMajor, 22, `Node HTTP E2E requires Node 22; received ${process.version}. Run with .nvmrc.`);
@@ -212,6 +230,8 @@ async function main(): Promise<void> {
 
     const tools = await withTimeout(client.listTools(), MCP_TIMEOUT_MS, 'tools/list');
     assert(tools.tools.some(tool => tool.name === 'original_language_lookup'));
+    const primarySourceSearch = tools.tools.find(tool => tool.name === 'primary_source_search');
+    assert(primarySourceSearch, 'tools/list must include primary_source_search');
     const resources = await withTimeout(client.listResources(), MCP_TIMEOUT_MS, 'resources/list');
     assert(resources.resources.some(resource => resource.uri === 'theologai://translations'));
     const prompts = await withTimeout(client.listPrompts(), MCP_TIMEOUT_MS, 'prompts/list');
@@ -238,6 +258,26 @@ async function main(): Promise<void> {
     const lookupText = resultText(lookup.content as Array<{ type: string; text?: string }>);
     assert.match(lookupText, /G25/);
     assert.match(lookupText, /agap/i);
+
+    const primarySources = await withTimeout(
+      client.callTool({
+        name: 'primary_source_search',
+        arguments: providerNeutralPrimarySourceArguments(primarySourceSearch.inputSchema),
+      }),
+      MCP_TIMEOUT_MS,
+      'provider-neutral primary_source_search',
+    );
+    assert.equal(primarySources.isError, undefined);
+    const primaryStructured = primarySources.structuredContent as {
+      schemaVersion?: string;
+      queries?: Array<{ providers?: Array<{ provider?: string }> }>;
+    } | undefined;
+    assert(primaryStructured?.schemaVersion === '6' || primaryStructured?.schemaVersion === '7');
+    assert.deepEqual(
+      primaryStructured.queries?.flatMap(query => query.providers ?? []).map(provider => provider.provider),
+      ['local'],
+      'provider-neutral local search must retain one local provider group',
+    );
 
     console.error('[node-http-e2e] Compiled Node HTTP MCP server passed process-boundary checks.');
   } catch (error) {

--- a/skills/confession-study/SKILL.md
+++ b/skills/confession-study/SKILL.md
@@ -19,10 +19,13 @@ returned by the server to establish what is available and what each document
 says. The workflow must not assign a tradition or author from a title or from a
 prewritten grouping.
 
-Production advertises the v6 local-only `primary_source_search` contract.
-Preview may advertise v7, which adds a separately reported CCEL discovery
-provider. Preserve that provider's state and unreviewed metadata separately; a
-disabled provider did not search or read CCEL.
+Inspect the advertised `primary_source_search` contract before building the
+plan. Version 6 uses the explicit local-only `providers: ["local"]` input.
+Version 7 is provider-neutral: `searchDepth: "standard"` searches the curated
+catalog, while one materially useful `searchDepth: "expanded"` query may add a
+separately grouped broader-discovery result. Preserve every returned group's
+state and unreviewed external metadata separately; a disabled or busy external
+group did not search or read an external page.
 
 ## Methodology
 
@@ -36,10 +39,16 @@ disabled provider did not search or read CCEL.
 
 ### Step 2: Search Across Traditions
 
-- Call `primary_source_search` with one bounded local query plan, for example
+- Call `primary_source_search` with one bounded, version-appropriate query
+  plan. For v6 use
   `{ "queries": [{ "id": "confession-topic", "text": "the doctrinal topic", "providers": ["local"], "match": "all_terms", "selection": "work_diversity", "limit": 5 }] }`.
-- On a v7 endpoint, request the separate `ccel` provider only when a discovery
-  lead is materially useful. It is never local catalog evidence.
+  For v7 use the same query with `searchDepth: "standard"` instead of
+  `providers`; change at most one query to `searchDepth: "expanded"` only when
+  broader discovery is materially useful.
+- Keep v7's ordered curated and external groups distinct. An expanded external
+  group is never local catalog evidence. If composition-year bounds were
+  requested, preserve the notice that expanded discovery omitted those bounds
+  and cannot establish membership in the requested historical period.
 - Treat returned snippets as discovery-only. Preserve document metadata, creator
   names, and creator roles exactly as returned.
 - Do not claim the search covered sources outside the hosted collection, and do

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -404,5 +404,11 @@ describe('published project contract', () => {
       );
       expect(normalized).not.toMatch(/deployed preview remains v5\/discovery-only/i);
     }
+
+    const liveAudit = documents[0]!;
+    expect(liveAudit).toContain('exactly two concurrent `searchDepth: "expanded"` contenders');
+    expect(liveAudit).toContain('`searchDepth: "standard"` call');
+    expect(liveAudit).toContain('partial, non-error response');
+    expect(liveAudit).not.toMatch(/CCEL-only contenders/i);
   });
 });

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -161,7 +161,12 @@ describe('published project contract', () => {
     expect(readme).toContain(`${strongs.toLocaleString('en-US')} Strong's entries`);
     expect(developerGuide).toContain(`${documents} historical documents`);
     expect(confessionSkill).toContain(`includes ${documents} historical documents`);
-    expect(confessionSkill).toContain('Call `primary_source_search` with one bounded local query plan');
+    expect(confessionSkill).toContain('Call `primary_source_search` with one bounded, version-appropriate query');
+    expect(confessionSkill).toContain('Version 6 uses the explicit local-only `providers: ["local"]` input');
+    expect(confessionSkill).toContain('Version 7 is provider-neutral');
+    expect(confessionSkill).toContain('`searchDepth: "standard"`');
+    expect(confessionSkill).toContain('`searchDepth: "expanded"`');
+    expect(confessionSkill).toContain('expanded discovery omitted those bounds');
     expect(confessionSkill).toContain('each selected canonical `resource_link` with MCP `resources/read`');
     expect(confessionSkill).toContain('Never relabel an issuing, drafting, revising, or');
     expect(confessionSkill).toContain('Never infer a tradition or author attribution');

--- a/test/unit/scripts/ccelCoordinatorOperator.test.ts
+++ b/test/unit/scripts/ccelCoordinatorOperator.test.ts
@@ -9,6 +9,7 @@ import {
   CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT,
   type CcelCoordinatorSnapshot,
 } from '../../../src/services/historical/CcelUpstreamCoordinator.js';
+import { CCEL_COMPOSITION_DATE_NOTICE } from '../../../src/services/historical/primarySourceTypes.js';
 import { parseOperatorCli, runOperatorRequest } from '../../../scripts/ccel-coordinator-operator.js';
 import { assertRetiredCcelScriptIsNetworkInert } from '../../adapters/ccel-test.js';
 import { assertRetiredCcelToolContractGuard } from '../../integration/ccel-tool-test.js';
@@ -41,20 +42,31 @@ function toolSchema(version: '3' | '6' | '7', includeCcel: boolean, retryAfterSe
   } };
 }
 
-function envelope(searchProvider: ReturnType<typeof provider>, planStatus = 'complete') {
-  const searched = searchProvider.searched;
-  const kind = searchProvider.provider;
-  const observation = { queryId: 'audit', provider: kind, status: searchProvider.status };
+function envelope(
+  searchProviders: ReturnType<typeof provider> | Array<ReturnType<typeof provider>>,
+  planStatus = 'complete',
+  queryId = 'audit',
+) {
+  const providers = Array.isArray(searchProviders) ? searchProviders : [searchProviders];
+  const observations = providers.map(searchProvider => ({
+    queryId, provider: searchProvider.provider, status: searchProvider.status,
+    returnedHitCount: searchProvider.hitCount, searched: searchProvider.searched,
+  }));
   return {
     schemaVersion: '7', kind: 'primary_source_search', planStatus,
     responseWindow: { unit: 'utf8_bytes', maximum: 32_768, truncated: false },
-    queries: [{ id: 'audit', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [searchProvider] }],
+    queries: [{ id: queryId, normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers }],
     coverage: {
-      localAttempted: kind === 'local' && searched, localHitCount: kind === 'local' ? searchProvider.hitCount : 0,
-      ccelAttempted: kind === 'ccel_live' && searched, ccelHitCount: kind === 'ccel_live' ? searchProvider.hitCount : 0,
-      notices: [], serverObserved: {
-        searched: searched ? [{ ...observation, returnedHitCount: searchProvider.hitCount }] : [],
-        notSearched: searched ? [] : [observation],
+      localAttempted: providers.some(item => item.provider === 'local' && item.searched),
+      localHitCount: providers.filter(item => item.provider === 'local').reduce((sum, item) => sum + item.hitCount, 0),
+      ccelAttempted: providers.some(item => item.provider === 'ccel_live' && item.searched),
+      ccelHitCount: providers.filter(item => item.provider === 'ccel_live').reduce((sum, item) => sum + item.hitCount, 0),
+      notices: [...new Set(providers.flatMap(item => item.notices))],
+      serverObserved: {
+        searched: observations.filter(item => item.searched)
+          .map(({ searched: _searched, ...item }) => item),
+        notSearched: observations.filter(item => !item.searched)
+          .map(({ searched: _searched, returnedHitCount: _returnedHitCount, ...item }) => item),
       },
     },
     evidencePolicy: {
@@ -78,7 +90,8 @@ function provider(
   return {
     provider: kind, status, searched, page: 1, hitCount: hits.length,
     resultWindow: { returnedHitCount: hits.length, additionalMatchStatus: 'no_additional_match_observed' },
-    hits, notices: [],
+    hits,
+    notices: kind === 'ccel_live' && searched ? [CCEL_COMPOSITION_DATE_NOTICE] : [],
     ...(kind === 'local' && searched ? { scope: { eligibleDocuments: [{ editionReadiness: localEditionReadiness }] } } : {}),
     ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
   };
@@ -97,6 +110,41 @@ function localHit() {
     provider: 'local', snippet: 'A local discovery snippet.', editionReadiness: localEditionReadiness,
     locator: { kind: 'mcp_resource', uri: 'theologai://documents/example' },
   };
+}
+
+function auditQuery(request: { arguments: Record<string, unknown> }) {
+  const query = (request.arguments.queries as Array<Record<string, unknown>>)[0]!;
+  expect(query).not.toHaveProperty('providers');
+  expect(query.page).toBeUndefined();
+  if (query.searchDepth === 'expanded') {
+    expect(query).toMatchObject({
+      expandedLimit: 2, startYear: 1500, endYear: 1700,
+    });
+  } else {
+    expect(query.searchDepth).toBe('standard');
+    expect(query).not.toHaveProperty('expandedLimit');
+    expect(query).not.toHaveProperty('startYear');
+    expect(query).not.toHaveProperty('endYear');
+  }
+  return query;
+}
+
+function expandedEnvelope(
+  request: { arguments: Record<string, unknown> },
+  external: ReturnType<typeof provider>,
+) {
+  const query = auditQuery(request);
+  expect(query.searchDepth).toBe('expanded');
+  return envelope(
+    [provider('local', 'ok', undefined, [localHit()]), external],
+    external.status === 'rate_limited' ? 'partial' : 'complete',
+    String(query.id),
+  );
+}
+
+function standardEnvelope(request: { arguments: Record<string, unknown> }) {
+  const query = auditQuery(request);
+  return envelope(provider('local', 'ok', undefined, [localHit()]), 'complete', String(query.id));
 }
 
 function coordinatorSnapshot(overrides: Partial<CcelCoordinatorSnapshot> = {}): CcelCoordinatorSnapshot {
@@ -168,16 +216,16 @@ describe('CCEL operational scripts', () => {
     };
     const privateMarker = 'never-report-this-private-snippet';
     preview.callTool.mockImplementation(async request => {
-      const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
-      if (providers.includes('ccel')) {
+      const query = auditQuery(request);
+      if (query.searchDepth === 'expanded') {
         ccelCalls++;
         if (ccelCalls === 1) {
           possibleOriginAdmissions++;
-          return { structuredContent: envelope(provider('ccel_live', 'ok', undefined, [externalHit(privateMarker)])) };
+          return { structuredContent: expandedEnvelope(request, provider('ccel_live', 'ok', undefined, [externalHit(privateMarker)])) };
         }
-        return { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+        return { structuredContent: expandedEnvelope(request, provider('ccel_live', 'rate_limited', 10)) };
       }
-      return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
+      return { structuredContent: standardEnvelope(request) };
     });
     const dependencies = auditDependencies(production, preview);
     const report = await runCcelPreviewAudit(auditOptions, dependencies);
@@ -200,6 +248,10 @@ describe('CCEL operational scripts', () => {
     expect(possibleOriginAdmissions).toBeLessThanOrEqual(2);
     expect(production.callTool).not.toHaveBeenCalled();
     expect(preview.callTool).toHaveBeenCalledTimes(3);
+    const requestedQueries = preview.callTool.mock.calls
+      .map(([request]) => (request.arguments.queries as Array<Record<string, unknown>>)[0]!);
+    expect(requestedQueries.filter(query => query.searchDepth === 'expanded')).toHaveLength(2);
+    expect(requestedQueries.filter(query => query.searchDepth === 'standard')).toHaveLength(1);
     expect(dependencies.snapshotCoordinator).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(report)).not.toContain(privateMarker);
     expect(report.productionControl).not.toHaveProperty('rolloutContract');
@@ -296,14 +348,14 @@ describe('CCEL operational scripts', () => {
     };
     const preview: CcelAuditClient = {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('7', true, true) }] }),
-      callTool: vi.fn(async () => {
+      callTool: vi.fn(async request => {
         ccelCalls++;
         if (ccelCalls === 1) {
-          const output = envelope(provider('ccel_live', 'no_results'));
+          const output = expandedEnvelope(request, provider('ccel_live', 'no_results'));
           corrupt(output);
           return { structuredContent: output };
         }
-        return { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+        return { structuredContent: expandedEnvelope(request, provider('ccel_live', 'rate_limited', 10)) };
       }),
       close: vi.fn().mockResolvedValue(undefined),
     };
@@ -320,9 +372,9 @@ describe('CCEL operational scripts', () => {
     };
     const preview: CcelAuditClient = {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('7', true, true) }] }),
-      callTool: vi.fn(async () => {
+      callTool: vi.fn(async request => {
         possibleOriginAdmissions++;
-        return { structuredContent: envelope(provider('ccel_live', 'no_results')) };
+        return { structuredContent: expandedEnvelope(request, provider('ccel_live', 'no_results')) };
       }),
       close: vi.fn().mockResolvedValue(undefined),
     };
@@ -332,14 +384,17 @@ describe('CCEL operational scripts', () => {
     expect(preview.callTool).toHaveBeenCalledTimes(2);
   });
 
-  it('rejects an isError response unless it is the exact CCEL-only rate-limit form', async () => {
+  it('rejects a busy expanded response marked as a tool error instead of partial success', async () => {
     const production: CcelAuditClient = {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('6', false) }] }),
       callTool: vi.fn(), close: vi.fn().mockResolvedValue(undefined),
     };
     const preview: CcelAuditClient = {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('7', true, true) }] }),
-      callTool: vi.fn().mockResolvedValue({ isError: true, structuredContent: envelope(provider('local', 'rate_limited', 3), 'unavailable') }),
+      callTool: vi.fn(async request => ({
+        isError: true,
+        structuredContent: expandedEnvelope(request, provider('ccel_live', 'rate_limited', 3)),
+      })),
       close: vi.fn().mockResolvedValue(undefined),
     };
     await expect(runCcelPreviewAudit(auditOptions, auditDependencies(production, preview)))
@@ -355,14 +410,14 @@ describe('CCEL operational scripts', () => {
     const preview: CcelAuditClient = {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('7', true, true) }] }),
       callTool: vi.fn(async request => {
-        const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
-        if (providers.includes('ccel')) {
+        const query = auditQuery(request);
+        if (query.searchDepth === 'expanded') {
           ccelCalls++;
           return ccelCalls === 1
-            ? { structuredContent: envelope(provider('ccel_live', 'no_results')) }
-            : { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+            ? { structuredContent: expandedEnvelope(request, provider('ccel_live', 'no_results')) }
+            : { structuredContent: expandedEnvelope(request, provider('ccel_live', 'rate_limited', 10)) };
         }
-        return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
+        return { structuredContent: standardEnvelope(request) };
       }), close: vi.fn().mockResolvedValue(undefined),
     };
     const report = await runCcelPreviewAudit(auditOptions, auditDependencies(production, preview, [
@@ -393,14 +448,14 @@ describe('CCEL operational scripts', () => {
     const preview: CcelAuditClient = {
       listTools: vi.fn().mockResolvedValue({ tools: [{ name: 'primary_source_search', outputSchema: toolSchema('7', true, true) }] }),
       callTool: vi.fn(async request => {
-        const providers = ((request.arguments.queries as Array<{ providers: string[] }>)[0]?.providers ?? []);
-        if (providers.includes('ccel')) {
+        const query = auditQuery(request);
+        if (query.searchDepth === 'expanded') {
           ccelCalls++;
           return ccelCalls === 1
-            ? { structuredContent: envelope(provider('ccel_live', 'no_results')) }
-            : { isError: true, structuredContent: envelope(provider('ccel_live', 'rate_limited', 10), 'unavailable') };
+            ? { structuredContent: expandedEnvelope(request, provider('ccel_live', 'no_results')) }
+            : { structuredContent: expandedEnvelope(request, provider('ccel_live', 'rate_limited', 10)) };
         }
-        return { structuredContent: envelope(provider('local', 'ok', undefined, [localHit()])) };
+        return { structuredContent: standardEnvelope(request) };
       }),
       close: vi.fn().mockResolvedValue(undefined),
     };


### PR DESCRIPTION
## Summary

- updates the dormant preview CCEL canary to the shipped v7 provider-neutral `standard`/`expanded` request contract
- requires local-first expanded results and partial, non-error global-busy behavior while retaining the hard maximum of two possible external calls
- verifies composition-date omission disclosure, production zero-tool-call isolation, and sanitized evidence boundaries
- updates Node process-boundary coverage, operator guidance, and the confession-study workflow without changing runtime behavior

## Release boundaries

- independent draft from current `main`; if release-record PR #109 lands first, rebase and rerun CI before merge
- no live CCEL request, flag, secret, binding, coordinator, runtime, schema, corpus, workflow, D1, preview, production, or deployment change
- v7 remains page-1-only and CCEL execution remains disabled

## Verification

- independent Sol review: SHIP after operator-guide repair
- `npm run test:ccel` — 131/131
- `npm run docs:check` — 10/10
- `npm run test:e2e` — build/typecheck/process-boundary PASS
- `git diff --check`