### PR TITLE
docs: reconcile post-PR113 release state

### DIFF
--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -68,12 +68,13 @@ assignment bound to that exact candidate D1. It remains v7/discovery-only with
 CCEL execution disabled before adapter, coordinator, or fetch. Production
 remains unchanged.
 
-Current `main` is `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
-`9922aedb74c690e7a3fcb926b3d621f28fa44535`) and is not deployed. PRs #109–#113
-are completed repository-only milestones: PR #109 records the PR #108
-production cutover, PR #110 aligns provider-neutral CCEL audit readiness,
-PR #111 adds inert canary transaction infrastructure, PR #112 records
-synthetic original-language context-capacity evidence, and PR #113 records
+At the reconciliation cutoff immediately after PR #113, `main` was
+`2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
+`9922aedb74c690e7a3fcb926b3d621f28fa44535`), and that revision was not
+deployed. PRs #109–#113 are completed repository-only milestones: PR #109
+records the PR #108 production cutover, PR #110 aligns provider-neutral CCEL
+audit readiness, PR #111 adds inert canary transaction infrastructure, PR #112
+records synthetic original-language context-capacity evidence, and PR #113 records
 provisional Norton capacity evidence that remains subject to local and release
 gates. Production runs for PRs #109–#113 were cancelled and preview jobs
 skipped, so they make no runtime, Worker, deployment, binding, remote-D1, or

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -62,9 +62,28 @@ passed primary readiness, Transform-8 (`1/12/12` pages), and the complete
 Transform-11 audit (`1/1/1/1/1/1/133/17` pages). No seed, migration, repair, or
 resume was repeated. The candidate was unbound during that preparation.
 Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550` now
-serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) as the sole active
-preview assignment bound to that exact candidate D1. Production remains
-unchanged.
+serves PR #107 head `1105b75cd8537632bdb20e598092f6ba94a6adc0` as Worker
+`06b9a603-8339-42b6-a246-ef9238563043` (#140), the sole active preview
+assignment bound to that exact candidate D1. It remains v7/discovery-only with
+CCEL execution disabled before adapter, coordinator, or fetch. Production
+remains unchanged.
+
+Current `main` is `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
+`9922aedb74c690e7a3fcb926b3d621f28fa44535`) and is not deployed. PRs #109–#113
+are completed repository-only milestones: PR #109 records the PR #108
+production cutover, PR #110 aligns provider-neutral CCEL audit readiness,
+PR #111 adds inert canary transaction infrastructure, PR #112 records
+synthetic original-language context-capacity evidence, and PR #113 records
+provisional Norton capacity evidence that remains subject to local and release
+gates. Production runs for PRs #109–#113 were cancelled and preview jobs
+skipped, so they make no runtime, Worker, deployment, binding, remote-D1, or
+corpus claim.
+Preview therefore remains the PR #107 assignment above. Production remains PR
+#108 merge `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`, deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`53211f50-a893-4b4c-be1e-bc625a595dc7`, with v6/local-only behavior and CCEL
+execution disabled before adapter, coordinator, or fetch.
 
 The candidate-binding observation is written before the strict gate and is uploaded through `always()` handling. It contains only version/deployment IDs, predecessor/active/candidate D1 IDs, the `d1Changed` value, and boolean configuration/binding verdicts; it excludes raw Wrangler JSON, headers, requests, sessions, and secrets. The final post-mutation observation is likewise retained and hashed even if the strict candidate-binding gate blocks both audits.
 

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -2,10 +2,12 @@
 
 This document records the completed PR #108 protected production cutover, its
 PR #101 rollback pair, and the safeguards required for later releases.
-Current `main` is `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
-`9922aedb74c690e7a3fcb926b3d621f28fa44535`) and is not deployed. PRs #109–#113
-are completed repository-only milestones: PR #109 records this cutover, PR #110
-aligns provider-neutral CCEL audit readiness, PR #111 supplies inert canary
+At the reconciliation cutoff immediately after PR #113, `main` was
+`2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
+`9922aedb74c690e7a3fcb926b3d621f28fa44535`), and that revision was not
+deployed. PRs #109–#113 are completed repository-only milestones: PR #109
+records this cutover, PR #110 aligns provider-neutral CCEL audit readiness,
+PR #111 supplies inert canary
 transaction infrastructure, PR #112 records synthetic original-language
 context-capacity evidence, and PR #113 records provisional Norton capacity
 evidence that remains subject to local and release gates. Production runs for

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -2,6 +2,17 @@
 
 This document records the completed PR #108 protected production cutover, its
 PR #101 rollback pair, and the safeguards required for later releases.
