### PR TITLE
fix: pin the observed CCEL search endpoint

### DIFF
--- a/docs/CCEL-UPSTREAM-COORDINATOR.md
+++ b/docs/CCEL-UPSTREAM-COORDINATOR.md
@@ -44,7 +44,9 @@ authoritative for this brand-new owner and for the local test namespace.
 
 An admitted cache miss reserves the origin synchronously **before** its single
 upstream GET begins. The minimum interval is 10,000 ms between admitted
-attempts globally. A busy response exposes only a bounded integer
+attempts globally. This applies to the sole fixed observed-canary hypothesis
+endpoint, not a claim that any result query succeeds. A busy response exposes
+only a bounded integer
 `retryAfterSeconds`—never queue position, request metadata, or another caller's
 identity.
 

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -9,11 +9,19 @@
 
 Originally recorded 2026-07-11, updated 2026-07-15 for dormant parser-policy
 hardening, and reconciled 2026-07-16 for preview-only v4 exposure. Updated
-2026-07-17 for preview-only v5 exposure. This is an architecture record, not
-an enablement approval. The live-search and coordinator flags remain off in
-production and preview.
+2026-07-17 for preview-only v5 exposure, and 2026-07-31 to pin the observed
+canary endpoint. This is an architecture record, not an enablement approval.
+The live-search and coordinator flags remain off in production and preview.
 
