### PR TITLE
data: add inert MACULA source contract

### DIFF
--- a/data/biblical-languages/macula/SOURCE-CONTRACT.json
+++ b/data/biblical-languages/macula/SOURCE-CONTRACT.json
@@ -19,7 +19,28 @@
       "noticePaths": [
         "README.md",
         "LICENSE.md"
-      ]
+      ],
+      "maturity": {
+        "baselineTag": "24.06.17",
+        "baselinePeeledCommit": "b5b7ecec0882a3e9a609ecac99e157391e5d9b46",
+        "selectedPinStatus": "untagged_snapshot",
+        "selectedPinDescendsFromBaseline": true,
+        "reachableCommitDistance": 29,
+        "selectedPathComparison": {
+          "selectedLowfatFileCount": 27,
+          "differingSelectedLowfatFileCount": 27,
+          "status": "all_selected_lowfat_files_differ_from_baseline_tag"
+        },
+        "repositoryLevelChangeSummary": "The selected pin is a later untagged snapshot; this lock records reproducibility, not a release or quality conclusion.",
+        "independentPublicationGates": [
+          "independent scholarly QA",
+          "product acceptance",
+          "full reproduction",
+          "rights review",
+          "nine-dangling relationship resolution-or-exclusion gate"
+        ],
+        "reproducibilityBoundary": "Exact pins prove reproducibility only."
+      }
     },
     {
       "id": "macula-hebrew",
@@ -40,29 +61,71 @@
         "LICENSE.md",
         "sources/README.md",
         "sources/GrovesCenter/README.md"
-      ]
+      ],
+      "maturity": {
+        "baselineTag": "26.04.13",
+        "baselinePeeledCommit": "09f8ea9e25025841ec45e2b6e7fc01595a080568",
+        "selectedPinStatus": "untagged_snapshot",
+        "selectedPinDescendsFromBaseline": true,
+        "reachableCommitDistance": 3,
+        "selectedPathComparison": {
+          "selectedLowfatFileCount": 929,
+          "differingSelectedLowfatFileCount": 0,
+          "differingSelectedNoticeCount": 0,
+          "status": "no_selected_WLC_lowfat_files_or_selected_notices_differ_from_baseline_tag"
+        },
+        "repositoryLevelChangeSummary": "Repository changes from the baseline tag cover CGJ stripping, NFC normalization, and merge work; they change zero selected WLC/lowfat files and zero selected notices.",
+        "independentPublicationGates": [
+          "independent scholarly QA",
+          "product acceptance",
+          "full reproduction",
+          "rights review",
+          "nine-dangling relationship resolution-or-exclusion gate"
+        ],
+        "reproducibilityBoundary": "Exact pins prove reproducibility only."
+      }
     }
   ],
   "fieldPolicy": {
-    "retainedWordAttributes": [
-      "xml:id",
-      "ref",
-      "class",
-      "role",
-      "lang"
-    ],
-    "retainedGroupAttributes": [
-      "class",
-      "role",
-      "rule",
-      "Rule",
-      "head"
-    ],
-    "retainedParticipantAttributes": [
-      "subjref",
-      "referent",
-      "participantref"
-    ],
+    "capabilityMatrix": {
+      "greek": {
+        "word": [
+          "xml:id",
+          "ref",
+          "class",
+          "role"
+        ],
+        "group": [
+          "class",
+          "role",
+          "rule",
+          "Rule"
+        ],
+        "participant": [
+          "referent",
+          "subjref"
+        ]
+      },
+      "hebrew": {
+        "word": [
+          "xml:id",
+          "ref",
+          "class",
+          "role",
+          "lang"
+        ],
+        "group": [
+          "class",
+          "role",
+          "rule",
+          "head"
+        ],
+        "participant": [
+          "subjref",
+          "participantref"
+        ]
+      }
+    },
     "alignmentOnlyEphemeral": [
       "word element text"
     ],
@@ -188,8 +251,44 @@
         "Identify modifications and do not imply upstream endorsement or impose additional restrictions."
       ]
     },
-    "faithlifeSblgntStandaloneNotice": {
-      "role": "notice_only_not_materializer_input",
+    "langRetention": {
+      "attribute": "lang",
+      "corpus": "hebrew",
+      "retainedAs": "raw OSHB-derived H/A language evidence",
+      "notA": [
+        "morphology",
+        "an ISO code",
+        "an independently adjudicated language conclusion",
+        "a general classifier",
+        "a Greek capability",
+        "authorization to retain other OSHB morphology"
+      ],
+      "pipelineEvidence": {
+        "maculaHebrewNotice": "MACULA Hebrew trees combine Westminster syntax with OSHB morphology.",
+        "selectedSource": "The selected source is derivative, reorganized, and corrected OSHB material.",
+        "sourceReadme": "The selected source README records the selected source provenance.",
+        "selectedXquery": "The selected XQuery copies node @lang.",
+        "observedTokenLanguages": {
+          "allSelectedHebrewTokensHaveLang": true,
+          "total": 475911,
+          "H": 468362,
+          "A": 7549,
+          "absentFromGreekSource": true
+        }
+      },
+      "openScripturesHebrewBible": {
+        "name": "Open Scriptures Hebrew Bible",
+        "sourceUri": "https://github.com/openscriptures/morphhb",
+        "license": "CC BY 4.0",
+        "licenseUri": "https://creativecommons.org/licenses/by/4.0/",
+        "noticeAndAttributionRequirement": "Retain the supplied attribution, notices, and source URI; do not invent a replacement attribution phrase.",
+        "modificationRequirement": "Identify modifications.",
+        "restrictionsRequirement": "Do not imply endorsement or impose additional restrictions."
+      },
+      "operationalBoundary": "This is an operational provenance record, not a legal conclusion or publication authorization."
+    },
+    "standaloneFaithlifeNotice": {
+      "role": "notice_only_provenance_evidence_not_selected_corpus_input",
       "repository": "https://github.com/Faithlife/SBLGNT.git",
       "commit": "c4d241a9c1c479a55b989ba35a4976c1d0b8052c",
       "tree": "1237db9d579eb13457157ca266a6f822dd4353b9",
@@ -197,7 +296,32 @@
         "README.md",
         "LICENSE"
       ],
-      "prohibition": "Do not use the standalone Faithlife checkout or its XML as an alignment input, projection input, deterministic-hash input, or public-output source."
+      "selectedCorpusInput": false,
+      "prohibitedUses": [
+        "selection",
+        "materialization",
+        "alignment",
+        "projection",
+        "deterministic identity",
+        "public output"
+      ]
+    },
+    "sblgntRightsForMaculaGreekDerivedInput": {
+      "selectedInput": "MACULA Greek SBLGNT/lowfat XML",
+      "derivation": "The selected MACULA Greek lowfat input is SBLGNT-derived.",
+      "upstream": "SBL Greek New Testament",
+      "license": "CC BY 4.0",
+      "licenseUri": "https://creativecommons.org/licenses/by/4.0/",
+      "copyrightNotice": "Copyright 2010 Society of Biblical Literature and Logos Bible Software",
+      "upstreamSourceUri": "https://sblgnt.com/",
+      "futureDistributionObligations": [
+        "Retain supplied source, link, license, copyright, and disclaimer notices.",
+        "Identify modifications.",
+        "Do not imply endorsement or impose additional restrictions."
+      ],
+      "standaloneCheckoutBoundary": "The standalone Faithlife checkout did not supply the selected XML.",
+      "publicationGate": "Obligations may attach to a future projection; mandatory source-by-source and legal review is required before publication.",
+      "operationalBoundary": "This is an operational rights record, not a legal conclusion or publication authorization."
     },
     "legalReviewGate": "This contract records source notices and operational obligations; it is not a legal opinion and does not authorize publication."
   },