+Current `main` is `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
+`9922aedb74c690e7a3fcb926b3d621f28fa44535`) and is not deployed. PRs #109–#113
+are completed repository-only milestones: PR #109 records this cutover, PR #110
+aligns provider-neutral CCEL audit readiness, PR #111 supplies inert canary
+transaction infrastructure, PR #112 records synthetic original-language
+context-capacity evidence, and PR #113 records provisional Norton capacity
+evidence that remains subject to local and release gates. Production runs for
+PRs #109–#113 were cancelled and preview jobs skipped; they make no runtime, Worker,
+deployment, binding, remote-D1, or corpus claim. Production therefore remains
+the PR #108 v6/local-only release below, with CCEL execution disabled before
+adapter, coordinator, or fetch.
 The checked-out local catalog and preview have 35 works (the legacy 17 plus 18
 reviewed editions); production now serves the same 35-work Transform-11
 catalog after the successor cutover. The Transform-10 Aquinas packet remains local-only and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -356,9 +356,11 @@ binding—at merge `72a8ee5eef9b909a373b085d1a4f193484ddfe8a`, deployment
   original-language context-capacity evidence; and PR #113 records provisional
   Norton capacity evidence, still subject to local and release gates. Production
   runs for PRs #109–#113 were cancelled and preview jobs skipped, so none makes
-  a Worker, deployment, remote-D1, binding, corpus, or runtime claim. Current
-  `main` at `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
-  `9922aedb74c690e7a3fcb926b3d621f28fa44535`) is not deployed. Preview remains
+  a Worker, deployment, remote-D1, binding, corpus, or runtime claim. At the
+  reconciliation cutoff immediately after PR #113, `main` was
+  `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
+  `9922aedb74c690e7a3fcb926b3d621f28fa44535`), and that revision was not
+  deployed. Preview remains
   PR #107 head `1105b75cd8537632bdb20e598092f6ba94a6adc0`, deployment
   `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
   `06b9a603-8339-42b6-a246-ef9238563043`, and D1

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,11 +151,14 @@ is local source context only and does not define the current product contract.
   behavior. Its normal protected production run `29578634873` deployed the
   behaviorally inactive code as Worker
   `96adff83-dd42-4604-b253-f135dbb7120c` against the existing production D1.
-- **Inactive UBS semantic aggregate / PR #64:** added a source-free,
+- **UBS semantic aggregate foundation / PR #64:** added a then-source-free,
   unregistered aggregate contract, merged as
-  `e20132f63cf22fa54d3a4821807efbce93879ae8`. This is a foundation only, not
-  a public feature or deployment: it did not add semantic artifacts, migration
-  `0004`, transform 7, D1 rows, runtime wiring, or an MCP surface.
+  `e20132f63cf22fa54d3a4821807efbce93879ae8`. At that point it was a foundation
+  only, not a public feature or deployment: it did not add semantic artifacts,
+  migration `0004`, transform 7, D1 rows, runtime wiring, or an MCP surface.
+  PR #96 later activated the released `original_language_study` v2 surface, so
+  this entry records its historical foundation state, not a claim that the
+  aggregate remains inactive today.
   Its GitHub deployment record `5490679777` moved from waiting to error when
   production run `29587993437` was cancelled before protected approval; the
   run had no steps, no Worker was deployed, and no Worker version was created.