-- Search surface reviewed: `https://ccel.org/?page=1&text=...`
+- Observed canary hypothesis: the search interface was fetched at
+  `https://www.ccel.org/search`, where the observed form declared `GET` and
+  the relative action `/home3/search`. The dormant adapter therefore has one
+  fixed candidate endpoint, `https://www.ccel.org/home3/search`, and encodes
+  only its bounded `page=1` and `text` query parameters. This observation is
+  not proof that a result query succeeds, permission to query it, or a durable
+  interface guarantee. No HTML, query, result, or snippet evidence is retained.
+  There is no endpoint configuration, root/alternate-path probing, or fallback
+  host/path in the adapter.
 - Search contract reviewed: [CCEL Search Help](https://www.ccel.org/help/search), including the documented `author`, `authorID`, `title`, and `bookID` fields.
 - Exact locator shape reviewed: `https://ccel.org/ccel/{author}/{work}/{section}.html`.
 - Product boundary approved by the owner on 2026-07-16: retain the existing

--- a/src/adapters/commentary/CcelSearchAdapter.ts
+++ b/src/adapters/commentary/CcelSearchAdapter.ts
@@ -24,7 +24,11 @@ import type {
 } from '../../services/historical/CcelUpstreamCoordinator.js';
 
 export const CCEL_SEARCH_ATTRIBUTION = 'CCEL (Christian Classics Ethereal Library)' as const;
-export const CCEL_SEARCH_URL = 'https://ccel.org/';
+/**
+ * The one observed CCEL form action retained for a separately authorized
+ * canary. This is not evidence that a result query succeeds.
+ */
+export const CCEL_SEARCH_URL = 'https://www.ccel.org/home3/search';
 
 export const CCEL_SEARCH_LIMITS = Object.freeze({
   maxTextCharacters: 200,
@@ -79,8 +83,6 @@ export interface CcelSearchAdapterOptions {
   featureFlags?: Partial<PrimarySourceFeatureFlags>;
   fetchImpl?: FetchImplementation;
   now?: Clock;
-  /** Only the verified CCEL origin and root search path are accepted. */
-  baseUrl?: string;
   /** Lower test/deployment budgets are allowed; the locked maxima cannot be raised. */
   cacheMaxEntries?: number;
   cacheMaxBytes?: number;
@@ -334,7 +336,6 @@ export class CcelSearchAdapter {
   private readonly enabled: boolean;
   private readonly fetchImpl: FetchImplementation;
   private readonly now: Clock;
-  private readonly baseUrl: string;
   private readonly cache: MetadataCache;
   private readonly telemetry: (event: CcelCoordinatorEvent) => void | Promise<void>;
   private activeRequests = 0;
@@ -343,7 +344,6 @@ export class CcelSearchAdapter {
     this.enabled = options.enabled ?? options.featureFlags?.ccelLiveSearch ?? false;
     this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
     this.now = options.now ?? Date.now;
-    this.baseUrl = validateSearchOrigin(options.baseUrl ?? CCEL_SEARCH_URL);
     this.telemetry = options.telemetry ?? (() => undefined);
     const cacheMaxEntries = options.cacheMaxEntries ?? CCEL_SEARCH_LIMITS.cacheMaxEntries;
     const cacheMaxBytes = options.cacheMaxBytes ?? CCEL_SEARCH_LIMITS.cacheMaxBytes;
@@ -499,7 +499,7 @@ export class CcelSearchAdapter {
 
   private async fetchSearchHtml(url: string, deadline: number): Promise<string> {
     if (this.now() >= deadline) throw new CcelSearchFailure('network');
-    const validated = validateSearchUrl(url, this.baseUrl);
+    const validated = validateSearchUrl(url);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(TIMEOUT_ABORT_REASON), Math.min(CCEL_SEARCH_LIMITS.timeoutMs, Math.max(1, deadline - this.now())));
     let response: Response;
@@ -1158,25 +1158,31 @@ export function normalizeCcelSectionLocator(input: string): { kind: 'ccel_sectio
   return { kind: 'ccel_section', url: canonicalUrl, work, section };
 }
 
-function validateSearchOrigin(input: string): string {
+function validateSearchUrl(input: string): string {
   let url: URL;
   try {
     url = new URL(input);
   } catch {
-    throw new Error('CCEL search origin is invalid');
+    throw new CcelSearchFailure('policy');
   }
-  if (url.protocol !== 'https:' || !['ccel.org', 'www.ccel.org'].includes(url.hostname.toLowerCase()) || url.username || url.password || url.port || url.pathname !== '/' || url.search || url.hash) {
-    throw new Error('CCEL search origin is not an approved HTTPS origin');
+  const pageValues = url.searchParams.getAll('page');
+  const textValues = url.searchParams.getAll('text');
+  // The observed interface names one GET form action. Do not probe root,
+  // alternate hosts, alternate paths, or unreviewed query variants.
+  if (url.protocol !== 'https:'
+    || url.hostname !== 'www.ccel.org'
+    || url.port
+    || url.username
+    || url.password
+    || url.pathname !== '/home3/search'
+    || url.hash
+    || url.searchParams.size !== 2
+    || pageValues.length !== 1
+    || pageValues[0] !== '1'
+    || textValues.length !== 1
+    || textValues[0] === '') {
+    throw new CcelSearchFailure('policy');
   }
-  return CCEL_SEARCH_URL;
-}
-
-function validateSearchUrl(input: string, baseUrl: string): string {
-  const url = new URL(input);
-  // Redirects may normalize between the two documented CCEL hostnames, but
-  // may not leave the approved origin family or search path.
-  void baseUrl;
-  if (url.protocol !== 'https:' || !['ccel.org', 'www.ccel.org'].includes(url.hostname.toLowerCase()) || url.port || url.username || url.password || url.pathname !== '/') throw new CcelSearchFailure('policy');
   return url.toString();
 }
 

--- a/test/unit/adapters/commentary/CcelLegacyReaderRetirement.test.ts
+++ b/test/unit/adapters/commentary/CcelLegacyReaderRetirement.test.ts
@@ -3,8 +3,8 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import ts from 'typescript';
 import {
+  CCEL_SEARCH_URL,
   CCEL_SEARCH_LIMITS,
-  CcelSearchAdapter,
   composeCcelSearchRequest,
   normalizeCcelSectionLocator,
 } from '../../../../src/adapters/commentary/CcelSearchAdapter.js';
@@ -55,27 +55,25 @@ describe('retired direct CCEL body-reader architecture', () => {
     expect(directFetchInvocations(source, 'synthetic.ts')).toHaveLength(1);
   });
 
-  it('locks the sole CCEL fetch to a bounded root search and never dereferences result locators', () => {
+  it('locks the sole CCEL fetch to the fixed observed GET action and never dereferences result locators', () => {
     const request = composeCcelSearchRequest({
       text: 'grace and truth',
       page: 1,
       limit: CCEL_SEARCH_LIMITS.maxHitsPerResponse,
     });
     const url = new URL(request.url);
-    expect(url).toMatchObject({ protocol: 'https:', hostname: 'ccel.org', pathname: '/' });
+    expect(CCEL_SEARCH_URL).toBe('https://www.ccel.org/home3/search');
+    expect(url).toMatchObject({ protocol: 'https:', hostname: 'www.ccel.org', pathname: '/home3/search' });
     expect([...url.searchParams.keys()].sort()).toEqual(['page', 'text']);
     expect(url.searchParams.get('page')).toBe('1');
-
-    expect(() => new CcelSearchAdapter({ baseUrl: 'https://ccel.org/ccel/author/work/' }))
-      .toThrow('not an approved HTTPS origin');
-    expect(() => new CcelSearchAdapter({ baseUrl: 'https://ccel.org/?text=grace' }))
-      .toThrow('not an approved HTTPS origin');
 
     const searchSource = readFileSync(SEARCH_ADAPTER_PATH, 'utf8');
     expect(directFetchInvocations(searchSource, SEARCH_ADAPTER_PATH)).toEqual(['this.fetchImpl(validated, {']);
     expect(searchSource.match(/this\.fetchImpl\s*\(/g)).toHaveLength(1);
     expect(searchSource).toContain('this.fetchImpl(validated, {');
-    expect(searchSource).toContain("url.pathname !== '/'");
+    expect(searchSource).toContain("url.hostname !== 'www.ccel.org'");
+    expect(searchSource).toContain("url.pathname !== '/home3/search'");
+    expect(searchSource).not.toContain('baseUrl');
     expect(searchSource).toContain('class MetadataCache');
 
     const locator = normalizeCcelSectionLocator('/ccel/augustine/confessions/confessions.i.html?tracking=discarded');

--- a/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
+++ b/test/unit/adapters/commentary/CcelSearchAdapter.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { Window } from 'happy-dom';
 import {
+  CCEL_SEARCH_URL,
   CCEL_SEARCH_LIMITS,
   CcelSearchAdapter,
   composeCcelSearchRequest,
@@ -285,8 +286,10 @@ describe('composeCcelSearchRequest', () => {
   it('uses URLSearchParams encoding and escapes Lucene syntax as literals', () => {
     const composed = composeCcelSearchRequest({ text: '  (grace) + truth  ', match: 'all_terms', page: 1, limit: 5 });
     const url = new URL(composed.url);
-    expect(url.origin).toBe('https://ccel.org');
-    expect(url.pathname).toBe('/');
+    expect(CCEL_SEARCH_URL).toBe('https://www.ccel.org/home3/search');
+    expect(url.origin).toBe('https://www.ccel.org');
+    expect(url.pathname).toBe('/home3/search');
+    expect([...url.searchParams.keys()].sort()).toEqual(['page', 'text']);
     expect(url.searchParams.get('page')).toBe('1');
     expect(url.searchParams.get('text')).toBe('\\(grace\\) AND \\+ AND truth');
     expect(composed.url).not.toContain('(grace)');
@@ -368,6 +371,38 @@ describe('CcelSearchAdapter', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('accepts only the fixed observed GET action and does not make endpoint overrides active', async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const adapter = new CcelSearchAdapter({ enabled: true, fetchImpl });
+    const internals = adapter as unknown as {
+      fetchSearchHtml(url: string, deadline: number): Promise<string>;
+    };
+    const deadline = Date.now() + CCEL_SEARCH_LIMITS.totalRequestMs;
+    const rejectedUrls = [
+      'https://www.ccel.org/?page=1&text=grace',
+      'https://ccel.org/home3/search?page=1&text=grace',
+      'https://www.ccel.org/search?page=1&text=grace',
+      'https://www.ccel.org/home3/search?page=1&text=grace&fallback=root',
+    ];
+
+    for (const url of rejectedUrls) {
+      await expect(internals.fetchSearchHtml(url, deadline)).rejects.toThrow('policy');
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    const configuredFetch = vi.fn<typeof fetch>().mockResolvedValue(htmlResponse(noResultsFixture));
+    const configuredAtRuntime = testAdapter({
+      enabled: true,
+      fetchImpl: configuredFetch,
+      // `baseUrl` is deliberately absent from the public options type and
+      // ignored if a JavaScript caller still supplies an obsolete key.
+      baseUrl: 'https://ccel.org/',
+    } as never);
+    await configuredAtRuntime.search(query({ text: 'obsolete endpoint key' }));
+    expect(configuredFetch).toHaveBeenCalledOnce();
+    expect(configuredFetch.mock.calls[0]![0]).toMatch(/^https:\/\/www\.ccel\.org\/home3\/search\?page=1&text=/);
+  });
+
   it('locks the dormant rollout to page 1, five hits, 240 Unicode snippet characters, and zero retries or redirects', () => {
     expect(CCEL_SEARCH_LIMITS).toMatchObject({
       maxPage: 1,
@@ -394,7 +429,7 @@ describe('CcelSearchAdapter', () => {
     expect(result.hits[0].snippet).not.toContain('<');
     expect(JSON.stringify(result)).not.toMatch(/token|queryID|resultID|synthetic-redacted/);
     expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(fetchImpl.mock.calls[0][0]).toMatch(/^https:\/\/ccel\.org\/\?page=1&text=/);
+    expect(fetchImpl.mock.calls[0][0]).toMatch(/^https:\/\/www\.ccel\.org\/home3\/search\?page=1&text=/);
     expect(fetchImpl.mock.calls[0][1]).toMatchObject({ method: 'GET', redirect: 'manual', signal: expect.any(AbortSignal) });
   });
 
@@ -735,7 +770,7 @@ describe('CcelSearchAdapter', () => {
     await testAdapter({ enabled: true, fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(wrongType.response) }).search(query({ text: 'wrong type body' }));
     expect(wrongType.cancel).toHaveBeenCalled();
 
-    const redirect = discardableResponse(302, { location: 'https://ccel.org/?page=1&text=redirected' });
+    const redirect = discardableResponse(302, { location: 'https://www.ccel.org/home3/search?page=1&text=redirected' });
     const redirectFetch = vi.fn<typeof fetch>()
       .mockResolvedValueOnce(redirect.response)
       .mockImplementationOnce(async () => htmlResponse(resultsFixture));
@@ -747,7 +782,7 @@ describe('CcelSearchAdapter', () => {
   it('never follows same-host redirects', async () => {
     const cancels: Array<ReturnType<typeof vi.spyOn>> = [];
     const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () => {
-      const redirect = discardableResponse(302, { location: 'https://ccel.org/?page=1&text=redirect' });
+      const redirect = discardableResponse(302, { location: 'https://www.ccel.org/home3/search?page=1&text=redirect' });
       cancels.push(redirect.cancel);
       return redirect.response;
     });

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -406,9 +406,14 @@ describe('published project contract', () => {
     }
 
     const liveAudit = documents[0]!;
+    const preflight = documents[2]!;
     expect(liveAudit).toContain('exactly two concurrent `searchDepth: "expanded"` contenders');
     expect(liveAudit).toContain('`searchDepth: "standard"` call');
     expect(liveAudit).toContain('partial, non-error response');
     expect(liveAudit).not.toMatch(/CCEL-only contenders/i);
+    expect(preflight).toContain('https://www.ccel.org/home3/search');
+    expect(preflight).toContain('Observed canary hypothesis');
+    expect(preflight).toContain('not proof that a result query succeeds');
+    expect(preflight).toContain('No HTML, query, result, or snippet evidence is retained.');
   });
 });

--- a/test/unit/services/historical/CcelUpstreamCoordinator.test.ts
+++ b/test/unit/services/historical/CcelUpstreamCoordinator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CCEL_UPSTREAM_MIN_INTERVAL_MS,
   CCEL_UPSTREAM_MAX_RETRY_AFTER_SECONDS,
   ProcessLocalCcelUpstreamCoordinator,
   initialCcelCoordinatorState,
@@ -9,7 +10,8 @@ import {
 } from '../../../../src/services/historical/CcelUpstreamCoordinator.js';
 
 describe('CCEL upstream coordinator policy', () => {
-  it('admits exactly one of simultaneous process-local requests', async () => {
+  it('locks the global ten-second admission interval and admits exactly one simultaneous process-local request', async () => {
+    expect(CCEL_UPSTREAM_MIN_INTERVAL_MS).toBe(10_000);
     let now = 100_000;
     const coordinator = new ProcessLocalCcelUpstreamCoordinator({ enabled: true, now: () => now });
     const decisions = await Promise.all(Array.from({ length: 20 }, () => coordinator.admit()));
@@ -22,7 +24,7 @@ describe('CCEL upstream coordinator policy', () => {
         retryAfterSeconds: 10,
       }))));
 
-    now += 10_000;
+    now += CCEL_UPSTREAM_MIN_INTERVAL_MS;
     await expect(coordinator.admit()).resolves.toMatchObject({ kind: 'admitted' });
   });
 


### PR DESCRIPTION
# Summary

- Replace the obsolete root-search hypothesis with the exact currently observed form target `https://www.ccel.org/home3/search`.
- Remove endpoint injection/configurability from the adapter surface.
- Require one canonical GET containing only `page=1` and `text`.
- Reject alternate hosts, root or wrong paths, duplicate/extra query keys, credentials, fragments, non-HTTPS URLs, redirects, and noncanonical page values.
- Preserve canonical result locators at `https://ccel.org/ccel/...`.
- Update the offline preflight contract, coordinator documentation, and exact endpoint tests.

# Safety boundary

This is an offline repair of dormant infrastructure. It does not establish that
a live result query succeeds. Runtime flags remain disabled; manual redirect
handling, zero retries, bounded parsing, the circuit breaker, and the global
ten-second admission interval are unchanged.

No CCEL request, secret provisioning, deployment, feature-flag change, D1
operation, or production change is included. The temporary live canary remains
separately authorized and approval-gated.

If merged, cancel the automatic production workflow before any deploy step. No
preview deployment or canary execution is authorized.

# Verification

- Node 22.23.1 CCEL suite: 140/140
- Full unit suite: 2,443 passed, 2 skipped
- Integration: 3/3
- Node, Worker, and release-script typechecks: pass
- Documentation checks: pass
- `git diff --check`: pass
- Independent Sol review: SHIP, no findings

# Commit

- Base: `2f12262c9a37d3588bee9b5071954823c15cbd12`
- Head: `87b664017f9410e08b757d387b0e5046595699a0`
- Tree: `670c7284c14081583dabb6d9b485683b9ecd235d`