--- a/data/biblical-languages/macula/SOURCE-CONTRACT.json
+++ b/data/biblical-languages/macula/SOURCE-CONTRACT.json
@@ -245,7 +245,7 @@
     "maculaHebrew": {
       "license": "CC BY 4.0 per the pinned MACULA Hebrew notice",
       "requiredAttribution": "MACULA Hebrew Linguistic Datasets, available at https://github.com/Clear-Bible/macula-hebrew/",
-      "selectedInputProvenance": "The selected lowfat inputs have composite provenance. The source contract excludes morphology, semantic data, glosses, and Cherith/SILHA material, but future publication still requires a source-by-source rights review.",
+      "selectedInputProvenance": "The selected WLC lowfat input otherwise has composite provenance. All morphology and morphological-analysis fields are excluded except the Hebrew-only raw lang evidence expressly identified below; future publication still requires a source-by-source rights review.",
       "modificationNoticeRequirements": [
         "Before any distribution, provide the required attribution, a link to CC BY 4.0, and applicable copyright or license notices.",
         "Identify modifications and do not imply upstream endorsement or impose additional restrictions."
@@ -254,20 +254,20 @@
     "langRetention": {
       "attribute": "lang",
       "corpus": "hebrew",
-      "retainedAs": "raw OSHB-derived H/A language evidence",
+      "retainedAs": "raw OSHB-derived H/A language evidence only",
       "notA": [
-        "morphology",
+        "morphological analysis",
         "an ISO code",
         "an independently adjudicated language conclusion",
         "a general classifier",
         "a Greek capability",
-        "authorization to retain other OSHB morphology"
+        "authorization to retain any other OSHB morphology field"
       ],
       "pipelineEvidence": {
         "maculaHebrewNotice": "MACULA Hebrew trees combine Westminster syntax with OSHB morphology.",
-        "selectedSource": "The selected source is derivative, reorganized, and corrected OSHB material.",
-        "sourceReadme": "The selected source README records the selected source provenance.",
-        "selectedXquery": "The selected XQuery copies node @lang.",
+        "selectedSource": "The retained lang attribute is copied from MACULA's derivative, reorganized, and corrected OSHB source layer; the selected WLC lowfat input otherwise has composite provenance.",
+        "sourceReadme": "The pinned repository source README records the MACULA source layer provenance.",
+        "pinnedRepositoryXquery": "The pinned repository XQuery copies node @lang; it is provenance evidence and not one of the 933 selected paths.",
         "observedTokenLanguages": {
           "allSelectedHebrewTokensHaveLang": true,
           "total": 475911,

--- a/data/biblical-languages/macula/SOURCE-CONTRACT.json
+++ b/data/biblical-languages/macula/SOURCE-CONTRACT.json
@@ -217,7 +217,39 @@
       "bytes": 207106048,
       "sha256": "c5a61cf047e662a6d2238093edefa7dc540ce8f2b2bbeb49115cb94329fab414",
       "verificationPolicy": "recorded_only_not_opened_by_compact_verifier"
-    }
+    },
+    "authorityArtifacts": [
+      {
+        "base": "audit-output",
+        "path": "EVIDENCE-STATUS.md",
+        "bytes": 1150,
+        "sha256": "c40d6a96945ef15bd56363bbcd06c8d76c97058b5980e42b7707a128c6adf0f8"
+      },
+      {
+        "base": "final-replay-2",
+        "path": "run-summary.json",
+        "bytes": 8779,
+        "sha256": "e46fbf33ce0b15a5db0dde0f3212b33d8a9204c8a3449e549dea6ac7cf179959"
+      },
+      {
+        "base": "final-replay-2",
+        "path": "REPORT.md",
+        "bytes": 6545,
+        "sha256": "d27aaf26496568023617cf7d8470442ca5a321d3e52e15e568adba1767a12a52"
+      },
+      {
+        "base": "final-replay-2",
+        "path": "provenance-license-notice.json",
+        "bytes": 1823,
+        "sha256": "d81d2ccfef76bc682ed2c147f47dc6bcc3fb7ae2cc3bab150686191d30ca320f"
+      },
+      {
+        "base": "final-replay-2",
+        "path": "replay-comparison.json",
+        "bytes": 856,
+        "sha256": "c20858d3d10fa95f9bc86013089a9ab206e2ef7f97c919a9c55dd61d40848d34"
+      }
+    ]
   },
   "currentMainAttestation": {
     "commit": "2f12262c9a37d3588bee9b5071954823c15cbd12",

--- a/data/biblical-languages/macula/SOURCE-CONTRACT.json
+++ b/data/biblical-languages/macula/SOURCE-CONTRACT.json
@@ -1,0 +1,219 @@
+{
+  "schemaVersion": "theologai-macula-source-contract.v1",
+  "status": "candidate_contract_only",
+  "sources": [
+    {
+      "id": "macula-greek",
+      "corpus": "greek",
+      "repository": "https://github.com/Clear-Bible/macula-greek.git",
+      "revision": {
+        "commit": "8423afe47b9e8f24b7772e808af45c7159a6fe7e",
+        "tree": "eea78df4b0f1efb857f1575243a1ec4548267a11",
+        "releaseStatus": "unreleased_main_snapshot"
+      },
+      "selection": {
+        "xmlPathPattern": "SBLGNT/lowfat/*.xml",
+        "xmlFileCount": 27,
+        "selectedPathCount": 29
+      },
+      "noticePaths": [
+        "README.md",
+        "LICENSE.md"
+      ]
+    },
+    {
+      "id": "macula-hebrew",
+      "corpus": "hebrew",
+      "repository": "https://github.com/Clear-Bible/macula-hebrew.git",
+      "revision": {
+        "commit": "47db250bd55d0d8577f2a94fba114ef16c35b23c",
+        "tree": "594f395cf473795d6984003800b4bf86ca691a26",
+        "releaseStatus": "unreleased_main_snapshot"
+      },
+      "selection": {
+        "xmlPathPattern": "WLC/lowfat/*-lowfat.xml",
+        "xmlFileCount": 929,
+        "selectedPathCount": 933
+      },
+      "noticePaths": [
+        "README.md",
+        "LICENSE.md",
+        "sources/README.md",
+        "sources/GrovesCenter/README.md"
+      ]
+    }
+  ],
+  "fieldPolicy": {
+    "retainedWordAttributes": [
+      "xml:id",
+      "ref",
+      "class",
+      "role",
+      "lang"
+    ],
+    "retainedGroupAttributes": [
+      "class",
+      "role",
+      "rule",
+      "Rule",
+      "head"
+    ],
+    "retainedParticipantAttributes": [
+      "subjref",
+      "referent",
+      "participantref"
+    ],
+    "alignmentOnlyEphemeral": [
+      "word element text"
+    ],
+    "knownRejectedWordAttributes": [
+      "after",
+      "case",
+      "coredomain",
+      "degree",
+      "discontinuous",
+      "domain",
+      "english",
+      "frame",
+      "gender",
+      "gloss",
+      "greek",
+      "greekstrong",
+      "junction",
+      "lemma",
+      "lexdomain",
+      "ln",
+      "mandarin",
+      "mood",
+      "morph",
+      "normalized",
+      "note",
+      "number",
+      "person",
+      "pos",
+      "rule",
+      "sdbh",
+      "sensenumber",
+      "state",
+      "stem",
+      "strong",
+      "stronglemma",
+      "strongnumberx",
+      "tense",
+      "transliteration",
+      "type",
+      "unicode",
+      "voice"
+    ],
+    "knownRejectedGroupAttributes": [
+      "articular",
+      "clauseType",
+      "clausetype",
+      "junction",
+      "nodeId",
+      "predication",
+      "type"
+    ],
+    "unknownAttributePolicy": "fail_closed_review_required"
+  },
+  "danglingParticipantExclusionLedger": {
+    "status": "unresolved_excluded_from_public_output",
+    "records": [
+      {
+        "corpus": "hebrew",
+        "relationship": "participantref",
+        "count": 4
+      },
+      {
+        "corpus": "hebrew",
+        "relationship": "subjref",
+        "count": 5
+      }
+    ],
+    "total": 9,
+    "correctionPolicy": "no_guessed_target_corrections",
+    "publicOutputPolicy": "fail_closed"
+  },
+  "auditEvidence": {
+    "authority": "only_final_replay_2_under_the_local_audit_output",
+    "deterministicIdentity": "2d5e770ee05260fbbf4f6810153f815e55b86b602ca301e30b7274c3637124b7",
+    "compactArtifacts": [
+      {
+        "path": "source-manifest.json",
+        "bytes": 240952,
+        "sha256": "b9dbd2ca6353fa76740650ffa85247b449e0e2f687fc1f40e227a7677f571988"
+      },
+      {
+        "path": "inspection.json",
+        "bytes": 54523,
+        "sha256": "505e715901635db876539358f9456830ff51b17445cd372045d665834c9896b9"
+      }
+    ],
+    "projectionArtifact": {
+      "path": "macula-structural-projection.sqlite",
+      "bytes": 207106048,
+      "sha256": "c5a61cf047e662a6d2238093edefa7dc540ce8f2b2bbeb49115cb94329fab414",
+      "verificationPolicy": "recorded_only_not_opened_by_compact_verifier"
+    }
+  },
+  "currentMainAttestation": {
+    "commit": "2f12262c9a37d3588bee9b5071954823c15cbd12",
+    "tree": "9922aedb74c690e7a3fcb926b3d621f28fa44535",
+    "morphologyUsageIdentity": "c3600bb55da75aa600f8c97885efa7d58a3e8c29c3fcc6445a553091011beabd",
+    "runtimeContentInventory": {
+      "artifactCount": 72,
+      "identityPolicy": "canonical_decompressed_json_v1_sha256_for_json_gz_else_raw_sha256",
+      "sha256": "caf58814f24cc72837586c901c42f3556b59e45ec81bb0af7f5cfb9fa1629dcd"
+    },
+    "stepBibleCommit": "0f60797c170f11a1f8dc75c5f7617973e2e66b0d",
+    "d1CorpusIdentity": "29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4",
+    "d1CorpusIdentityDerivation": "computeD1CorpusIdentity(parseDataManifest(data/data-manifest.json))"
+  },
+  "rightsAndProvenance": {
+    "maculaGreek": {
+      "license": "CC BY 4.0 per the pinned MACULA Greek notice",
+      "requiredAttribution": "MACULA Greek Linguistic Datasets, available at https://github.com/Clear-Bible/macula-greek/",
+      "selectedInputProvenance": "MACULA SBLGNT lowfat inputs are SBLGNT-derived and may contain data migrated or persisted from the upstream edition; excluded fields do not erase applicable upstream notices.",
+      "modificationNoticeRequirements": [
+        "Before any distribution, provide the required attribution, a link to CC BY 4.0, and applicable copyright or license notices.",
+        "Identify modifications and do not imply upstream endorsement or impose additional restrictions."
+      ]
+    },
+    "maculaHebrew": {
+      "license": "CC BY 4.0 per the pinned MACULA Hebrew notice",
+      "requiredAttribution": "MACULA Hebrew Linguistic Datasets, available at https://github.com/Clear-Bible/macula-hebrew/",
+      "selectedInputProvenance": "The selected lowfat inputs have composite provenance. The source contract excludes morphology, semantic data, glosses, and Cherith/SILHA material, but future publication still requires a source-by-source rights review.",
+      "modificationNoticeRequirements": [
+        "Before any distribution, provide the required attribution, a link to CC BY 4.0, and applicable copyright or license notices.",
+        "Identify modifications and do not imply upstream endorsement or impose additional restrictions."
+      ]
+    },
+    "faithlifeSblgntStandaloneNotice": {
+      "role": "notice_only_not_materializer_input",
+      "repository": "https://github.com/Faithlife/SBLGNT.git",
+      "commit": "c4d241a9c1c479a55b989ba35a4976c1d0b8052c",
+      "tree": "1237db9d579eb13457157ca266a6f822dd4353b9",
+      "noticePaths": [
+        "README.md",
+        "LICENSE"
+      ],
+      "prohibition": "Do not use the standalone Faithlife checkout or its XML as an alignment input, projection input, deterministic-hash input, or public-output source."
+    },
+    "legalReviewGate": "This contract records source notices and operational obligations; it is not a legal opinion and does not authorize publication."
+  },
+  "inertness": {
+    "contractDoesNotActivate": [
+      "corpus acquisition",
+      "corpus storage",
+      "SQLite or D1 projection",
+      "migration",
+      "data-manifest activation",
+      "repository adapter",
+      "MCP schema, tool, output, catalog, or resource",
+      "composition-root binding",
+      "runtime reachability",
+      "preview, deployment, or Cloudflare workflow"
+    ],
+    "verifierBoundary": "The verifier is local, read-only, and deterministic. It performs no network request, source acquisition, mutation, database access, or runtime binding."
+  }
+}

--- a/docs/MACULA-SOURCE-CONTRACT.md
+++ b/docs/MACULA-SOURCE-CONTRACT.md
@@ -20,6 +20,21 @@ repository. Any later acquisition must happen in a reviewed, separate local
 workflow and must verify the exact commit, tree, selected-path count, and
 source-file evidence before a materializer reads anything.
 
+## Snapshot maturity is reproducibility evidence only
+
+The Greek pin is 29 reachable commits after baseline tag `24.06.17` (peeled
+commit `b5b7ecec0882a3e9a609ecac99e157391e5d9b46`); all 27 selected lowfat
+files differ from that tag. The Hebrew pin is three reachable commits after
+baseline tag `26.04.13` (peeled commit
+`09f8ea9e25025841ec45e2b6e7fc01595a080568`). Its repository-level changes
+cover CGJ stripping, NFC normalization, and merge work, while zero selected
+`WLC/lowfat` files and zero selected notices differ from the tag.
+
+Both pins are untagged snapshots. Exact pins prove reproducibility only: they
+do not establish independent scholarly QA, product acceptance, full
+reproduction, rights review, or resolution-or-exclusion of the nine dangling
+relationships. Those remain independent publication gates.
+
 ## Authoritative evidence and compatibility
 
 Only `/private/tmp/theologai-macula-source-audit/audit-output/final-replay-2`
@@ -46,22 +61,40 @@ npm run data:verify-macula-source-contract -- --audit-dir \
 ```
 
 It checks the source lock, the local historical commit/tree object, the two
-compact audited JSON artifacts, and their recorded relationship to the final
-replay. It does not fetch, move, or otherwise modify a Git ref.
+compact audited JSON artifacts, and every field of the unhashed final
+`run-summary.json`. Material evidence is exact; timestamps, absolute paths,
+host tooling, and benchmark timing are bounded non-authoritative diagnostics
+with closed shapes. Unknown nested fields fail closed. `pass: true` records
+structural projection checks, while `releaseEligible: false` is the separate
+publication result. It does not fetch, move, or otherwise modify a Git ref.
 It deliberately does not open the 197 MiB SQLite projection, source XML, any
 source checkout, or a superseded replay. Full projection reproduction is a
 separate, future gate.
 
 ## Field and publication boundary
 
-The only candidate retained source attributes are stable word coordinates and
-structural fields (`xml:id`, `ref`, `class`, `role`, `lang`), syntax-group
-fields (`class`, `role`, `rule`, `Rule`, `head`), and participant relationship
-fields (`subjref`, `referent`, `participantref`). Word-element text is
-alignment-only and must never be retained. Glosses, translations, semantic
-domains and senses, frames, Cherith/SILHA material, morphology, Strong's,
-lemmas, normalized forms, transliteration, Unicode duplicate data, synonyms,
-mappings, nodes, TSV, TEI, and aggregate lowfat files are excluded.
+The executable capability matrix is corpus-specific:
+
+| Corpus | Word | Group | Participant |
+| --- | --- | --- | --- |
+| Greek | `xml:id`, `ref`, `class`, `role` | `class`, `role`, `rule`, `Rule` | `referent`, `subjref` |
+| Hebrew | `xml:id`, `ref`, `class`, `role`, `lang` | `class`, `role`, `rule`, `head` | `subjref`, `participantref` |
+
+Word-element text is alignment-only and must never be retained. Glosses,
+translations, semantic domains and senses, frames, Cherith/SILHA material,
+morphology, Strong's, lemmas, normalized forms, transliteration, Unicode
+duplicate data, synonyms, mappings, nodes, TSV, TEI, and aggregate lowfat
+files are excluded.
+
+`lang` is retained only in MACULA Hebrew as raw OSHB-derived H/A language
+evidence. It is not morphology, an ISO code, an independently adjudicated
+language conclusion, a general classifier, a Greek capability, or permission
+to retain other OSHB morphology. The candidate records local pipeline evidence:
+the MACULA Hebrew notice says its trees combine Westminster syntax with OSHB
+morphology; the selected source is derivative/reorganized/corrected OSHB
+material; the selected source README records that provenance; and the selected
+XQuery copies node `@lang`. The audit observed `lang` on all 475,911 selected
+Hebrew tokens (H 468,362; A 7,549) and absent from the Greek source.
 
 The contract is closed: a materializer must reject every explicitly excluded
 attribute and fail closed on every unknown attribute until review updates the
@@ -83,13 +116,30 @@ distributed, the future change must provide the required attribution and CC BY
 upstream endorsement, and avoid additional restrictions. The selected fields
 and exclusions reduce scope; they do not erase source-specific obligations.
 
-MACULA Greek's selected SBLGNT lowfat inputs are SBLGNT-derived. That is
-different from the separately audited Faithlife SBLGNT checkout: the latter is
-a standalone notice-only provenance record at
+For Hebrew `lang`, the operational record identifies Open Scriptures Hebrew
+Bible, its [source URI](https://github.com/openscriptures/morphhb), and the
+[CC BY 4.0 license](https://creativecommons.org/licenses/by/4.0/). A future
+distribution must retain the supplied attribution, notices, and source URI;
+mark modifications; and avoid endorsement claims or additional restrictions.
+The contract deliberately does not invent an attribution phrase. This is not a
+legal conclusion or publication authorization.
+
+SBLGNT has two separate executable records. The standalone Faithlife checkout
+is notice-only provenance evidence at
 `c4d241a9c1c479a55b989ba35a4976c1d0b8052c` /
-`1237db9d579eb13457157ca266a6f822dd4353b9`, never an alignment, projection,
-deterministic-hash, or public-output input. The standalone XML and license
-content are neither copied nor read by the contract verifier.
+`1237db9d579eb13457157ca266a6f822dd4353b9`; it is never a selected corpus
+input and is prohibited from selection, materialization, alignment, projection,
+deterministic identity, and public output. Its XML and notices are neither
+copied nor read by this verifier.
+
+Separately, the selected MACULA Greek lowfat input is SBLGNT-derived. A future
+projection must carry the SBL Greek New Testament’s CC BY 4.0 obligations,
+including `Copyright 2010 Society of Biblical Literature and Logos Bible
+Software`, supplied source/link/license/copyright/disclaimer notices,
+modification marking, and no endorsement or additional restrictions. This does
+not claim that the standalone Faithlife checkout supplied the selected XML.
+Obligations may attach to future projection; source-by-source and legal review
+remain mandatory before publication.
 
 This is an operational rights record, not a legal opinion. Before any public
 use, separate review must settle rights/provenance, source acquisition,

--- a/docs/MACULA-SOURCE-CONTRACT.md
+++ b/docs/MACULA-SOURCE-CONTRACT.md
@@ -80,21 +80,25 @@ The executable capability matrix is corpus-specific:
 | Greek | `xml:id`, `ref`, `class`, `role` | `class`, `role`, `rule`, `Rule` | `referent`, `subjref` |
 | Hebrew | `xml:id`, `ref`, `class`, `role`, `lang` | `class`, `role`, `rule`, `head` | `subjref`, `participantref` |
 
-Word-element text is alignment-only and must never be retained. Glosses,
-translations, semantic domains and senses, frames, Cherith/SILHA material,
-morphology, Strong's, lemmas, normalized forms, transliteration, Unicode
-duplicate data, synonyms, mappings, nodes, TSV, TEI, and aggregate lowfat
-files are excluded.
+Word-element text is alignment-only and must never be retained. All morphology
+and morphological-analysis fields are excluded except the Hebrew-only raw
+`lang` evidence expressly identified below. Glosses, translations, semantic
+domains and senses, frames, Cherith/SILHA material, Strong's, lemmas,
+normalized forms, transliteration, Unicode duplicate data, synonyms, mappings,
+nodes, TSV, TEI, and aggregate lowfat files are excluded.
 
 `lang` is retained only in MACULA Hebrew as raw OSHB-derived H/A language
-evidence. It is not morphology, an ISO code, an independently adjudicated
-language conclusion, a general classifier, a Greek capability, or permission
-to retain other OSHB morphology. The candidate records local pipeline evidence:
-the MACULA Hebrew notice says its trees combine Westminster syntax with OSHB
-morphology; the selected source is derivative/reorganized/corrected OSHB
-material; the selected source README records that provenance; and the selected
-XQuery copies node `@lang`. The audit observed `lang` on all 475,911 selected
-Hebrew tokens (H 468,362; A 7,549) and absent from the Greek source.
+evidence only. It is not morphological analysis, an ISO code, an independently
+adjudicated language conclusion, a general classifier, a Greek capability, or
+authorization to retain any other OSHB morphology field. The candidate records
+local pipeline evidence: the MACULA Hebrew notice says its trees combine
+Westminster syntax with OSHB morphology; the retained `lang` attribute is
+copied from MACULA's derivative/reorganized/corrected OSHB source layer; and
+the selected WLC lowfat input otherwise has composite provenance. The pinned
+repository source README records the MACULA source layer provenance, while its
+XQuery copies node `@lang`; that XQuery is provenance evidence, not one of the 933 selected
+paths. The audit observed `lang` on all 475,911 selected Hebrew tokens (H
+468,362; A 7,549) and absent from the Greek source.
 
 The contract is closed: a materializer must reject every explicitly excluded
 attribute and fail closed on every unknown attribute until review updates the

--- a/docs/MACULA-SOURCE-CONTRACT.md
+++ b/docs/MACULA-SOURCE-CONTRACT.md
@@ -28,12 +28,15 @@ is the present local audit authority. Its deterministic identity is
 The root diagnostics and `replay-1`/`replay-2` are superseded and must not be
 cited, copied, packaged, or used as authority.
 
-The lock records the audited current-main source identity
+The lock records the historical source identity that was current-main when the
+audit ran:
 `2f12262c9a37d3588bee9b5071954823c15cbd12` /
 `9922aedb74c690e7a3fcb926b3d621f28fa44535`, plus the exact morphology-usage,
 72-artifact runtime-inventory, STEPBible, and D1 corpus identities. These are
 compatibility gates, not activation or a claim that any MACULA artifact exists
-in the runtime.
+in the runtime. The verifier checks that this pinned commit object and tree are
+available locally; it intentionally does not require `origin/main` to remain
+at the historical commit, because later main advancement is expected.
 
 Run the compact verifier without network access:
 
@@ -42,8 +45,9 @@ npm run data:verify-macula-source-contract -- --audit-dir \
   /private/tmp/theologai-macula-source-audit/audit-output/final-replay-2
 ```
 
-It checks the source lock, the local `origin/main` object, the two compact
-audited JSON artifacts, and their recorded relationship to the final replay.
+It checks the source lock, the local historical commit/tree object, the two
+compact audited JSON artifacts, and their recorded relationship to the final
+replay. It does not fetch, move, or otherwise modify a Git ref.
 It deliberately does not open the 197 MiB SQLite projection, source XML, any
 source checkout, or a superseded replay. Full projection reproduction is a
 separate, future gate.

--- a/docs/MACULA-SOURCE-CONTRACT.md
+++ b/docs/MACULA-SOURCE-CONTRACT.md
@@ -1,0 +1,94 @@
+# MACULA source contract (candidate only)
+
+This document describes a local-only source-contract candidate. It does not
+add MACULA corpus material to TheologAI and does not authorize source
+acquisition, a projection, a migration, D1 work, a repository adapter, an MCP
+surface, a composition-root binding, runtime reachability, a catalog entry, or
+a preview or production deployment.
+
+The executable lock is
+[`data/biblical-languages/macula/SOURCE-CONTRACT.json`](../data/biblical-languages/macula/SOURCE-CONTRACT.json).
+It pins untagged source commits and trees instead of tracking a branch:
+
+| Candidate | Commit | Tree | Selected local-only input shape |
+| --- | --- | --- | --- |
+| MACULA Greek | `8423afe47b9e8f24b7772e808af45c7159a6fe7e` | `eea78df4b0f1efb857f1575243a1ec4548267a11` | 27 `SBLGNT/lowfat/*.xml` files plus two notices |
+| MACULA Hebrew | `47db250bd55d0d8577f2a94fba114ef16c35b23c` | `594f395cf473795d6984003800b4bf86ca691a26` | 929 `WLC/lowfat/*-lowfat.xml` files plus four notices |
+
+There is no floating revision, URL fetcher, downloader, or corpus file in this
+repository. Any later acquisition must happen in a reviewed, separate local
+workflow and must verify the exact commit, tree, selected-path count, and
+source-file evidence before a materializer reads anything.
+
+## Authoritative evidence and compatibility
+
+Only `/private/tmp/theologai-macula-source-audit/audit-output/final-replay-2`
+is the present local audit authority. Its deterministic identity is
+`2d5e770ee05260fbbf4f6810153f815e55b86b602ca301e30b7274c3637124b7`.
+The root diagnostics and `replay-1`/`replay-2` are superseded and must not be
+cited, copied, packaged, or used as authority.
+
+The lock records the audited current-main source identity
+`2f12262c9a37d3588bee9b5071954823c15cbd12` /
+`9922aedb74c690e7a3fcb926b3d621f28fa44535`, plus the exact morphology-usage,
+72-artifact runtime-inventory, STEPBible, and D1 corpus identities. These are
+compatibility gates, not activation or a claim that any MACULA artifact exists
+in the runtime.
+
+Run the compact verifier without network access:
+
+```bash
+npm run data:verify-macula-source-contract -- --audit-dir \
+  /private/tmp/theologai-macula-source-audit/audit-output/final-replay-2
+```
+
+It checks the source lock, the local `origin/main` object, the two compact
+audited JSON artifacts, and their recorded relationship to the final replay.
+It deliberately does not open the 197 MiB SQLite projection, source XML, any
+source checkout, or a superseded replay. Full projection reproduction is a
+separate, future gate.
+
+## Field and publication boundary
+
+The only candidate retained source attributes are stable word coordinates and
+structural fields (`xml:id`, `ref`, `class`, `role`, `lang`), syntax-group
+fields (`class`, `role`, `rule`, `Rule`, `head`), and participant relationship
+fields (`subjref`, `referent`, `participantref`). Word-element text is
+alignment-only and must never be retained. Glosses, translations, semantic
+domains and senses, frames, Cherith/SILHA material, morphology, Strong's,
+lemmas, normalized forms, transliteration, Unicode duplicate data, synonyms,
+mappings, nodes, TSV, TEI, and aggregate lowfat files are excluded.
+
+The contract is closed: a materializer must reject every explicitly excluded
+attribute and fail closed on every unknown attribute until review updates the
+contract. Structural role labels remain source diagnostics, not theological,
+pastoral, grammatical-certainty, or interpretive verdicts; future presentation
+would need a separate review and must not expose excluded data by default.
+
+The content-free exclusion ledger records nine unresolved Hebrew participant
+relationships (four `participantref`, five `subjref`). They are ineligible for
+all public output. No source or target identifiers are preserved here, and no
+target may be guessed. This blocks publication until independent adjudication.
+
+## Rights, provenance, and later gates
+
+The pinned MACULA Greek and Hebrew notices identify their datasets as CC BY
+4.0 and specify the corresponding MACULA attribution. If any material is ever
+distributed, the future change must provide the required attribution and CC BY
+4.0 link, retain applicable notices, identify modifications, avoid implying
+upstream endorsement, and avoid additional restrictions. The selected fields
+and exclusions reduce scope; they do not erase source-specific obligations.
+
+MACULA Greek's selected SBLGNT lowfat inputs are SBLGNT-derived. That is
+different from the separately audited Faithlife SBLGNT checkout: the latter is
+a standalone notice-only provenance record at
+`c4d241a9c1c479a55b989ba35a4976c1d0b8052c` /
+`1237db9d579eb13457157ca266a6f822dd4353b9`, never an alignment, projection,
+deterministic-hash, or public-output input. The standalone XML and license
+content are neither copied nor read by the contract verifier.
+
+This is an operational rights record, not a legal opinion. Before any public
+use, separate review must settle rights/provenance, source acquisition,
+full-reproduction evidence, the nine dangling relationships, data modeling,
+materialization/import, runtime integration, public-output design, and release
+authorization.

--- a/docs/MACULA-SOURCE-CONTRACT.md
+++ b/docs/MACULA-SOURCE-CONTRACT.md
@@ -61,15 +61,20 @@ npm run data:verify-macula-source-contract -- --audit-dir \
 ```
 
 It checks the source lock, the local historical commit/tree object, the two
-compact audited JSON artifacts, and every field of the unhashed final
-`run-summary.json`. Material evidence is exact; timestamps, absolute paths,
-host tooling, and benchmark timing are bounded non-authoritative diagnostics
-with closed shapes. Unknown nested fields fail closed. `pass: true` records
-structural projection checks, while `releaseEligible: false` is the separate
-publication result. It does not fetch, move, or otherwise modify a Git ref.
-It deliberately does not open the 197 MiB SQLite projection, source XML, any
-source checkout, or a superseded replay. Full projection reproduction is a
-separate, future gate.
+compact audited JSON artifacts, and every field of the final
+`run-summary.json`. It also byte-pins the complete authority-bearing metadata
+packet: `EVIDENCE-STATUS.md`, `run-summary.json`, `REPORT.md`,
+`provenance-license-notice.json`, and `replay-comparison.json`. This prevents
+an otherwise well-shaped diagnostic edit or an appended contradictory claim
+from silently changing the reviewed evidence. Material evidence is exact;
+timestamps, absolute paths, host tooling, and benchmark timing remain
+non-authoritative diagnostics, but their observed values are preserved as part
+of this exact historical packet. Unknown nested fields fail closed. A `pass: true`
+result is never sufficient by itself: it records structural projection checks,
+while `releaseEligible: false` is the separate publication result. It does not
+fetch, move, or otherwise modify a Git ref. It deliberately does not open the
+197 MiB SQLite projection, source XML, any source checkout, or a superseded
+replay. Full projection reproduction is a separate, future gate.
 
 ## Field and publication boundary
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "data:verify-sources": "tsx scripts/verify-data-manifest.ts",
     "data:verify-section-keys": "tsx scripts/historical-section-key-plan.ts",
     "data:verify-language-sources": "tsx scripts/verify-biblical-language-sources.ts",
+    "data:verify-macula-source-contract": "tsx scripts/macula-source-contract.ts",
     "data:verify-ubs-hebrew-coordinate-audit": "tsx scripts/reproduce-ubs-hebrew-v092-coordinate-audit.ts",
     "data:build-ubs-hebrew-coordinate-bridge": "tsx scripts/build-ubs-hebrew-v092-coordinate-bridge.ts --write",
     "data:verify-ubs-hebrew-coordinate-bridge": "tsx scripts/build-ubs-hebrew-v092-coordinate-bridge.ts",

--- a/scripts/macula-source-contract.ts
+++ b/scripts/macula-source-contract.ts
@@ -292,22 +292,32 @@ export function assertMaculaSourceAttribute(scope: MaculaSourceAttributeScope, a
   fail(`${scope} attribute ${attribute} is unknown schema drift and requires review`);
 }
 
+/** Verify an exact local commit/tree pair without fetching or moving a ref. */
+export function verifyPinnedGitCommitTree(root: string, commit: string, tree: string, label: string): void {
+  const revision = (args: string[]) => {
+    try {
+      return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    } catch {
+      fail(`${label} Git object is unavailable for ${args.join(' ')}`);
+    }
+  };
+  revision(['cat-file', '-e', `${commit}^{commit}`]);
+  if (revision(['rev-parse', `${commit}^{tree}`]) !== tree) {
+    fail(`${label} tree differs from the source lock`);
+  }
+}
+
 /**
  * Verify the historical Git object used by the audit. It intentionally does
  * not compare `origin/main`: main is expected to advance after the audit.
  */
 export function verifyHistoricalCurrentMainAttestation(root: string): void {
-  const revision = (args: string[]) => {
-    try {
-      return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
-    } catch {
-      fail(`pinned historical current-main Git object is unavailable for ${args.join(' ')}`);
-    }
-  };
-  revision(['cat-file', '-e', `${expectedCurrentMain.commit}^{commit}`]);
-  if (revision(['rev-parse', `${expectedCurrentMain.commit}^{tree}`]) !== expectedCurrentMain.tree) {
-    fail('pinned historical current-main tree differs from source lock');
-  }
+  verifyPinnedGitCommitTree(
+    root,
+    expectedCurrentMain.commit,
+    expectedCurrentMain.tree,
+    'pinned historical current-main',
+  );
 }
 
 function assertAuditSelectedFiles(source: RecordValue, expected: typeof expectedSources[number]): void {

--- a/scripts/macula-source-contract.ts
+++ b/scripts/macula-source-contract.ts
@@ -198,7 +198,7 @@ const expectedRightsAndProvenance = {
   maculaHebrew: {
     license: 'CC BY 4.0 per the pinned MACULA Hebrew notice',
     requiredAttribution: 'MACULA Hebrew Linguistic Datasets, available at https://github.com/Clear-Bible/macula-hebrew/',
-    selectedInputProvenance: 'The selected lowfat inputs have composite provenance. The source contract excludes morphology, semantic data, glosses, and Cherith/SILHA material, but future publication still requires a source-by-source rights review.',
+    selectedInputProvenance: 'The selected WLC lowfat input otherwise has composite provenance. All morphology and morphological-analysis fields are excluded except the Hebrew-only raw lang evidence expressly identified below; future publication still requires a source-by-source rights review.',
     modificationNoticeRequirements: [
       'Before any distribution, provide the required attribution, a link to CC BY 4.0, and applicable copyright or license notices.',
       'Identify modifications and do not imply upstream endorsement or impose additional restrictions.',
@@ -207,20 +207,20 @@ const expectedRightsAndProvenance = {
   langRetention: {
     attribute: 'lang',
     corpus: 'hebrew',
-    retainedAs: 'raw OSHB-derived H/A language evidence',
+    retainedAs: 'raw OSHB-derived H/A language evidence only',
     notA: [
-      'morphology',
+      'morphological analysis',
       'an ISO code',
       'an independently adjudicated language conclusion',
       'a general classifier',
       'a Greek capability',
-      'authorization to retain other OSHB morphology',
+      'authorization to retain any other OSHB morphology field',
     ],
     pipelineEvidence: {
       maculaHebrewNotice: 'MACULA Hebrew trees combine Westminster syntax with OSHB morphology.',
-      selectedSource: 'The selected source is derivative, reorganized, and corrected OSHB material.',
-      sourceReadme: 'The selected source README records the selected source provenance.',
-      selectedXquery: 'The selected XQuery copies node @lang.',
+      selectedSource: "The retained lang attribute is copied from MACULA's derivative, reorganized, and corrected OSHB source layer; the selected WLC lowfat input otherwise has composite provenance.",
+      sourceReadme: 'The pinned repository source README records the MACULA source layer provenance.',
+      pinnedRepositoryXquery: 'The pinned repository XQuery copies node @lang; it is provenance evidence and not one of the 933 selected paths.',
       observedTokenLanguages: {
         allSelectedHebrewTokensHaveLang: true,
         total: 475_911,

--- a/scripts/macula-source-contract.ts
+++ b/scripts/macula-source-contract.ts
@@ -93,6 +93,31 @@ const expectedAuditEvidence = {
   },
 } as const;
 
+const expectedDeterministicArtifacts = [
+  { path: 'source-manifest.json', bytes: 240_952, sha256: 'b9dbd2ca6353fa76740650ffa85247b449e0e2f687fc1f40e227a7677f571988' },
+  { path: 'inspection.json', bytes: 54_523, sha256: '505e715901635db876539358f9456830ff51b17445cd372045d665834c9896b9' },
+  { path: 'macula-structural-projection.sqlite', bytes: 207_106_048, sha256: 'c5a61cf047e662a6d2238093edefa7dc540ce8f2b2bbeb49115cb94329fab414' },
+] as const;
+
+const expectedDeterministicHashDomain = {
+  excludes: [
+    'run-summary.json',
+    'timestamps',
+    'absolute paths',
+    'host-specific tool versions and benchmark timing',
+  ],
+  artifacts: expectedDeterministicArtifacts,
+  sha256: MACULA_AUDIT_IDENTITY,
+} as const;
+
+const expectedReplayComparison = {
+  status: 'identical',
+  priorOutput: 'audit-output/final-replay-1',
+  deterministicIdentity: MACULA_AUDIT_IDENTITY,
+  artifacts: expectedDeterministicArtifacts,
+  assertion: 'The complete projection was independently regenerated twice from the same clean, pinned local inputs and every deterministic artifact hash and byte count matched.',
+} as const;
+
 const expectedCurrentMain = {
   commit: '2f12262c9a37d3588bee9b5071954823c15cbd12',
   tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
@@ -105,6 +130,52 @@ const expectedCurrentMain = {
   stepBibleCommit: '0f60797c170f11a1f8dc75c5f7617973e2e66b0d',
   d1CorpusIdentity: '29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4',
   d1CorpusIdentityDerivation: 'computeD1CorpusIdentity(parseDataManifest(data/data-manifest.json))',
+} as const;
+
+const expectedRightsAndProvenance = {
+  maculaGreek: {
+    license: 'CC BY 4.0 per the pinned MACULA Greek notice',
+    requiredAttribution: 'MACULA Greek Linguistic Datasets, available at https://github.com/Clear-Bible/macula-greek/',
+    selectedInputProvenance: 'MACULA SBLGNT lowfat inputs are SBLGNT-derived and may contain data migrated or persisted from the upstream edition; excluded fields do not erase applicable upstream notices.',
+    modificationNoticeRequirements: [
+      'Before any distribution, provide the required attribution, a link to CC BY 4.0, and applicable copyright or license notices.',
+      'Identify modifications and do not imply upstream endorsement or impose additional restrictions.',
+    ],
+  },
+  maculaHebrew: {
+    license: 'CC BY 4.0 per the pinned MACULA Hebrew notice',
+    requiredAttribution: 'MACULA Hebrew Linguistic Datasets, available at https://github.com/Clear-Bible/macula-hebrew/',
+    selectedInputProvenance: 'The selected lowfat inputs have composite provenance. The source contract excludes morphology, semantic data, glosses, and Cherith/SILHA material, but future publication still requires a source-by-source rights review.',
+    modificationNoticeRequirements: [
+      'Before any distribution, provide the required attribution, a link to CC BY 4.0, and applicable copyright or license notices.',
+      'Identify modifications and do not imply upstream endorsement or impose additional restrictions.',
+    ],
+  },
+  faithlifeSblgntStandaloneNotice: {
+    role: 'notice_only_not_materializer_input',
+    repository: 'https://github.com/Faithlife/SBLGNT.git',
+    commit: 'c4d241a9c1c479a55b989ba35a4976c1d0b8052c',
+    tree: '1237db9d579eb13457157ca266a6f822dd4353b9',
+    noticePaths: ['README.md', 'LICENSE'],
+    prohibition: 'Do not use the standalone Faithlife checkout or its XML as an alignment input, projection input, deterministic-hash input, or public-output source.',
+  },
+  legalReviewGate: 'This contract records source notices and operational obligations; it is not a legal opinion and does not authorize publication.',
+} as const;
+
+const expectedInertness = {
+  contractDoesNotActivate: [
+    'corpus acquisition',
+    'corpus storage',
+    'SQLite or D1 projection',
+    'migration',
+    'data-manifest activation',
+    'repository adapter',
+    'MCP schema, tool, output, catalog, or resource',
+    'composition-root binding',
+    'runtime reachability',
+    'preview, deployment, or Cloudflare workflow',
+  ],
+  verifierBoundary: 'The verifier is local, read-only, and deterministic. It performs no network request, source acquisition, mutation, database access, or runtime binding.',
 } as const;
 
 function fail(message: string): never {
@@ -179,6 +250,7 @@ export function parseMaculaSourceContract(value: unknown): MaculaSourceContract 
 
   const rights = record(root.rightsAndProvenance, 'rights and provenance');
   exactKeys(rights, ['maculaGreek', 'maculaHebrew', 'faithlifeSblgntStandaloneNotice', 'legalReviewGate'], 'rights and provenance');
+  exactValue(rights, expectedRightsAndProvenance, 'rights and provenance');
   for (const key of ['maculaGreek', 'maculaHebrew'] as const) {
     const source = record(rights[key], `rights and provenance.${key}`);
     exactKeys(source, ['license', 'requiredAttribution', 'selectedInputProvenance', 'modificationNoticeRequirements'], `rights and provenance.${key}`);
@@ -191,6 +263,7 @@ export function parseMaculaSourceContract(value: unknown): MaculaSourceContract 
 
   const inertness = record(root.inertness, 'inertness');
   exactKeys(inertness, ['contractDoesNotActivate', 'verifierBoundary'], 'inertness');
+  exactValue(inertness, expectedInertness, 'inertness');
   stringArray(inertness.contractDoesNotActivate, 'inertness.contractDoesNotActivate');
   return root as unknown as MaculaSourceContract;
 }
@@ -201,6 +274,9 @@ export function readMaculaSourceContract(root: string): MaculaSourceContract {
 
 /** Reject both known non-retained fields and novel schema fields before materialization. */
 export function assertMaculaSourceAttribute(scope: MaculaSourceAttributeScope, attribute: string): void {
+  if (scope !== 'word' && scope !== 'group' && scope !== 'participant') {
+    fail(`invalid source attribute scope ${JSON.stringify(scope)}`);
+  }
   const allowed = scope === 'word'
     ? expectedFieldPolicy.retainedWordAttributes
     : scope === 'group'
@@ -216,12 +292,21 @@ export function assertMaculaSourceAttribute(scope: MaculaSourceAttributeScope, a
   fail(`${scope} attribute ${attribute} is unknown schema drift and requires review`);
 }
 
-/** Verify the pinned origin/main object locally without fetching or changing a checkout. */
-export function verifyCurrentMainAttestation(root: string): void {
-  const revision = (args: string[]) => execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
-  if (revision(['rev-parse', 'origin/main']) !== expectedCurrentMain.commit) fail('origin/main commit differs from audited current main');
+/**
+ * Verify the historical Git object used by the audit. It intentionally does
+ * not compare `origin/main`: main is expected to advance after the audit.
+ */
+export function verifyHistoricalCurrentMainAttestation(root: string): void {
+  const revision = (args: string[]) => {
+    try {
+      return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    } catch {
+      fail(`pinned historical current-main Git object is unavailable for ${args.join(' ')}`);
+    }
+  };
+  revision(['cat-file', '-e', `${expectedCurrentMain.commit}^{commit}`]);
   if (revision(['rev-parse', `${expectedCurrentMain.commit}^{tree}`]) !== expectedCurrentMain.tree) {
-    fail('audited current-main tree differs from source lock');
+    fail('pinned historical current-main tree differs from source lock');
   }
 }
 
@@ -282,6 +367,49 @@ function assertAuditSchema(schema: RecordValue, expected: typeof expectedSources
     .filter(attribute => !expectedFieldPolicy.retainedParticipantAttributes.includes(attribute as never));
   if (unknownWord.length || unknownGroup.length || unknownParticipant.length) {
     fail(`audit ${expected.id} source schema contains unknown attributes`);
+  }
+}
+
+/** Validate the content-free deterministic replay metadata without opening any corpus artifact. */
+export function verifyMaculaAuditRunSummary(value: unknown): void {
+  const summary = record(value, 'run summary');
+  exactKeys(summary, [
+    'attestations', 'auditRoot', 'benchmark', 'canonicalRuntimeCompatibility', 'command', 'deterministicHashDomain',
+    'environment', 'executedAt', 'faithlifeSblgntNotice', 'integrity', 'inventoryAssertions', 'replayComparison',
+    'replayScript', 'schemaVersion', 'workerdD1',
+  ], 'run summary');
+  const attestations = record(summary.attestations, 'run summary attestations');
+  for (const [key, expected] of [
+    ['maculaGreek', expectedSources[0]], ['maculaHebrew', expectedSources[1]],
+  ] as const) {
+    const attestation = record(attestations[key], `run summary ${key}`);
+    if (attestation.head !== expected.revision.commit || attestation.tree !== expected.revision.tree
+      || attestation.clean !== true || attestation.everySelectedPathTracked !== true
+      || attestation.selectedPathCount !== expected.selection.selectedPathCount) fail(`run summary ${key} attestation drifted`);
+  }
+  for (const key of ['theologaiMain', 'theologaiPreflight'] as const) {
+    const attestation = record(attestations[key], `run summary ${key}`);
+    if (attestation.head !== expectedCurrentMain.commit || attestation.tree !== expectedCurrentMain.tree
+      || attestation.originMain !== expectedCurrentMain.commit || attestation.clean !== true) {
+      fail(`run summary ${key} current-main attestation drifted`);
+    }
+  }
+  const hashDomain = record(summary.deterministicHashDomain, 'run summary deterministic hash domain');
+  exactKeys(hashDomain, ['artifacts', 'excludes', 'sha256'], 'run summary deterministic hash domain');
+  exactValue(hashDomain, expectedDeterministicHashDomain, 'run summary deterministic hash domain');
+  const replayComparison = record(summary.replayComparison, 'run summary replay comparison');
+  exactKeys(replayComparison, ['artifacts', 'assertion', 'deterministicIdentity', 'priorOutput', 'status'], 'run summary replay comparison');
+  exactValue(replayComparison, expectedReplayComparison, 'run summary replay comparison');
+  if (JSON.stringify(replayComparison.artifacts) !== JSON.stringify(hashDomain.artifacts)) {
+    fail('replay comparison artifacts differ from deterministic hash-domain artifacts');
+  }
+  const compatibility = record(summary.canonicalRuntimeCompatibility, 'run summary compatibility');
+  exactValue(compatibility.d1CorpusIdentity, expectedCurrentMain.d1CorpusIdentity, 'D1 corpus identity');
+  exactValue(compatibility.morphologyUsageIdentity, expectedCurrentMain.morphologyUsageIdentity, 'morphology usage identity');
+  exactValue(compatibility.runtimeContentInventory, expectedCurrentMain.runtimeContentInventory, 'runtime content inventory');
+  const faithlife = record(summary.faithlifeSblgntNotice, 'run summary Faithlife notice');
+  if (faithlife.status !== 'notice_only_excluded_from_alignment_projection_and_deterministic_identity') {
+    fail('standalone Faithlife checkout must remain notice-only');
   }
 }
 
@@ -350,49 +478,26 @@ export function verifyAuthoritativeMaculaAudit(finalReplayDirectory: string, con
   if (integrity.releaseEligible !== false || integrity.releaseGateDanglingParticipantReferences !== 9
     || decision.eligibleForPublication !== false) fail('audit must remain publication-ineligible');
 
-  const summary = record(parseJson(readFileSync(join(finalDirectory, 'run-summary.json')), 'run-summary.json'), 'run summary');
-  exactKeys(summary, [
-    'attestations', 'auditRoot', 'benchmark', 'canonicalRuntimeCompatibility', 'command', 'deterministicHashDomain',
-    'environment', 'executedAt', 'faithlifeSblgntNotice', 'integrity', 'inventoryAssertions', 'replayComparison',
-    'replayScript', 'schemaVersion', 'workerdD1',
-  ], 'run summary');
-  const attestations = record(summary.attestations, 'run summary attestations');
-  for (const [key, expected] of [
-    ['maculaGreek', expectedSources[0]], ['maculaHebrew', expectedSources[1]],
-  ] as const) {
-    const attestation = record(attestations[key], `run summary ${key}`);
-    if (attestation.head !== expected.revision.commit || attestation.tree !== expected.revision.tree
-      || attestation.clean !== true || attestation.everySelectedPathTracked !== true
-      || attestation.selectedPathCount !== expected.selection.selectedPathCount) fail(`run summary ${key} attestation drifted`);
+  verifyMaculaAuditRunSummary(parseJson(readFileSync(join(finalDirectory, 'run-summary.json')), 'run-summary.json'));
+}
+
+/** Accept only no arguments or one exact local audit-directory option. */
+export function parseMaculaSourceContractCliArgs(argumentsAfterScript: readonly string[]): string | undefined {
+  if (argumentsAfterScript.length === 0) return undefined;
+  if (argumentsAfterScript.length === 2
+    && argumentsAfterScript[0] === '--audit-dir'
+    && argumentsAfterScript[1]
+    && !argumentsAfterScript[1].startsWith('-')) {
+    return resolve(argumentsAfterScript[1]);
   }
-  for (const key of ['theologaiMain', 'theologaiPreflight'] as const) {
-    const attestation = record(attestations[key], `run summary ${key}`);
-    if (attestation.head !== expectedCurrentMain.commit || attestation.tree !== expectedCurrentMain.tree
-      || attestation.originMain !== expectedCurrentMain.commit || attestation.clean !== true) {
-      fail(`run summary ${key} current-main attestation drifted`);
-    }
-  }
-  const hashDomain = record(summary.deterministicHashDomain, 'run summary deterministic hash domain');
-  if (hashDomain.sha256 !== MACULA_AUDIT_IDENTITY) fail('run summary deterministic identity drifted');
-  const compatibility = record(summary.canonicalRuntimeCompatibility, 'run summary compatibility');
-  exactValue(compatibility.d1CorpusIdentity, expectedCurrentMain.d1CorpusIdentity, 'D1 corpus identity');
-  exactValue(compatibility.morphologyUsageIdentity, expectedCurrentMain.morphologyUsageIdentity, 'morphology usage identity');
-  exactValue(compatibility.runtimeContentInventory, expectedCurrentMain.runtimeContentInventory, 'runtime content inventory');
-  const faithlife = record(summary.faithlifeSblgntNotice, 'run summary Faithlife notice');
-  if (faithlife.status !== 'notice_only_excluded_from_alignment_projection_and_deterministic_identity') {
-    fail('standalone Faithlife checkout must remain notice-only');
-  }
+  fail('usage: tsx scripts/macula-source-contract.ts [--audit-dir /absolute/or/resolved/path/to/final-replay-2]');
 }
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
-  const argumentsAfterScript = process.argv.slice(2);
-  const auditIndex = argumentsAfterScript.indexOf('--audit-dir');
-  if (auditIndex >= 0 && (auditIndex !== 0 || argumentsAfterScript.length !== 2 || !argumentsAfterScript[1])) {
-    fail('usage: tsx scripts/macula-source-contract.ts [--audit-dir /absolute/path/to/final-replay-2]');
-  }
+  const auditDirectory = parseMaculaSourceContractCliArgs(process.argv.slice(2));
   readMaculaSourceContract(ROOT);
-  verifyCurrentMainAttestation(ROOT);
-  if (auditIndex >= 0) verifyAuthoritativeMaculaAudit(argumentsAfterScript[1]!, ROOT);
-  console.error('[macula-source-contract] Verified local-only pins, field policy, inertness, and current-main attestation.');
+  verifyHistoricalCurrentMainAttestation(ROOT);
+  if (auditDirectory) verifyAuthoritativeMaculaAudit(auditDirectory, ROOT);
+  console.error('[macula-source-contract] Verified local-only pins, field policy, inertness, and historical current-main attestation.');
 }

--- a/scripts/macula-source-contract.ts
+++ b/scripts/macula-source-contract.ts
@@ -388,6 +388,7 @@ export function verifyMaculaAuditRunSummary(value: unknown): void {
     'environment', 'executedAt', 'faithlifeSblgntNotice', 'integrity', 'inventoryAssertions', 'replayComparison',
     'replayScript', 'schemaVersion', 'workerdD1',
   ], 'run summary');
+  if (summary.schemaVersion !== 2) fail('run summary schema version drifted');
   const attestations = record(summary.attestations, 'run summary attestations');
   for (const [key, expected] of [
     ['maculaGreek', expectedSources[0]], ['maculaHebrew', expectedSources[1]],

--- a/scripts/macula-source-contract.ts
+++ b/scripts/macula-source-contract.ts
@@ -144,6 +144,38 @@ const expectedAuditEvidence = {
     sha256: 'c5a61cf047e662a6d2238093edefa7dc540ce8f2b2bbeb49115cb94329fab414',
     verificationPolicy: 'recorded_only_not_opened_by_compact_verifier',
   },
+  authorityArtifacts: [
+    {
+      base: 'audit-output',
+      path: 'EVIDENCE-STATUS.md',
+      bytes: 1_150,
+      sha256: 'c40d6a96945ef15bd56363bbcd06c8d76c97058b5980e42b7707a128c6adf0f8',
+    },
+    {
+      base: 'final-replay-2',
+      path: 'run-summary.json',
+      bytes: 8_779,
+      sha256: 'e46fbf33ce0b15a5db0dde0f3212b33d8a9204c8a3449e549dea6ac7cf179959',
+    },
+    {
+      base: 'final-replay-2',
+      path: 'REPORT.md',
+      bytes: 6_545,
+      sha256: 'd27aaf26496568023617cf7d8470442ca5a321d3e52e15e568adba1767a12a52',
+    },
+    {
+      base: 'final-replay-2',
+      path: 'provenance-license-notice.json',
+      bytes: 1_823,
+      sha256: 'd81d2ccfef76bc682ed2c147f47dc6bcc3fb7ae2cc3bab150686191d30ca320f',
+    },
+    {
+      base: 'final-replay-2',
+      path: 'replay-comparison.json',
+      bytes: 856,
+      sha256: 'c20858d3d10fa95f9bc86013089a9ab206e2ef7f97c919a9c55dd61d40848d34',
+    },
+  ],
 } as const;
 
 const expectedDeterministicArtifacts = [
@@ -751,6 +783,24 @@ export function verifyAuthoritativeMaculaAudit(finalReplayDirectory: string, con
   const finalDirectory = resolve(finalReplayDirectory);
   if (basename(finalDirectory) !== 'final-replay-2') fail('only final-replay-2 is authoritative');
   const auditOutput = dirname(finalDirectory);
+  const contract = readMaculaSourceContract(contractRoot);
+  const evidence = record(contract.auditEvidence, 'audit evidence');
+  const authorityArtifacts = evidence.authorityArtifacts as readonly RecordValue[];
+  for (const artifact of authorityArtifacts) {
+    const base = artifact.base === 'audit-output'
+      ? auditOutput
+      : artifact.base === 'final-replay-2'
+        ? finalDirectory
+        : fail('authority artifact has an unknown base');
+    if (typeof artifact.path !== 'string' || typeof artifact.bytes !== 'number' || typeof artifact.sha256 !== 'string') {
+      fail('malformed authority artifact lock');
+    }
+    const bytes = readFileSync(join(base, artifact.path));
+    if (bytes.length !== artifact.bytes || sha256(bytes) !== artifact.sha256) {
+      fail(`authority artifact ${artifact.path} drifted`);
+    }
+  }
+
   const status = readFileSync(join(auditOutput, 'EVIDENCE-STATUS.md'), 'utf8');
   for (const phrase of [
     'The only authoritative Gate-0 candidate in this directory is:',
@@ -759,8 +809,7 @@ export function verifyAuthoritativeMaculaAudit(finalReplayDirectory: string, con
     'not publication-eligible: nine Hebrew participant relationships remain dangling',
   ]) if (!status.includes(phrase)) fail(`EVIDENCE-STATUS.md does not establish ${phrase}`);
 
-  const contract = readMaculaSourceContract(contractRoot);
-  const compact = record(contract.auditEvidence, 'audit evidence').compactArtifacts as readonly RecordValue[];
+  const compact = evidence.compactArtifacts as readonly RecordValue[];
   const audit = new Map<string, RecordValue>();
   for (const artifact of compact) {
     const path = artifact.path;

--- a/scripts/macula-source-contract.ts
+++ b/scripts/macula-source-contract.ts
@@ -1,0 +1,398 @@
+#!/usr/bin/env tsx
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const MACULA_SOURCE_CONTRACT_VERSION = 'theologai-macula-source-contract.v1';
+export const MACULA_SOURCE_CONTRACT_PATH = 'data/biblical-languages/macula/SOURCE-CONTRACT.json';
+export const MACULA_AUDIT_IDENTITY = '2d5e770ee05260fbbf4f6810153f815e55b86b602ca301e30b7274c3637124b7';
+
+type RecordValue = Record<string, unknown>;
+export type MaculaSourceAttributeScope = 'word' | 'group' | 'participant';
+
+export interface MaculaSourceContract {
+  schemaVersion: typeof MACULA_SOURCE_CONTRACT_VERSION;
+  status: 'candidate_contract_only';
+  sources: readonly RecordValue[];
+  fieldPolicy: RecordValue;
+  danglingParticipantExclusionLedger: RecordValue;
+  auditEvidence: RecordValue;
+  currentMainAttestation: RecordValue;
+  rightsAndProvenance: RecordValue;
+  inertness: RecordValue;
+}
+
+const expectedSources = [
+  {
+    id: 'macula-greek',
+    corpus: 'greek',
+    repository: 'https://github.com/Clear-Bible/macula-greek.git',
+    revision: {
+      commit: '8423afe47b9e8f24b7772e808af45c7159a6fe7e',
+      tree: 'eea78df4b0f1efb857f1575243a1ec4548267a11',
+      releaseStatus: 'unreleased_main_snapshot',
+    },
+    selection: { xmlPathPattern: 'SBLGNT/lowfat/*.xml', xmlFileCount: 27, selectedPathCount: 29 },
+    noticePaths: ['README.md', 'LICENSE.md'],
+  },
+  {
+    id: 'macula-hebrew',
+    corpus: 'hebrew',
+    repository: 'https://github.com/Clear-Bible/macula-hebrew.git',
+    revision: {
+      commit: '47db250bd55d0d8577f2a94fba114ef16c35b23c',
+      tree: '594f395cf473795d6984003800b4bf86ca691a26',
+      releaseStatus: 'unreleased_main_snapshot',
+    },
+    selection: { xmlPathPattern: 'WLC/lowfat/*-lowfat.xml', xmlFileCount: 929, selectedPathCount: 933 },
+    noticePaths: ['README.md', 'LICENSE.md', 'sources/README.md', 'sources/GrovesCenter/README.md'],
+  },
+] as const;
+
+const expectedFieldPolicy = {
+  retainedWordAttributes: ['xml:id', 'ref', 'class', 'role', 'lang'],
+  retainedGroupAttributes: ['class', 'role', 'rule', 'Rule', 'head'],
+  retainedParticipantAttributes: ['subjref', 'referent', 'participantref'],
+  alignmentOnlyEphemeral: ['word element text'],
+  knownRejectedWordAttributes: [
+    'after', 'case', 'coredomain', 'degree', 'discontinuous', 'domain', 'english', 'frame', 'gender',
+    'gloss', 'greek', 'greekstrong', 'junction', 'lemma', 'lexdomain', 'ln', 'mandarin', 'mood',
+    'morph', 'normalized', 'note', 'number', 'person', 'pos', 'rule', 'sdbh', 'sensenumber', 'state',
+    'stem', 'strong', 'stronglemma', 'strongnumberx', 'tense', 'transliteration', 'type', 'unicode', 'voice',
+  ],
+  knownRejectedGroupAttributes: ['articular', 'clauseType', 'clausetype', 'junction', 'nodeId', 'predication', 'type'],
+  unknownAttributePolicy: 'fail_closed_review_required',
+} as const;
+
+const expectedDanglingLedger = {
+  status: 'unresolved_excluded_from_public_output',
+  records: [
+    { corpus: 'hebrew', relationship: 'participantref', count: 4 },
+    { corpus: 'hebrew', relationship: 'subjref', count: 5 },
+  ],
+  total: 9,
+  correctionPolicy: 'no_guessed_target_corrections',
+  publicOutputPolicy: 'fail_closed',
+} as const;
+
+const expectedAuditEvidence = {
+  authority: 'only_final_replay_2_under_the_local_audit_output',
+  deterministicIdentity: MACULA_AUDIT_IDENTITY,
+  compactArtifacts: [
+    { path: 'source-manifest.json', bytes: 240_952, sha256: 'b9dbd2ca6353fa76740650ffa85247b449e0e2f687fc1f40e227a7677f571988' },
+    { path: 'inspection.json', bytes: 54_523, sha256: '505e715901635db876539358f9456830ff51b17445cd372045d665834c9896b9' },
+  ],
+  projectionArtifact: {
+    path: 'macula-structural-projection.sqlite',
+    bytes: 207_106_048,
+    sha256: 'c5a61cf047e662a6d2238093edefa7dc540ce8f2b2bbeb49115cb94329fab414',
+    verificationPolicy: 'recorded_only_not_opened_by_compact_verifier',
+  },
+} as const;
+
+const expectedCurrentMain = {
+  commit: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+  tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
+  morphologyUsageIdentity: 'c3600bb55da75aa600f8c97885efa7d58a3e8c29c3fcc6445a553091011beabd',
+  runtimeContentInventory: {
+    artifactCount: 72,
+    identityPolicy: 'canonical_decompressed_json_v1_sha256_for_json_gz_else_raw_sha256',
+    sha256: 'caf58814f24cc72837586c901c42f3556b59e45ec81bb0af7f5cfb9fa1629dcd',
+  },
+  stepBibleCommit: '0f60797c170f11a1f8dc75c5f7617973e2e66b0d',
+  d1CorpusIdentity: '29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4',
+  d1CorpusIdentityDerivation: 'computeD1CorpusIdentity(parseDataManifest(data/data-manifest.json))',
+} as const;
+
+function fail(message: string): never {
+  throw new Error(`MACULA source contract violation: ${message}`);
+}
+
+function record(value: unknown, label: string): RecordValue {
+  if (!value || Array.isArray(value) || typeof value !== 'object') fail(`${label} must be an object`);
+  return value as RecordValue;
+}
+
+function exactKeys(value: RecordValue, keys: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail(`${label} has unknown or missing fields: expected ${expected.join(', ')}, received ${actual.join(', ')}`);
+  }
+}
+
+function exactValue(value: unknown, expected: unknown, label: string): void {
+  if (JSON.stringify(value) !== JSON.stringify(expected)) fail(`${label} drifted from the reviewed lock`);
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) fail(`${label} must be a string array`);
+  if (new Set(value).size !== value.length) fail(`${label} must not contain duplicates`);
+  return value;
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function parseJson(bytes: Buffer, label: string): unknown {
+  try {
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+  } catch (error) {
+    fail(`${label} is not strict UTF-8 JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export function parseMaculaSourceContract(value: unknown): MaculaSourceContract {
+  const root = record(value, 'contract');
+  exactKeys(root, [
+    'schemaVersion', 'status', 'sources', 'fieldPolicy', 'danglingParticipantExclusionLedger', 'auditEvidence',
+    'currentMainAttestation', 'rightsAndProvenance', 'inertness',
+  ], 'contract');
+  if (root.schemaVersion !== MACULA_SOURCE_CONTRACT_VERSION || root.status !== 'candidate_contract_only') {
+    fail('schema version or candidate-only status drifted');
+  }
+  if (!Array.isArray(root.sources)) fail('sources must be an array');
+  exactValue(root.sources, expectedSources, 'source pins');
+
+  const policy = record(root.fieldPolicy, 'fieldPolicy');
+  exactKeys(policy, Object.keys(expectedFieldPolicy), 'fieldPolicy');
+  exactValue(policy, expectedFieldPolicy, 'fieldPolicy');
+  for (const [name, value] of Object.entries(policy)) {
+    if (name.endsWith('Attributes') || name === 'alignmentOnlyEphemeral') stringArray(value, `fieldPolicy.${name}`);
+  }
+
+  const ledger = record(root.danglingParticipantExclusionLedger, 'dangling participant exclusion ledger');
+  exactKeys(ledger, Object.keys(expectedDanglingLedger), 'dangling participant exclusion ledger');
+  exactValue(ledger, expectedDanglingLedger, 'dangling participant exclusion ledger');
+
+  const evidence = record(root.auditEvidence, 'audit evidence');
+  exactKeys(evidence, Object.keys(expectedAuditEvidence), 'audit evidence');
+  exactValue(evidence, expectedAuditEvidence, 'audit evidence');
+
+  const currentMain = record(root.currentMainAttestation, 'current main attestation');
+  exactKeys(currentMain, Object.keys(expectedCurrentMain), 'current main attestation');
+  exactValue(currentMain, expectedCurrentMain, 'current main attestation');
+
+  const rights = record(root.rightsAndProvenance, 'rights and provenance');
+  exactKeys(rights, ['maculaGreek', 'maculaHebrew', 'faithlifeSblgntStandaloneNotice', 'legalReviewGate'], 'rights and provenance');
+  for (const key of ['maculaGreek', 'maculaHebrew'] as const) {
+    const source = record(rights[key], `rights and provenance.${key}`);
+    exactKeys(source, ['license', 'requiredAttribution', 'selectedInputProvenance', 'modificationNoticeRequirements'], `rights and provenance.${key}`);
+    stringArray(source.modificationNoticeRequirements, `rights and provenance.${key}.modificationNoticeRequirements`);
+  }
+  const faithlife = record(rights.faithlifeSblgntStandaloneNotice, 'Faithlife SBLGNT notice');
+  exactKeys(faithlife, ['role', 'repository', 'commit', 'tree', 'noticePaths', 'prohibition'], 'Faithlife SBLGNT notice');
+  stringArray(faithlife.noticePaths, 'Faithlife SBLGNT notice paths');
+  if (faithlife.role !== 'notice_only_not_materializer_input') fail('Faithlife SBLGNT must remain notice-only');
+
+  const inertness = record(root.inertness, 'inertness');
+  exactKeys(inertness, ['contractDoesNotActivate', 'verifierBoundary'], 'inertness');
+  stringArray(inertness.contractDoesNotActivate, 'inertness.contractDoesNotActivate');
+  return root as unknown as MaculaSourceContract;
+}
+
+export function readMaculaSourceContract(root: string): MaculaSourceContract {
+  return parseMaculaSourceContract(parseJson(readFileSync(join(root, MACULA_SOURCE_CONTRACT_PATH)), MACULA_SOURCE_CONTRACT_PATH));
+}
+
+/** Reject both known non-retained fields and novel schema fields before materialization. */
+export function assertMaculaSourceAttribute(scope: MaculaSourceAttributeScope, attribute: string): void {
+  const allowed = scope === 'word'
+    ? expectedFieldPolicy.retainedWordAttributes
+    : scope === 'group'
+      ? expectedFieldPolicy.retainedGroupAttributes
+      : expectedFieldPolicy.retainedParticipantAttributes;
+  const rejected = scope === 'word'
+    ? expectedFieldPolicy.knownRejectedWordAttributes
+    : scope === 'group'
+      ? expectedFieldPolicy.knownRejectedGroupAttributes
+      : [];
+  if (allowed.includes(attribute as never)) return;
+  if (rejected.includes(attribute as never)) fail(`${scope} attribute ${attribute} is explicitly excluded`);
+  fail(`${scope} attribute ${attribute} is unknown schema drift and requires review`);
+}
+
+/** Verify the pinned origin/main object locally without fetching or changing a checkout. */
+export function verifyCurrentMainAttestation(root: string): void {
+  const revision = (args: string[]) => execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim();
+  if (revision(['rev-parse', 'origin/main']) !== expectedCurrentMain.commit) fail('origin/main commit differs from audited current main');
+  if (revision(['rev-parse', `${expectedCurrentMain.commit}^{tree}`]) !== expectedCurrentMain.tree) {
+    fail('audited current-main tree differs from source lock');
+  }
+}
+
+function assertAuditSelectedFiles(source: RecordValue, expected: typeof expectedSources[number]): void {
+  exactKeys(source, ['corpus', 'files', 'id', 'releaseStatus', 'repository', 'requestedRef', 'resolvedCommit', 'resolvedTree'], `audit source ${expected.id}`);
+  if (source.id !== expected.id || source.corpus !== expected.corpus || source.repository !== expected.repository
+    || source.requestedRef !== expected.revision.commit || source.resolvedCommit !== expected.revision.commit
+    || source.resolvedTree !== expected.revision.tree || source.releaseStatus !== 'unreleased-main-snapshot') {
+    fail(`audit source ${expected.id} drifted from the source lock`);
+  }
+  if (!Array.isArray(source.files) || source.files.length !== expected.selection.selectedPathCount) fail(`audit source ${expected.id} selected path count drifted`);
+  const notices = new Set<string>(expected.noticePaths);
+  let xmlCount = 0;
+  for (const rawFile of source.files) {
+    const file = record(rawFile, `audit source ${expected.id} file`);
+    exactKeys(file, ['bytes', 'kind', 'path', 'sha256'], `audit source ${expected.id} file`);
+    if (typeof file.bytes !== 'number' || !Number.isSafeInteger(file.bytes) || file.bytes < 1
+      || typeof file.path !== 'string' || typeof file.sha256 !== 'string' || !/^[0-9a-f]{64}$/.test(file.sha256)
+      || (file.kind !== 'selected-xml' && file.kind !== 'license-or-source-notice')) {
+      fail(`audit source ${expected.id} has malformed selected-file evidence`);
+    }
+    if (file.kind === 'license-or-source-notice') {
+      if (!notices.delete(file.path)) fail(`audit source ${expected.id} contains an unexpected notice path`);
+      continue;
+    }
+    const validXml = expected.id === 'macula-greek'
+      ? /^SBLGNT\/lowfat\/[a-z0-9-]+\.xml$/.test(file.path)
+      : /^WLC\/lowfat\/[0-9]{2}-[A-Za-z0-9]+-[0-9]{3}-lowfat\.xml$/.test(file.path);
+    if (!validXml) fail(`audit source ${expected.id} contains an unexpected XML path`);
+    xmlCount += 1;
+  }
+  if (notices.size !== 0 || xmlCount !== expected.selection.xmlFileCount) fail(`audit source ${expected.id} selection drifted`);
+}
+
+function auditAttributeKeys(value: RecordValue, key: string, label: string): string[] {
+  return Object.keys(record(value[key], label)).sort();
+}
+
+function assertAuditSchema(schema: RecordValue, expected: typeof expectedSources[number]): void {
+  exactKeys(schema, [
+    'corpus', 'danglingExamples', 'files', 'groupAttributesObserved', 'groups', 'idCollisions', 'languages',
+    'maxDepth', 'maxReferenceMultiplicity', 'participantAttributesObserved', 'participantResolutions', 'references',
+    'roots', 'selectedXmlBytes', 'syntheticUngroupedGroups', 'tokens', 'wordAttributesObserved',
+  ], `audit ${expected.id} schema`);
+  if (schema.corpus !== expected.corpus || schema.files !== expected.selection.xmlFileCount) fail(`audit ${expected.id} schema identity drifted`);
+  const knownWord = new Set<string>([
+    ...expectedFieldPolicy.retainedWordAttributes,
+    ...expectedFieldPolicy.retainedParticipantAttributes,
+    ...expectedFieldPolicy.knownRejectedWordAttributes,
+  ]);
+  const knownGroup = new Set<string>([
+    ...expectedFieldPolicy.retainedGroupAttributes,
+    ...expectedFieldPolicy.knownRejectedGroupAttributes,
+  ]);
+  const unknownWord = auditAttributeKeys(schema, 'wordAttributesObserved', `audit ${expected.id} word attributes`).filter(attribute => !knownWord.has(attribute));
+  const unknownGroup = auditAttributeKeys(schema, 'groupAttributesObserved', `audit ${expected.id} group attributes`).filter(attribute => !knownGroup.has(attribute));
+  const unknownParticipant = auditAttributeKeys(schema, 'participantAttributesObserved', `audit ${expected.id} participant attributes`)
+    .filter(attribute => !expectedFieldPolicy.retainedParticipantAttributes.includes(attribute as never));
+  if (unknownWord.length || unknownGroup.length || unknownParticipant.length) {
+    fail(`audit ${expected.id} source schema contains unknown attributes`);
+  }
+}
+
+/**
+ * Check only the compact, authoritative final replay. It never opens the
+ * 197 MiB projection and never reads source checkouts, XML, SQLite, or a
+ * superseded replay. A full future materializer remains a separate gate.
+ */
+export function verifyAuthoritativeMaculaAudit(finalReplayDirectory: string, contractRoot = ROOT): void {
+  const finalDirectory = resolve(finalReplayDirectory);
+  if (basename(finalDirectory) !== 'final-replay-2') fail('only final-replay-2 is authoritative');
+  const auditOutput = dirname(finalDirectory);
+  const status = readFileSync(join(auditOutput, 'EVIDENCE-STATUS.md'), 'utf8');
+  for (const phrase of [
+    'The only authoritative Gate-0 candidate in this directory is:',
+    '`final-replay-2/`',
+    MACULA_AUDIT_IDENTITY,
+    'not publication-eligible: nine Hebrew participant relationships remain dangling',
+  ]) if (!status.includes(phrase)) fail(`EVIDENCE-STATUS.md does not establish ${phrase}`);
+
+  const contract = readMaculaSourceContract(contractRoot);
+  const compact = record(contract.auditEvidence, 'audit evidence').compactArtifacts as readonly RecordValue[];
+  const audit = new Map<string, RecordValue>();
+  for (const artifact of compact) {
+    const path = artifact.path;
+    if (typeof path !== 'string' || typeof artifact.bytes !== 'number' || typeof artifact.sha256 !== 'string') fail('malformed compact artifact lock');
+    const bytes = readFileSync(join(finalDirectory, path));
+    if (bytes.length !== artifact.bytes || sha256(bytes) !== artifact.sha256) fail(`compact audit artifact ${path} drifted`);
+    audit.set(path, record(parseJson(bytes, path), path));
+  }
+  const sourceManifest = audit.get('source-manifest.json')!;
+  exactKeys(sourceManifest, ['runtimeIdentity', 'schemaVersion', 'scope', 'sources', 'strictRightsAllowlist'], 'source-manifest');
+  if (sourceManifest.schemaVersion !== 2 || !Array.isArray(sourceManifest.sources) || sourceManifest.sources.length !== expectedSources.length) {
+    fail('source-manifest identity drifted');
+  }
+  const runtimeIdentity = record(sourceManifest.runtimeIdentity, 'source-manifest runtime identity');
+  exactKeys(runtimeIdentity, ['commit', 'compatibilityGate', 'files', 'originMain', 'repository', 'tree'], 'source-manifest runtime identity');
+  if (runtimeIdentity.commit !== expectedCurrentMain.commit || runtimeIdentity.tree !== expectedCurrentMain.tree
+    || runtimeIdentity.originMain !== expectedCurrentMain.commit) fail('source-manifest current-main identity drifted');
+  const compatibilityGate = record(runtimeIdentity.compatibilityGate, 'source-manifest compatibility gate');
+  exactKeys(compatibilityGate, [
+    'd1CorpusIdentity', 'd1CorpusIdentityDerivation', 'morphologyUsageIdentity', 'primary',
+    'runtimeContentInventory', 'stepBibleSourceCommit',
+  ], 'source-manifest compatibility gate');
+  exactValue(compatibilityGate.d1CorpusIdentity, expectedCurrentMain.d1CorpusIdentity, 'source-manifest D1 corpus identity');
+  exactValue(compatibilityGate.d1CorpusIdentityDerivation, `${expectedCurrentMain.d1CorpusIdentityDerivation} from the exact audit checkout`, 'source-manifest D1 identity derivation');
+  exactValue(compatibilityGate.morphologyUsageIdentity, expectedCurrentMain.morphologyUsageIdentity, 'source-manifest morphology usage identity');
+  exactValue(compatibilityGate.runtimeContentInventory, expectedCurrentMain.runtimeContentInventory, 'source-manifest runtime content inventory');
+  exactValue(compatibilityGate.stepBibleSourceCommit, expectedCurrentMain.stepBibleCommit, 'source-manifest STEPBible source commit');
+  for (const expected of expectedSources) {
+    const source = sourceManifest.sources.find(candidate => record(candidate, 'source-manifest source').id === expected.id);
+    if (!source) fail(`source-manifest omits ${expected.id}`);
+    assertAuditSelectedFiles(record(source, `source-manifest ${expected.id}`), expected);
+  }
+
+  const inspection = audit.get('inspection.json')!;
+  exactKeys(inspection, [
+    'integrity', 'projection', 'releaseDecision', 'runtimeAlignment', 'schemaVersion', 'scope', 'sourceSchema',
+    'strictRightsAllowlist', 'userFacingRoleDiagnosticHygiene', 'workerdD1',
+  ], 'inspection');
+  const sourceSchema = record(inspection.sourceSchema, 'inspection sourceSchema');
+  exactKeys(sourceSchema, ['greek', 'hebrew', 'parser'], 'inspection sourceSchema');
+  for (const expected of expectedSources) assertAuditSchema(record(sourceSchema[expected.corpus], `inspection ${expected.corpus}`), expected);
+  const integrity = record(inspection.integrity, 'inspection integrity');
+  const decision = record(inspection.releaseDecision, 'inspection release decision');
+  if (integrity.releaseEligible !== false || integrity.releaseGateDanglingParticipantReferences !== 9
+    || decision.eligibleForPublication !== false) fail('audit must remain publication-ineligible');
+
+  const summary = record(parseJson(readFileSync(join(finalDirectory, 'run-summary.json')), 'run-summary.json'), 'run summary');
+  exactKeys(summary, [
+    'attestations', 'auditRoot', 'benchmark', 'canonicalRuntimeCompatibility', 'command', 'deterministicHashDomain',
+    'environment', 'executedAt', 'faithlifeSblgntNotice', 'integrity', 'inventoryAssertions', 'replayComparison',
+    'replayScript', 'schemaVersion', 'workerdD1',
+  ], 'run summary');
+  const attestations = record(summary.attestations, 'run summary attestations');
+  for (const [key, expected] of [
+    ['maculaGreek', expectedSources[0]], ['maculaHebrew', expectedSources[1]],
+  ] as const) {
+    const attestation = record(attestations[key], `run summary ${key}`);
+    if (attestation.head !== expected.revision.commit || attestation.tree !== expected.revision.tree
+      || attestation.clean !== true || attestation.everySelectedPathTracked !== true
+      || attestation.selectedPathCount !== expected.selection.selectedPathCount) fail(`run summary ${key} attestation drifted`);
+  }
+  for (const key of ['theologaiMain', 'theologaiPreflight'] as const) {
+    const attestation = record(attestations[key], `run summary ${key}`);
+    if (attestation.head !== expectedCurrentMain.commit || attestation.tree !== expectedCurrentMain.tree
+      || attestation.originMain !== expectedCurrentMain.commit || attestation.clean !== true) {
+      fail(`run summary ${key} current-main attestation drifted`);
+    }
+  }
+  const hashDomain = record(summary.deterministicHashDomain, 'run summary deterministic hash domain');
+  if (hashDomain.sha256 !== MACULA_AUDIT_IDENTITY) fail('run summary deterministic identity drifted');
+  const compatibility = record(summary.canonicalRuntimeCompatibility, 'run summary compatibility');
+  exactValue(compatibility.d1CorpusIdentity, expectedCurrentMain.d1CorpusIdentity, 'D1 corpus identity');
+  exactValue(compatibility.morphologyUsageIdentity, expectedCurrentMain.morphologyUsageIdentity, 'morphology usage identity');
+  exactValue(compatibility.runtimeContentInventory, expectedCurrentMain.runtimeContentInventory, 'runtime content inventory');
+  const faithlife = record(summary.faithlifeSblgntNotice, 'run summary Faithlife notice');
+  if (faithlife.status !== 'notice_only_excluded_from_alignment_projection_and_deterministic_identity') {
+    fail('standalone Faithlife checkout must remain notice-only');
+  }
+}
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const argumentsAfterScript = process.argv.slice(2);
+  const auditIndex = argumentsAfterScript.indexOf('--audit-dir');
+  if (auditIndex >= 0 && (auditIndex !== 0 || argumentsAfterScript.length !== 2 || !argumentsAfterScript[1])) {
+    fail('usage: tsx scripts/macula-source-contract.ts [--audit-dir /absolute/path/to/final-replay-2]');
+  }
+  readMaculaSourceContract(ROOT);
+  verifyCurrentMainAttestation(ROOT);
+  if (auditIndex >= 0) verifyAuthoritativeMaculaAudit(argumentsAfterScript[1]!, ROOT);
+  console.error('[macula-source-contract] Verified local-only pins, field policy, inertness, and current-main attestation.');
+}

--- a/scripts/macula-source-contract.ts
+++ b/scripts/macula-source-contract.ts
@@ -11,6 +11,7 @@ export const MACULA_SOURCE_CONTRACT_PATH = 'data/biblical-languages/macula/SOURC
 export const MACULA_AUDIT_IDENTITY = '2d5e770ee05260fbbf4f6810153f815e55b86b602ca301e30b7274c3637124b7';
 
 type RecordValue = Record<string, unknown>;
+export type MaculaCorpus = 'greek' | 'hebrew';
 export type MaculaSourceAttributeScope = 'word' | 'group' | 'participant';
 
 export interface MaculaSourceContract {
@@ -37,6 +38,27 @@ const expectedSources = [
     },
     selection: { xmlPathPattern: 'SBLGNT/lowfat/*.xml', xmlFileCount: 27, selectedPathCount: 29 },
     noticePaths: ['README.md', 'LICENSE.md'],
+    maturity: {
+      baselineTag: '24.06.17',
+      baselinePeeledCommit: 'b5b7ecec0882a3e9a609ecac99e157391e5d9b46',
+      selectedPinStatus: 'untagged_snapshot',
+      selectedPinDescendsFromBaseline: true,
+      reachableCommitDistance: 29,
+      selectedPathComparison: {
+        selectedLowfatFileCount: 27,
+        differingSelectedLowfatFileCount: 27,
+        status: 'all_selected_lowfat_files_differ_from_baseline_tag',
+      },
+      repositoryLevelChangeSummary: 'The selected pin is a later untagged snapshot; this lock records reproducibility, not a release or quality conclusion.',
+      independentPublicationGates: [
+        'independent scholarly QA',
+        'product acceptance',
+        'full reproduction',
+        'rights review',
+        'nine-dangling relationship resolution-or-exclusion gate',
+      ],
+      reproducibilityBoundary: 'Exact pins prove reproducibility only.',
+    },
   },
   {
     id: 'macula-hebrew',
@@ -49,13 +71,44 @@ const expectedSources = [
     },
     selection: { xmlPathPattern: 'WLC/lowfat/*-lowfat.xml', xmlFileCount: 929, selectedPathCount: 933 },
     noticePaths: ['README.md', 'LICENSE.md', 'sources/README.md', 'sources/GrovesCenter/README.md'],
+    maturity: {
+      baselineTag: '26.04.13',
+      baselinePeeledCommit: '09f8ea9e25025841ec45e2b6e7fc01595a080568',
+      selectedPinStatus: 'untagged_snapshot',
+      selectedPinDescendsFromBaseline: true,
+      reachableCommitDistance: 3,
+      selectedPathComparison: {
+        selectedLowfatFileCount: 929,
+        differingSelectedLowfatFileCount: 0,
+        differingSelectedNoticeCount: 0,
+        status: 'no_selected_WLC_lowfat_files_or_selected_notices_differ_from_baseline_tag',
+      },
+      repositoryLevelChangeSummary: 'Repository changes from the baseline tag cover CGJ stripping, NFC normalization, and merge work; they change zero selected WLC/lowfat files and zero selected notices.',
+      independentPublicationGates: [
+        'independent scholarly QA',
+        'product acceptance',
+        'full reproduction',
+        'rights review',
+        'nine-dangling relationship resolution-or-exclusion gate',
+      ],
+      reproducibilityBoundary: 'Exact pins prove reproducibility only.',
+    },
   },
 ] as const;
 
 const expectedFieldPolicy = {
-  retainedWordAttributes: ['xml:id', 'ref', 'class', 'role', 'lang'],
-  retainedGroupAttributes: ['class', 'role', 'rule', 'Rule', 'head'],
-  retainedParticipantAttributes: ['subjref', 'referent', 'participantref'],
+  capabilityMatrix: {
+    greek: {
+      word: ['xml:id', 'ref', 'class', 'role'],
+      group: ['class', 'role', 'rule', 'Rule'],
+      participant: ['referent', 'subjref'],
+    },
+    hebrew: {
+      word: ['xml:id', 'ref', 'class', 'role', 'lang'],
+      group: ['class', 'role', 'rule', 'head'],
+      participant: ['subjref', 'participantref'],
+    },
+  },
   alignmentOnlyEphemeral: ['word element text'],
   knownRejectedWordAttributes: [
     'after', 'case', 'coredomain', 'degree', 'discontinuous', 'domain', 'english', 'frame', 'gender',
@@ -151,13 +204,67 @@ const expectedRightsAndProvenance = {
       'Identify modifications and do not imply upstream endorsement or impose additional restrictions.',
     ],
   },
-  faithlifeSblgntStandaloneNotice: {
-    role: 'notice_only_not_materializer_input',
+  langRetention: {
+    attribute: 'lang',
+    corpus: 'hebrew',
+    retainedAs: 'raw OSHB-derived H/A language evidence',
+    notA: [
+      'morphology',
+      'an ISO code',
+      'an independently adjudicated language conclusion',
+      'a general classifier',
+      'a Greek capability',
+      'authorization to retain other OSHB morphology',
+    ],
+    pipelineEvidence: {
+      maculaHebrewNotice: 'MACULA Hebrew trees combine Westminster syntax with OSHB morphology.',
+      selectedSource: 'The selected source is derivative, reorganized, and corrected OSHB material.',
+      sourceReadme: 'The selected source README records the selected source provenance.',
+      selectedXquery: 'The selected XQuery copies node @lang.',
+      observedTokenLanguages: {
+        allSelectedHebrewTokensHaveLang: true,
+        total: 475_911,
+        H: 468_362,
+        A: 7_549,
+        absentFromGreekSource: true,
+      },
+    },
+    openScripturesHebrewBible: {
+      name: 'Open Scriptures Hebrew Bible',
+      sourceUri: 'https://github.com/openscriptures/morphhb',
+      license: 'CC BY 4.0',
+      licenseUri: 'https://creativecommons.org/licenses/by/4.0/',
+      noticeAndAttributionRequirement: 'Retain the supplied attribution, notices, and source URI; do not invent a replacement attribution phrase.',
+      modificationRequirement: 'Identify modifications.',
+      restrictionsRequirement: 'Do not imply endorsement or impose additional restrictions.',
+    },
+    operationalBoundary: 'This is an operational provenance record, not a legal conclusion or publication authorization.',
+  },
+  standaloneFaithlifeNotice: {
+    role: 'notice_only_provenance_evidence_not_selected_corpus_input',
     repository: 'https://github.com/Faithlife/SBLGNT.git',
     commit: 'c4d241a9c1c479a55b989ba35a4976c1d0b8052c',
     tree: '1237db9d579eb13457157ca266a6f822dd4353b9',
     noticePaths: ['README.md', 'LICENSE'],
-    prohibition: 'Do not use the standalone Faithlife checkout or its XML as an alignment input, projection input, deterministic-hash input, or public-output source.',
+    selectedCorpusInput: false,
+    prohibitedUses: ['selection', 'materialization', 'alignment', 'projection', 'deterministic identity', 'public output'],
+  },
+  sblgntRightsForMaculaGreekDerivedInput: {
+    selectedInput: 'MACULA Greek SBLGNT/lowfat XML',
+    derivation: 'The selected MACULA Greek lowfat input is SBLGNT-derived.',
+    upstream: 'SBL Greek New Testament',
+    license: 'CC BY 4.0',
+    licenseUri: 'https://creativecommons.org/licenses/by/4.0/',
+    copyrightNotice: 'Copyright 2010 Society of Biblical Literature and Logos Bible Software',
+    upstreamSourceUri: 'https://sblgnt.com/',
+    futureDistributionObligations: [
+      'Retain supplied source, link, license, copyright, and disclaimer notices.',
+      'Identify modifications.',
+      'Do not imply endorsement or impose additional restrictions.',
+    ],
+    standaloneCheckoutBoundary: 'The standalone Faithlife checkout did not supply the selected XML.',
+    publicationGate: 'Obligations may attach to a future projection; mandatory source-by-source and legal review is required before publication.',
+    operationalBoundary: 'This is an operational rights record, not a legal conclusion or publication authorization.',
   },
   legalReviewGate: 'This contract records source notices and operational obligations; it is not a legal opinion and does not authorize publication.',
 } as const;
@@ -176,6 +283,92 @@ const expectedInertness = {
     'preview, deployment, or Cloudflare workflow',
   ],
   verifierBoundary: 'The verifier is local, read-only, and deterministic. It performs no network request, source acquisition, mutation, database access, or runtime binding.',
+} as const;
+
+const expectedRunSummaryAttestations = {
+  maculaGreek: {
+    head: '8423afe47b9e8f24b7772e808af45c7159a6fe7e',
+    tree: 'eea78df4b0f1efb857f1575243a1ec4548267a11',
+    clean: true,
+    selectedPathCount: 29,
+    everySelectedPathTracked: true,
+    branch: '(detached)',
+  },
+  maculaHebrew: {
+    head: '47db250bd55d0d8577f2a94fba114ef16c35b23c',
+    tree: '594f395cf473795d6984003800b4bf86ca691a26',
+    clean: true,
+    selectedPathCount: 933,
+    everySelectedPathTracked: true,
+    branch: '(detached)',
+  },
+  theologaiMain: {
+    head: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+    tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
+    clean: true,
+    selectedPathCount: 68,
+    everySelectedPathTracked: true,
+    branch: 'main',
+    originMain: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+  },
+  theologaiPreflight: {
+    head: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+    tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
+    clean: true,
+    selectedPathCount: 0,
+    everySelectedPathTracked: true,
+    branch: 'main',
+    originMain: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+  },
+} as const;
+
+const expectedRunSummaryCompatibilityDerivation = {
+  d1CorpusIdentity: 'computeD1CorpusIdentity(parseDataManifest(data/data-manifest.json)) from the exact audit checkout',
+  morphologyUsageIdentity: 'computeMorphologyUsageIdentity(parseDataManifest(data/data-manifest.json)) from the exact audit checkout',
+  runtimeContentInventory: 'canonical content identity over the repository-owned 72-artifact OpenScriptures/STEPBible runtime inventory',
+} as const;
+
+const expectedRunSummaryReplayScript = {
+  path: 'scripts/inspect-macula-v2.mjs',
+  sha256: '0ce62ee220cd49893c59f23c0b32d00a02ccbe8f1f1c6373ebead010a94f6149',
+  requiredNode: '22.23.1',
+} as const;
+
+const expectedRunSummaryFaithlifeNotice = {
+  status: 'notice_only_excluded_from_alignment_projection_and_deterministic_identity',
+  output: 'provenance-license-notice.json',
+} as const;
+
+const expectedRunSummaryInventoryAssertions = {
+  selectedMaculaGreekFiles: 29,
+  selectedMaculaHebrewFiles: 933,
+  runtimeCorpusFiles: 66,
+  runtimeContentInventoryArtifacts: 72,
+  faithlifeSblgntAlignmentInput: false,
+  allSelectedPathsTracked: true,
+} as const;
+
+const expectedRunSummaryWorkerdD1 = {
+  status: 'not_run',
+  reason: 'A full D1/Workerd probe requires a reviewed D1 materializer/import path. Native SQLite was run against the complete projection; D1 rows_read and remote-equivalent latency remain deliberately unclaimed.',
+} as const;
+
+const expectedRunSummaryIntegrity = {
+  foreignKeyViolations: 0,
+  tokensWithoutImmediateGroup: 0,
+  tokensWithMissingGroup: 0,
+  groupsWithMissingParent: 0,
+  totalGroups: 441_272,
+  reachableGroups: 441_272,
+  unreachableGroups: 0,
+  groupCycleMembers: 0,
+  tokenMembershipRows: 613_652,
+  groupReferenceRows: 1_965_769,
+  referencesWithoutGroupContext: 0,
+  duplicateTokenIds: 0,
+  releaseGateDanglingParticipantReferences: 9,
+  pass: true,
+  releaseEligible: false,
 } as const;
 
 function fail(message: string): never {
@@ -203,6 +396,36 @@ function stringArray(value: unknown, label: string): string[] {
   if (!Array.isArray(value) || value.some(item => typeof item !== 'string')) fail(`${label} must be a string array`);
   if (new Set(value).size !== value.length) fail(`${label} must not contain duplicates`);
   return value;
+}
+
+function nonEmptyString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\0')) fail(`${label} must be a non-empty string`);
+  return value;
+}
+
+function safeNonNegativeInteger(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) fail(`${label} must be a non-negative safe integer`);
+  return value;
+}
+
+function sha256String(value: unknown, label: string): string {
+  const hash = nonEmptyString(value, label);
+  if (!/^[0-9a-f]{64}$/.test(hash)) fail(`${label} must be a lower-case SHA-256`);
+  return hash;
+}
+
+function absolutePathDiagnostic(value: unknown, label: string): string {
+  const path = nonEmptyString(value, label);
+  if (!path.startsWith('/')) fail(`${label} must be an absolute path diagnostic`);
+  return path;
+}
+
+function isoTimestampDiagnostic(value: unknown, label: string): string {
+  const timestamp = nonEmptyString(value, label);
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(timestamp) || Number.isNaN(Date.parse(timestamp))) {
+    fail(`${label} must be an ISO-8601 UTC timestamp diagnostic`);
+  }
+  return timestamp;
 }
 
 function sha256(bytes: Buffer): string {
@@ -235,6 +458,15 @@ export function parseMaculaSourceContract(value: unknown): MaculaSourceContract 
   for (const [name, value] of Object.entries(policy)) {
     if (name.endsWith('Attributes') || name === 'alignmentOnlyEphemeral') stringArray(value, `fieldPolicy.${name}`);
   }
+  const matrix = record(policy.capabilityMatrix, 'fieldPolicy capability matrix');
+  exactKeys(matrix, ['greek', 'hebrew'], 'fieldPolicy capability matrix');
+  for (const corpus of ['greek', 'hebrew'] as const) {
+    const capabilities = record(matrix[corpus], `fieldPolicy ${corpus} capabilities`);
+    exactKeys(capabilities, ['word', 'group', 'participant'], `fieldPolicy ${corpus} capabilities`);
+    for (const scope of ['word', 'group', 'participant'] as const) {
+      stringArray(capabilities[scope], `fieldPolicy ${corpus}.${scope}`);
+    }
+  }
 
   const ledger = record(root.danglingParticipantExclusionLedger, 'dangling participant exclusion ledger');
   exactKeys(ledger, Object.keys(expectedDanglingLedger), 'dangling participant exclusion ledger');
@@ -249,17 +481,23 @@ export function parseMaculaSourceContract(value: unknown): MaculaSourceContract 
   exactValue(currentMain, expectedCurrentMain, 'current main attestation');
 
   const rights = record(root.rightsAndProvenance, 'rights and provenance');
-  exactKeys(rights, ['maculaGreek', 'maculaHebrew', 'faithlifeSblgntStandaloneNotice', 'legalReviewGate'], 'rights and provenance');
+  exactKeys(rights, [
+    'maculaGreek', 'maculaHebrew', 'langRetention', 'standaloneFaithlifeNotice',
+    'sblgntRightsForMaculaGreekDerivedInput', 'legalReviewGate',
+  ], 'rights and provenance');
   exactValue(rights, expectedRightsAndProvenance, 'rights and provenance');
   for (const key of ['maculaGreek', 'maculaHebrew'] as const) {
     const source = record(rights[key], `rights and provenance.${key}`);
     exactKeys(source, ['license', 'requiredAttribution', 'selectedInputProvenance', 'modificationNoticeRequirements'], `rights and provenance.${key}`);
     stringArray(source.modificationNoticeRequirements, `rights and provenance.${key}.modificationNoticeRequirements`);
   }
-  const faithlife = record(rights.faithlifeSblgntStandaloneNotice, 'Faithlife SBLGNT notice');
-  exactKeys(faithlife, ['role', 'repository', 'commit', 'tree', 'noticePaths', 'prohibition'], 'Faithlife SBLGNT notice');
+  const faithlife = record(rights.standaloneFaithlifeNotice, 'Faithlife SBLGNT notice');
+  exactKeys(faithlife, ['role', 'repository', 'commit', 'tree', 'noticePaths', 'selectedCorpusInput', 'prohibitedUses'], 'Faithlife SBLGNT notice');
   stringArray(faithlife.noticePaths, 'Faithlife SBLGNT notice paths');
-  if (faithlife.role !== 'notice_only_not_materializer_input') fail('Faithlife SBLGNT must remain notice-only');
+  stringArray(faithlife.prohibitedUses, 'Faithlife SBLGNT prohibited uses');
+  if (faithlife.role !== 'notice_only_provenance_evidence_not_selected_corpus_input' || faithlife.selectedCorpusInput !== false) {
+    fail('Faithlife SBLGNT must remain notice-only and outside selected corpus inputs');
+  }
 
   const inertness = record(root.inertness, 'inertness');
   exactKeys(inertness, ['contractDoesNotActivate', 'verifierBoundary'], 'inertness');
@@ -273,23 +511,26 @@ export function readMaculaSourceContract(root: string): MaculaSourceContract {
 }
 
 /** Reject both known non-retained fields and novel schema fields before materialization. */
-export function assertMaculaSourceAttribute(scope: MaculaSourceAttributeScope, attribute: string): void {
+export function assertMaculaSourceAttribute(corpus: MaculaCorpus, scope: MaculaSourceAttributeScope, attribute: string): void {
+  if (corpus !== 'greek' && corpus !== 'hebrew') {
+    fail(`invalid source attribute corpus ${JSON.stringify(corpus)}`);
+  }
   if (scope !== 'word' && scope !== 'group' && scope !== 'participant') {
     fail(`invalid source attribute scope ${JSON.stringify(scope)}`);
   }
-  const allowed = scope === 'word'
-    ? expectedFieldPolicy.retainedWordAttributes
-    : scope === 'group'
-      ? expectedFieldPolicy.retainedGroupAttributes
-      : expectedFieldPolicy.retainedParticipantAttributes;
+  const allowed = expectedFieldPolicy.capabilityMatrix[corpus][scope];
   const rejected = scope === 'word'
     ? expectedFieldPolicy.knownRejectedWordAttributes
     : scope === 'group'
       ? expectedFieldPolicy.knownRejectedGroupAttributes
       : [];
   if (allowed.includes(attribute as never)) return;
+  if ((corpus === 'greek' ? expectedFieldPolicy.capabilityMatrix.hebrew : expectedFieldPolicy.capabilityMatrix.greek)[scope]
+    .includes(attribute as never)) {
+    fail(`${corpus} ${scope} attribute ${attribute} is not approved for that corpus`);
+  }
   if (rejected.includes(attribute as never)) fail(`${scope} attribute ${attribute} is explicitly excluded`);
-  fail(`${scope} attribute ${attribute} is unknown schema drift and requires review`);
+  fail(`${corpus} ${scope} attribute ${attribute} is unknown schema drift and requires review`);
 }
 
 /** Verify an exact local commit/tree pair without fetching or moving a ref. */
@@ -362,25 +603,65 @@ function assertAuditSchema(schema: RecordValue, expected: typeof expectedSources
     'roots', 'selectedXmlBytes', 'syntheticUngroupedGroups', 'tokens', 'wordAttributesObserved',
   ], `audit ${expected.id} schema`);
   if (schema.corpus !== expected.corpus || schema.files !== expected.selection.xmlFileCount) fail(`audit ${expected.id} schema identity drifted`);
+  const capabilities = expectedFieldPolicy.capabilityMatrix[expected.corpus];
   const knownWord = new Set<string>([
-    ...expectedFieldPolicy.retainedWordAttributes,
-    ...expectedFieldPolicy.retainedParticipantAttributes,
+    ...capabilities.word,
+    ...capabilities.participant,
     ...expectedFieldPolicy.knownRejectedWordAttributes,
   ]);
   const knownGroup = new Set<string>([
-    ...expectedFieldPolicy.retainedGroupAttributes,
+    ...capabilities.group,
     ...expectedFieldPolicy.knownRejectedGroupAttributes,
   ]);
   const unknownWord = auditAttributeKeys(schema, 'wordAttributesObserved', `audit ${expected.id} word attributes`).filter(attribute => !knownWord.has(attribute));
   const unknownGroup = auditAttributeKeys(schema, 'groupAttributesObserved', `audit ${expected.id} group attributes`).filter(attribute => !knownGroup.has(attribute));
   const unknownParticipant = auditAttributeKeys(schema, 'participantAttributesObserved', `audit ${expected.id} participant attributes`)
-    .filter(attribute => !expectedFieldPolicy.retainedParticipantAttributes.includes(attribute as never));
+    .filter(attribute => !capabilities.participant.includes(attribute as never));
   if (unknownWord.length || unknownGroup.length || unknownParticipant.length) {
     fail(`audit ${expected.id} source schema contains unknown attributes`);
   }
 }
 
