### PR TITLE
Add transactional CCEL preview canary infrastructure

### DIFF
--- a/.github/workflows/ccel-live-preview-canary.yml
+++ b/.github/workflows/ccel-live-preview-canary.yml
@@ -1,0 +1,262 @@
+name: CCEL Live Preview Canary
+
+# Manual only. This path never reuses ordinary PR preview authorization.
+on:
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: 'Exact current main commit SHA'
+        required: true
+        type: string
+      expected_preview_predecessor_version_id:
+        description: 'Exact preview 100 predecessor Worker version UUID'
+        required: true
+        type: string
+      expected_production_control_version_id:
+        description: 'Exact production v6 / 000 Worker version UUID (read-only control)'
+        required: true
+        type: string
+      confirmation:
+        description: 'Type I AUTHORIZE THE TEMPORARY CCEL LIVE PREVIEW CANARY'
+        required: true
+        type: string
+
+# This is deliberately the same repository-wide lock used by the ordinary PR
+# preview deployment and the emergency restore workflow.
+concurrency:
+  group: theologai-shared-preview-mutation
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # This environment must be provisioned manually. GitHub environments only
+    # gate secret availability; the least-privilege Cloudflare token scope is an
+    # external prerequisite documented in CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.
+    environment: ccel-canary
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - run: npm ci --no-audit
+
+      # No Wrangler command may run until all dispatch IDs and the dedicated
+      # externally-provisioned credentials have passed local validation.
+      - name: Require exact main authorization, IDs, and dedicated credentials
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          PREDECESSOR: ${{ inputs.expected_preview_predecessor_version_id }}
+          PRODUCTION_CONTROL: ${{ inputs.expected_production_control_version_id }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          CCEL_CANARY_CREDENTIALS_CONFIGURED: ${{ secrets.CCEL_CANARY_CREDENTIALS_CONFIGURED }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+          THEOLOGAI_CCEL_OPERATOR_TOKEN: ${{ secrets.CCEL_CANARY_OPERATOR_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          LIVE_MAIN_SHA="$(git rev-parse origin/main)"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-dispatch \
+            --ref "$DISPATCH_REF" --sha "$DISPATCH_SHA" --expected-sha "$EXPECTED_MAIN_SHA" \
+            --live-main-sha "$LIVE_MAIN_SHA" --confirmation "$CONFIRMATION" --config wrangler.toml
+          npx tsx scripts/ccel-live-preview-canary.ts validate-canary-inputs \
+            --preview-predecessor "$PREDECESSOR" --production-control "$PRODUCTION_CONTROL"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-canary-credentials
+
+      - name: Prove production is only the v6 / 000 read-only control
+        id: production-control
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+          EXPECTED: ${{ inputs.expected_production_control_version_id }}
+        run: |
+          set -euo pipefail
+          npx wrangler deployments list --json > "$RUNNER_TEMP/production-deployments.json"
+          npx wrangler versions view "$EXPECTED" --json > "$RUNNER_TEMP/production-version.json"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-production-control \
+            --config wrangler.toml --deployments "$RUNNER_TEMP/production-deployments.json" \
+            --version-view "$RUNNER_TEMP/production-version.json" --expected-version "$EXPECTED"
+
+      - name: Capture and validate exact preview 100 predecessor
+        id: preview-baseline
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+          EXPECTED: ${{ inputs.expected_preview_predecessor_version_id }}
+        run: |
+          set -euo pipefail
+          npx wrangler versions list --env preview --json > "$RUNNER_TEMP/preview-versions-before.json"
+          npx wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-deployments-before.json"
+          npx wrangler versions view "$EXPECTED" --env preview --json > "$RUNNER_TEMP/preview-predecessor.json"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-preview-baseline \
+            --config wrangler.toml --deployments "$RUNNER_TEMP/preview-deployments-before.json" \
+            --version-view "$RUNNER_TEMP/preview-predecessor.json" --expected-version "$EXPECTED"
+          printf '%s' "$EXPECTED" > "$RUNNER_TEMP/ccel-canary-predecessor-version.txt"
+          echo "predecessor_version=$EXPECTED" >> "$GITHUB_OUTPUT"
+
+      - name: Retain the private predecessor recovery anchor
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ccel-canary-predecessor-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/preview-predecessor.json
+            ${{ runner.temp }}/ccel-canary-predecessor-version.txt
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Render undeployed preview-only 111 configuration
+        id: render
+        run: >-
+          npx tsx scripts/ccel-live-preview-canary.ts render-preview-config
+          --config wrangler.toml --output "$GITHUB_WORKSPACE/.wrangler.ccel-live-preview-canary.toml"
+
+      # Failure remains non-terminal until the in-job restore step below has
+      # checked the active deployment and re-proved the predecessor.
+      - name: Upload exactly one undeployed candidate and validate its exact state
+        id: stage
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+          PREDECESSOR: ${{ steps.preview-baseline.outputs.predecessor_version }}
+        run: |
+          set -euo pipefail
+          npx wrangler versions upload --config "$GITHUB_WORKSPACE/.wrangler.ccel-live-preview-canary.toml" --env preview \
+            --message 'Temporary preview-only CCEL live canary; always restore exact predecessor' --tag ccel-live-preview-canary
+          npx wrangler versions list --env preview --json > "$RUNNER_TEMP/preview-versions-after.json"
+          npx wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-deployments-after-upload.json"
+          CANARY="$(npx tsx scripts/ccel-live-preview-canary.ts identify-upload \
+            --before-versions "$RUNNER_TEMP/preview-versions-before.json" --after-versions "$RUNNER_TEMP/preview-versions-after.json" \
+            --before-deployments "$RUNNER_TEMP/preview-deployments-before.json" --after-deployments "$RUNNER_TEMP/preview-deployments-after-upload.json" \
+            --expected-baseline "$PREDECESSOR")"
+          npx wrangler versions view "$CANARY" --env preview --json > "$RUNNER_TEMP/preview-canary.json"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-canary-version \
+            --config wrangler.toml --baseline-view "$RUNNER_TEMP/preview-predecessor.json" --canary-view "$RUNNER_TEMP/preview-canary.json" \
+            --expected-baseline "$PREDECESSOR" --expected-canary "$CANARY"
+          echo "canary_version=$CANARY" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy the reviewed canary to preview only
+        id: deploy
+        if: steps.stage.outcome == 'success'
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+          CANARY: ${{ steps.stage.outputs.canary_version }}
+        run: |
+          set -euo pipefail
+          npx wrangler versions deploy "$CANARY@100" --env preview --yes
+          npx wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-deployments-canary.json"
+          npx wrangler versions view "$CANARY" --env preview --json > "$RUNNER_TEMP/preview-canary-deployed.json"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-canary-deployment \
+            --config wrangler.toml --deployments "$RUNNER_TEMP/preview-deployments-canary.json" \
+            --version-view "$RUNNER_TEMP/preview-canary-deployed.json" --expected-canary "$CANARY"
+
+      - name: Run the existing authorized two-attempt audit exactly once
+        id: audit
+        if: steps.deploy.outcome == 'success'
+        continue-on-error: true
+        env:
+          THEOLOGAI_CCEL_OPERATOR_TOKEN: ${{ secrets.CCEL_CANARY_OPERATOR_TOKEN }}
+          PRODUCTION_CONTROL: ${{ inputs.expected_production_control_version_id }}
+        run: >-
+          npm run audit:ccel-preview --
+          --preview-url https://preview-mcp.theologai.xyz/mcp
+          --production-url https://mcp.theologai.xyz/mcp
+          --production-worker-version-id "$PRODUCTION_CONTROL"
+          --authorize-live-ccel 'I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS'
+          > "$RUNNER_TEMP/ccel-live-preview-audit.json"
+
+      - name: Always restore the exact preview predecessor before job exit
+        id: restore
+        if: always() && steps.preview-baseline.outcome == 'success'
+        continue-on-error: true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+          PREDECESSOR: ${{ steps.preview-baseline.outputs.predecessor_version }}
+          CANARY: ${{ steps.stage.outputs.canary_version }}
+        run: |
+          set -euo pipefail
+          npx wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-deployments-before-restore.json"
+          CURRENT="$(jq -er 'sort_by(.created_on) | last | .versions | select(length == 1) | .[0] | select(.percentage == 100) | .version_id' "$RUNNER_TEMP/preview-deployments-before-restore.json")"
+          CANARY="${CANARY:-$CURRENT}"
+          npx wrangler versions view "$CURRENT" --env preview --json > "$RUNNER_TEMP/preview-current.json"
+          npx wrangler versions view "$PREDECESSOR" --env preview --json > "$RUNNER_TEMP/preview-predecessor-recheck.json"
+          PLAN="$(npx tsx scripts/ccel-live-preview-canary.ts restore-plan \
+            --config wrangler.toml --deployments "$RUNNER_TEMP/preview-deployments-before-restore.json" \
+            --current-view "$RUNNER_TEMP/preview-current.json" --target-view "$RUNNER_TEMP/preview-predecessor-recheck.json" \
+            --expected-current "$CANARY" --expected-target "$PREDECESSOR")"
+          if [ "$PLAN" = deploy ]; then npx wrangler versions deploy "$PREDECESSOR@100" --env preview --yes; fi
+          npx wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-deployments-restored.json"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-restore-result \
+            --config wrangler.toml --deployments "$RUNNER_TEMP/preview-deployments-restored.json" \
+            --target-view "$RUNNER_TEMP/preview-predecessor-recheck.json" --expected-target "$PREDECESSOR"
+
+      - name: Write identifier-and-hash-only evidence after restoration
+        id: evidence
+        if: always() && steps.restore.outcome == 'success' && steps.stage.outputs.canary_version != ''
+        env:
+          PREDECESSOR: ${{ steps.preview-baseline.outputs.predecessor_version }}
+          CANARY: ${{ steps.stage.outputs.canary_version }}
+          PRODUCTION_CONTROL: ${{ inputs.expected_production_control_version_id }}
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+        run: |
+          set -euo pipefail
+          if [ "$AUDIT_OUTCOME" = success ]; then
+            AUDIT_SHA256="$(sha256sum "$RUNNER_TEMP/ccel-live-preview-audit.json" | awk '{print $1}')"
+            AUDIT_STATUS=success
+          else
+            AUDIT_SHA256="$(printf '%s' audit-step-failed | sha256sum | awk '{print $1}')"
+            AUDIT_STATUS=failure
+          fi
+          npx tsx scripts/ccel-live-preview-canary.ts emit-evidence \
+            --commit "$GITHUB_SHA" --predecessor "$PREDECESSOR" --canary "$CANARY" \
+            --production-control "$PRODUCTION_CONTROL" --audit-sha256 "$AUDIT_SHA256" \
+            --audit-outcome "$AUDIT_STATUS" --restored true \
+            > "$RUNNER_TEMP/ccel-live-preview-transaction-evidence.json"
+
+      - name: Retain audit output when it passed
+        if: always() && steps.audit.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ccel-live-preview-audit-${{ github.run_id }}
+          path: ${{ runner.temp }}/ccel-live-preview-audit.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Retain sanitized transaction evidence after every recoverable audit outcome
+        if: always() && steps.evidence.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ccel-live-preview-transaction-evidence-${{ github.run_id }}
+          path: ${{ runner.temp }}/ccel-live-preview-transaction-evidence.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Fail only after recovery and evidence are complete
+        if: always()
+        env:
+          PRODUCTION_CONTROL_OUTCOME: ${{ steps.production-control.outcome }}
+          PREVIEW_BASELINE_OUTCOME: ${{ steps.preview-baseline.outcome }}
+          RENDER_OUTCOME: ${{ steps.render.outcome }}
+          STAGE_OUTCOME: ${{ steps.stage.outcome }}
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+          RESTORE_OUTCOME: ${{ steps.restore.outcome }}
+        run: |
+          set -euo pipefail
+          test "$PRODUCTION_CONTROL_OUTCOME" = success
+          test "$PREVIEW_BASELINE_OUTCOME" = success
+          test "$RENDER_OUTCOME" = success
+          test "$STAGE_OUTCOME" = success
+          test "$DEPLOY_OUTCOME" = success
+          test "$AUDIT_OUTCOME" = success
+          test "$RESTORE_OUTCOME" = success

--- a/.github/workflows/ccel-live-preview-canary.yml
+++ b/.github/workflows/ccel-live-preview-canary.yml
@@ -34,9 +34,9 @@ jobs:
   canary:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # This environment must be provisioned manually. GitHub environments only
-    # gate secret availability; the least-privilege Cloudflare token scope is an
-    # external prerequisite documented in CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.
+    # This environment must be provisioned manually. GitHub gates secret
+    # availability, but Cloudflare Workers Script Write is account-scoped. The
+    # separate exact owner acknowledgment is required before any Wrangler call.
     environment: ccel-canary
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -62,6 +62,7 @@ jobs:
           PRODUCTION_CONTROL: ${{ inputs.expected_production_control_version_id }}
           CONFIRMATION: ${{ inputs.confirmation }}
           CCEL_CANARY_CREDENTIALS_CONFIGURED: ${{ secrets.CCEL_CANARY_CREDENTIALS_CONFIGURED }}
+          CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK: ${{ secrets.CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
           THEOLOGAI_CCEL_OPERATOR_TOKEN: ${{ secrets.CCEL_CANARY_OPERATOR_TOKEN }}
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -216,10 +216,11 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(github.event.pull_request.labels.*.name, 'deploy-preview')
-    # This deliberately differs from the workflow-wide per-PR group above:
-    # one shared preview Worker cannot safely audit two deploying PRs at once.
+    # Repository-wide serialization: this exact group is also held by the
+    # manual CCEL canary and emergency restore, so neither can observe or
+    # overwrite an ordinary preview deployment mid-transaction.
     concurrency:
-      group: theologai-shared-preview-deploy-and-audit
+      group: theologai-shared-preview-mutation
       cancel-in-progress: false
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/restore-ccel-live-preview-canary.yml
+++ b/.github/workflows/restore-ccel-live-preview-canary.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # This is the same manually provisioned environment used by the canary.
-    # It intentionally contains no operator token because recovery is preview-only.
+    # Recovery never references or injects its operator-token secret.
     environment: ccel-canary
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -51,6 +51,7 @@ jobs:
           TARGET: ${{ inputs.expected_target_version_id }}
           CONFIRMATION: ${{ inputs.confirmation }}
           CCEL_CANARY_CREDENTIALS_CONFIGURED: ${{ secrets.CCEL_CANARY_CREDENTIALS_CONFIGURED }}
+          CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK: ${{ secrets.CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
         run: |
           set -euo pipefail

--- a/.github/workflows/restore-ccel-live-preview-canary.yml
+++ b/.github/workflows/restore-ccel-live-preview-canary.yml
@@ -1,0 +1,82 @@
+name: Restore CCEL Live Preview Canary
+
+# Standalone recovery path for a cancelled workflow or any ambiguous canary
+# state. It is manual, main-only, preview-scoped, and has no operator secret.
+on:
+  workflow_dispatch:
+    inputs:
+      expected_current_version_id:
+        description: 'Exact active preview Worker version UUID (canary or already-restored predecessor)'
+        required: true
+        type: string
+      expected_target_version_id:
+        description: 'Exact reviewed preview 100 predecessor Worker version UUID'
+        required: true
+        type: string
+      confirmation:
+        description: 'Type RESTORE THE EXACT CCEL PREVIEW PREDECESSOR'
+        required: true
+        type: string
+
+concurrency:
+  group: theologai-shared-preview-mutation
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  restore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # This is the same manually provisioned environment used by the canary.
+    # It intentionally contains no operator token because recovery is preview-only.
+    environment: ccel-canary
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - run: npm ci --no-audit
+
+      - name: Validate dedicated credentials and every recovery input before any Wrangler invocation
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          CURRENT: ${{ inputs.expected_current_version_id }}
+          TARGET: ${{ inputs.expected_target_version_id }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          CCEL_CANARY_CREDENTIALS_CONFIGURED: ${{ secrets.CCEL_CANARY_CREDENTIALS_CONFIGURED }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          npx tsx scripts/ccel-live-preview-canary.ts validate-emergency-credentials
+          npx tsx scripts/ccel-live-preview-canary.ts validate-emergency-inputs \
+            --ref "$DISPATCH_REF" --current "$CURRENT" --target "$TARGET" \
+            --confirmation "$CONFIRMATION" --config wrangler.toml
+
+      - name: Validate, restore if necessary, and re-prove exact preview 100
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN }}
+          CURRENT: ${{ inputs.expected_current_version_id }}
+          TARGET: ${{ inputs.expected_target_version_id }}
+        run: |
+          set -euo pipefail
+          npx wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-deployments.json"
+          OBSERVED="$(jq -er 'sort_by(.created_on) | last | .versions | select(length == 1) | .[0] | select(.percentage == 100) | .version_id' "$RUNNER_TEMP/preview-deployments.json")"
+          test "$OBSERVED" = "$CURRENT"
+          npx wrangler versions view "$CURRENT" --env preview --json > "$RUNNER_TEMP/preview-current.json"
+          npx wrangler versions view "$TARGET" --env preview --json > "$RUNNER_TEMP/preview-target.json"
+          PLAN="$(npx tsx scripts/ccel-live-preview-canary.ts restore-plan \
+            --config wrangler.toml --deployments "$RUNNER_TEMP/preview-deployments.json" \
+            --current-view "$RUNNER_TEMP/preview-current.json" --target-view "$RUNNER_TEMP/preview-target.json" \
+            --expected-current "$CURRENT" --expected-target "$TARGET")"
+          if [ "$PLAN" = deploy ]; then npx wrangler versions deploy "$TARGET@100" --env preview --yes; fi
+          npx wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-deployments-restored.json"
+          npx tsx scripts/ccel-live-preview-canary.ts validate-restore-result \
+            --config wrangler.toml --deployments "$RUNNER_TEMP/preview-deployments-restored.json" \
+            --target-view "$RUNNER_TEMP/preview-target.json" --expected-target "$TARGET"

--- a/docs/CCEL-LIVE-PREVIEW-AUDIT.md
+++ b/docs/CCEL-LIVE-PREVIEW-AUDIT.md
@@ -53,3 +53,7 @@ phrase or canonical URL, or supplying a malformed production Worker UUID, fails
 before any connection. A different but syntactically valid UUID is rejected by
 the signed operator route after the production and preview `tools/list` checks
 but before any preview `tools/call` invocation.
+
+For the main-only, temporary preview 111 deployment and exact-predecessor
+recovery procedure that may invoke this audit, see
+[CCEL live-preview canary transaction](CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md).

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -1,0 +1,139 @@
+# CCEL live-preview canary transaction
+
+This is the release procedure for the one deliberately temporary state in
+which preview may execute CCEL discovery. It is infrastructure only: it does
+not change a corpus, D1 schema, MCP behavior, rate-limit policy, production
+deployment, secret value, or the ordinary PR preview workflow.
+
+## Fixed baseline and authorization gates
+
+Tracked `wrangler.toml` is always the safe baseline:
+
+| Surface | Discovery | Live search | Coordinator | Role |
+| --- | ---: | ---: | ---: | --- |
+| Production | 0 | 0 | 0 | v6 local-only control and protected snapshot owner |
+| Preview | 1 | 0 | 0 | v7 discovery-contract baseline |
+| Ephemeral canary | 1 | 1 | 1 | preview-only audit candidate; never committed |
+
+The only way to create the third row is the main-only, manually dispatched
+`CCEL Live Preview Canary` workflow. It requires all of the following:
+
+1. The workflow is dispatched from `refs/heads/main`, its checked-out SHA,
+   supplied SHA, and freshly fetched `origin/main` SHA are the same exact full
+   commit ID.
+2. The operator supplies the exact active preview predecessor UUID and exact
+   production control UUID. Both must be the sole 100% deployments. Full Worker
+   version views re-prove their D1 identities, Durable Object identity,
+   rate-limit namespaces, compatibility settings, flags, and exact binding
+   sets. The canonical custom-domain routes are validated from committed
+   `wrangler.toml`; the audit then exercises both canonical MCP endpoints. That
+   endpoint exercise proves reachability for this transaction, not an
+   independent inventory of Cloudflare zone-route ownership.
+3. The exact confirmation text is entered:
+   `I AUTHORIZE THE TEMPORARY CCEL LIVE PREVIEW CANARY`.
+4. A repository administrator has first provisioned the dedicated GitHub
+   `ccel-canary` environment. It must contain only these dedicated names:
+   `CCEL_CANARY_CREDENTIALS_CONFIGURED` (with the exact sentinel value
+   `CCEL_CANARY_CREDENTIALS_CONFIGURED`),
+   `CCEL_CANARY_CLOUDFLARE_API_TOKEN`, and `CCEL_CANARY_OPERATOR_TOKEN`.
+   The workflow fails before any Wrangler command if any is absent or malformed.
+   It never falls back to the `production` or ordinary `preview` environment
+   credentials.
+
+The dedicated Cloudflare token is an external configuration prerequisite, not
+a security boundary this repository can prove. Before enabling the environment,
+an administrator must verify in Cloudflare that this distinct token permits the
+read operations needed on the production Worker (deployment/version views and
+the protected audit snapshot) and the read/write version operations needed on
+the preview Worker, with no D1 deletion, secret mutation, route mutation, or
+production deployment permission. Cloudflare's available resource-scoping
+granularity is authoritative; GitHub environment selection merely controls
+secret availability and cannot attest the token's effective permissions. If
+that least-privilege scope cannot be configured, do not set the sentinel and
+do not run the canary workflow.
+
+The workflow renders a temporary file in the runner, not a repository change.
+It changes precisely the two preview values
+`THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH` and
+`THEOLOGAI_ENABLE_CCEL_COORDINATOR` from `false` to `true`. Version validation
+requires the complete authorized binding set: the shared `ESV_API_KEY` secret,
+the D1/DO/rate/version metadata bindings, and exactly the declared plain-text
+variables. Production must additionally contain exactly one
+`THEOLOGAI_CCEL_OPERATOR_TOKEN` `secret_text` binding; preview must not contain
+it. No extra binding of any type is accepted. The dedicated job-only operator
+credential is never passed to Wrangler, stored in preview, written to a command
+line, or retained as evidence.
+
+## Transaction sequence
+
+1. Capture the current preview 100 predecessor and retain a short-lived,
+   private recovery anchor.
+2. Generate the 111 runner-local config and run `wrangler versions upload`.
+   The version must be exactly one new, immediately-next version and must leave
+   preview traffic unchanged.
+3. Compare the uploaded version with the predecessor. Only the two authorized
+   plain-text flags may differ; code, compatibility settings, bindings, D1,
+   Durable Object, rate namespaces, routes, and all other variables must be
+   identical. The candidate must bear the fixed message and tag.
+4. Deploy that exact candidate to **preview only** at 100%, then re-prove its
+   full 111 state.
+5. Invoke the existing `audit:ccel-preview` command once. That command itself
+   mechanically caps the operation to exactly two expanded/live attempts; it
+   also makes one separate local-only standard call. No workflow step makes a
+   direct CCEL HTTP request.
+6. The same already-approved transaction job runs its `restore` step with
+   `always()`, before any final job failure. It re-reads the live preview
+   deployment, restores only the dynamically captured predecessor, and proves
+   preview is back to exact 100. A repeated restoration detects that state and
+   performs no deployment. Even a failed audit produces a sanitized
+   identifier/hash-only transaction record after successful recovery; only then
+   does the workflow report the audit failure.
+
+The resulting public audit artifact is already sanitized by the audit program:
+it contains no query, title, snippet, text, URL, header, token, nonce, or
+client identity. The transaction script's optional summary admits only commit
+and Worker IDs, a SHA-256 of that audit file, booleans, and a fixed privacy
+label. The private predecessor anchor is retained for seven days and contains
+only preview version metadata required for exact recovery.
+
+## Failure, cancellation, and emergency recovery
+
+An ordinary command, validation, deployment, or audit failure still reaches
+the in-job `always()` recovery step before the job exits. The ordinary PR
+preview deployment, canary, and emergency recovery all hold the same
+non-cancelling repository-wide `theologai-shared-preview-mutation` concurrency
+group, so no one can observe or overwrite another's preview mutation
+mid-transaction. If a failure happens after preview deployment but before the
+staged version ID is published as a step output, recovery uses the currently
+active version only after re-proving its tagged 111 shape and equivalence
+outside the two flags. It otherwise refuses to overwrite an unexpected preview
+release.
+
+GitHub can terminate a manually cancelled workflow or unavailable runner
+without executing the remaining steps. This is an external orchestration
+limit, so the separately callable `Restore CCEL Live Preview Canary` workflow
+is reserved for an interrupted/ambiguous run. It requires explicit current and
+target UUIDs, validates their syntax before its first Wrangler command, and
+requires:
+
+```
+RESTORE THE EXACT CCEL PREVIEW PREDECESSOR
+```
+
+It verifies the currently active UUID before doing anything, validates both
+full version views, restores only the specified predecessor if the current
+version is a tagged/equivalent 111 candidate, and re-proves a sole preview 100
+deployment. If it is already restored, it is deliberately idempotent. Neither
+workflow deletes a version, route, database, deployment, secret, or artifact
+outside its normal short retention period.
+
+## Explicitly out of scope
+
+- There is no automatic trigger, no `deploy-preview` label use, and no
+  ordinary PR-preview reuse.
+- There is no actual workflow dispatch, Cloudflare mutation, direct CCEL call,
+  secret creation/promotion, production deployment, or production config
+  change in this source change.
+- A successful canary is an authorization-gated operational observation; it
+  does not authorize a broader CCEL release or change the default 000/100
+  state.

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -35,34 +35,63 @@ The only way to create the third row is the main-only, manually dispatched
    `ccel-canary` environment. It must contain only these dedicated names:
    `CCEL_CANARY_CREDENTIALS_CONFIGURED` (with the exact sentinel value
    `CCEL_CANARY_CREDENTIALS_CONFIGURED`),
+   `CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK` (with the exact value
+   `I ACCEPT ACCOUNT-WIDE WORKERS SCRIPT WRITE FOR THIS CCEL CANARY TRANSACTION`),
    `CCEL_CANARY_CLOUDFLARE_API_TOKEN`, and `CCEL_CANARY_OPERATOR_TOKEN`.
    The workflow fails before any Wrangler command if any is absent or malformed.
    It never falls back to the `production` or ordinary `preview` environment
    credentials.
 
 The dedicated Cloudflare token is an external configuration prerequisite, not
-a security boundary this repository can prove. Before enabling the environment,
-an administrator must verify in Cloudflare that this distinct token permits the
-read operations needed on the production Worker (deployment/version views and
-the protected audit snapshot) and the read/write version operations needed on
-the preview Worker, with no D1 deletion, secret mutation, route mutation, or
-production deployment permission. Cloudflare's available resource-scoping
-granularity is authoritative; GitHub environment selection merely controls
-secret availability and cannot attest the token's effective permissions. If
-that least-privilege scope cannot be configured, do not set the sentinel and
-do not run the canary workflow.
+a Worker-level security boundary. Cloudflare documents Workers Scripts
+Read/Write as [account permissions](https://developers.cloudflare.com/fundamentals/api/reference/permissions/),
+and API-token resource policies support
+[User, Account, and Zone resources](https://developers.cloudflare.com/fundamentals/api/how-to/create-via-api/),
+not an individual Worker script. Consequently, a token that can upload and
+deploy a preview Worker version in the same Cloudflare account also has
+Cloudflare-authorized Workers Script Write scope across that selected account.
+It cannot be Cloudflare-enforced as preview-write/production-read-only.
+
+The exact acknowledgment above is deliberately separate from the generic
+credentials sentinel. It records the owner's acceptance of that account-wide
+scope for this bounded transaction; this source change does not set it. The
+repository workflow then supplies narrower procedural controls: every mutation
+command includes `--env preview`, production is read only, exact version and
+binding guards run before the first preview mutation, and no command mutates a
+secret, route, D1 database, or production deployment. Those are repository
+constraints, not Cloudflare credential isolation. A preview Worker in a
+separate Cloudflare account, using a token selected only for that account, is
+the only route to hard credential isolation between preview and production.
 
 The workflow renders a temporary file in the runner, not a repository change.
 It changes precisely the two preview values
 `THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH` and
 `THEOLOGAI_ENABLE_CCEL_COORDINATOR` from `false` to `true`. Version validation
-requires the complete authorized binding set: the shared `ESV_API_KEY` secret,
-the D1/DO/rate/version metadata bindings, and exactly the declared plain-text
-variables. Production must additionally contain exactly one
-`THEOLOGAI_CCEL_OPERATOR_TOKEN` `secret_text` binding; preview must not contain
-it. No extra binding of any type is accepted. The dedicated job-only operator
-credential is never passed to Wrangler, stored in preview, written to a command
-line, or retained as evidence.
+requires the complete authorized binding set: the D1/DO/rate/version metadata
+bindings, exactly the declared plain-text variables, and an exact secret-name
+allowlist. The sanitized read-only inventory captured on 2026-07-29 observed:
+
+| Surface | Worker version | Exact `secret_text` binding names |
+| --- | --- | --- |
+| Production 000 | `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` | `AUTH_TOKEN`, `ESV_API_KEY`, `SBC_FACILITATOR_API_KEY` |
+| Preview 100 | `06b9a603-8339-42b6-a246-ef9238563043` | `ESV_API_KEY` |
+
+`AUTH_TOKEN` and `SBC_FACILITATOR_API_KEY` are absent from current tracked
+source and Worker configuration. This transaction therefore preserves them as
+exact production-only legacy compatibility binding names and types; it makes
+no claim about their values, consumers, or purpose. Preview and the canary
+reject both names, the operator token, and every other extra binding.
+
+The observed production inventory is valid as a 000 control inventory but is
+not canary-ready because it lacks
+`THEOLOGAI_CCEL_OPERATOR_TOKEN`. Before any preview upload, production must
+separately have been staged and promoted to the exact same allowlist plus
+exactly one correctly typed operator binding. The validator reports this as an
+explicit missing-operator prerequisite on the current state. This PR does not
+authorize or perform that staging, promotion, secret creation, or any other
+remote change. The dedicated job-only operator credential is never passed to
+Wrangler, stored in preview, written to a command line, or retained as
+evidence.
 
 ## Transaction sequence
 
@@ -126,6 +155,10 @@ version is a tagged/equivalent 111 candidate, and re-proves a sole preview 100
 deployment. If it is already restored, it is deliberately idempotent. Neither
 workflow deletes a version, route, database, deployment, secret, or artifact
 outside its normal short retention period.
+
+Because emergency restoration also performs a preview Worker deployment with
+the same same-account token, it requires the same exact account-wide Workers
+write acknowledgment before its first Wrangler command.
 
 ## Explicitly out of scope
 

--- a/docs/CCEL-OPERATOR-SECRET-PROVISIONING.md
+++ b/docs/CCEL-OPERATOR-SECRET-PROVISIONING.md
@@ -42,15 +42,28 @@ paste it into chat, save it in a repository file, or leave it in shell history.
 The workflow reads it only from a protected environment secret and pipes it to
 Wrangler over standard input with command tracing disabled.
 
-The identical value belongs in exactly two places:
+The identical value belongs in exactly three approved places:
 
 1. GitHub environment `production`, secret
-   `THEOLOGAI_CCEL_OPERATOR_TOKEN`; and
-2. Cloudflare Worker `theologai`, secret binding with the same name.
+   `THEOLOGAI_CCEL_OPERATOR_TOKEN`;
+2. GitHub environment `ccel-canary`, secret
+   `CCEL_CANARY_OPERATOR_TOKEN`; and
+3. Cloudflare Worker `theologai`, secret binding
+   `THEOLOGAI_CCEL_OPERATOR_TOKEN`.
 
 Do not provision it on `theologai-preview` or
 `theologai-ccel-coordinator`. The production route observes the shared
 coordinator Durable Object without modifying its owner Worker.
+
+The two GitHub copies and the Cloudflare binding do not synchronize
+automatically. An authorized rotation must replace all three with the same new
+value before the canary is run again; rotating only one copy intentionally
+causes authentication or equality checks to fail closed. Each copy also has an
+independent custody and deletion boundary. Removing
+`CCEL_CANARY_OPERATOR_TOKEN` only disables the canary's authenticated audit; it
+does not revoke the production Worker credential. Full revocation must address
+all three copies, with separately authorized deletion for each storage
+location.
 
 ## Cloudflare credential boundary
 
@@ -66,8 +79,9 @@ needed. Cloudflare API tokens are account-resource scoped rather than
 single-Worker scoped for these operations, so `wrangler.release.toml`, the
 literal `--name theologai`, exact account-ID equality, and postcondition checks
 provide the additional script boundary. Keep `CLOUDFLARE_API_TOKEN`,
-`CLOUDFLARE_ACCOUNT_ID`, and the operator token only in the protected GitHub
-environment. Rotate the Cloudflare token independently if exposure is
+`CLOUDFLARE_ACCOUNT_ID` only in the protected `production` GitHub environment,
+and keep the operator token only in the two exact protected GitHub locations
+listed above. Rotate the Cloudflare token independently if exposure is
 suspected.
 
 ## Why staging and promotion are separate
@@ -170,15 +184,15 @@ require the changed-secret force path when moving to the older secretless
 version; `--yes` is safe here only because the tested preflight proved the sole
 changed secret is `THEOLOGAI_CCEL_OPERATOR_TOKEN`. The `if: always()` verifier
 requires the exact baseline at 100% and the exact baseline secret-name set with
-the operator token absent. The GitHub copy remains until separately approved
+the operator token absent. Both GitHub copies remain until separately approved
 for deletion.
 
 A planned forward revocation is distinct from rollback: stage
 `wrangler versions secret delete THEOLOGAI_CCEL_OPERATOR_TOKEN`, independently
 review the resulting secretless version, and promote that exact version. This
 repository intentionally provides no deletion workflow. Running the command or
-removing either stored copy requires separate deletion authorization; none is
-granted by staging, promotion, rollback, or generic approval. Never use plain
+removing any of the three stored copies requires separate deletion authorization;
+none is granted by staging, promotion, rollback, or generic approval. Never use plain
 `wrangler secret delete`, which deploys immediately.
 
 No procedure here deletes or replaces D1, the shared Durable Object, the

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "test:e2e": "npm run build && npm run test:e2e:compiled",
     "test:e2e:compiled": "tsx scripts/test-node-http-e2e.ts",
     "test:coverage": "vitest run --coverage",
-    "test:ccel": "vitest run test/unit/adapters/commentary/CcelSearchAdapter.test.ts test/unit/services/historical/CcelUpstreamCoordinator.test.ts test/unit/presenters/primarySourceSearchV4Structured.test.ts test/unit/http/worker/ccelOperator.test.ts test/unit/scripts/ccelCoordinatorOperator.test.ts",
+    "test:ccel": "vitest run test/unit/adapters/commentary/CcelSearchAdapter.test.ts test/unit/services/historical/CcelUpstreamCoordinator.test.ts test/unit/presenters/primarySourceSearchV4Structured.test.ts test/unit/http/worker/ccelOperator.test.ts test/unit/scripts/ccelCoordinatorOperator.test.ts test/unit/scripts/ccelLivePreviewCanary.test.ts",
     "test:netbible": "tsx test/adapters/netbible-test.ts",
     "test:bibleapi": "tsx test/adapters/bibleapi-test.ts",
     "test:commentary": "tsx test/integration/public-commentary-test.ts",

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -1,0 +1,508 @@
+/**
+ * Fail-closed checks for the manually authorized, temporary CCEL preview canary.
+ *
+ * This program never calls Cloudflare.  Workflows supply JSON emitted by Wrangler
+ * and use its outputs only after every exact-state check has succeeded.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parse as parseToml } from 'smol-toml';
+
+export const CANARY_CONFIRMATION = 'I AUTHORIZE THE TEMPORARY CCEL LIVE PREVIEW CANARY';
+export const CANARY_MESSAGE = 'Temporary preview-only CCEL live canary; always restore exact predecessor';
+export const CANARY_TAG = 'ccel-live-preview-canary';
+export const OPERATOR_TOKEN = 'THEOLOGAI_CCEL_OPERATOR_TOKEN';
+
+const PRODUCTION = {
+  worker: 'theologai', route: 'mcp.theologai.xyz', d1: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+  requestNamespace: '361201', operatorNamespace: '361203', version: '3.6.0',
+  discovery: 'false', live: 'false', coordinator: 'false', logs: 'false',
+};
+const PREVIEW = {
+  worker: 'theologai-preview', route: 'preview-mcp.theologai.xyz', d1: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+  requestNamespace: '361202', operatorNamespace: '361204', version: '3.6.0-preview',
+  discovery: 'true', live: 'false', coordinator: 'false', logs: 'true',
+};
+const COMPATIBILITY_DATE = '2026-07-09';
+const COMPATIBILITY_FLAGS = ['nodejs_compat'];
+const DO = { name: 'THEOLOGAI_CCEL_COORDINATOR', type: 'durable_object_namespace', class_name: 'CcelGlobalCoordinator', script_name: 'theologai-ccel-coordinator' };
+
+type JsonRecord = Record<string, unknown>;
+type VersionSummary = { id: string; number: number; metadata: { created_on: string }; annotations?: Record<string, string> };
+type FullVersion = VersionSummary & { resources: JsonRecord & { bindings: JsonRecord[] } };
+type Deployment = { id: string; created_on: string; versions: Array<{ version_id: string; percentage: number }> };
+type Mode = '100' | '111' | '000';
+
+export interface DispatchInput {
+  ref: string;
+  sha: string;
+  expectedSha: string;
+  liveMainSha: string;
+  confirmation: string;
+  configText: string;
+}
+
+export interface CanaryInputs {
+  previewPredecessor: string;
+  productionControl: string;
+}
+
+/** The workflow must be manually dispatched from the current main commit. */
+export function validateCanaryDispatch(input: DispatchInput): void {
+  refuse(input.ref === 'refs/heads/main', 'dispatch must use refs/heads/main');
+  refuse(isSha(input.sha) && input.sha === input.expectedSha, 'expected main SHA must equal the dispatched SHA');
+  refuse(isSha(input.liveMainSha) && input.liveMainSha === input.sha, 'dispatched SHA must still be the live main SHA');
+  refuse(input.confirmation === CANARY_CONFIRMATION, 'confirmation must match exactly');
+  assertCommittedConfig(input.configText);
+}
+
+/** Reject all user-supplied Worker IDs before a workflow calls Wrangler. */
+export function validateCanaryInputs(input: CanaryInputs): void {
+  refuse(isUuid(input.previewPredecessor), 'preview predecessor must be an exact UUID');
+  refuse(isUuid(input.productionControl), 'production control must be an exact UUID');
+  refuse(input.previewPredecessor !== input.productionControl, 'preview predecessor and production control must differ');
+}
+
+/** The dedicated environment must be explicitly provisioned outside this repo. */
+export function validateCanaryCredentials(marker: unknown, cloudflareToken: unknown, operatorToken: unknown): void {
+  refuse(marker === 'CCEL_CANARY_CREDENTIALS_CONFIGURED', 'dedicated ccel-canary credentials are not provisioned');
+  refuse(typeof cloudflareToken === 'string' && cloudflareToken.length > 0, 'dedicated Cloudflare token is absent');
+  refuse(typeof operatorToken === 'string' && operatorToken.length === 43 && /^[A-Za-z0-9_-]{43}$/.test(operatorToken),
+    'dedicated operator token is absent or malformed');
+}
+
+export function validateEmergencyCredentials(marker: unknown, cloudflareToken: unknown): void {
+  refuse(marker === 'CCEL_CANARY_CREDENTIALS_CONFIGURED', 'dedicated ccel-canary credentials are not provisioned');
+  refuse(typeof cloudflareToken === 'string' && cloudflareToken.length > 0, 'dedicated Cloudflare token is absent');
+}
+
+/** Emergency recovery receives no production ID, but it still validates both inputs before Wrangler. */
+export function validateEmergencyInputs(ref: string, current: string, target: string, confirmation: string, configText: string): void {
+  refuse(ref === 'refs/heads/main', 'emergency restore must use refs/heads/main');
+  refuse(confirmation === 'RESTORE THE EXACT CCEL PREVIEW PREDECESSOR', 'emergency confirmation must match exactly');
+  refuse(isUuid(current) && isUuid(target), 'emergency restore IDs must be exact UUIDs');
+  assertCommittedConfig(configText);
+}
+
+/**
+ * Produces a throwaway config with only preview live/coordinator flags changed.
+ * It is deliberately an output file, never a tracked configuration edit.
+ */
+export function renderCanaryPreviewConfig(configText: string): string {
+  assertCommittedConfig(configText);
+  const start = configText.indexOf('[env.preview.vars]');
+  const end = configText.indexOf('\n[', start + 1);
+  refuse(start >= 0 && end > start, 'preview vars section is missing or ambiguous');
+  const before = configText.slice(0, start);
+  const section = configText.slice(start, end);
+  const after = configText.slice(end);
+  const changed = section
+    .replace('THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH = "false"', 'THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH = "true"')
+    .replace('THEOLOGAI_ENABLE_CCEL_COORDINATOR = "false"', 'THEOLOGAI_ENABLE_CCEL_COORDINATOR = "true"');
+  refuse(changed !== section, 'canary flags were not found exactly once');
+  const rendered = `${before}${changed}${after}`;
+  assertCanaryConfig(rendered);
+  return rendered;
+}
+
+/** Check that the deployed preview predecessor is an exact 100 baseline. */
+export function validatePreviewBaseline(
+  configText: string, deploymentsValue: unknown, versionValue: unknown, expectedVersion: string,
+): FullVersion {
+  assertCommittedConfig(configText);
+  refuse(isUuid(expectedVersion), 'expected preview predecessor must be an exact UUID');
+  const version = parseFullVersion(versionValue);
+  refuse(version.id === expectedVersion, 'preview predecessor view identity mismatch');
+  refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedVersion, 'preview predecessor is not the sole 100% deployment');
+  assertVersion(version, '100');
+  return version;
+}
+
+/** Production is read-only control evidence and must remain v6 / flags 000. */
+export function validateProductionControl(
+  configText: string, deploymentsValue: unknown, versionValue: unknown, expectedVersion: string,
+): FullVersion {
+  assertCommittedConfig(configText);
+  refuse(isUuid(expectedVersion), 'expected production control must be an exact UUID');
+  const version = parseFullVersion(versionValue);
+  refuse(version.id === expectedVersion, 'production control view identity mismatch');
+  refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedVersion, 'production control is not the sole 100% deployment');
+  assertVersion(version, '000');
+  return version;
+}
+
+/** Uploading must add exactly one undeployed immediately-next version. */
+export function identifyCanaryUpload(
+  beforeVersionsValue: unknown, afterVersionsValue: unknown,
+  beforeDeploymentsValue: unknown, afterDeploymentsValue: unknown, expectedBaseline: string,
+): string {
+  const before = parseVersionSummaries(beforeVersionsValue);
+  const after = parseVersionSummaries(afterVersionsValue);
+  const beforeDeployments = parseDeployments(beforeDeploymentsValue);
+  const afterDeployments = parseDeployments(afterDeploymentsValue);
+  refuse(newest(before).id === expectedBaseline, 'pre-upload latest preview version drifted');
+  refuse(activeVersion(beforeDeployments) === expectedBaseline, 'pre-upload active preview version drifted');
+  refuse(stableJson(beforeDeployments) === stableJson(afterDeployments), 'upload changed a deployment or traffic allocation');
+  const beforeIds = new Set(before.map(item => item.id));
+  const added = after.filter(item => !beforeIds.has(item.id));
+  refuse(added.length === 1, 'upload must create exactly one version');
+  const canary = added[0]!;
+  refuse(canary.id !== expectedBaseline && newest(after).id === canary.id, 'canary must be the newest version');
+  refuse(canary.number === newest(before).number + 1, 'canary version number must immediately follow predecessor');
+  return canary.id;
+}
+
+/** The uploaded candidate may differ from the predecessor in exactly two flags. */
+export function validateCanaryVersion(
+  configText: string, baselineValue: unknown, canaryValue: unknown, expectedBaseline: string, expectedCanary: string,
+): void {
+  assertCommittedConfig(configText);
+  const baseline = parseFullVersion(baselineValue);
+  const canary = parseFullVersion(canaryValue);
+  refuse(baseline.id === expectedBaseline && canary.id === expectedCanary, 'canary version identity mismatch');
+  refuse(isUuid(expectedBaseline) && isUuid(expectedCanary) && expectedBaseline !== expectedCanary, 'canary and predecessor IDs must be distinct UUIDs');
+  refuse(canary.number > baseline.number, 'canary version sequence is invalid');
+  assertVersion(baseline, '100');
+  assertVersion(canary, '111');
+  refuse(canary.annotations?.['workers/message'] === CANARY_MESSAGE, 'canary version message mismatch');
+  refuse(canary.annotations?.['workers/tag'] === CANARY_TAG, 'canary version tag mismatch');
+  refuse(stableJson(resourcesWithoutCanaryFlags(baseline)) === stableJson(resourcesWithoutCanaryFlags(canary)),
+    'canary changed code, compatibility, a binding, or an unrelated variable');
+}
+
+export function validateCanaryDeployment(
+  configText: string, deploymentsValue: unknown, canaryValue: unknown, expectedCanary: string,
+): void {
+  assertCommittedConfig(configText);
+  const canary = parseFullVersion(canaryValue);
+  refuse(canary.id === expectedCanary && isUuid(expectedCanary), 'canary deployment identity is invalid');
+  refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedCanary, 'canary is not the sole 100% preview deployment');
+  assertVersion(canary, '111');
+}
+
+/**
+ * Refuse to overwrite any unexpected deployment.  Returning `already` proves
+ * that repeated recovery calls are harmless; returning `deploy` authorizes one
+ * `wrangler versions deploy <target>@100 --env preview` command.
+ */
+export function planRestore(
+  configText: string, deploymentsValue: unknown, currentValue: unknown, targetValue: unknown,
+  expectedCurrent: string, expectedTarget: string,
+): 'already' | 'deploy' {
+  assertCommittedConfig(configText);
+  refuse(isUuid(expectedCurrent) && isUuid(expectedTarget), 'restore IDs must be exact UUIDs');
+  const current = parseFullVersion(currentValue);
+  const target = parseFullVersion(targetValue);
+  refuse(target.id === expectedTarget, 'restore target view identity mismatch');
+  const active = activeVersion(parseDeployments(deploymentsValue));
+  assertVersion(target, '100');
+  if (active === expectedTarget) {
+    refuse(expectedCurrent === expectedTarget && current.id === expectedTarget, 'active baseline view identity mismatch');
+    assertVersion(current, '100');
+    return 'already';
+  }
+  refuse(expectedCurrent !== expectedTarget, 'restore candidate and target IDs must differ');
+  refuse(active === expectedCurrent && current.id === expectedCurrent, 'active preview version is not the authorized canary');
+  assertVersion(current, '111');
+  refuse(current.annotations?.['workers/tag'] === CANARY_TAG, 'active preview version is not the tagged canary');
+  refuse(stableJson(resourcesWithoutCanaryFlags(target)) === stableJson(resourcesWithoutCanaryFlags(current)),
+    'restore would overwrite a preview change beyond the two canary flags');
+  return 'deploy';
+}
+
+export function validateRestoreResult(
+  configText: string, deploymentsValue: unknown, targetValue: unknown, expectedTarget: string,
+): void {
+  assertCommittedConfig(configText);
+  const target = parseFullVersion(targetValue);
+  refuse(target.id === expectedTarget && isUuid(expectedTarget), 'restore target identity is invalid');
+  refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedTarget, 'exact preview predecessor was not restored to 100%');
+  assertVersion(target, '100');
+}
+
+/** Sanitized evidence deliberately permits only identifiers, booleans and hashes. */
+export function sanitizedCanaryEvidence(input: {
+  commit: string; predecessor: string; canary: string; productionControl: string; auditSha256: string;
+  auditOutcome: 'success' | 'failure'; restored: boolean;
+}): Record<string, string | boolean> {
+  refuse(isSha(input.commit), 'evidence commit must be a full SHA');
+  for (const [name, value] of Object.entries({ predecessor: input.predecessor, canary: input.canary, productionControl: input.productionControl })) {
+    refuse(isUuid(value), `evidence ${name} must be an exact UUID`);
+  }
+  refuse(input.predecessor !== input.canary, 'evidence predecessor and canary must differ');
+  refuse(/^[a-f0-9]{64}$/.test(input.auditSha256), 'evidence audit hash must be lowercase SHA-256');
+  return {
+    schemaVersion: '1', commit: input.commit, predecessorVersionId: input.predecessor,
+    canaryVersionId: input.canary, productionControlVersionId: input.productionControl,
+    auditOutcome: input.auditOutcome, auditSha256: input.auditSha256, restored: input.restored,
+    privacy: 'identifiers_hashes_and_booleans_only',
+  };
+}
+
+export function assertCommittedConfig(configText: string): void {
+  refuse(!configText.includes(OPERATOR_TOKEN), 'operator token must never be stored in Wrangler config');
+  const root = parseConfig(configText);
+  assertEnvironment(root, PRODUCTION, '000');
+  const preview = recordAt(recordAt(root, 'env'), 'preview');
+  assertEnvironment(preview, PREVIEW, '100');
+  refuse(PREVIEW.d1 !== PRODUCTION.d1, 'preview and production D1 identities must differ');
+  refuse(PREVIEW.requestNamespace !== PRODUCTION.requestNamespace && PREVIEW.operatorNamespace !== PRODUCTION.operatorNamespace,
+    'preview and production rate-limit namespaces must differ');
+}
+
+export function assertCanaryConfig(configText: string): void {
+  refuse(!configText.includes(OPERATOR_TOKEN), 'operator token must never be stored in canary config');
+  const root = parseConfig(configText);
+  assertEnvironment(root, PRODUCTION, '000');
+  const preview = recordAt(recordAt(root, 'env'), 'preview');
+  assertEnvironment(preview, { ...PREVIEW, live: 'true', coordinator: 'true' }, '111');
+}
+
+function assertEnvironment(config: JsonRecord, expected: typeof PREVIEW, mode: Mode): void {
+  refuse(config.name === expected.worker, `${expected.worker} Worker name mismatch`);
+  const inheritedMain = expected.worker === PRODUCTION.worker;
+  if (inheritedMain) {
+    refuse(config.main === 'src/worker.ts' && config.compatibility_date === COMPATIBILITY_DATE
+      && stableJson(config.compatibility_flags) === stableJson(COMPATIBILITY_FLAGS), 'production compatibility settings mismatch');
+  }
+  const routes = arrayAt(config, 'routes').map((entry, index) => asRecord(entry, `route ${index}`));
+  refuse(routes.length === 1 && routes[0]?.pattern === expected.route && routes[0]?.custom_domain === true,
+    `${expected.worker} canonical custom-domain route mismatch`);
+  const metadata = recordAt(config, 'version_metadata');
+  exactKeys(metadata, ['binding'], `${expected.worker} version metadata`);
+  refuse(metadata.binding === 'CF_VERSION_METADATA', `${expected.worker} version metadata binding mismatch`);
+  const vars = recordAt(config, 'vars');
+  const expectedVars: Record<string, string> = {
+    THEOLOGAI_VERSION: expected.version,
+    THEOLOGAI_ALLOWED_ORIGINS: 'https://theologai.xyz,https://theologai.pages.dev',
+    THEOLOGAI_MAX_REQUEST_BYTES: '1048576',
+    THEOLOGAI_REQUEST_LOGS: expected.logs,
+    THEOLOGAI_EXPOSE_CCEL_DISCOVERY: expected.discovery,
+    THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH: expected.live,
+    THEOLOGAI_ENABLE_CCEL_COORDINATOR: expected.coordinator,
+  };
+  exactKeys(vars, Object.keys(expectedVars), `${expected.worker} vars`);
+  for (const [key, value] of Object.entries(expectedVars)) refuse(vars[key] === value, `${expected.worker} ${key} mismatch`);
+  const d1 = only(arrayAt(config, 'd1_databases').map((entry, index) => asRecord(entry, `D1 ${index}`)), `${expected.worker} D1 binding`);
+  exactKeys(d1, ['binding', 'database_name', 'database_id', 'migrations_dir'], `${expected.worker} D1 binding`);
+  refuse(d1.binding === 'THEOLOGAI_DB' && d1.database_id === expected.d1 && d1.migrations_dir === 'migrations', `${expected.worker} D1 binding mismatch`);
+  const durable = only(arrayAt(recordAt(config, 'durable_objects'), 'bindings').map((entry, index) => asRecord(entry, `DO ${index}`)), `${expected.worker} DO binding`);
+  exactKeys(durable, ['name', 'class_name', 'script_name'], `${expected.worker} DO binding`);
+  for (const [key, value] of Object.entries({ name: DO.name, class_name: DO.class_name, script_name: DO.script_name })) {
+    refuse(durable[key] === value, `${expected.worker} DO binding mismatch`);
+  }
+  const limits = arrayAt(config, 'ratelimits').map((entry, index) => asRecord(entry, `rate limit ${index}`));
+  refuse(limits.length === 2, `${expected.worker} must define exactly two rate-limit bindings`);
+  assertConfigRate(limits, 'THEOLOGAI_RATE_LIMITER', expected.requestNamespace, 120);
+  assertConfigRate(limits, 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', expected.operatorNamespace, 12);
+  uniqueNames([{ name: d1.binding }, durable, ...limits, { name: metadata.binding }], `${expected.worker} critical bindings`);
+  if (mode === '000') refuse(expected.live === 'false' && expected.coordinator === 'false' && expected.discovery === 'false', 'production flags must remain 000');
+}
+
+function assertVersion(version: FullVersion, mode: Mode): void {
+  const runtime = recordAt(version.resources, 'script_runtime');
+  refuse(runtime.compatibility_date === COMPATIBILITY_DATE && stableJson(runtime.compatibility_flags) === stableJson(COMPATIBILITY_FLAGS),
+    'version compatibility settings mismatch');
+  const bindings = version.resources.bindings;
+  if (mode === '000') {
+    const operatorSecrets = bindings.filter(binding => binding.name === OPERATOR_TOKEN);
+    refuse(operatorSecrets.length === 1 && operatorSecrets[0]?.type === 'secret_text',
+      'production version must contain exactly one operator secret_text binding');
+  }
+  uniqueNames(bindings, 'version bindings');
+  const expectedNames = new Set([
+    'THEOLOGAI_DB', DO.name, 'THEOLOGAI_RATE_LIMITER', 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', 'CF_VERSION_METADATA',
+    'THEOLOGAI_VERSION', 'THEOLOGAI_ALLOWED_ORIGINS', 'THEOLOGAI_MAX_REQUEST_BYTES', 'THEOLOGAI_REQUEST_LOGS',
+    'THEOLOGAI_EXPOSE_CCEL_DISCOVERY', 'THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH', 'THEOLOGAI_ENABLE_CCEL_COORDINATOR',
+    'ESV_API_KEY',
+    ...(mode === '000' ? [OPERATOR_TOKEN] : []),
+  ]);
+  refuse(bindings.length === expectedNames.size && bindings.every(binding => expectedNames.has(String(binding.name))),
+    'version bindings must be the exact authorized set');
+  const values = mode === '000' ? PRODUCTION : PREVIEW;
+  assertVersionBinding(bindings, 'THEOLOGAI_DB', 'd1', { id: values.d1 });
+  assertVersionBinding(bindings, DO.name, DO.type, { class_name: DO.class_name, script_name: DO.script_name });
+  assertVersionRate(bindings, 'THEOLOGAI_RATE_LIMITER', values.requestNamespace, 120);
+  assertVersionRate(bindings, 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', values.operatorNamespace, 12);
+  assertVersionBinding(bindings, 'CF_VERSION_METADATA', 'version_metadata', {});
+  assertVersionBinding(bindings, 'ESV_API_KEY', 'secret_text', {});
+  if (mode === '000') assertVersionBinding(bindings, OPERATOR_TOKEN, 'secret_text', {});
+  const flags = mode === '111' ? { discovery: 'true', live: 'true', coordinator: 'true' } : values;
+  const expected: Record<string, string> = {
+    THEOLOGAI_VERSION: values.version,
+    THEOLOGAI_ALLOWED_ORIGINS: 'https://theologai.xyz,https://theologai.pages.dev',
+    THEOLOGAI_MAX_REQUEST_BYTES: '1048576', THEOLOGAI_REQUEST_LOGS: values.logs,
+    THEOLOGAI_EXPOSE_CCEL_DISCOVERY: flags.discovery,
+    THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH: flags.live,
+    THEOLOGAI_ENABLE_CCEL_COORDINATOR: flags.coordinator,
+  };
+  for (const [name, text] of Object.entries(expected)) assertVersionBinding(bindings, name, 'plain_text', { text });
+}
+
+function assertConfigRate(bindings: JsonRecord[], name: string, namespace: string, limit: number): void {
+  const value = one(bindings.filter(item => item.name === name), `${name} config binding`);
+  exactKeys(value, ['name', 'namespace_id', 'simple'], `${name} config binding`);
+  const simple = recordAt(value, 'simple');
+  exactKeys(simple, ['limit', 'period'], `${name} simple policy`);
+  refuse(value.namespace_id === namespace && simple.limit === limit && simple.period === 60, `${name} config policy mismatch`);
+}
+
+function assertVersionRate(bindings: JsonRecord[], name: string, namespace: string, limit: number): void {
+  const value = one(bindings.filter(item => item.name === name), `${name} version binding`);
+  exactKeys(value, ['name', 'type', 'namespace_id', 'simple'], `${name} version binding`);
+  const simple = recordAt(value, 'simple');
+  exactKeys(simple, ['limit', 'period'], `${name} version simple policy`);
+  refuse(value.type === 'ratelimit' && value.namespace_id === namespace && simple.limit === limit && simple.period === 60,
+    `${name} version policy mismatch`);
+}
+
+function assertVersionBinding(bindings: JsonRecord[], name: string, type: string, fields: JsonRecord): void {
+  const value = one(bindings.filter(item => item.name === name), `${name} version binding`);
+  exactKeys(value, ['name', 'type', ...Object.keys(fields)], `${name} version binding`);
+  refuse(value.type === type, `${name} version binding type mismatch`);
+  for (const [key, expected] of Object.entries(fields)) refuse(value[key] === expected, `${name} version binding mismatch`);
+}
+
+function resourcesWithoutCanaryFlags(version: FullVersion): JsonRecord {
+  return {
+    ...version.resources,
+    bindings: version.resources.bindings
+      .filter(binding => !['THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH', 'THEOLOGAI_ENABLE_CCEL_COORDINATOR'].includes(String(binding.name)))
+      .sort((left, right) => String(left.name).localeCompare(String(right.name))),
+  };
+}
+
+function parseVersionSummaries(value: unknown): VersionSummary[] {
+  refuse(Array.isArray(value) && value.length > 0, 'version summaries must be a nonempty array');
+  const result = value.map((entry, index) => parseVersionSummary(entry, `version summary ${index}`));
+  refuse(new Set(result.map(item => item.id)).size === result.length && new Set(result.map(item => item.number)).size === result.length,
+    'version identities and numbers must be unique');
+  return result;
+}
+
+function parseVersionSummary(value: unknown, label: string): VersionSummary {
+  const item = asRecord(value, label); const metadata = recordAt(item, 'metadata');
+  refuse(isUuid(item.id) && Number.isSafeInteger(item.number) && Number(item.number) > 0, `${label} is invalid`);
+  refuse(typeof metadata.created_on === 'string' && Number.isFinite(Date.parse(metadata.created_on)), `${label} timestamp is invalid`);
+  if (item.annotations !== undefined) asRecord(item.annotations, `${label} annotations`);
+  return item as unknown as VersionSummary;
+}
+
+function parseFullVersion(value: unknown): FullVersion {
+  const summary = parseVersionSummary(value, 'full version view');
+  const item = asRecord(value, 'full version view'); const resources = recordAt(item, 'resources');
+  const bindings = arrayAt(resources, 'bindings').map((entry, index) => asRecord(entry, `version binding ${index}`));
+  return { ...(summary as FullVersion), resources: { ...resources, bindings } };
+}
+
+function parseDeployments(value: unknown): Deployment[] {
+  refuse(Array.isArray(value) && value.length > 0, 'deployment list must be nonempty');
+  return value.map((entry, index) => {
+    const item = asRecord(entry, `deployment ${index}`); const versions = arrayAt(item, 'versions').map((nested, nestedIndex) => asRecord(nested, `deployment ${index} version ${nestedIndex}`));
+    refuse(isUuid(item.id) && typeof item.created_on === 'string' && Number.isFinite(Date.parse(item.created_on)) && versions.length > 0,
+      `deployment ${index} is invalid`);
+    for (const version of versions) refuse(isUuid(version.version_id) && typeof version.percentage === 'number', `deployment ${index} traffic is invalid`);
+    return { id: item.id as string, created_on: item.created_on as string, versions: versions as Array<{ version_id: string; percentage: number }> };
+  });
+}
+
+function activeVersion(deployments: Deployment[]): string {
+  const latest = [...deployments].sort((left, right) => left.created_on.localeCompare(right.created_on)).at(-1)!;
+  refuse(latest.versions.length === 1 && latest.versions[0]?.percentage === 100, 'latest deployment must contain one 100% version');
+  return latest.versions[0]!.version_id;
+}
+
+function newest(versions: VersionSummary[]): VersionSummary { return [...versions].sort((a, b) => a.number - b.number).at(-1)!; }
+function parseConfig(text: string): JsonRecord {
+  try { return asRecord(parseToml(text), 'Worker config'); }
+  catch (error) { throw new Error(`CCEL canary refused: Worker config is not valid TOML (${error instanceof Error ? error.message : 'unknown parser error'}).`); }
+}
+function asRecord(value: unknown, label: string): JsonRecord { refuse(isRecord(value), `${label} must be an object`); return value; }
+function recordAt(value: JsonRecord, key: string): JsonRecord { return asRecord(value[key], key); }
+function arrayAt(value: JsonRecord, key: string): unknown[] { const result = value[key]; refuse(Array.isArray(result), `${key} must be an array`); return result; }
+function one<T>(values: T[], label: string): T { refuse(values.length === 1, `${label} must be unique`); return values[0]!; }
+function only<T>(values: T[], label: string): T { return one(values, label); }
+function uniqueNames(values: JsonRecord[], label: string): void {
+  const names = values.map(value => value.name); refuse(names.every(name => typeof name === 'string') && new Set(names).size === names.length, `${label} names must be unique strings`);
+}
+function exactKeys(value: JsonRecord, keys: string[], label: string): void { refuse(Object.keys(value).sort().join(',') === [...keys].sort().join(','), `${label} must contain exactly authorized keys`); }
+function isRecord(value: unknown): value is JsonRecord { return typeof value === 'object' && value !== null && !Array.isArray(value); }
+function isUuid(value: unknown): value is string { return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value); }
+function isSha(value: unknown): value is string { return typeof value === 'string' && /^[0-9a-f]{40}$/.test(value); }
+function stableJson(value: unknown): string { return JSON.stringify(value, (_, nested) => isRecord(nested) ? Object.fromEntries(Object.entries(nested).sort(([a], [b]) => a.localeCompare(b))) : nested); }
+function refuse(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(`CCEL canary refused: ${message}.`); }
+
+function parseCli(argv: string[]): { command: string; args: Map<string, string> } {
+  const command = argv[0]; refuse(typeof command === 'string' && !command.startsWith('--'), 'command is missing');
+  const args = new Map<string, string>();
+  for (let index = 1; index < argv.length; index += 2) {
+    const key = argv[index]; const value = argv[index + 1];
+    refuse(key?.startsWith('--') && value !== undefined && !args.has(key), 'arguments are invalid or duplicated'); args.set(key, value);
+  }
+  return { command, args };
+}
+function exactArgs(args: Map<string, string>, keys: string[]): void { refuse(args.size === keys.length && [...args.keys()].every(key => keys.includes(key)), 'unexpected or missing argument'); }
+function required(args: Map<string, string>, key: string): string { const value = args.get(key); refuse(value !== undefined, `${key} is required`); return value; }
+function jsonFile(args: Map<string, string>, key: string): unknown { return JSON.parse(readFileSync(required(args, key), 'utf8')) as unknown; }
+function textFile(args: Map<string, string>, key: string): string { return readFileSync(required(args, key), 'utf8'); }
+
+export function runCli(argv: string[]): void {
+  const { command, args } = parseCli(argv);
+  if (command === 'validate-canary-inputs') {
+    exactArgs(args, ['--preview-predecessor', '--production-control']);
+    validateCanaryInputs({ previewPredecessor: required(args, '--preview-predecessor'), productionControl: required(args, '--production-control') }); return;
+  }
+  if (command === 'validate-canary-credentials') {
+    exactArgs(args, []);
+    validateCanaryCredentials(process.env.CCEL_CANARY_CREDENTIALS_CONFIGURED, process.env.CLOUDFLARE_API_TOKEN, process.env[OPERATOR_TOKEN]); return;
+  }
+  if (command === 'validate-emergency-credentials') {
+    exactArgs(args, []);
+    validateEmergencyCredentials(process.env.CCEL_CANARY_CREDENTIALS_CONFIGURED, process.env.CLOUDFLARE_API_TOKEN); return;
+  }
+  if (command === 'validate-emergency-inputs') {
+    exactArgs(args, ['--ref', '--current', '--target', '--confirmation', '--config']);
+    validateEmergencyInputs(required(args, '--ref'), required(args, '--current'), required(args, '--target'), required(args, '--confirmation'), textFile(args, '--config')); return;
+  }
+  if (command === 'validate-dispatch') {
+    exactArgs(args, ['--ref', '--sha', '--expected-sha', '--live-main-sha', '--confirmation', '--config']);
+    validateCanaryDispatch({ ref: required(args, '--ref'), sha: required(args, '--sha'), expectedSha: required(args, '--expected-sha'), liveMainSha: required(args, '--live-main-sha'), confirmation: required(args, '--confirmation'), configText: textFile(args, '--config') }); return;
+  }
+  if (command === 'render-preview-config') {
+    exactArgs(args, ['--config', '--output']); writeFileSync(required(args, '--output'), renderCanaryPreviewConfig(textFile(args, '--config'))); return;
+  }
+  if (command === 'validate-preview-baseline' || command === 'validate-production-control') {
+    exactArgs(args, ['--config', '--deployments', '--version-view', '--expected-version']);
+    const values = [textFile(args, '--config'), jsonFile(args, '--deployments'), jsonFile(args, '--version-view'), required(args, '--expected-version')] as const;
+    if (command === 'validate-preview-baseline') validatePreviewBaseline(...values); else validateProductionControl(...values); return;
+  }
+  if (command === 'identify-upload') {
+    exactArgs(args, ['--before-versions', '--after-versions', '--before-deployments', '--after-deployments', '--expected-baseline']);
+    process.stdout.write(identifyCanaryUpload(jsonFile(args, '--before-versions'), jsonFile(args, '--after-versions'), jsonFile(args, '--before-deployments'), jsonFile(args, '--after-deployments'), required(args, '--expected-baseline'))); return;
+  }
+  if (command === 'validate-canary-version') {
+    exactArgs(args, ['--config', '--baseline-view', '--canary-view', '--expected-baseline', '--expected-canary']);
+    validateCanaryVersion(textFile(args, '--config'), jsonFile(args, '--baseline-view'), jsonFile(args, '--canary-view'), required(args, '--expected-baseline'), required(args, '--expected-canary')); return;
+  }
+  if (command === 'validate-canary-deployment') {
+    exactArgs(args, ['--config', '--deployments', '--version-view', '--expected-canary']);
+    validateCanaryDeployment(textFile(args, '--config'), jsonFile(args, '--deployments'), jsonFile(args, '--version-view'), required(args, '--expected-canary')); return;
+  }
+  if (command === 'restore-plan') {
+    exactArgs(args, ['--config', '--deployments', '--current-view', '--target-view', '--expected-current', '--expected-target']);
+    process.stdout.write(planRestore(textFile(args, '--config'), jsonFile(args, '--deployments'), jsonFile(args, '--current-view'), jsonFile(args, '--target-view'), required(args, '--expected-current'), required(args, '--expected-target'))); return;
+  }
+  if (command === 'validate-restore-result') {
+    exactArgs(args, ['--config', '--deployments', '--target-view', '--expected-target']);
+    validateRestoreResult(textFile(args, '--config'), jsonFile(args, '--deployments'), jsonFile(args, '--target-view'), required(args, '--expected-target')); return;
+  }
+  if (command === 'emit-evidence') {
+    exactArgs(args, ['--commit', '--predecessor', '--canary', '--production-control', '--audit-sha256', '--audit-outcome', '--restored']);
+    const restored = required(args, '--restored'); refuse(restored === 'true' || restored === 'false', 'restored must be true or false');
+    const auditOutcome = required(args, '--audit-outcome');
+    refuse(auditOutcome === 'success' || auditOutcome === 'failure', 'audit outcome must be success or failure');
+    process.stdout.write(`${JSON.stringify(sanitizedCanaryEvidence({ commit: required(args, '--commit'), predecessor: required(args, '--predecessor'), canary: required(args, '--canary'), productionControl: required(args, '--production-control'), auditSha256: required(args, '--audit-sha256'), auditOutcome, restored: restored === 'true' }))}\n`); return;
+  }
+  throw new Error(`Unknown CCEL canary command: ${command}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) runCli(process.argv.slice(2));

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -11,6 +11,10 @@ export const CANARY_CONFIRMATION = 'I AUTHORIZE THE TEMPORARY CCEL LIVE PREVIEW 
 export const CANARY_MESSAGE = 'Temporary preview-only CCEL live canary; always restore exact predecessor';
 export const CANARY_TAG = 'ccel-live-preview-canary';
 export const OPERATOR_TOKEN = 'THEOLOGAI_CCEL_OPERATOR_TOKEN';
+export const ACCOUNT_WIDE_WORKERS_WRITE_ACK =
+  'I ACCEPT ACCOUNT-WIDE WORKERS SCRIPT WRITE FOR THIS CCEL CANARY TRANSACTION';
+export const PRODUCTION_BASE_SECRET_BINDINGS =
+  ['AUTH_TOKEN', 'ESV_API_KEY', 'SBC_FACILITATOR_API_KEY'] as const;
 
 const PRODUCTION = {
   worker: 'theologai', route: 'mcp.theologai.xyz', d1: '53211f50-a893-4b4c-be1e-bc625a595dc7',
@@ -63,15 +67,21 @@ export function validateCanaryInputs(input: CanaryInputs): void {
 }
 
 /** The dedicated environment must be explicitly provisioned outside this repo. */
-export function validateCanaryCredentials(marker: unknown, cloudflareToken: unknown, operatorToken: unknown): void {
+export function validateCanaryCredentials(
+  marker: unknown, accountWideWriteAck: unknown, cloudflareToken: unknown, operatorToken: unknown,
+): void {
   refuse(marker === 'CCEL_CANARY_CREDENTIALS_CONFIGURED', 'dedicated ccel-canary credentials are not provisioned');
+  refuse(accountWideWriteAck === ACCOUNT_WIDE_WORKERS_WRITE_ACK,
+    'account-wide Workers Script Write scope has not been explicitly acknowledged for this transaction');
   refuse(typeof cloudflareToken === 'string' && cloudflareToken.length > 0, 'dedicated Cloudflare token is absent');
   refuse(typeof operatorToken === 'string' && operatorToken.length === 43 && /^[A-Za-z0-9_-]{43}$/.test(operatorToken),
     'dedicated operator token is absent or malformed');
 }
 
-export function validateEmergencyCredentials(marker: unknown, cloudflareToken: unknown): void {
+export function validateEmergencyCredentials(marker: unknown, accountWideWriteAck: unknown, cloudflareToken: unknown): void {
   refuse(marker === 'CCEL_CANARY_CREDENTIALS_CONFIGURED', 'dedicated ccel-canary credentials are not provisioned');
+  refuse(accountWideWriteAck === ACCOUNT_WIDE_WORKERS_WRITE_ACK,
+    'account-wide Workers Script Write scope has not been explicitly acknowledged for this transaction');
   refuse(typeof cloudflareToken === 'string' && cloudflareToken.length > 0, 'dedicated Cloudflare token is absent');
 }
 
@@ -126,8 +136,14 @@ export function validateProductionControl(
   const version = parseFullVersion(versionValue);
   refuse(version.id === expectedVersion, 'production control view identity mismatch');
   refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedVersion, 'production control is not the sole 100% deployment');
-  assertVersion(version, '000');
+  assertVersion(version, '000', true);
   return version;
+}
+
+/** Validate the exact sanitized production binding inventory independently of canary readiness. */
+export function validateProductionBindingInventory(versionValue: unknown): { operatorReady: boolean } {
+  const version = parseFullVersion(versionValue);
+  return { operatorReady: assertVersion(version, '000', false) };
 }
 
 /** Uploading must add exactly one undeployed immediately-next version. */
@@ -298,23 +314,21 @@ function assertEnvironment(config: JsonRecord, expected: typeof PREVIEW, mode: M
   if (mode === '000') refuse(expected.live === 'false' && expected.coordinator === 'false' && expected.discovery === 'false', 'production flags must remain 000');
 }
 
-function assertVersion(version: FullVersion, mode: Mode): void {
+function assertVersion(version: FullVersion, mode: Mode, requireProductionOperator = false): boolean {
   const runtime = recordAt(version.resources, 'script_runtime');
   refuse(runtime.compatibility_date === COMPATIBILITY_DATE && stableJson(runtime.compatibility_flags) === stableJson(COMPATIBILITY_FLAGS),
     'version compatibility settings mismatch');
   const bindings = version.resources.bindings;
-  if (mode === '000') {
-    const operatorSecrets = bindings.filter(binding => binding.name === OPERATOR_TOKEN);
-    refuse(operatorSecrets.length === 1 && operatorSecrets[0]?.type === 'secret_text',
-      'production version must contain exactly one operator secret_text binding');
-  }
   uniqueNames(bindings, 'version bindings');
+  const operatorBindings = bindings.filter(binding => binding.name === OPERATOR_TOKEN);
+  const operatorReady = mode === '000' && operatorBindings.length === 1;
+  if (operatorReady) assertVersionBinding(bindings, OPERATOR_TOKEN, 'secret_text', {});
   const expectedNames = new Set([
     'THEOLOGAI_DB', DO.name, 'THEOLOGAI_RATE_LIMITER', 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', 'CF_VERSION_METADATA',
     'THEOLOGAI_VERSION', 'THEOLOGAI_ALLOWED_ORIGINS', 'THEOLOGAI_MAX_REQUEST_BYTES', 'THEOLOGAI_REQUEST_LOGS',
     'THEOLOGAI_EXPOSE_CCEL_DISCOVERY', 'THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH', 'THEOLOGAI_ENABLE_CCEL_COORDINATOR',
-    'ESV_API_KEY',
-    ...(mode === '000' ? [OPERATOR_TOKEN] : []),
+    ...(mode === '000' ? PRODUCTION_BASE_SECRET_BINDINGS : ['ESV_API_KEY']),
+    ...(operatorReady ? [OPERATOR_TOKEN] : []),
   ]);
   refuse(bindings.length === expectedNames.size && bindings.every(binding => expectedNames.has(String(binding.name))),
     'version bindings must be the exact authorized set');
@@ -324,8 +338,9 @@ function assertVersion(version: FullVersion, mode: Mode): void {
   assertVersionRate(bindings, 'THEOLOGAI_RATE_LIMITER', values.requestNamespace, 120);
   assertVersionRate(bindings, 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', values.operatorNamespace, 12);
   assertVersionBinding(bindings, 'CF_VERSION_METADATA', 'version_metadata', {});
-  assertVersionBinding(bindings, 'ESV_API_KEY', 'secret_text', {});
-  if (mode === '000') assertVersionBinding(bindings, OPERATOR_TOKEN, 'secret_text', {});
+  if (mode === '000') {
+    for (const name of PRODUCTION_BASE_SECRET_BINDINGS) assertVersionBinding(bindings, name, 'secret_text', {});
+  } else assertVersionBinding(bindings, 'ESV_API_KEY', 'secret_text', {});
   const flags = mode === '111' ? { discovery: 'true', live: 'true', coordinator: 'true' } : values;
   const expected: Record<string, string> = {
     THEOLOGAI_VERSION: values.version,
@@ -336,6 +351,9 @@ function assertVersion(version: FullVersion, mode: Mode): void {
     THEOLOGAI_ENABLE_CCEL_COORDINATOR: flags.coordinator,
   };
   for (const [name, text] of Object.entries(expected)) assertVersionBinding(bindings, name, 'plain_text', { text });
+  refuse(mode !== '000' || !requireProductionOperator || operatorReady,
+    `production operator prerequisite is missing: active 000 version must contain exactly one ${OPERATOR_TOKEN} secret_text binding before any preview mutation`);
+  return operatorReady;
 }
 
 function assertConfigRate(bindings: JsonRecord[], name: string, namespace: string, limit: number): void {
@@ -453,11 +471,17 @@ export function runCli(argv: string[]): void {
   }
   if (command === 'validate-canary-credentials') {
     exactArgs(args, []);
-    validateCanaryCredentials(process.env.CCEL_CANARY_CREDENTIALS_CONFIGURED, process.env.CLOUDFLARE_API_TOKEN, process.env[OPERATOR_TOKEN]); return;
+    validateCanaryCredentials(
+      process.env.CCEL_CANARY_CREDENTIALS_CONFIGURED, process.env.CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK,
+      process.env.CLOUDFLARE_API_TOKEN, process.env[OPERATOR_TOKEN],
+    ); return;
   }
   if (command === 'validate-emergency-credentials') {
     exactArgs(args, []);
-    validateEmergencyCredentials(process.env.CCEL_CANARY_CREDENTIALS_CONFIGURED, process.env.CLOUDFLARE_API_TOKEN); return;
+    validateEmergencyCredentials(
+      process.env.CCEL_CANARY_CREDENTIALS_CONFIGURED, process.env.CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK,
+      process.env.CLOUDFLARE_API_TOKEN,
+    ); return;
   }
   if (command === 'validate-emergency-inputs') {
     exactArgs(args, ['--ref', '--current', '--target', '--confirmation', '--config']);

--- a/test/fixtures/wrangler/ccel-canary-live-binding-shapes.json
+++ b/test/fixtures/wrangler/ccel-canary-live-binding-shapes.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "1",
+  "capturedAt": "2026-07-29",
+  "privacy": "worker_version_ids_and_binding_names_types_only",
+  "production": {
+    "versionId": "291f3292-3fa9-44fc-bf6f-b68fd2f4cef6",
+    "flags": "000",
+    "secretTextBindingNames": [
+      "AUTH_TOKEN",
+      "ESV_API_KEY",
+      "SBC_FACILITATOR_API_KEY"
+    ],
+    "operatorReady": false
+  },
+  "preview": {
+    "versionId": "06b9a603-8339-42b6-a246-ef9238563043",
+    "flags": "100",
+    "secretTextBindingNames": [
+      "ESV_API_KEY"
+    ],
+    "operatorReady": false
+  }
+}

--- a/test/unit/config/ccelOperatorSecretProvisioning.test.ts
+++ b/test/unit/config/ccelOperatorSecretProvisioning.test.ts
@@ -121,6 +121,13 @@ describe('protected CCEL operator-secret provisioning', () => {
       'Do not dispatch `reset`',
       'versions secret delete',
       'separate deletion authorization',
+      'identical value belongs in exactly three approved places',
+      'GitHub environment `ccel-canary`',
+      '`CCEL_CANARY_OPERATOR_TOKEN`',
     ]) expect(guide).toContain(text);
+    expect(guide).toMatch(/do not synchronize\s+automatically/);
+    expect(guide).toMatch(/Full revocation must address\s+all three copies/);
+    expect(guide).toContain('Do not provision it on `theologai-preview`');
+    expect(guide).toContain('`theologai-ccel-coordinator`');
   });
 });

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -1,0 +1,201 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  CANARY_CONFIRMATION,
+  CANARY_MESSAGE,
+  CANARY_TAG,
+  assertCommittedConfig,
+  identifyCanaryUpload,
+  planRestore,
+  renderCanaryPreviewConfig,
+  sanitizedCanaryEvidence,
+  validateCanaryCredentials,
+  validateCanaryDeployment,
+  validateCanaryDispatch,
+  validateCanaryInputs,
+  validateCanaryVersion,
+  validateEmergencyCredentials,
+  validateEmergencyInputs,
+  validatePreviewBaseline,
+  validateProductionControl,
+  validateRestoreResult,
+} from '../../../scripts/ccel-live-preview-canary.js';
+
+const predecessor = '123e4567-e89b-42d3-a456-426614174000';
+const canary = '123e4567-e89b-42d3-a456-426614174001';
+const production = '123e4567-e89b-42d3-a456-426614174002';
+const deployment = '223e4567-e89b-42d3-a456-426614174000';
+const config = readFileSync(new URL('../../../wrangler.toml', import.meta.url), 'utf8');
+const workflow = readFileSync(new URL('../../../.github/workflows/ccel-live-preview-canary.yml', import.meta.url), 'utf8');
+const emergencyWorkflow = readFileSync(new URL('../../../.github/workflows/restore-ccel-live-preview-canary.yml', import.meta.url), 'utf8');
+const prWorkflow = readFileSync(new URL('../../../.github/workflows/pr.yml', import.meta.url), 'utf8');
+
+function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false) {
+  const productionMode = mode === '000';
+  return [
+    { name: 'THEOLOGAI_DB', type: 'd1', id: productionMode ? '53211f50-a893-4b4c-be1e-bc625a595dc7' : '62b871a6-5b4d-4d9b-8f52-301f6c878f48' },
+    { name: 'THEOLOGAI_CCEL_COORDINATOR', type: 'durable_object_namespace', class_name: 'CcelGlobalCoordinator', script_name: 'theologai-ccel-coordinator' },
+    { name: 'THEOLOGAI_RATE_LIMITER', type: 'ratelimit', namespace_id: productionMode ? '361201' : '361202', simple: { limit: 120, period: 60 } },
+    { name: 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', type: 'ratelimit', namespace_id: productionMode ? '361203' : '361204', simple: { limit: 12, period: 60 } },
+    { name: 'CF_VERSION_METADATA', type: 'version_metadata' },
+    { name: 'THEOLOGAI_VERSION', type: 'plain_text', text: productionMode ? '3.6.0' : '3.6.0-preview' },
+    { name: 'THEOLOGAI_ALLOWED_ORIGINS', type: 'plain_text', text: 'https://theologai.xyz,https://theologai.pages.dev' },
+    { name: 'THEOLOGAI_MAX_REQUEST_BYTES', type: 'plain_text', text: '1048576' },
+    { name: 'THEOLOGAI_REQUEST_LOGS', type: 'plain_text', text: productionMode ? 'false' : 'true' },
+    { name: 'THEOLOGAI_EXPOSE_CCEL_DISCOVERY', type: 'plain_text', text: productionMode ? 'false' : 'true' },
+    { name: 'THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH', type: 'plain_text', text: mode === '111' ? 'true' : 'false' },
+    { name: 'THEOLOGAI_ENABLE_CCEL_COORDINATOR', type: 'plain_text', text: mode === '111' ? 'true' : 'false' },
+    { name: 'ESV_API_KEY', type: 'secret_text' },
+    ...(includeOperatorSecret ? [{ name: 'THEOLOGAI_CCEL_OPERATOR_TOKEN', type: 'secret_text' }] : []),
+  ];
+}
+
+function view(id: string, number: number, mode: '100' | '111' | '000' = '100', options: { message?: string; tag?: string; secret?: boolean } = {}) {
+  return {
+    id, number, metadata: { created_on: '2026-07-29T00:00:00.000Z' },
+    ...(options.message === undefined ? {} : { annotations: { 'workers/message': options.message, 'workers/tag': options.tag ?? '' } }),
+    resources: {
+      script_runtime: { compatibility_date: '2026-07-09', compatibility_flags: ['nodejs_compat'] },
+      bindings: bindings(mode, options.secret),
+    },
+  };
+}
+
+function deployments(versionId: string) {
+  return [{ id: deployment, created_on: '2026-07-29T00:00:00.000Z', versions: [{ version_id: versionId, percentage: 100 }] }];
+}
+
+describe('CCEL live preview canary transaction', () => {
+  it('holds the tracked configuration at production 000 and preview 100, then renders only ephemeral preview 111', () => {
+    expect(() => assertCommittedConfig(config)).not.toThrow();
+    const candidate = renderCanaryPreviewConfig(config);
+    expect(candidate).toContain('THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH = "true"');
+    expect(candidate).toContain('THEOLOGAI_ENABLE_CCEL_COORDINATOR = "true"');
+    expect(candidate).toContain('THEOLOGAI_EXPOSE_CCEL_DISCOVERY = "false"');
+    expect(candidate).not.toContain('THEOLOGAI_CCEL_OPERATOR_TOKEN');
+    expect(config).toContain('THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH = "false"');
+  });
+
+  it('fails closed for wrong branch, SHA, confirmation, custom route, D1, DO, or rate namespace', () => {
+    expect(() => validateCanaryDispatch({
+      ref: 'refs/heads/main', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
+      confirmation: CANARY_CONFIRMATION, configText: config,
+    })).not.toThrow();
+    expect(() => validateCanaryDispatch({
+      ref: 'refs/heads/feature', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
+      confirmation: CANARY_CONFIRMATION, configText: config,
+    })).toThrow(/refs\/heads\/main/);
+    expect(() => validateCanaryDispatch({
+      ref: 'refs/heads/main', sha: 'a'.repeat(40), expectedSha: 'b'.repeat(40), liveMainSha: 'a'.repeat(40),
+      confirmation: 'wrong', configText: config,
+    })).toThrow();
+    for (const tampered of [
+      config.replace('preview-mcp.theologai.xyz', 'wrong.example'),
+      config.replace('62b871a6-5b4d-4d9b-8f52-301f6c878f48', '11111111-1111-4111-8111-111111111111'),
+      config.replace('class_name = "CcelGlobalCoordinator"', 'class_name = "WrongCoordinator"'),
+      config.replace('namespace_id = "361204"', 'namespace_id = "999999"'),
+    ]) expect(() => assertCommittedConfig(tampered)).toThrow();
+  });
+
+  it('rejects option-like, malformed, or duplicate user IDs and unprovisioned dedicated credentials before Wrangler', () => {
+    expect(() => validateCanaryInputs({ previewPredecessor: predecessor, productionControl: production })).not.toThrow();
+    expect(() => validateCanaryInputs({ previewPredecessor: '--env', productionControl: production })).toThrow(/UUID/);
+    expect(() => validateCanaryInputs({ previewPredecessor: predecessor, productionControl: predecessor })).toThrow(/differ/);
+    expect(() => validateEmergencyInputs('refs/heads/main', canary, predecessor, 'RESTORE THE EXACT CCEL PREVIEW PREDECESSOR', config)).not.toThrow();
+    expect(() => validateEmergencyInputs('refs/heads/main', '--env', predecessor, 'RESTORE THE EXACT CCEL PREVIEW PREDECESSOR', config)).toThrow(/UUID/);
+    expect(() => validateCanaryCredentials('missing', 'cf-token', 'a'.repeat(43))).toThrow(/provisioned/);
+    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', '', 'a'.repeat(43))).toThrow(/Cloudflare/);
+    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'cf-token', 'bad')).toThrow(/operator/);
+    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'cf-token', 'a'.repeat(43))).not.toThrow();
+    expect(() => validateEmergencyCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'cf-token')).not.toThrow();
+    expect(() => validateEmergencyCredentials('missing', 'cf-token')).toThrow(/provisioned/);
+  });
+
+  it('requires a sole predecessor, stages one undeployed candidate, validates exact 111, and never accepts the operator token in preview', () => {
+    const baseline = view(predecessor, 10);
+    expect(() => validatePreviewBaseline(config, deployments(predecessor), baseline, predecessor)).not.toThrow();
+    expect(() => validatePreviewBaseline(config, deployments(predecessor), baseline, 'not-an-id')).toThrow(/UUID/);
+    expect(identifyCanaryUpload(
+      [{ id: predecessor, number: 10, metadata: baseline.metadata }],
+      [{ id: predecessor, number: 10, metadata: baseline.metadata }, { id: canary, number: 11, metadata: baseline.metadata }],
+      deployments(predecessor), deployments(predecessor), predecessor,
+    )).toBe(canary);
+    const candidate = view(canary, 11, '111', { message: CANARY_MESSAGE, tag: CANARY_TAG });
+    expect(() => validateCanaryVersion(config, baseline, candidate, predecessor, canary)).not.toThrow();
+    expect(() => validateCanaryDeployment(config, deployments(canary), candidate, canary)).not.toThrow();
+    const withPreviewToken = view(canary, 11, '111', { message: CANARY_MESSAGE, tag: CANARY_TAG, secret: true });
+    expect(() => validateCanaryVersion(config, baseline, withPreviewToken, predecessor, canary)).toThrow(/exact authorized set/);
+    const wrongNamespace = view(canary, 11, '111', { message: CANARY_MESSAGE, tag: CANARY_TAG });
+    (wrongNamespace.resources.bindings.find(binding => binding.name === 'THEOLOGAI_RATE_LIMITER') as { namespace_id: string }).namespace_id = '361201';
+    expect(() => validateCanaryVersion(config, baseline, wrongNamespace, predecessor, canary)).toThrow(/policy/);
+    const extraBinding = view(canary, 11, '111', { message: CANARY_MESSAGE, tag: CANARY_TAG });
+    extraBinding.resources.bindings.push({ name: 'UNAUTHORIZED_BINDING', type: 'plain_text', text: 'nope' });
+    expect(() => validateCanaryVersion(config, baseline, extraBinding, predecessor, canary)).toThrow(/exact authorized set/);
+    const missingSecret = view(canary, 11, '111', { message: CANARY_MESSAGE, tag: CANARY_TAG });
+    missingSecret.resources.bindings.splice(missingSecret.resources.bindings.findIndex(binding => binding.name === 'ESV_API_KEY'), 1);
+    expect(() => validateCanaryVersion(config, baseline, missingSecret, predecessor, canary)).toThrow(/exact authorized set/);
+  });
+
+  it('requires ESV plus exactly one correctly typed production-only operator secret before preview upload', () => {
+    const control = view(production, 9, '000', { secret: true });
+    expect(() => validateProductionControl(config, deployments(production), control, production)).not.toThrow();
+    const absent = view(production, 9, '000');
+    expect(() => validateProductionControl(config, deployments(production), absent, production)).toThrow(/operator secret_text/);
+    const duplicate = view(production, 9, '000', { secret: true });
+    duplicate.resources.bindings.push({ name: 'THEOLOGAI_CCEL_OPERATOR_TOKEN', type: 'secret_text' });
+    expect(() => validateProductionControl(config, deployments(production), duplicate, production)).toThrow(/operator secret_text/);
+    const wrongType = view(production, 9, '000', { secret: true });
+    (wrongType.resources.bindings.find(binding => binding.name === 'THEOLOGAI_CCEL_OPERATOR_TOKEN') as { type: string }).type = 'plain_text';
+    expect(() => validateProductionControl(config, deployments(production), wrongType, production)).toThrow(/operator secret_text/);
+  });
+
+  it('restores only the exact captured predecessor and makes a second restore idempotent', () => {
+    const baseline = view(predecessor, 10);
+    const candidate = view(canary, 11, '111', { message: CANARY_MESSAGE, tag: CANARY_TAG });
+    expect(planRestore(config, deployments(canary), candidate, baseline, canary, predecessor)).toBe('deploy');
+    expect(() => validateRestoreResult(config, deployments(predecessor), baseline, predecessor)).not.toThrow();
+    expect(planRestore(config, deployments(predecessor), baseline, baseline, predecessor, predecessor)).toBe('already');
+    expect(() => planRestore(config, deployments(production), view(production, 99, '000', { secret: true }), baseline, canary, predecessor)).toThrow(/authorized canary/);
+  });
+
+  it('retains only sanitized canary evidence and invokes the existing two-call audit exactly once', () => {
+    const evidence = sanitizedCanaryEvidence({
+      commit: 'a'.repeat(40), predecessor, canary, productionControl: production,
+      auditSha256: 'b'.repeat(64), auditOutcome: 'success', restored: true,
+    });
+    expect(JSON.stringify(evidence)).not.toMatch(/query|snippet|token|https?:\/\//i);
+    expect(() => sanitizedCanaryEvidence({
+      commit: 'not-a-sha', predecessor, canary, productionControl: production,
+      auditSha256: 'b'.repeat(64), auditOutcome: 'failure', restored: true,
+    })).toThrow(/commit/);
+    expect(workflow.match(/npm run audit:ccel-preview/g)).toHaveLength(1);
+    expect(workflow).toContain('I AUTHORIZE TWO LIVE CCEL PREVIEW REQUESTS');
+    expect(workflow).not.toMatch(/labels\.\*\.name.*deploy-preview/);
+    expect(workflow).toMatch(/^on:\n  workflow_dispatch:/m);
+    expect(workflow).not.toMatch(/^  (push|pull_request):/m);
+    expect(workflow).toContain('environment: ccel-canary');
+    expect(workflow).not.toContain('environment: production');
+    expect(workflow).not.toContain('secrets.CLOUDFLARE_API_TOKEN');
+    expect(workflow).toContain('secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN');
+    expect(workflow).toContain('validate-canary-credentials');
+    expect(workflow.indexOf('Run the existing authorized two-attempt audit exactly once'))
+      .toBeLessThan(workflow.indexOf('Always restore the exact preview predecessor before job exit'));
+    expect(workflow).toMatch(/id: restore\n        if: always\(\)/);
+    expect(workflow.indexOf('Always restore the exact preview predecessor before job exit'))
+      .toBeLessThan(workflow.indexOf('Fail only after recovery and evidence are complete'));
+    for (const command of workflow.match(/npx wrangler versions (?:upload|deploy)[^\n]*/g) ?? []) {
+      expect(command).toContain('--env preview');
+    }
+    expect(emergencyWorkflow).toMatch(/^on:\n  workflow_dispatch:/m);
+    expect(emergencyWorkflow).not.toContain('THEOLOGAI_CCEL_OPERATOR_TOKEN');
+    expect(emergencyWorkflow).toContain('environment: ccel-canary');
+    expect(emergencyWorkflow).toContain('validate-emergency-inputs');
+    expect(emergencyWorkflow).toContain('validate-restore-result');
+    for (const source of [prWorkflow, workflow, emergencyWorkflow]) {
+      expect(source).toContain('group: theologai-shared-preview-mutation');
+      expect(source).toContain('cancel-in-progress: false');
+      expect(source).not.toContain('theologai-shared-preview-deploy-and-audit');
+      expect(source).not.toContain('theologai-ccel-live-preview-canary');
+    }
+  });
+});

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
+  ACCOUNT_WIDE_WORKERS_WRITE_ACK,
   CANARY_CONFIRMATION,
   CANARY_MESSAGE,
   CANARY_TAG,
+  PRODUCTION_BASE_SECRET_BINDINGS,
   assertCommittedConfig,
   identifyCanaryUpload,
   planRestore,
@@ -17,6 +19,7 @@ import {
   validateEmergencyCredentials,
   validateEmergencyInputs,
   validatePreviewBaseline,
+  validateProductionBindingInventory,
   validateProductionControl,
   validateRestoreResult,
 } from '../../../scripts/ccel-live-preview-canary.js';
@@ -29,6 +32,15 @@ const config = readFileSync(new URL('../../../wrangler.toml', import.meta.url), 
 const workflow = readFileSync(new URL('../../../.github/workflows/ccel-live-preview-canary.yml', import.meta.url), 'utf8');
 const emergencyWorkflow = readFileSync(new URL('../../../.github/workflows/restore-ccel-live-preview-canary.yml', import.meta.url), 'utf8');
 const prWorkflow = readFileSync(new URL('../../../.github/workflows/pr.yml', import.meta.url), 'utf8');
+const liveBindingShapes = JSON.parse(readFileSync(
+  new URL('../../fixtures/wrangler/ccel-canary-live-binding-shapes.json', import.meta.url), 'utf8',
+)) as {
+  schemaVersion: string;
+  capturedAt: string;
+  privacy: string;
+  production: { versionId: string; flags: string; secretTextBindingNames: string[]; operatorReady: boolean };
+  preview: { versionId: string; flags: string; secretTextBindingNames: string[]; operatorReady: boolean };
+};
 
 function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false) {
   const productionMode = mode === '000';
@@ -46,6 +58,10 @@ function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false) {
     { name: 'THEOLOGAI_ENABLE_CCEL_LIVE_SEARCH', type: 'plain_text', text: mode === '111' ? 'true' : 'false' },
     { name: 'THEOLOGAI_ENABLE_CCEL_COORDINATOR', type: 'plain_text', text: mode === '111' ? 'true' : 'false' },
     { name: 'ESV_API_KEY', type: 'secret_text' },
+    ...(productionMode ? [
+      { name: 'AUTH_TOKEN', type: 'secret_text' },
+      { name: 'SBC_FACILITATOR_API_KEY', type: 'secret_text' },
+    ] : []),
     ...(includeOperatorSecret ? [{ name: 'THEOLOGAI_CCEL_OPERATOR_TOKEN', type: 'secret_text' }] : []),
   ];
 }
@@ -103,12 +119,18 @@ describe('CCEL live preview canary transaction', () => {
     expect(() => validateCanaryInputs({ previewPredecessor: predecessor, productionControl: predecessor })).toThrow(/differ/);
     expect(() => validateEmergencyInputs('refs/heads/main', canary, predecessor, 'RESTORE THE EXACT CCEL PREVIEW PREDECESSOR', config)).not.toThrow();
     expect(() => validateEmergencyInputs('refs/heads/main', '--env', predecessor, 'RESTORE THE EXACT CCEL PREVIEW PREDECESSOR', config)).toThrow(/UUID/);
-    expect(() => validateCanaryCredentials('missing', 'cf-token', 'a'.repeat(43))).toThrow(/provisioned/);
-    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', '', 'a'.repeat(43))).toThrow(/Cloudflare/);
-    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'cf-token', 'bad')).toThrow(/operator/);
-    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'cf-token', 'a'.repeat(43))).not.toThrow();
-    expect(() => validateEmergencyCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'cf-token')).not.toThrow();
-    expect(() => validateEmergencyCredentials('missing', 'cf-token')).toThrow(/provisioned/);
+    expect(() => validateCanaryCredentials('missing', ACCOUNT_WIDE_WORKERS_WRITE_ACK, 'cf-token', 'a'.repeat(43))).toThrow(/provisioned/);
+    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'missing', 'cf-token', 'a'.repeat(43))).toThrow(/account-wide/);
+    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', ACCOUNT_WIDE_WORKERS_WRITE_ACK, '', 'a'.repeat(43))).toThrow(/Cloudflare/);
+    expect(() => validateCanaryCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', ACCOUNT_WIDE_WORKERS_WRITE_ACK, 'cf-token', 'bad')).toThrow(/operator/);
+    expect(() => validateCanaryCredentials(
+      'CCEL_CANARY_CREDENTIALS_CONFIGURED', ACCOUNT_WIDE_WORKERS_WRITE_ACK, 'cf-token', 'a'.repeat(43),
+    )).not.toThrow();
+    expect(() => validateEmergencyCredentials(
+      'CCEL_CANARY_CREDENTIALS_CONFIGURED', ACCOUNT_WIDE_WORKERS_WRITE_ACK, 'cf-token',
+    )).not.toThrow();
+    expect(() => validateEmergencyCredentials('CCEL_CANARY_CREDENTIALS_CONFIGURED', 'missing', 'cf-token')).toThrow(/account-wide/);
+    expect(() => validateEmergencyCredentials('missing', ACCOUNT_WIDE_WORKERS_WRITE_ACK, 'cf-token')).toThrow(/provisioned/);
   });
 
   it('requires a sole predecessor, stages one undeployed candidate, validates exact 111, and never accepts the operator token in preview', () => {
@@ -136,17 +158,62 @@ describe('CCEL live preview canary transaction', () => {
     expect(() => validateCanaryVersion(config, baseline, missingSecret, predecessor, canary)).toThrow(/exact authorized set/);
   });
 
-  it('requires ESV plus exactly one correctly typed production-only operator secret before preview upload', () => {
+  it('pins the sanitized live binding shapes and requires the separately staged operator secret before preview mutation', () => {
+    expect(liveBindingShapes).toEqual({
+      schemaVersion: '1',
+      capturedAt: '2026-07-29',
+      privacy: 'worker_version_ids_and_binding_names_types_only',
+      production: {
+        versionId: '291f3292-3fa9-44fc-bf6f-b68fd2f4cef6',
+        flags: '000',
+        secretTextBindingNames: [...PRODUCTION_BASE_SECRET_BINDINGS],
+        operatorReady: false,
+      },
+      preview: {
+        versionId: '06b9a603-8339-42b6-a246-ef9238563043',
+        flags: '100',
+        secretTextBindingNames: ['ESV_API_KEY'],
+        operatorReady: false,
+      },
+    });
+    const currentLiveShape = view(liveBindingShapes.production.versionId, 9, '000');
+    expect(validateProductionBindingInventory(currentLiveShape)).toEqual({ operatorReady: false });
+    expect(() => validateProductionControl(
+      config, deployments(liveBindingShapes.production.versionId), currentLiveShape, liveBindingShapes.production.versionId,
+    )).toThrow(/production operator prerequisite is missing.*before any preview mutation/);
+
     const control = view(production, 9, '000', { secret: true });
     expect(() => validateProductionControl(config, deployments(production), control, production)).not.toThrow();
-    const absent = view(production, 9, '000');
-    expect(() => validateProductionControl(config, deployments(production), absent, production)).toThrow(/operator secret_text/);
+    expect(validateProductionBindingInventory(control)).toEqual({ operatorReady: true });
     const duplicate = view(production, 9, '000', { secret: true });
     duplicate.resources.bindings.push({ name: 'THEOLOGAI_CCEL_OPERATOR_TOKEN', type: 'secret_text' });
-    expect(() => validateProductionControl(config, deployments(production), duplicate, production)).toThrow(/operator secret_text/);
+    expect(() => validateProductionControl(config, deployments(production), duplicate, production)).toThrow(/unique/);
     const wrongType = view(production, 9, '000', { secret: true });
     (wrongType.resources.bindings.find(binding => binding.name === 'THEOLOGAI_CCEL_OPERATOR_TOKEN') as { type: string }).type = 'plain_text';
-    expect(() => validateProductionControl(config, deployments(production), wrongType, production)).toThrow(/operator secret_text/);
+    expect(() => validateProductionControl(config, deployments(production), wrongType, production)).toThrow(/type mismatch/);
+    for (const requiredSecret of PRODUCTION_BASE_SECRET_BINDINGS) {
+      const missing = view(production, 9, '000', { secret: true });
+      missing.resources.bindings.splice(missing.resources.bindings.findIndex(binding => binding.name === requiredSecret), 1);
+      expect(() => validateProductionBindingInventory(missing)).toThrow(/exact authorized set/);
+      const wrongBaseType = view(production, 9, '000', { secret: true });
+      (wrongBaseType.resources.bindings.find(binding => binding.name === requiredSecret) as { type: string }).type = 'plain_text';
+      expect(() => validateProductionBindingInventory(wrongBaseType)).toThrow(/type mismatch/);
+    }
+    const extra = view(production, 9, '000', { secret: true });
+    extra.resources.bindings.push({ name: 'UNAUTHORIZED_SECRET', type: 'secret_text' });
+    expect(() => validateProductionBindingInventory(extra)).toThrow(/exact authorized set/);
+  });
+
+  it('accepts only ESV in preview and rejects every production-only or unknown secret', () => {
+    const previewLiveShape = view(liveBindingShapes.preview.versionId, 10, '100');
+    expect(() => validatePreviewBaseline(
+      config, deployments(liveBindingShapes.preview.versionId), previewLiveShape, liveBindingShapes.preview.versionId,
+    )).not.toThrow();
+    for (const forbiddenSecret of ['AUTH_TOKEN', 'SBC_FACILITATOR_API_KEY', 'THEOLOGAI_CCEL_OPERATOR_TOKEN', 'UNKNOWN_SECRET']) {
+      const forbidden = view(predecessor, 10, '100');
+      forbidden.resources.bindings.push({ name: forbiddenSecret, type: 'secret_text' });
+      expect(() => validatePreviewBaseline(config, deployments(predecessor), forbidden, predecessor)).toThrow(/exact authorized set/);
+    }
   });
 
   it('restores only the exact captured predecessor and makes a second restore idempotent', () => {
@@ -177,7 +244,10 @@ describe('CCEL live preview canary transaction', () => {
     expect(workflow).not.toContain('environment: production');
     expect(workflow).not.toContain('secrets.CLOUDFLARE_API_TOKEN');
     expect(workflow).toContain('secrets.CCEL_CANARY_CLOUDFLARE_API_TOKEN');
+    expect(workflow).toContain('secrets.CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK');
     expect(workflow).toContain('validate-canary-credentials');
+    expect(workflow.indexOf('validate-canary-credentials')).toBeLessThan(workflow.indexOf('npx wrangler'));
+    expect(workflow.indexOf('validate-production-control')).toBeLessThan(workflow.indexOf('npx wrangler versions upload'));
     expect(workflow.indexOf('Run the existing authorized two-attempt audit exactly once'))
       .toBeLessThan(workflow.indexOf('Always restore the exact preview predecessor before job exit'));
     expect(workflow).toMatch(/id: restore\n        if: always\(\)/);
@@ -188,7 +258,9 @@ describe('CCEL live preview canary transaction', () => {
     }
     expect(emergencyWorkflow).toMatch(/^on:\n  workflow_dispatch:/m);
     expect(emergencyWorkflow).not.toContain('THEOLOGAI_CCEL_OPERATOR_TOKEN');
+    expect(emergencyWorkflow).not.toContain('CCEL_CANARY_OPERATOR_TOKEN');
     expect(emergencyWorkflow).toContain('environment: ccel-canary');
+    expect(emergencyWorkflow).toContain('secrets.CCEL_CANARY_ACCOUNT_WIDE_WORKERS_WRITE_ACK');
     expect(emergencyWorkflow).toContain('validate-emergency-inputs');
     expect(emergencyWorkflow).toContain('validate-restore-result');
     for (const source of [prWorkflow, workflow, emergencyWorkflow]) {

--- a/test/unit/scripts/originalLanguageV2PreviewAudit.test.ts
+++ b/test/unit/scripts/originalLanguageV2PreviewAudit.test.ts
@@ -87,7 +87,7 @@ describe('original-language v2 preview audit contract', () => {
     expect(audit).toBeGreaterThan(preAuditIdentity);
     expect(postAuditIdentity).toBeGreaterThan(audit);
     expect(comment).toBeGreaterThan(postAuditIdentity);
-    expect(workflow).toContain('group: theologai-shared-preview-deploy-and-audit');
+    expect(workflow).toContain('group: theologai-shared-preview-mutation');
     expect(workflow).toContain('Verify exact active preview Worker version (read-only)');
     expect(workflow).toContain('wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-worker-deployments-post-audit.json"');
     expect(workflow).toContain('Upload protected preview audit evidence');

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -18,6 +18,7 @@
     "scripts/replay-historical-spine-source-packs.ts",
     "scripts/release-corpus-capacity-policy.ts",
     "scripts/release-corpus-capacity.ts",
-    "scripts/verify-database.ts"
+    "scripts/verify-database.ts",
+    "scripts/ccel-live-preview-canary.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- Add a manually dispatched, fail-closed CCEL live-preview canary transaction.
- Serialize every preview mutation behind one repository-wide concurrency lock.
- Require a dedicated `ccel-canary` GitHub environment and an exact, separate owner acknowledgment of Cloudflare's account-wide Workers Scripts Write scope.
- Preserve the real production secret-name inventory (`AUTH_TOKEN`, `ESV_API_KEY`, `SBC_FACILITATOR_API_KEY`) and require the separately staged operator secret before any preview mutation.
- Restore the exact preview predecessor in the same approved job before propagating failures.
- Add a separate exact-state emergency restore workflow for cancellation or runner loss.
- Add validators, sanitized live-shape fixtures, tests, operator documentation, and identifier/hash-only evidence handling.

## Safety boundary

This PR does not enable CCEL, create an environment, add or change secrets, contact CCEL, deploy preview, or mutate production. Committed runtime state remains production `000` and preview `100`. A future canary requires separate authorization and manual prerequisite configuration.

Cloudflare Workers Scripts Write is account-scoped, not Worker-scoped. The dedicated token therefore cannot be Cloudflare-enforced as preview-write/production-read-only while both Workers share one account. The workflow documents this limitation, requires exact owner acknowledgment, and narrows the transaction procedurally through the protected GitHub environment, exact configs, allowlists, version identities, and restoration checks.

## Verification

- CCEL-focused tests: 139/139
- Provisioning/public-contract tests: 25/25
- Final focused canary/provisioning tests: 23/23
- Node 22 typechecks: all three configurations passed
- `git diff --check`: passed
- Independent Sol review of repair commit `01f6673`: SHIP, no actionable findings
- Fresh PR CI on `01f6673`: all required checks passed; Deploy Preview skipped

## Review notes

Documented residual limitations:

- hard runner cancellation can bypass in-job restoration, so a separately approved emergency restore workflow is retained;
- the Cloudflare credential can write Worker scripts account-wide;
- exact binding allowlists intentionally stop if a legitimate binding changes until the transaction is reviewed again; and
- out-of-band Cloudflare writers cannot be serialized by GitHub.