@@ -345,6 +348,28 @@ binding—at merge `72a8ee5eef9b909a373b085d1a4f193484ddfe8a`, deployment
 > `theologai-production-20260723-a` (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`),
 > sole 100%; identity SHA-256
 > `a6959d24fb7f50a9848fe2d011f425894718471b8a0609e7833780a291721a44`.
+
+- **Phase 3 release-state reconciliation / PRs #109–#113:** completed
+  repository-only milestones after the PR #108 cutover. PR #109 records that
+  cutover; PR #110 aligns provider-neutral CCEL audit readiness; PR #111 adds
+  inert canary transaction infrastructure; PR #112 records synthetic
+  original-language context-capacity evidence; and PR #113 records provisional
+  Norton capacity evidence, still subject to local and release gates. Production
+  runs for PRs #109–#113 were cancelled and preview jobs skipped, so none makes
+  a Worker, deployment, remote-D1, binding, corpus, or runtime claim. Current
+  `main` at `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
+  `9922aedb74c690e7a3fcb926b3d621f28fa44535`) is not deployed. Preview remains
+  PR #107 head `1105b75cd8537632bdb20e598092f6ba94a6adc0`, deployment
+  `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+  `06b9a603-8339-42b6-a246-ef9238563043`, and D1
+  `62b871a6-5b4d-4d9b-8f52-301f6c878f48`, with v7/discovery-only behavior and
+  CCEL execution disabled before adapter, coordinator, or fetch. Production
+  remains PR #108 merge `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`, deployment
+  `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+  `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+  `53211f50-a893-4b4c-be1e-bc625a595dc7`, with v6/local-only behavior and
+  CCEL execution disabled. The retained PR #101 rollback identities remain
+  unchanged.
 
 ## Shipped Phase 3 release train
 

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -386,6 +386,38 @@ describe('published project contract', () => {
     }
   });
 
+  it('keeps post-PR #108 repository milestones distinct from deployed release state', async () => {
+    const [roadmap, production, preview] = await Promise.all([
+      readProjectFile('docs/ROADMAP.md'),
+      readProjectFile('docs/PRODUCTION-RELEASE-RECONCILIATION.md'),
+      readProjectFile('docs/PREVIEW-RELEASE-RECONCILIATION.md'),
+    ]);
+    const currentMain = '2f12262c9a37d3588bee9b5071954823c15cbd12';
+    const currentTree = '9922aedb74c690e7a3fcb926b3d621f28fa44535';
+    const previewHead = '1105b75cd8537632bdb20e598092f6ba94a6adc0';
+
+    for (const document of [roadmap, production, preview]) {
+      const normalized = document.replace(/\s+/g, ' ');
+      expect(document).toContain(currentMain);
+      expect(document).toContain(currentTree);
+      expect(document).toContain('not deployed');
+      expect(normalized).toContain('Production runs for PRs #109–#113 were cancelled and preview jobs skipped');
+      expect(document).toContain('PR #109');
+      expect(document).toContain('PR #110');
+      expect(document).toContain('PR #111');
+      expect(document).toContain('PR #112');
+      expect(document).toContain('PR #113');
+      expect(normalized).toContain('inert canary transaction infrastructure');
+      expect(normalized).toContain('synthetic original-language context-capacity evidence');
+      expect(normalized).toContain('provisional Norton capacity evidence');
+    }
+    expect(roadmap).toContain('UBS semantic aggregate foundation / PR #64');
+    expect(roadmap).toContain('historical foundation state, not a claim that the\n  aggregate remains inactive today');
+    expect(preview).toContain(previewHead);
+    expect(preview).toContain('CCEL execution disabled before adapter, coordinator, or fetch');
+    expect(production).toContain('PR #108 v6/local-only release');
+  });
+
   it('keeps current CCEL rollout status aligned across operator documents', async () => {
     const documents = await Promise.all([
       readProjectFile('docs/CCEL-LIVE-PREVIEW-AUDIT.md'),

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -386,21 +386,33 @@ describe('published project contract', () => {
     }
   });
 
-  it('keeps post-PR #108 repository milestones distinct from deployed release state', async () => {
+  it('keeps the PR #113 reconciliation cutoff distinct from durable deployed release state', async () => {
     const [roadmap, production, preview] = await Promise.all([
       readProjectFile('docs/ROADMAP.md'),
       readProjectFile('docs/PRODUCTION-RELEASE-RECONCILIATION.md'),
       readProjectFile('docs/PREVIEW-RELEASE-RECONCILIATION.md'),
     ]);
-    const currentMain = '2f12262c9a37d3588bee9b5071954823c15cbd12';
-    const currentTree = '9922aedb74c690e7a3fcb926b3d621f28fa44535';
-    const previewHead = '1105b75cd8537632bdb20e598092f6ba94a6adc0';
+    const reconciliationCutoffCommit = '2f12262c9a37d3588bee9b5071954823c15cbd12';
+    const reconciliationCutoffTree = '9922aedb74c690e7a3fcb926b3d621f28fa44535';
+    const durablePreview = {
+      head: '1105b75cd8537632bdb20e598092f6ba94a6adc0',
+      deployment: '5e812152-355b-4a5f-a123-2485e89f1550',
+      worker: '06b9a603-8339-42b6-a246-ef9238563043',
+      d1: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+    };
+    const durableProduction = {
+      merge: '8da99fd0a161b90a4bd90ab29bde1abf796b3bf6',
+      deployment: '3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8',
+      worker: '291f3292-3fa9-44fc-bf6f-b68fd2f4cef6',
+      d1: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+    };
 
     for (const document of [roadmap, production, preview]) {
       const normalized = document.replace(/\s+/g, ' ');
-      expect(document).toContain(currentMain);
-      expect(document).toContain(currentTree);
-      expect(document).toContain('not deployed');
+      expect(document).toContain(reconciliationCutoffCommit);
+      expect(document).toContain(reconciliationCutoffTree);
+      expect(normalized).toContain('At the reconciliation cutoff immediately after PR #113');
+      expect(normalized).toContain('and that revision was not deployed');
       expect(normalized).toContain('Production runs for PRs #109–#113 were cancelled and preview jobs skipped');
       expect(document).toContain('PR #109');
       expect(document).toContain('PR #110');
@@ -413,7 +425,12 @@ describe('published project contract', () => {
     }
     expect(roadmap).toContain('UBS semantic aggregate foundation / PR #64');
     expect(roadmap).toContain('historical foundation state, not a claim that the\n  aggregate remains inactive today');
-    expect(preview).toContain(previewHead);
+    for (const document of [roadmap, preview]) {
+      for (const value of Object.values(durablePreview)) expect(document).toContain(value);
+    }
+    for (const document of [roadmap, production, preview]) {
+      for (const value of Object.values(durableProduction)) expect(document).toContain(value);
+    }
     expect(preview).toContain('CCEL execution disabled before adapter, coordinator, or fetch');
     expect(production).toContain('PR #108 v6/local-only release');
   });


### PR DESCRIPTION
# Summary

- Record PRs #109–#113 as repository-only milestones after the PR #108 production release.
- Time-bound `2f12262c9a37d3588bee9b5071954823c15cbd12` as the reconciliation cutoff immediately after PR #113, rather than calling it permanently current `main`.
- Preserve the durable release split: preview remains the reviewed PR #107 Transform-11 v7 deployment; production remains the reviewed PR #108 Transform-11 v6 deployment.
- Clarify that PR #64 was an inactive foundation whose successor was later activated by PR #96.
- Keep PR #111 inert, PR #112 synthetic-only, and PR #113 provisional and separately release-gated.

# Release boundary

Documentation and documentation-contract tests only. No application behavior,
corpus, migration, D1 binding, Worker configuration, secret, preview deployment,
production deployment, or live CCEL request.

If merged, cancel the automatic production workflow before any deploy step. No
preview deployment is authorized.

# Verification

- Node 22.23.1 `npm run docs:check`: 11/11
- Release reconciliation/guard tests: 10/10
- Release-script typecheck: pass
- Wrangler release-config dry run: pass, no deployment
- `git diff --check`: pass
- Independent Sol re-review: SHIP after the cutoff-wording repair

# Commit range

- Base: `2f12262c9a37d3588bee9b5071954823c15cbd12`
- Head: `2b255c0dd95697c747dae7dbf225e143e7d3ba3c`
- Tree: `82c20ac7cfb09ab29c5710f59e31ea614358d919`