-/** Validate the content-free deterministic replay metadata without opening any corpus artifact. */
+function verifyRunSummaryBenchmark(value: unknown): void {
+  const benchmark = record(value, 'run summary benchmark');
+  exactKeys(benchmark, [
+    'contextQueryPlan', 'd1RowsRead', 'engine', 'iterations', 'medianMilliseconds', 'p95Milliseconds',
+    'qualification', 'representativeReferences', 'returnedContextRows',
+  ], 'run summary benchmark');
+  if (benchmark.engine !== 'node:sqlite/native-SQLite' || benchmark.qualification !== 'This is a full-projection local SQLite benchmark. It is not a Workerd/D1 billing or latency claim.'
+    || benchmark.d1RowsRead !== null) fail('run summary benchmark diagnostic drifted');
+  if (!Array.isArray(benchmark.representativeReferences) || benchmark.representativeReferences.length < 1 || benchmark.representativeReferences.length > 12) {
+    fail('run summary benchmark representative references have an invalid diagnostic shape');
+  }
+  for (const candidate of benchmark.representativeReferences) {
+    const reference = record(candidate, 'run summary benchmark representative reference');
+    exactKeys(reference, ['corpus', 'group_count', 'reference_id', 'source_reference', 'token_count'], 'run summary benchmark representative reference');
+    if (safeNonNegativeInteger(reference.reference_id, 'run summary benchmark reference id') < 1
+      || reference.corpus !== 'hebrew'
+      || !/^[1-3]?[A-Z][A-Z0-9]* \d+:\d+!\d+$/.test(nonEmptyString(reference.source_reference, 'run summary benchmark source reference'))
+      || safeNonNegativeInteger(reference.token_count, 'run summary benchmark token count') < 1
+      || safeNonNegativeInteger(reference.group_count, 'run summary benchmark group count') < 1) {
+      fail('run summary benchmark representative reference drifted');
+    }
+  }
+  if (safeNonNegativeInteger(benchmark.iterations, 'run summary benchmark iterations') < 1
+    || safeNonNegativeInteger(benchmark.returnedContextRows, 'run summary benchmark returned context rows') < 1
+    || typeof benchmark.medianMilliseconds !== 'number' || !Number.isFinite(benchmark.medianMilliseconds) || benchmark.medianMilliseconds < 0
+    || typeof benchmark.p95Milliseconds !== 'number' || !Number.isFinite(benchmark.p95Milliseconds) || benchmark.p95Milliseconds < 0) {
+    fail('run summary benchmark timing diagnostic drifted');
+  }
+  if (!Array.isArray(benchmark.contextQueryPlan) || benchmark.contextQueryPlan.length < 1) fail('run summary benchmark query plan has an invalid diagnostic shape');
+  for (const candidate of benchmark.contextQueryPlan) {
+    const plan = record(candidate, 'run summary benchmark query plan row');
+    exactKeys(plan, ['detail', 'id', 'notused', 'parent'], 'run summary benchmark query plan row');
+    safeNonNegativeInteger(plan.id, 'run summary benchmark query plan id');
+    safeNonNegativeInteger(plan.parent, 'run summary benchmark query plan parent');
+    safeNonNegativeInteger(plan.notused, 'run summary benchmark query plan notused');
+    nonEmptyString(plan.detail, 'run summary benchmark query plan detail');
+  }
+}
+
+/** Validate all unhashed run-summary metadata without opening any corpus artifact. */
 export function verifyMaculaAuditRunSummary(value: unknown): void {
   const summary = record(value, 'run summary');
   exactKeys(summary, [
@@ -389,38 +670,75 @@ export function verifyMaculaAuditRunSummary(value: unknown): void {
     'replayScript', 'schemaVersion', 'workerdD1',
   ], 'run summary');
   if (summary.schemaVersion !== 2) fail('run summary schema version drifted');
+  isoTimestampDiagnostic(summary.executedAt, 'run summary execution timestamp');
+  absolutePathDiagnostic(summary.auditRoot, 'run summary audit root');
+  const command = nonEmptyString(summary.command, 'run summary command');
+  if (!command.includes('scripts/inspect-macula-v2.mjs') || !command.includes('--output audit-output/final-replay-2') || !command.includes('--compare audit-output/final-replay-1')) {
+    fail('run summary command diagnostic drifted');
+  }
+
+  const environment = record(summary.environment, 'run summary environment');
+  exactKeys(environment, ['git', 'node', 'sqlite'], 'run summary environment');
+  if (!/^v\d+\.\d+\.\d+$/.test(nonEmptyString(environment.node, 'run summary Node diagnostic'))
+    || !/^\d+\.\d+(?:\.\d+)?$/.test(nonEmptyString(environment.sqlite, 'run summary SQLite diagnostic'))
+    || !/^git version .+$/.test(nonEmptyString(environment.git, 'run summary Git diagnostic'))) {
+    fail('run summary host tooling diagnostic drifted');
+  }
+  const replayScript = record(summary.replayScript, 'run summary replay script');
+  exactKeys(replayScript, Object.keys(expectedRunSummaryReplayScript), 'run summary replay script');
+  exactValue(replayScript, expectedRunSummaryReplayScript, 'run summary replay script');
+
   const attestations = record(summary.attestations, 'run summary attestations');
-  for (const [key, expected] of [
-    ['maculaGreek', expectedSources[0]], ['maculaHebrew', expectedSources[1]],
-  ] as const) {
+  exactKeys(attestations, Object.keys(expectedRunSummaryAttestations), 'run summary attestations');
+  for (const [key, expected] of Object.entries(expectedRunSummaryAttestations)) {
     const attestation = record(attestations[key], `run summary ${key}`);
-    if (attestation.head !== expected.revision.commit || attestation.tree !== expected.revision.tree
-      || attestation.clean !== true || attestation.everySelectedPathTracked !== true
-      || attestation.selectedPathCount !== expected.selection.selectedPathCount) fail(`run summary ${key} attestation drifted`);
+    exactKeys(attestation, Object.keys(expected), `run summary ${key}`);
+    exactValue(attestation, expected, `run summary ${key}`);
   }
-  for (const key of ['theologaiMain', 'theologaiPreflight'] as const) {
-    const attestation = record(attestations[key], `run summary ${key}`);
-    if (attestation.head !== expectedCurrentMain.commit || attestation.tree !== expectedCurrentMain.tree
-      || attestation.originMain !== expectedCurrentMain.commit || attestation.clean !== true) {
-      fail(`run summary ${key} current-main attestation drifted`);
-    }
+
+  const compatibility = record(summary.canonicalRuntimeCompatibility, 'run summary compatibility');
+  exactKeys(compatibility, ['d1CorpusIdentity', 'derivation', 'loader', 'morphologyUsageIdentity', 'runtimeContentInventory'], 'run summary compatibility');
+  exactValue(compatibility.d1CorpusIdentity, expectedCurrentMain.d1CorpusIdentity, 'run summary D1 corpus identity');
+  exactValue(compatibility.morphologyUsageIdentity, expectedCurrentMain.morphologyUsageIdentity, 'run summary morphology usage identity');
+  exactValue(compatibility.runtimeContentInventory, expectedCurrentMain.runtimeContentInventory, 'run summary runtime content inventory');
+  const derivation = record(compatibility.derivation, 'run summary compatibility derivation');
+  exactKeys(derivation, Object.keys(expectedRunSummaryCompatibilityDerivation), 'run summary compatibility derivation');
+  exactValue(derivation, expectedRunSummaryCompatibilityDerivation, 'run summary compatibility derivation');
+  const loader = record(compatibility.loader, 'run summary compatibility loader');
+  exactKeys(loader, ['executable', 'tsxCliSha256', 'tsxVersion'], 'run summary compatibility loader');
+  absolutePathDiagnostic(loader.executable, 'run summary loader executable');
+  sha256String(loader.tsxCliSha256, 'run summary loader tsx CLI SHA-256');
+  if (!/^\d+\.\d+\.\d+$/.test(nonEmptyString(loader.tsxVersion, 'run summary loader tsx version'))) {
+    fail('run summary loader diagnostic drifted');
   }
+
+  const faithlife = record(summary.faithlifeSblgntNotice, 'run summary Faithlife notice');
+  exactKeys(faithlife, Object.keys(expectedRunSummaryFaithlifeNotice), 'run summary Faithlife notice');
+  exactValue(faithlife, expectedRunSummaryFaithlifeNotice, 'run summary Faithlife notice');
   const hashDomain = record(summary.deterministicHashDomain, 'run summary deterministic hash domain');
   exactKeys(hashDomain, ['artifacts', 'excludes', 'sha256'], 'run summary deterministic hash domain');
   exactValue(hashDomain, expectedDeterministicHashDomain, 'run summary deterministic hash domain');
+  const inventory = record(summary.inventoryAssertions, 'run summary inventory assertions');
+  exactKeys(inventory, Object.keys(expectedRunSummaryInventoryAssertions), 'run summary inventory assertions');
+  exactValue(inventory, expectedRunSummaryInventoryAssertions, 'run summary inventory assertions');
   const replayComparison = record(summary.replayComparison, 'run summary replay comparison');
   exactKeys(replayComparison, ['artifacts', 'assertion', 'deterministicIdentity', 'priorOutput', 'status'], 'run summary replay comparison');
   exactValue(replayComparison, expectedReplayComparison, 'run summary replay comparison');
   if (JSON.stringify(replayComparison.artifacts) !== JSON.stringify(hashDomain.artifacts)) {
     fail('replay comparison artifacts differ from deterministic hash-domain artifacts');
   }
-  const compatibility = record(summary.canonicalRuntimeCompatibility, 'run summary compatibility');
-  exactValue(compatibility.d1CorpusIdentity, expectedCurrentMain.d1CorpusIdentity, 'D1 corpus identity');
-  exactValue(compatibility.morphologyUsageIdentity, expectedCurrentMain.morphologyUsageIdentity, 'morphology usage identity');
-  exactValue(compatibility.runtimeContentInventory, expectedCurrentMain.runtimeContentInventory, 'runtime content inventory');
-  const faithlife = record(summary.faithlifeSblgntNotice, 'run summary Faithlife notice');
-  if (faithlife.status !== 'notice_only_excluded_from_alignment_projection_and_deterministic_identity') {
-    fail('standalone Faithlife checkout must remain notice-only');
+  verifyRunSummaryBenchmark(summary.benchmark);
+  const workerdD1 = record(summary.workerdD1, 'run summary Workerd/D1');
+  exactKeys(workerdD1, Object.keys(expectedRunSummaryWorkerdD1), 'run summary Workerd/D1');
+  exactValue(workerdD1, expectedRunSummaryWorkerdD1, 'run summary Workerd/D1');
+  const integrity = record(summary.integrity, 'run summary integrity');
+  exactKeys(integrity, Object.keys(expectedRunSummaryIntegrity), 'run summary integrity');
+  exactValue(integrity, expectedRunSummaryIntegrity, 'run summary integrity');
+  if (safeNonNegativeInteger(integrity.totalGroups, 'run summary total groups')
+      !== safeNonNegativeInteger(integrity.reachableGroups, 'run summary reachable groups') + safeNonNegativeInteger(integrity.unreachableGroups, 'run summary unreachable groups')
+    || integrity.releaseGateDanglingParticipantReferences !== expectedDanglingLedger.total
+    || integrity.pass !== true || integrity.releaseEligible !== false) {
+    fail('run summary integrity arithmetic or publication gate drifted');
   }
 }
 

--- a/test/unit/scripts/maculaSourceContract.test.ts
+++ b/test/unit/scripts/maculaSourceContract.test.ts
@@ -12,6 +12,7 @@ import {
   verifyAuthoritativeMaculaAudit,
   verifyHistoricalCurrentMainAttestation,
   verifyMaculaAuditRunSummary,
+  verifyPinnedGitCommitTree,
 } from '../../../scripts/macula-source-contract.js';
 
 const repo = new URL('../../../', import.meta.url);
@@ -24,6 +25,17 @@ const expectedMaculaPaths = [
 const authoritativeAuditOutput = '/private/tmp/theologai-macula-source-audit/audit-output';
 const authoritativeFinalReplay = join(authoritativeAuditOutput, 'final-replay-2');
 const hasAuthoritativeAudit = existsSync(authoritativeFinalReplay);
+const hasHistoricalCurrentMainObject = (() => {
+  try {
+    execFileSync('git', ['cat-file', '-e', '2f12262c9a37d3588bee9b5071954823c15cbd12^{commit}'], {
+      cwd: new URL('.', repo),
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+})();
 
 function contractFixture(): Record<string, unknown> {
   return JSON.parse(readFileSync(new URL('data/biblical-languages/macula/SOURCE-CONTRACT.json', repo), 'utf8'));
@@ -144,6 +156,23 @@ describe('MACULA local-only source contract', () => {
       morphologyUsageIdentity: 'c3600bb55da75aa600f8c97885efa7d58a3e8c29c3fcc6445a553091011beabd',
       d1CorpusIdentity: '29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4',
     });
+  });
+
+  it('verifies an exact Git commit/tree pair available in every checkout and rejects mismatches', () => {
+    const revision = (args: string[]) => execFileSync('git', args, {
+      cwd: new URL('.', repo),
+      encoding: 'utf8',
+    }).trim();
+    const head = revision(['rev-parse', 'HEAD']);
+    const tree = revision(['rev-parse', 'HEAD^{tree}']);
+    expect(() => verifyPinnedGitCommitTree(process.cwd(), head, tree, 'test checkout HEAD')).not.toThrow();
+    expect(() => verifyPinnedGitCommitTree(process.cwd(), head, '0'.repeat(40), 'test checkout HEAD'))
+      .toThrow('test checkout HEAD tree differs from the source lock');
+    expect(() => verifyPinnedGitCommitTree(process.cwd(), '0'.repeat(40), tree, 'test checkout missing'))
+      .toThrow('test checkout missing Git object is unavailable');
+  });
+
+  it.skipIf(!hasHistoricalCurrentMainObject)('verifies the historical current-main object when this checkout contains it', () => {
     expect(() => verifyHistoricalCurrentMainAttestation(process.cwd())).not.toThrow();
   });
 

--- a/test/unit/scripts/maculaSourceContract.test.ts
+++ b/test/unit/scripts/maculaSourceContract.test.ts
@@ -192,6 +192,53 @@ function withAuditCopy(mutateRunSummary: (summary: Record<string, unknown>) => v
   }
 }
 
+type RunSummaryMutation = readonly [label: string, mutate: (summary: Record<string, unknown>) => void];
+
+/**
+ * Every summary boundary is exercised against the content-free fixture in normal
+ * CI. The conditional copied-audit replay below provides separate local
+ * end-to-end evidence without making those semantic checks conditional.
+ */
+const runSummaryMutations: readonly RunSummaryMutation[] = [
+  ['unknown top-level field', summary => { summary.unreviewed = true; }],
+  ['schema version', summary => { summary.schemaVersion = 999; }],
+  ['replay artifact', summary => { ((summary.replayComparison as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[0]!.sha256 = '0'.repeat(64); }],
+  ['hash-domain artifact', summary => { ((summary.deterministicHashDomain as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[2]!.bytes = 1; }],
+  ['replay status', summary => { (summary.replayComparison as Record<string, unknown>).status = 'not_identical'; }],
+  ['source attestation', summary => { ((summary.attestations as Record<string, unknown>).maculaGreek as Record<string, unknown>).clean = false; }],
+  ['compatibility identity', summary => { (summary.canonicalRuntimeCompatibility as Record<string, unknown>).d1CorpusIdentity = '0'.repeat(64); }],
+  ['compatibility unknown nested field', summary => { (summary.canonicalRuntimeCompatibility as Record<string, unknown>).unreviewed = true; }],
+  ['Faithlife contradiction', summary => { (summary.faithlifeSblgntNotice as Record<string, unknown>).status = 'selected_alignment_input'; }],
+  ['Faithlife unknown field', summary => { (summary.faithlifeSblgntNotice as Record<string, unknown>).unreviewed = true; }],
+  ['inventory boolean', summary => { (summary.inventoryAssertions as Record<string, unknown>).allSelectedPathsTracked = false; }],
+  ['inventory count', summary => { (summary.inventoryAssertions as Record<string, unknown>).runtimeContentInventoryArtifacts = 71; }],
+  ['benchmark unknown nested field', summary => { (summary.benchmark as Record<string, unknown>).unreviewed = true; }],
+  ['Workerd pass claim', summary => { (summary.workerdD1 as Record<string, unknown>).status = 'passed'; }],
+  ['integrity foreign-key count', summary => { (summary.integrity as Record<string, unknown>).foreignKeyViolations = 1; }],
+  ['publication eligibility', summary => { (summary.integrity as Record<string, unknown>).releaseEligible = true; }],
+  ['dangling participant count', summary => { (summary.integrity as Record<string, unknown>).releaseGateDanglingParticipantReferences = 8; }],
+  ['integrity pass claim', summary => { (summary.integrity as Record<string, unknown>).pass = false; }],
+  ['integrity group count', summary => { (summary.integrity as Record<string, unknown>).totalGroups = 1; }],
+  ['integrity unknown nested field', summary => { (summary.integrity as Record<string, unknown>).unreviewed = true; }],
+  ['environment unknown nested field', summary => { (summary.environment as Record<string, unknown>).unreviewed = true; }],
+];
+
+function applyCombinedRunSummaryMutation(summary: Record<string, unknown>): void {
+  summary.unreviewed = true;
+  (summary.replayComparison as Record<string, unknown>).status = 'not_identical';
+  ((summary.attestations as Record<string, unknown>).maculaHebrew as Record<string, unknown>).clean = false;
+  (summary.canonicalRuntimeCompatibility as Record<string, unknown>).d1CorpusIdentity = '0'.repeat(64);
+  (summary.faithlifeSblgntNotice as Record<string, unknown>).unreviewed = true;
+  (summary.inventoryAssertions as Record<string, unknown>).allSelectedPathsTracked = false;
+  (summary.benchmark as Record<string, unknown>).unreviewed = true;
+  (summary.workerdD1 as Record<string, unknown>).status = 'passed';
+  (summary.integrity as Record<string, unknown>).releaseEligible = true;
+  (summary.integrity as Record<string, unknown>).releaseGateDanglingParticipantReferences = 8;
+  (summary.integrity as Record<string, unknown>).pass = false;
+  (summary.integrity as Record<string, unknown>).totalGroups = 1;
+  (summary.environment as Record<string, unknown>).unreviewed = true;
+}
+
 describe('MACULA local-only source contract', () => {
   it('pins the approved untagged revisions, final audit identity, and historical current-main compatibility values', () => {
     const contract = readMaculaSourceContract(process.cwd());
@@ -270,6 +317,9 @@ describe('MACULA local-only source contract', () => {
       ['Greek license', value => { ((value.rightsAndProvenance as Record<string, unknown>).maculaGreek as Record<string, unknown>).license = 'unreviewed'; }],
       ['Greek attribution', value => { ((value.rightsAndProvenance as Record<string, unknown>).maculaGreek as Record<string, unknown>).requiredAttribution = 'unreviewed'; }],
       ['lang evidence', value => { (((value.rightsAndProvenance as Record<string, unknown>).langRetention as Record<string, unknown>).pipelineEvidence as Record<string, unknown>).observedTokenLanguages = 'unreviewed'; }],
+      ['pinned repository README provenance', value => { (((value.rightsAndProvenance as Record<string, unknown>).langRetention as Record<string, unknown>).pipelineEvidence as Record<string, unknown>).sourceReadme = 'unreviewed'; }],
+      ['pinned repository XQuery provenance', value => { (((value.rightsAndProvenance as Record<string, unknown>).langRetention as Record<string, unknown>).pipelineEvidence as Record<string, unknown>).pinnedRepositoryXquery = 'unreviewed'; }],
+      ['legacy selected XQuery provenance key', value => { (((value.rightsAndProvenance as Record<string, unknown>).langRetention as Record<string, unknown>).pipelineEvidence as Record<string, unknown>).selectedXquery = 'unreviewed'; }],
       ['Faithlife commit', value => { ((value.rightsAndProvenance as Record<string, unknown>).standaloneFaithlifeNotice as Record<string, unknown>).commit = 'unreviewed'; }],
       ['Faithlife tree', value => { ((value.rightsAndProvenance as Record<string, unknown>).standaloneFaithlifeNotice as Record<string, unknown>).tree = 'unreviewed'; }],
       ['Faithlife role', value => { ((value.rightsAndProvenance as Record<string, unknown>).standaloneFaithlifeNotice as Record<string, unknown>).role = 'unreviewed'; }],
@@ -309,53 +359,27 @@ describe('MACULA local-only source contract', () => {
     }
   });
 
-  it('validates deterministic replay metadata in a fresh checkout and fails closed on contradictions', () => {
+  it('validates every deterministic and semantic summary boundary in normal CI', () => {
     expect(() => verifyMaculaAuditRunSummary(runSummaryFixture())).not.toThrow();
-    const replayArtifactMutation = runSummaryFixture();
-    ((replayArtifactMutation.replayComparison as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[0]!.sha256 = '0'.repeat(64);
-    expect(() => verifyMaculaAuditRunSummary(replayArtifactMutation)).toThrow('run summary replay comparison drifted');
-    const hashDomainMutation = runSummaryFixture();
-    ((hashDomainMutation.deterministicHashDomain as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[2]!.bytes = 1;
-    expect(() => verifyMaculaAuditRunSummary(hashDomainMutation)).toThrow('run summary deterministic hash domain drifted');
-    const statusMutation = runSummaryFixture();
-    (statusMutation.replayComparison as Record<string, unknown>).status = 'not_identical';
-    expect(() => verifyMaculaAuditRunSummary(statusMutation)).toThrow('run summary replay comparison drifted');
-    const schemaVersionMutation = runSummaryFixture();
-    schemaVersionMutation.schemaVersion = 999;
-    expect(() => verifyMaculaAuditRunSummary(schemaVersionMutation)).toThrow('run summary schema version drifted');
+    for (const [label, mutate] of runSummaryMutations) {
+      const mutated = runSummaryFixture();
+      mutate(mutated);
+      expect(() => verifyMaculaAuditRunSummary(mutated), label).toThrow('run summary');
+    }
+    const combined = runSummaryFixture();
+    applyCombinedRunSummaryMutation(combined);
+    expect(() => verifyMaculaAuditRunSummary(combined)).toThrow('run summary');
   });
 
   it.skipIf(!hasAuthoritativeAudit)('directly verifies the authoritative final replay without opening its projection', () => {
     expect(() => verifyAuthoritativeMaculaAudit(authoritativeFinalReplay, process.cwd())).not.toThrow();
   });
 
-  it.skipIf(!hasAuthoritativeAudit)('recursively fails closed for individual and combined unhashed run-summary contradictions', () => {
-    const mutations: Array<readonly [string, (summary: Record<string, unknown>) => void]> = [
-      ['replay artifact', summary => { ((summary.replayComparison as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[0]!.sha256 = '0'.repeat(64); }],
-      ['hash-domain artifact', summary => { ((summary.deterministicHashDomain as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[2]!.bytes = 1; }],
-      ['replay status', summary => { (summary.replayComparison as Record<string, unknown>).status = 'not_identical'; }],
-      ['publication eligibility', summary => { (summary.integrity as Record<string, unknown>).releaseEligible = true; }],
-      ['Workerd pass claim', summary => { (summary.workerdD1 as Record<string, unknown>).status = 'passed'; }],
-      ['Faithlife contradiction', summary => { (summary.faithlifeSblgntNotice as Record<string, unknown>).status = 'selected_alignment_input'; }],
-      ['Faithlife unknown field', summary => { (summary.faithlifeSblgntNotice as Record<string, unknown>).unreviewed = true; }],
-      ['inventory boolean', summary => { (summary.inventoryAssertions as Record<string, unknown>).allSelectedPathsTracked = false; }],
-      ['inventory count', summary => { (summary.inventoryAssertions as Record<string, unknown>).runtimeContentInventoryArtifacts = 71; }],
-      ['compatibility identity', summary => { (summary.canonicalRuntimeCompatibility as Record<string, unknown>).d1CorpusIdentity = '0'.repeat(64); }],
-      ['source attestation', summary => { ((summary.attestations as Record<string, unknown>).maculaGreek as Record<string, unknown>).clean = false; }],
-      ['unknown nested field', summary => { (summary.environment as Record<string, unknown>).unreviewed = true; }],
-    ];
-    for (const [label, mutate] of mutations) {
+  it.skipIf(!hasAuthoritativeAudit)('replays the complete summary mutation suite against the copied authoritative evidence', () => {
+    for (const [label, mutate] of runSummaryMutations) {
       expect(() => withAuditCopy(mutate), label).toThrow('MACULA source contract violation');
     }
-    expect(() => withAuditCopy(summary => {
-      (summary.integrity as Record<string, unknown>).releaseEligible = true;
-      (summary.workerdD1 as Record<string, unknown>).status = 'passed';
-      (summary.faithlifeSblgntNotice as Record<string, unknown>).unreviewed = true;
-      (summary.inventoryAssertions as Record<string, unknown>).allSelectedPathsTracked = false;
-      (summary.canonicalRuntimeCompatibility as Record<string, unknown>).d1CorpusIdentity = '0'.repeat(64);
-      ((summary.attestations as Record<string, unknown>).maculaHebrew as Record<string, unknown>).clean = false;
-      (summary.environment as Record<string, unknown>).unreviewed = true;
-    })).toThrow('MACULA source contract violation');
+    expect(() => withAuditCopy(applyCombinedRunSummaryMutation)).toThrow('MACULA source contract violation');
   });
 
   it('keeps the packet content-free and completely outside runtime, migration, manifest, and public-surface wiring', () => {

--- a/test/unit/scripts/maculaSourceContract.test.ts
+++ b/test/unit/scripts/maculaSourceContract.test.ts
@@ -48,40 +48,52 @@ function runSummaryFixture(): Record<string, unknown> {
     { path: 'inspection.json', bytes: 54_523, sha256: '505e715901635db876539358f9456830ff51b17445cd372045d665834c9896b9' },
     { path: 'macula-structural-projection.sqlite', bytes: 207_106_048, sha256: 'c5a61cf047e662a6d2238093edefa7dc540ce8f2b2bbeb49115cb94329fab414' },
   ];
-  const currentMain = {
-    head: '2f12262c9a37d3588bee9b5071954823c15cbd12',
-    tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
-    originMain: '2f12262c9a37d3588bee9b5071954823c15cbd12',
-    clean: true,
-  };
   return {
     schemaVersion: 2,
     auditRoot: '/synthetic/local-only-audit',
-    command: 'synthetic',
-    environment: {},
-    executedAt: 'synthetic',
-    replayScript: {},
-    integrity: {},
-    inventoryAssertions: {},
-    benchmark: {},
-    workerdD1: {},
+    command: 'node scripts/inspect-macula-v2.mjs --output audit-output/final-replay-2 --compare audit-output/final-replay-1',
+    environment: { node: 'v22.0.0', sqlite: '3.0.0', git: 'git version synthetic' },
+    executedAt: '2026-01-01T00:00:00.000Z',
+    replayScript: {
+      path: 'scripts/inspect-macula-v2.mjs',
+      sha256: '0ce62ee220cd49893c59f23c0b32d00a02ccbe8f1f1c6373ebead010a94f6149',
+      requiredNode: '22.23.1',
+    },
     attestations: {
       maculaGreek: {
         head: '8423afe47b9e8f24b7772e808af45c7159a6fe7e',
         tree: 'eea78df4b0f1efb857f1575243a1ec4548267a11',
         clean: true,
-        everySelectedPathTracked: true,
         selectedPathCount: 29,
+        everySelectedPathTracked: true,
+        branch: '(detached)',
       },
       maculaHebrew: {
         head: '47db250bd55d0d8577f2a94fba114ef16c35b23c',
         tree: '594f395cf473795d6984003800b4bf86ca691a26',
         clean: true,
-        everySelectedPathTracked: true,
         selectedPathCount: 933,
+        everySelectedPathTracked: true,
+        branch: '(detached)',
       },
-      theologaiMain: currentMain,
-      theologaiPreflight: currentMain,
+      theologaiMain: {
+        head: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+        tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
+        clean: true,
+        selectedPathCount: 68,
+        everySelectedPathTracked: true,
+        branch: 'main',
+        originMain: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+      },
+      theologaiPreflight: {
+        head: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+        tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
+        clean: true,
+        selectedPathCount: 0,
+        everySelectedPathTracked: true,
+        branch: 'main',
+        originMain: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+      },
     },
     canonicalRuntimeCompatibility: {
       d1CorpusIdentity: '29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4',
@@ -90,6 +102,16 @@ function runSummaryFixture(): Record<string, unknown> {
         artifactCount: 72,
         identityPolicy: 'canonical_decompressed_json_v1_sha256_for_json_gz_else_raw_sha256',
         sha256: 'caf58814f24cc72837586c901c42f3556b59e45ec81bb0af7f5cfb9fa1629dcd',
+      },
+      derivation: {
+        d1CorpusIdentity: 'computeD1CorpusIdentity(parseDataManifest(data/data-manifest.json)) from the exact audit checkout',
+        morphologyUsageIdentity: 'computeMorphologyUsageIdentity(parseDataManifest(data/data-manifest.json)) from the exact audit checkout',
+        runtimeContentInventory: 'canonical content identity over the repository-owned 72-artifact OpenScriptures/STEPBible runtime inventory',
+      },
+      loader: {
+        executable: '/synthetic/node',
+        tsxCliSha256: '293360f3bf5826200d31375aea1267ccdad675d2a9cd1ad832e00b9f16509a7a',
+        tsxVersion: '4.20.6',
       },
     },
     deterministicHashDomain: {
@@ -106,6 +128,47 @@ function runSummaryFixture(): Record<string, unknown> {
     },
     faithlifeSblgntNotice: {
       status: 'notice_only_excluded_from_alignment_projection_and_deterministic_identity',
+      output: 'provenance-license-notice.json',
+    },
+    inventoryAssertions: {
+      selectedMaculaGreekFiles: 29,
+      selectedMaculaHebrewFiles: 933,
+      runtimeCorpusFiles: 66,
+      runtimeContentInventoryArtifacts: 72,
+      faithlifeSblgntAlignmentInput: false,
+      allSelectedPathsTracked: true,
+    },
+    benchmark: {
+      engine: 'node:sqlite/native-SQLite',
+      representativeReferences: [{ reference_id: 1, corpus: 'hebrew', source_reference: 'GEN 1:1!1', token_count: 1, group_count: 1 }],
+      iterations: 1,
+      medianMilliseconds: 0,
+      p95Milliseconds: 0,
+      returnedContextRows: 1,
+      contextQueryPlan: [{ id: 0, parent: 0, notused: 0, detail: 'synthetic diagnostic' }],
+      d1RowsRead: null,
+      qualification: 'This is a full-projection local SQLite benchmark. It is not a Workerd/D1 billing or latency claim.',
+    },
+    workerdD1: {
+      status: 'not_run',
+      reason: 'A full D1/Workerd probe requires a reviewed D1 materializer/import path. Native SQLite was run against the complete projection; D1 rows_read and remote-equivalent latency remain deliberately unclaimed.',
+    },
+    integrity: {
+      foreignKeyViolations: 0,
+      tokensWithoutImmediateGroup: 0,
+      tokensWithMissingGroup: 0,
+      groupsWithMissingParent: 0,
+      totalGroups: 441_272,
+      reachableGroups: 441_272,
+      unreachableGroups: 0,
+      groupCycleMembers: 0,
+      tokenMembershipRows: 613_652,
+      groupReferenceRows: 1_965_769,
+      referencesWithoutGroupContext: 0,
+      duplicateTokenIds: 0,
+      releaseGateDanglingParticipantReferences: 9,
+      pass: true,
+      releaseEligible: false,
     },
   };
 }
@@ -177,13 +240,20 @@ describe('MACULA local-only source contract', () => {
   });
 
   it('allows only the reviewed structural attributes and fails closed for excluded or unknown fields', () => {
-    expect(() => assertMaculaSourceAttribute('word', 'xml:id')).not.toThrow();
-    expect(() => assertMaculaSourceAttribute('group', 'Rule')).not.toThrow();
-    expect(() => assertMaculaSourceAttribute('participant', 'participantref')).not.toThrow();
-    expect(() => assertMaculaSourceAttribute('word', 'lemma')).toThrow('explicitly excluded');
-    expect(() => assertMaculaSourceAttribute('group', 'unreviewed-field')).toThrow('unknown schema drift');
-    expect(() => assertMaculaSourceAttribute('participant', 'unreviewed-field')).toThrow('unknown schema drift');
-    expect(() => assertMaculaSourceAttribute('invalid-scope' as never, 'participantref')).toThrow('invalid source attribute scope');
+    expect(() => assertMaculaSourceAttribute('greek', 'word', 'xml:id')).not.toThrow();
+    expect(() => assertMaculaSourceAttribute('greek', 'group', 'Rule')).not.toThrow();
+    expect(() => assertMaculaSourceAttribute('hebrew', 'participant', 'participantref')).not.toThrow();
+    expect(() => assertMaculaSourceAttribute('hebrew', 'word', 'lang')).not.toThrow();
+    expect(() => assertMaculaSourceAttribute('greek', 'word', 'lemma')).toThrow('explicitly excluded');
+    expect(() => assertMaculaSourceAttribute('greek', 'group', 'unreviewed-field')).toThrow('unknown schema drift');
+    expect(() => assertMaculaSourceAttribute('hebrew', 'participant', 'unreviewed-field')).toThrow('unknown schema drift');
+    expect(() => assertMaculaSourceAttribute('greek', 'word', 'lang')).toThrow('not approved for that corpus');
+    expect(() => assertMaculaSourceAttribute('greek', 'group', 'head')).toThrow('not approved for that corpus');
+    expect(() => assertMaculaSourceAttribute('greek', 'participant', 'participantref')).toThrow('not approved for that corpus');
+    expect(() => assertMaculaSourceAttribute('hebrew', 'participant', 'referent')).toThrow('not approved for that corpus');
+    expect(() => assertMaculaSourceAttribute('hebrew', 'group', 'Rule')).toThrow('not approved for that corpus');
+    expect(() => assertMaculaSourceAttribute('greek', 'invalid-scope' as never, 'participantref')).toThrow('invalid source attribute scope');
+    expect(() => assertMaculaSourceAttribute('invalid-corpus' as never, 'word', 'xml:id')).toThrow('invalid source attribute corpus');
   });
 
   it('rejects unknown contract fields, dangling-ledger changes, and every reviewed rights or inertness mutation', () => {
@@ -199,9 +269,11 @@ describe('MACULA local-only source contract', () => {
     const rightsMutations: Array<readonly [string, (value: Record<string, unknown>) => void]> = [
       ['Greek license', value => { ((value.rightsAndProvenance as Record<string, unknown>).maculaGreek as Record<string, unknown>).license = 'unreviewed'; }],
       ['Greek attribution', value => { ((value.rightsAndProvenance as Record<string, unknown>).maculaGreek as Record<string, unknown>).requiredAttribution = 'unreviewed'; }],
-      ['Faithlife commit', value => { ((value.rightsAndProvenance as Record<string, unknown>).faithlifeSblgntStandaloneNotice as Record<string, unknown>).commit = 'unreviewed'; }],
-      ['Faithlife tree', value => { ((value.rightsAndProvenance as Record<string, unknown>).faithlifeSblgntStandaloneNotice as Record<string, unknown>).tree = 'unreviewed'; }],
-      ['Faithlife role', value => { ((value.rightsAndProvenance as Record<string, unknown>).faithlifeSblgntStandaloneNotice as Record<string, unknown>).role = 'unreviewed'; }],
+      ['lang evidence', value => { (((value.rightsAndProvenance as Record<string, unknown>).langRetention as Record<string, unknown>).pipelineEvidence as Record<string, unknown>).observedTokenLanguages = 'unreviewed'; }],
+      ['Faithlife commit', value => { ((value.rightsAndProvenance as Record<string, unknown>).standaloneFaithlifeNotice as Record<string, unknown>).commit = 'unreviewed'; }],
+      ['Faithlife tree', value => { ((value.rightsAndProvenance as Record<string, unknown>).standaloneFaithlifeNotice as Record<string, unknown>).tree = 'unreviewed'; }],
+      ['Faithlife role', value => { ((value.rightsAndProvenance as Record<string, unknown>).standaloneFaithlifeNotice as Record<string, unknown>).role = 'unreviewed'; }],
+      ['SBLGNT derived-input notice', value => { ((value.rightsAndProvenance as Record<string, unknown>).sblgntRightsForMaculaGreekDerivedInput as Record<string, unknown>).copyrightNotice = 'unreviewed'; }],
       ['legal gate', value => { (value.rightsAndProvenance as Record<string, unknown>).legalReviewGate = 'unreviewed'; }],
     ];
     for (const [label, mutate] of rightsMutations) {
@@ -216,6 +288,10 @@ describe('MACULA local-only source contract', () => {
     const boundaryMutation = contractFixture();
     (boundaryMutation.inertness as Record<string, unknown>).verifierBoundary = 'unreviewed';
     expect(() => parseMaculaSourceContract(boundaryMutation)).toThrow('inertness drifted');
+
+    const maturityMutation = contractFixture();
+    (((maturityMutation.sources as Array<Record<string, unknown>>)[0]!.maturity as Record<string, unknown>).selectedPathComparison as Record<string, unknown>).differingSelectedLowfatFileCount = 0;
+    expect(() => parseMaculaSourceContract(maturityMutation)).toThrow('source pins drifted');
   });
 
   it('accepts only the exact local verifier CLI forms', () => {
@@ -253,16 +329,33 @@ describe('MACULA local-only source contract', () => {
     expect(() => verifyAuthoritativeMaculaAudit(authoritativeFinalReplay, process.cwd())).not.toThrow();
   });
 
-  it.skipIf(!hasAuthoritativeAudit)('fails closed when replay metadata contradicts the deterministic replay evidence', () => {
+  it.skipIf(!hasAuthoritativeAudit)('recursively fails closed for individual and combined unhashed run-summary contradictions', () => {
+    const mutations: Array<readonly [string, (summary: Record<string, unknown>) => void]> = [
+      ['replay artifact', summary => { ((summary.replayComparison as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[0]!.sha256 = '0'.repeat(64); }],
+      ['hash-domain artifact', summary => { ((summary.deterministicHashDomain as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[2]!.bytes = 1; }],
+      ['replay status', summary => { (summary.replayComparison as Record<string, unknown>).status = 'not_identical'; }],
+      ['publication eligibility', summary => { (summary.integrity as Record<string, unknown>).releaseEligible = true; }],
+      ['Workerd pass claim', summary => { (summary.workerdD1 as Record<string, unknown>).status = 'passed'; }],
+      ['Faithlife contradiction', summary => { (summary.faithlifeSblgntNotice as Record<string, unknown>).status = 'selected_alignment_input'; }],
+      ['Faithlife unknown field', summary => { (summary.faithlifeSblgntNotice as Record<string, unknown>).unreviewed = true; }],
+      ['inventory boolean', summary => { (summary.inventoryAssertions as Record<string, unknown>).allSelectedPathsTracked = false; }],
+      ['inventory count', summary => { (summary.inventoryAssertions as Record<string, unknown>).runtimeContentInventoryArtifacts = 71; }],
+      ['compatibility identity', summary => { (summary.canonicalRuntimeCompatibility as Record<string, unknown>).d1CorpusIdentity = '0'.repeat(64); }],
+      ['source attestation', summary => { ((summary.attestations as Record<string, unknown>).maculaGreek as Record<string, unknown>).clean = false; }],
+      ['unknown nested field', summary => { (summary.environment as Record<string, unknown>).unreviewed = true; }],
+    ];
+    for (const [label, mutate] of mutations) {
+      expect(() => withAuditCopy(mutate), label).toThrow('MACULA source contract violation');
+    }
     expect(() => withAuditCopy(summary => {
-      ((summary.replayComparison as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[0]!.sha256 = '0'.repeat(64);
-    })).toThrow('run summary replay comparison drifted');
-    expect(() => withAuditCopy(summary => {
-      ((summary.deterministicHashDomain as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[2]!.bytes = 1;
-    })).toThrow('run summary deterministic hash domain drifted');
-    expect(() => withAuditCopy(summary => {
-      (summary.replayComparison as Record<string, unknown>).status = 'not_identical';
-    })).toThrow('run summary replay comparison drifted');
+      (summary.integrity as Record<string, unknown>).releaseEligible = true;
+      (summary.workerdD1 as Record<string, unknown>).status = 'passed';
+      (summary.faithlifeSblgntNotice as Record<string, unknown>).unreviewed = true;
+      (summary.inventoryAssertions as Record<string, unknown>).allSelectedPathsTracked = false;
+      (summary.canonicalRuntimeCompatibility as Record<string, unknown>).d1CorpusIdentity = '0'.repeat(64);
+      ((summary.attestations as Record<string, unknown>).maculaHebrew as Record<string, unknown>).clean = false;
+      (summary.environment as Record<string, unknown>).unreviewed = true;
+    })).toThrow('MACULA source contract violation');
   });
 
   it('keeps the packet content-free and completely outside runtime, migration, manifest, and public-surface wiring', () => {

--- a/test/unit/scripts/maculaSourceContract.test.ts
+++ b/test/unit/scripts/maculaSourceContract.test.ts
@@ -244,6 +244,9 @@ describe('MACULA local-only source contract', () => {
     const statusMutation = runSummaryFixture();
     (statusMutation.replayComparison as Record<string, unknown>).status = 'not_identical';
     expect(() => verifyMaculaAuditRunSummary(statusMutation)).toThrow('run summary replay comparison drifted');
+    const schemaVersionMutation = runSummaryFixture();
+    schemaVersionMutation.schemaVersion = 999;
+    expect(() => verifyMaculaAuditRunSummary(schemaVersionMutation)).toThrow('run summary schema version drifted');
   });
 
   it.skipIf(!hasAuthoritativeAudit)('directly verifies the authoritative final replay without opening its projection', () => {

--- a/test/unit/scripts/maculaSourceContract.test.ts
+++ b/test/unit/scripts/maculaSourceContract.test.ts
@@ -1,12 +1,17 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   MACULA_AUDIT_IDENTITY,
   assertMaculaSourceAttribute,
+  parseMaculaSourceContractCliArgs,
   parseMaculaSourceContract,
   readMaculaSourceContract,
-  verifyCurrentMainAttestation,
+  verifyAuthoritativeMaculaAudit,
+  verifyHistoricalCurrentMainAttestation,
+  verifyMaculaAuditRunSummary,
 } from '../../../scripts/macula-source-contract.js';
 
 const repo = new URL('../../../', import.meta.url);
@@ -16,13 +21,104 @@ const expectedMaculaPaths = [
   'scripts/macula-source-contract.ts',
   'test/unit/scripts/maculaSourceContract.test.ts',
 ].sort();
+const authoritativeAuditOutput = '/private/tmp/theologai-macula-source-audit/audit-output';
+const authoritativeFinalReplay = join(authoritativeAuditOutput, 'final-replay-2');
+const hasAuthoritativeAudit = existsSync(authoritativeFinalReplay);
 
 function contractFixture(): Record<string, unknown> {
   return JSON.parse(readFileSync(new URL('data/biblical-languages/macula/SOURCE-CONTRACT.json', repo), 'utf8'));
 }
 
+/** Synthetic, content-free metadata fixture; it is not copied audit output. */
+function runSummaryFixture(): Record<string, unknown> {
+  const artifacts = [
+    { path: 'source-manifest.json', bytes: 240_952, sha256: 'b9dbd2ca6353fa76740650ffa85247b449e0e2f687fc1f40e227a7677f571988' },
+    { path: 'inspection.json', bytes: 54_523, sha256: '505e715901635db876539358f9456830ff51b17445cd372045d665834c9896b9' },
+    { path: 'macula-structural-projection.sqlite', bytes: 207_106_048, sha256: 'c5a61cf047e662a6d2238093edefa7dc540ce8f2b2bbeb49115cb94329fab414' },
+  ];
+  const currentMain = {
+    head: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+    tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
+    originMain: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+    clean: true,
+  };
+  return {
+    schemaVersion: 2,
+    auditRoot: '/synthetic/local-only-audit',
+    command: 'synthetic',
+    environment: {},
+    executedAt: 'synthetic',
+    replayScript: {},
+    integrity: {},
+    inventoryAssertions: {},
+    benchmark: {},
+    workerdD1: {},
+    attestations: {
+      maculaGreek: {
+        head: '8423afe47b9e8f24b7772e808af45c7159a6fe7e',
+        tree: 'eea78df4b0f1efb857f1575243a1ec4548267a11',
+        clean: true,
+        everySelectedPathTracked: true,
+        selectedPathCount: 29,
+      },
+      maculaHebrew: {
+        head: '47db250bd55d0d8577f2a94fba114ef16c35b23c',
+        tree: '594f395cf473795d6984003800b4bf86ca691a26',
+        clean: true,
+        everySelectedPathTracked: true,
+        selectedPathCount: 933,
+      },
+      theologaiMain: currentMain,
+      theologaiPreflight: currentMain,
+    },
+    canonicalRuntimeCompatibility: {
+      d1CorpusIdentity: '29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4',
+      morphologyUsageIdentity: 'c3600bb55da75aa600f8c97885efa7d58a3e8c29c3fcc6445a553091011beabd',
+      runtimeContentInventory: {
+        artifactCount: 72,
+        identityPolicy: 'canonical_decompressed_json_v1_sha256_for_json_gz_else_raw_sha256',
+        sha256: 'caf58814f24cc72837586c901c42f3556b59e45ec81bb0af7f5cfb9fa1629dcd',
+      },
+    },
+    deterministicHashDomain: {
+      excludes: ['run-summary.json', 'timestamps', 'absolute paths', 'host-specific tool versions and benchmark timing'],
+      artifacts: artifacts.map(artifact => ({ ...artifact })),
+      sha256: MACULA_AUDIT_IDENTITY,
+    },
+    replayComparison: {
+      status: 'identical',
+      priorOutput: 'audit-output/final-replay-1',
+      deterministicIdentity: MACULA_AUDIT_IDENTITY,
+      artifacts: artifacts.map(artifact => ({ ...artifact })),
+      assertion: 'The complete projection was independently regenerated twice from the same clean, pinned local inputs and every deterministic artifact hash and byte count matched.',
+    },
+    faithlifeSblgntNotice: {
+      status: 'notice_only_excluded_from_alignment_projection_and_deterministic_identity',
+    },
+  };
+}
+
+function withAuditCopy(mutateRunSummary: (summary: Record<string, unknown>) => void): void {
+  const root = mkdtempSync(join(tmpdir(), 'theologai-macula-audit-'));
+  const auditOutput = join(root, 'audit-output');
+  const finalReplay = join(auditOutput, 'final-replay-2');
+  mkdirSync(finalReplay, { recursive: true });
+  try {
+    copyFileSync(join(authoritativeAuditOutput, 'EVIDENCE-STATUS.md'), join(auditOutput, 'EVIDENCE-STATUS.md'));
+    for (const path of ['source-manifest.json', 'inspection.json', 'run-summary.json']) {
+      copyFileSync(join(authoritativeFinalReplay, path), join(finalReplay, path));
+    }
+    const runSummary = JSON.parse(readFileSync(join(finalReplay, 'run-summary.json'), 'utf8')) as Record<string, unknown>;
+    mutateRunSummary(runSummary);
+    writeFileSync(join(finalReplay, 'run-summary.json'), `${JSON.stringify(runSummary)}\n`, 'utf8');
+    verifyAuthoritativeMaculaAudit(finalReplay, process.cwd());
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 describe('MACULA local-only source contract', () => {
-  it('pins the approved untagged revisions, final audit identity, and audited current-main compatibility values', () => {
+  it('pins the approved untagged revisions, final audit identity, and historical current-main compatibility values', () => {
     const contract = readMaculaSourceContract(process.cwd());
     expect(contract.status).toBe('candidate_contract_only');
     expect(contract.sources).toEqual(expect.arrayContaining([
@@ -48,7 +144,7 @@ describe('MACULA local-only source contract', () => {
       morphologyUsageIdentity: 'c3600bb55da75aa600f8c97885efa7d58a3e8c29c3fcc6445a553091011beabd',
       d1CorpusIdentity: '29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4',
     });
-    expect(() => verifyCurrentMainAttestation(process.cwd())).not.toThrow();
+    expect(() => verifyHistoricalCurrentMainAttestation(process.cwd())).not.toThrow();
   });
 
   it('allows only the reviewed structural attributes and fails closed for excluded or unknown fields', () => {
@@ -58,9 +154,10 @@ describe('MACULA local-only source contract', () => {
     expect(() => assertMaculaSourceAttribute('word', 'lemma')).toThrow('explicitly excluded');
     expect(() => assertMaculaSourceAttribute('group', 'unreviewed-field')).toThrow('unknown schema drift');
     expect(() => assertMaculaSourceAttribute('participant', 'unreviewed-field')).toThrow('unknown schema drift');
+    expect(() => assertMaculaSourceAttribute('invalid-scope' as never, 'participantref')).toThrow('invalid source attribute scope');
   });
 
-  it('rejects unknown contract fields and changes to the dangling relationship exclusion ledger', () => {
+  it('rejects unknown contract fields, dangling-ledger changes, and every reviewed rights or inertness mutation', () => {
     const unknown = contractFixture();
     unknown.unreviewed = true;
     expect(() => parseMaculaSourceContract(unknown)).toThrow('unknown or missing fields');
@@ -69,6 +166,71 @@ describe('MACULA local-only source contract', () => {
     const ledger = changedLedger.danglingParticipantExclusionLedger as { total: number };
     ledger.total = 8;
     expect(() => parseMaculaSourceContract(changedLedger)).toThrow('dangling participant exclusion ledger drifted');
+
+    const rightsMutations: Array<readonly [string, (value: Record<string, unknown>) => void]> = [
+      ['Greek license', value => { ((value.rightsAndProvenance as Record<string, unknown>).maculaGreek as Record<string, unknown>).license = 'unreviewed'; }],
+      ['Greek attribution', value => { ((value.rightsAndProvenance as Record<string, unknown>).maculaGreek as Record<string, unknown>).requiredAttribution = 'unreviewed'; }],
+      ['Faithlife commit', value => { ((value.rightsAndProvenance as Record<string, unknown>).faithlifeSblgntStandaloneNotice as Record<string, unknown>).commit = 'unreviewed'; }],
+      ['Faithlife tree', value => { ((value.rightsAndProvenance as Record<string, unknown>).faithlifeSblgntStandaloneNotice as Record<string, unknown>).tree = 'unreviewed'; }],
+      ['Faithlife role', value => { ((value.rightsAndProvenance as Record<string, unknown>).faithlifeSblgntStandaloneNotice as Record<string, unknown>).role = 'unreviewed'; }],
+      ['legal gate', value => { (value.rightsAndProvenance as Record<string, unknown>).legalReviewGate = 'unreviewed'; }],
+    ];
+    for (const [label, mutate] of rightsMutations) {
+      const mutated = contractFixture();
+      mutate(mutated);
+      expect(() => parseMaculaSourceContract(mutated), label).toThrow('rights and provenance drifted');
+    }
+
+    const activationMutation = contractFixture();
+    ((activationMutation.inertness as Record<string, unknown>).contractDoesNotActivate as string[])[0] = 'unreviewed';
+    expect(() => parseMaculaSourceContract(activationMutation)).toThrow('inertness drifted');
+    const boundaryMutation = contractFixture();
+    (boundaryMutation.inertness as Record<string, unknown>).verifierBoundary = 'unreviewed';
+    expect(() => parseMaculaSourceContract(boundaryMutation)).toThrow('inertness drifted');
+  });
+
+  it('accepts only the exact local verifier CLI forms', () => {
+    expect(parseMaculaSourceContractCliArgs([])).toBeUndefined();
+    expect(parseMaculaSourceContractCliArgs(['--audit-dir', 'audit-output/final-replay-2']))
+      .toMatch(/audit-output\/final-replay-2$/);
+    for (const argumentsAfterScript of [
+      ['unexpected'],
+      ['--audit-dir'],
+      ['--audit-dir', 'audit-output/final-replay-2', 'extra'],
+      ['--unknown', 'audit-output/final-replay-2'],
+      ['--audit-dir', '--unknown'],
+    ]) {
+      expect(() => parseMaculaSourceContractCliArgs(argumentsAfterScript)).toThrow('usage:');
+    }
+  });
+
+  it('validates deterministic replay metadata in a fresh checkout and fails closed on contradictions', () => {
+    expect(() => verifyMaculaAuditRunSummary(runSummaryFixture())).not.toThrow();
+    const replayArtifactMutation = runSummaryFixture();
+    ((replayArtifactMutation.replayComparison as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[0]!.sha256 = '0'.repeat(64);
+    expect(() => verifyMaculaAuditRunSummary(replayArtifactMutation)).toThrow('run summary replay comparison drifted');
+    const hashDomainMutation = runSummaryFixture();
+    ((hashDomainMutation.deterministicHashDomain as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[2]!.bytes = 1;
+    expect(() => verifyMaculaAuditRunSummary(hashDomainMutation)).toThrow('run summary deterministic hash domain drifted');
+    const statusMutation = runSummaryFixture();
+    (statusMutation.replayComparison as Record<string, unknown>).status = 'not_identical';
+    expect(() => verifyMaculaAuditRunSummary(statusMutation)).toThrow('run summary replay comparison drifted');
+  });
+
+  it.skipIf(!hasAuthoritativeAudit)('directly verifies the authoritative final replay without opening its projection', () => {
+    expect(() => verifyAuthoritativeMaculaAudit(authoritativeFinalReplay, process.cwd())).not.toThrow();
+  });
+
+  it.skipIf(!hasAuthoritativeAudit)('fails closed when replay metadata contradicts the deterministic replay evidence', () => {
+    expect(() => withAuditCopy(summary => {
+      ((summary.replayComparison as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[0]!.sha256 = '0'.repeat(64);
+    })).toThrow('run summary replay comparison drifted');
+    expect(() => withAuditCopy(summary => {
+      ((summary.deterministicHashDomain as Record<string, unknown>).artifacts as Array<Record<string, unknown>>)[2]!.bytes = 1;
+    })).toThrow('run summary deterministic hash domain drifted');
+    expect(() => withAuditCopy(summary => {
+      (summary.replayComparison as Record<string, unknown>).status = 'not_identical';
+    })).toThrow('run summary replay comparison drifted');
   });
 
   it('keeps the packet content-free and completely outside runtime, migration, manifest, and public-surface wiring', () => {

--- a/test/unit/scripts/maculaSourceContract.test.ts
+++ b/test/unit/scripts/maculaSourceContract.test.ts
@@ -1,0 +1,99 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  MACULA_AUDIT_IDENTITY,
+  assertMaculaSourceAttribute,
+  parseMaculaSourceContract,
+  readMaculaSourceContract,
+  verifyCurrentMainAttestation,
+} from '../../../scripts/macula-source-contract.js';
+
+const repo = new URL('../../../', import.meta.url);
+const expectedMaculaPaths = [
+  'data/biblical-languages/macula/SOURCE-CONTRACT.json',
+  'docs/MACULA-SOURCE-CONTRACT.md',
+  'scripts/macula-source-contract.ts',
+  'test/unit/scripts/maculaSourceContract.test.ts',
+].sort();
+
+function contractFixture(): Record<string, unknown> {
+  return JSON.parse(readFileSync(new URL('data/biblical-languages/macula/SOURCE-CONTRACT.json', repo), 'utf8'));
+}
+
+describe('MACULA local-only source contract', () => {
+  it('pins the approved untagged revisions, final audit identity, and audited current-main compatibility values', () => {
+    const contract = readMaculaSourceContract(process.cwd());
+    expect(contract.status).toBe('candidate_contract_only');
+    expect(contract.sources).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'macula-greek',
+        revision: expect.objectContaining({
+          commit: '8423afe47b9e8f24b7772e808af45c7159a6fe7e',
+          tree: 'eea78df4b0f1efb857f1575243a1ec4548267a11',
+        }),
+      }),
+      expect.objectContaining({
+        id: 'macula-hebrew',
+        revision: expect.objectContaining({
+          commit: '47db250bd55d0d8577f2a94fba114ef16c35b23c',
+          tree: '594f395cf473795d6984003800b4bf86ca691a26',
+        }),
+      }),
+    ]));
+    expect((contract.auditEvidence as { deterministicIdentity: string }).deterministicIdentity).toBe(MACULA_AUDIT_IDENTITY);
+    expect(contract.currentMainAttestation).toMatchObject({
+      commit: '2f12262c9a37d3588bee9b5071954823c15cbd12',
+      tree: '9922aedb74c690e7a3fcb926b3d621f28fa44535',
+      morphologyUsageIdentity: 'c3600bb55da75aa600f8c97885efa7d58a3e8c29c3fcc6445a553091011beabd',
+      d1CorpusIdentity: '29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4',
+    });
+    expect(() => verifyCurrentMainAttestation(process.cwd())).not.toThrow();
+  });
+
+  it('allows only the reviewed structural attributes and fails closed for excluded or unknown fields', () => {
+    expect(() => assertMaculaSourceAttribute('word', 'xml:id')).not.toThrow();
+    expect(() => assertMaculaSourceAttribute('group', 'Rule')).not.toThrow();
+    expect(() => assertMaculaSourceAttribute('participant', 'participantref')).not.toThrow();
+    expect(() => assertMaculaSourceAttribute('word', 'lemma')).toThrow('explicitly excluded');
+    expect(() => assertMaculaSourceAttribute('group', 'unreviewed-field')).toThrow('unknown schema drift');
+    expect(() => assertMaculaSourceAttribute('participant', 'unreviewed-field')).toThrow('unknown schema drift');
+  });
+
+  it('rejects unknown contract fields and changes to the dangling relationship exclusion ledger', () => {
+    const unknown = contractFixture();
+    unknown.unreviewed = true;
+    expect(() => parseMaculaSourceContract(unknown)).toThrow('unknown or missing fields');
+
+    const changedLedger = contractFixture();
+    const ledger = changedLedger.danglingParticipantExclusionLedger as { total: number };
+    ledger.total = 8;
+    expect(() => parseMaculaSourceContract(changedLedger)).toThrow('dangling participant exclusion ledger drifted');
+  });
+
+  it('keeps the packet content-free and completely outside runtime, migration, manifest, and public-surface wiring', () => {
+    const maculaPaths = execFileSync('git', ['ls-files', '--cached', '--others', '--exclude-standard'], {
+      cwd: new URL('.', repo),
+      encoding: 'utf8',
+    }).split('\n').filter(path => /macula/i.test(path)).sort();
+    expect(maculaPaths).toEqual(expectedMaculaPaths);
+
+    const contract = readFileSync(new URL('data/biblical-languages/macula/SOURCE-CONTRACT.json', repo), 'utf8');
+    expect(contract).not.toMatch(/<\/?(?:w|wg)\b|o\d{11,}|[\u0590-\u05ff\u0370-\u03ff]/);
+    expect(contract).not.toMatch(/(?:\.xml|\.sqlite|\.sql)"\s*$/m);
+
+    for (const path of [
+      'src/index.ts', 'src/worker.ts', 'src/server.ts', 'src/worker-server.ts', 'src/mcp/tools.ts',
+      'src/tools/v2/index.ts', 'src/tools/worker/index.ts', 'data/data-manifest.json', 'wrangler.toml',
+    ]) {
+      expect(readFileSync(new URL(path, repo), 'utf8'), path).not.toMatch(/macula/i);
+    }
+    const packageJson = JSON.parse(readFileSync(new URL('package.json', repo), 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+    expect(packageJson.scripts['data:verify-macula-source-contract'])
+      .toBe('tsx scripts/macula-source-contract.ts');
+    expect(Object.values(packageJson.scripts).filter(command => /macula/i.test(command)))
+      .toEqual(['tsx scripts/macula-source-contract.ts']);
+  });
+});

--- a/test/unit/scripts/maculaSourceContract.test.ts
+++ b/test/unit/scripts/maculaSourceContract.test.ts
@@ -180,7 +180,14 @@ function withAuditCopy(mutateRunSummary: (summary: Record<string, unknown>) => v
   mkdirSync(finalReplay, { recursive: true });
   try {
     copyFileSync(join(authoritativeAuditOutput, 'EVIDENCE-STATUS.md'), join(auditOutput, 'EVIDENCE-STATUS.md'));
-    for (const path of ['source-manifest.json', 'inspection.json', 'run-summary.json']) {
+    for (const path of [
+      'source-manifest.json',
+      'inspection.json',
+      'run-summary.json',
+      'REPORT.md',
+      'provenance-license-notice.json',
+      'replay-comparison.json',
+    ]) {
       copyFileSync(join(authoritativeFinalReplay, path), join(finalReplay, path));
     }
     const runSummary = JSON.parse(readFileSync(join(finalReplay, 'run-summary.json'), 'utf8')) as Record<string, unknown>;
@@ -196,8 +203,9 @@ type RunSummaryMutation = readonly [label: string, mutate: (summary: Record<stri
 
 /**
  * Every summary boundary is exercised against the content-free fixture in normal
- * CI. The conditional copied-audit replay below provides separate local
- * end-to-end evidence without making those semantic checks conditional.
+ * CI. The conditional copied-audit checks below prove that the exact historical
+ * packet passes and that any mutation is rejected at either the semantic or
+ * byte-identity boundary without making the semantic checks conditional.
  */
 const runSummaryMutations: readonly RunSummaryMutation[] = [
   ['unknown top-level field', summary => { summary.unreviewed = true; }],
@@ -375,7 +383,42 @@ describe('MACULA local-only source contract', () => {
     expect(() => verifyAuthoritativeMaculaAudit(authoritativeFinalReplay, process.cwd())).not.toThrow();
   });
 
-  it.skipIf(!hasAuthoritativeAudit)('replays the complete summary mutation suite against the copied authoritative evidence', () => {
+  it.skipIf(!hasAuthoritativeAudit)('rejects drift in every authority-bearing metadata file', () => {
+    const root = mkdtempSync(join(tmpdir(), 'theologai-macula-authority-'));
+    const auditOutput = join(root, 'audit-output');
+    const finalReplay = join(auditOutput, 'final-replay-2');
+    mkdirSync(finalReplay, { recursive: true });
+    try {
+      copyFileSync(join(authoritativeAuditOutput, 'EVIDENCE-STATUS.md'), join(auditOutput, 'EVIDENCE-STATUS.md'));
+      for (const path of [
+        'source-manifest.json',
+        'inspection.json',
+        'run-summary.json',
+        'REPORT.md',
+        'provenance-license-notice.json',
+        'replay-comparison.json',
+      ]) copyFileSync(join(authoritativeFinalReplay, path), join(finalReplay, path));
+
+      for (const [base, path] of [
+        [auditOutput, 'EVIDENCE-STATUS.md'],
+        [finalReplay, 'run-summary.json'],
+        [finalReplay, 'REPORT.md'],
+        [finalReplay, 'provenance-license-notice.json'],
+        [finalReplay, 'replay-comparison.json'],
+      ] as const) {
+        const target = join(base, path);
+        const original = readFileSync(target);
+        writeFileSync(target, Buffer.concat([original, Buffer.from('\ncontradictory unreviewed claim\n')]));
+        expect(() => verifyAuthoritativeMaculaAudit(finalReplay, process.cwd()), path)
+          .toThrow(`authority artifact ${path} drifted`);
+        writeFileSync(target, original);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(!hasAuthoritativeAudit)('rejects the complete summary mutation suite against the copied authoritative packet', () => {
     for (const [label, mutate] of runSummaryMutations) {
       expect(() => withAuditCopy(mutate), label).toThrow('MACULA source contract violation');
     }

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -18,6 +18,7 @@
     "scripts/replay-historical-spine-source-packs.ts",
     "scripts/release-corpus-capacity-policy.ts",
     "scripts/release-corpus-capacity.ts",
+    "scripts/macula-source-contract.ts",
     "scripts/verify-database.ts",
     "scripts/ccel-live-preview-canary.ts"
   ]


### PR DESCRIPTION
## Summary

- add an inert, exact-pinned MACULA Greek/Hebrew source contract
- enforce a corpus-specific structural-field allowlist and fail-closed exclusion policy
- retain a content-free audit ledger for nine unresolved Hebrew participant relationships
- add strict local verification for source pins, historical compatibility, rights/provenance, inertness, and deterministic replay metadata
- recursively validate the complete audit summary and reject contradictory or unknown nested authority claims
- byte-pin every authority-bearing metadata file so diagnostic drift or appended contradictory claims fail closed

## Boundary

This is a candidate contract and planning artifact only. It does not acquire or commit MACULA corpus data, add a migration or database projection, alter the data manifest, expose an MCP surface, wire a runtime repository, change Worker/D1 configuration, or authorize preview or production deployment.

The nine unresolved relationships remain excluded from public output and publication eligibility remains false. Any source acquisition, materializer, runtime integration, D1 preparation, or release requires separate review and authorization.

## Verification

- exact repaired head: `d03c74a3b6f4001d063d25fcafbf0b6a55b8173b`
- exact tree: `f138d67d474ca5cdbeeb6ff3a45d4de9d979952e`
- Node 22 full typecheck: pass
- targeted MACULA contract and authority-packet tests: 11/11
- adjacent source/public-contract tests: 40/40
- full unit suite: 2,455 passed, 2 skipped
- current-architecture integration suite: 3/3
- build and diff-check: pass
- language-source verifier: pass
- MACULA verifier, zero-argument and authoritative `final-replay-2`: pass
- independent Sol review of the exact repaired head: SHIP, no findings
- fresh GitHub CI on the exact repaired head: all six applicable checks pass; preview deployment skipped

## Provenance

The contract pins exact untagged MACULA Greek and Hebrew commits and trees, records their latest official-release baselines and selected-path differences, distinguishes the SBLGNT-derived MACULA input from the notice-only standalone Faithlife checkout, and records attribution/modification obligations without presenting them as a legal opinion or publication authorization.

Hebrew `lang` is retained only as raw OSHB-derived H/A language evidence. It is not morphological analysis, an independently adjudicated language conclusion, a Greek capability, or permission to retain other OSHB morphology fields.
