### PR TITLE
Harden CCEL canary schema prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,13 @@ unpublished pin to `https://www.ccel.org/home3/search`. It is not a valid
 code/resource-equivalent `100` predecessor for a `111` canary built from
 current `main`. Current `main` also includes PR #117's Transform-12 schema
 `0009` contract, while the retained PR #107/PR #108 D1 records are schema
-`0008`. Before the safe `100` current-main preview refresh or production
-credential staging, separately authorized fresh schema-`0009` preview and
-production D1 preparation, remote readiness/authority audit, binding, and
-environment-isolation verification are required. Those D1 gates do not
-authorize the refresh, credential work, or canary; see the
+`0008`. Before credential staging, separately authorized fresh schema-`0009`
+preview and production D1 preparation and remote readiness/authority audit are
+required while both candidates remain unbound. The reviewed release sequence is
+then preview bind/deploy/audit, production bind/deploy/audit, and read-only
+environment-isolation verification. The preview release is the sole safe
+current-main `100` refresh; it is not repeated later. Those D1 gates do not
+authorize credential work or the canary; see the
 [CCEL canary transaction](docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md).
 
 PR #101's former production assignment, retained as the rollback pair, is

--- a/docs/CCEL-LIVE-PREVIEW-AUDIT.md
+++ b/docs/CCEL-LIVE-PREVIEW-AUDIT.md
@@ -26,7 +26,10 @@ proceeds. These schema observations prove v6 local-only versus v7 CCEL
 exposure; they do not prove which endpoint-bearing code revision is deployed
 or attest exact deployed flag bits. In particular, observing the v7 schema does
 not prove PR #115's repository-only `/home3/search` pin is active. The safe
-current-main `100` refresh prerequisite is documented in
+current-main `100` prerequisite is the one separately approved preview
+bind/deploy/audit after both schema-`0009` candidates were prepared unbound and
+before the production bind/deploy/audit; it is not a second refresh. The full
+ordering is documented in
 [CCEL live-preview canary transaction](CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md).
 A successful
 origin admission separately proves that the separately authorized canary's live

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -29,34 +29,45 @@ The retained PR #107 preview and PR #108 production D1 records were prepared
 against schema `0008`; neither is a current-main-compatible D1 baseline. The
 historical `0008` readiness records remain evidence for those releases only.
 
-Operational readiness therefore has four separately authorized stages, in this
+Operational readiness therefore has five separately authorized stages, in this
 order:
 
 1. Prepare **fresh, separate preview and production D1 candidates** compatible
    with schema `0009`. Each preparation needs its own authorization and must
    complete the remote readiness and authority audit for the checked-out
-   schema/seed before any candidate binding. Then, through its separately
-   approved environment release path, bind the exact prepared candidate and
-   record the authoritative Worker/D1 binding. A read-only environment-isolation
-   verification must prove distinct preview and production D1 name/UUID pairs,
-   that each active Worker is bound only to its matching environment candidate,
-   and that neither retained schema-`0008` D1 was silently reused or crossed.
-   Failure or missing evidence is a stop condition; do not reuse, repair, or
-   bind a failed candidate.
-2. Safely refresh preview to an exact-current-`main` `100` Worker and complete
-   its protected preview audit. The refreshed predecessor must be equivalent
-   to the future current-`main` canary in code and resources; only the two
-   canary flags may later differ.
-3. Stage the operator credential as an undeployed production Worker version,
+   schema/seed **while both candidates remain unbound**. Failure or missing
+   evidence is a stop condition; do not reuse, repair, or bind a failed
+   candidate.
+2. Through a separately approved preview release, bind and deploy the exact
+   prepared preview candidate with current-`main` `100` flags, then complete
+   its protected preview audit. This one release creates the exact-current-main,
+   code/resource-equivalent preview predecessor for the later `111` candidate;
+   it is the safe preview refresh, not a prerequisite for a second refresh.
+3. Only after the preview audit passes, through a separately approved production
+   release, bind and deploy the exact prepared production candidate and complete
+   its protected production audit. Then perform a read-only environment-isolation
+   verification proving distinct preview and production D1 name/UUID pairs, each
+   active Worker is bound only to its matching environment candidate, and neither
+   retained schema-`0008` D1 was silently reused or crossed.
+4. Stage the operator credential as an undeployed production Worker version,
    then separately promote the reviewed version. Promotion is a real
    production Worker deployment and traffic mutation.
-4. Run this temporary `111` two-request preview canary transaction and restore
+5. Run this temporary `111` two-request preview canary transaction and restore
    the exact refreshed `100` predecessor.
 
 Completion or authorization of any stage does not authorize the next stage.
-In particular, the stage-1 D1 release evidence is a prerequisite—not
-authorization—for the safe preview refresh or production credential staging;
-those two stage-2/3 operations remain independent gates.
+In particular, the two unbound stage-1 preparations do not authorize either
+environment binding; the preview audit does not authorize the production release;
+and the completed releases/isolation evidence do not authorize credential staging
+or the canary.
+
+The repository currently records neither schema-`0009` candidate identity nor
+its readiness/authority evidence. Until a separate reviewed release replaces the
+hard inert schema-`0009` canary gate, the canary workflow rejects both retained
+schema-`0008` D1 identities during its first local validation, before any
+Wrangler command or Cloudflare read. Changing only a D1 ID is insufficient: the
+future change must update the reviewed identity/evidence gate and the committed
+configuration together.
 
 The only way to create the third row is the main-only, manually dispatched
 `CCEL Live Preview Canary` workflow. It requires all of the following:
@@ -144,11 +155,12 @@ evidence.
 
 ## Transaction sequence
 
-1. Confirm the separately retained stage-1 schema-`0009` preview/production
-   preparation, readiness/authority, binding, and environment-isolation
-   evidence. Capture the separately refreshed, current-`main`,
-   code/resource-equivalent preview 100 predecessor and retain a short-lived
-   private recovery anchor.
+1. Confirm the separately retained schema-`0009` evidence in order: both
+   candidates prepared and audited while unbound; the one safe current-`main`
+   preview `100` bind/deploy/audit; then the production bind/deploy/audit and
+   environment-isolation verification. Capture that already-refreshed,
+   code/resource-equivalent preview `100` predecessor and retain a short-lived
+   private recovery anchor. Do not perform a second preview refresh here.
 2. Generate the 111 runner-local config and run `wrangler versions upload`.
    The version must be exactly one new, immediately-next version and must leave
    preview traffic unchanged.

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -71,9 +71,9 @@ for each environment: exact D1 name/UUID plus separately pinned readiness and
 authority evidence identities and SHA-256 values, plus one separately pinned
 environment-isolation evidence identity and SHA-256. The local validator rejects
 unknown or incomplete `ready` records, malformed evidence, any recorded
-schema-`0008` UUID regardless of database name, any shared preview/production
-identity, and any mismatch between those reviewed D1 pairs and committed
-configuration.
+schema-`0008` D1 name or UUID regardless of pairing, any shared
+preview/production identity, and any mismatch between those reviewed D1 pairs
+and committed configuration.
 
 The only way to create the third row is the main-only, manually dispatched
 `CCEL Live Preview Canary` workflow. It requires all of the following:

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -68,10 +68,12 @@ schema-`0008` D1 identities during its first local validation, before any
 Wrangler command or Cloudflare read. Changing only a D1 ID is insufficient: the
 future change must replace the `unrecorded` gate with a reviewed `ready` record
 for each environment: exact D1 name/UUID plus separately pinned readiness and
-authority evidence identities and SHA-256 values. The local validator rejects
-unknown or incomplete `ready` records, malformed evidence, any shared
-preview/production identity, and any mismatch between those reviewed D1 pairs
-and committed configuration.
+authority evidence identities and SHA-256 values, plus one separately pinned
+environment-isolation evidence identity and SHA-256. The local validator rejects
+unknown or incomplete `ready` records, malformed evidence, any recorded
+schema-`0008` UUID regardless of database name, any shared preview/production
+identity, and any mismatch between those reviewed D1 pairs and committed
+configuration.
 
 The only way to create the third row is the main-only, manually dispatched
 `CCEL Live Preview Canary` workflow. It requires all of the following:

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -66,8 +66,12 @@ its readiness/authority evidence. Until a separate reviewed release replaces the
 hard inert schema-`0009` canary gate, the canary workflow rejects both retained
 schema-`0008` D1 identities during its first local validation, before any
 Wrangler command or Cloudflare read. Changing only a D1 ID is insufficient: the
-future change must update the reviewed identity/evidence gate and the committed
-configuration together.
+future change must replace the `unrecorded` gate with a reviewed `ready` record
+for each environment: exact D1 name/UUID plus separately pinned readiness and
+authority evidence identities and SHA-256 values. The local validator rejects
+unknown or incomplete `ready` records, malformed evidence, any shared
+preview/production identity, and any mismatch between those reviewed D1 pairs
+and committed configuration.
 
 The only way to create the third row is the main-only, manually dispatched
 `CCEL Live Preview Canary` workflow. It requires all of the following:

--- a/docs/CCEL-OPERATOR-SECRET-PROVISIONING.md
+++ b/docs/CCEL-OPERATOR-SECRET-PROVISIONING.md
@@ -19,16 +19,18 @@ Promotion is a separate protected decision requiring:
 Executing staging is a production Worker-version upload mutation even though
 the new version remains undeployed and traffic does not move. Promotion is an
 actual production Worker deployment and traffic mutation. Neither staging nor
-promotion authorizes the separate safe-`100` preview refresh or the temporary
-`111` canary, and preview refresh does not authorize either credential stage.
+promotion authorizes the temporary `111` canary. The one safe current-main
+preview `100` release occurs earlier in the D1 release sequence; it must not be
+repeated as a second refresh after credential work.
 
 Before staging or promotion can be authorized, the CCEL canary transaction's
-separate schema-`0009` D1 gate must have completed for **both** environments:
-fresh preview and production candidates, remote readiness/authority audits,
-their approved Worker bindings, and a read-only environment-isolation
-verification. The PR #107/#108 schema-`0008` D1 evidence does not satisfy this
-current-main prerequisite. Completing it still does not authorize this
-credential operation; see [the canary transaction](CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md).
+separate schema-`0009` D1 sequence must have completed in order: fresh preview
+and production candidates prepared and remotely readiness/authority-audited
+while unbound; the preview candidate bound, deployed, and audited; then the
+production candidate bound, deployed, and audited; then a read-only
+environment-isolation verification. The PR #107/#108 schema-`0008` D1 evidence
+does not satisfy this current-main prerequisite. Completing the sequence still
+does not authorize this credential operation; see [the canary transaction](CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md).
 
 Emergency rollback is also separate and requires:
 

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -16,6 +16,40 @@ export const ACCOUNT_WIDE_WORKERS_WRITE_ACK =
 export const PRODUCTION_BASE_SECRET_BINDINGS =
   ['AUTH_TOKEN', 'ESV_API_KEY', 'SBC_FACILITATOR_API_KEY'] as const;
 
+/**
+ * These are the retained Transform-11 / schema-0008 D1 identities.  They are
+ * deployment history, not current-main canary baselines.  Keep the rejection
+ * literal: a later schema-0009 release must deliberately replace this hard
+ * inert gate with reviewed candidate identities and retained readiness evidence.
+ */
+export const LEGACY_SCHEMA_0008_D1 = {
+  production: {
+    name: 'theologai-production-20260729-transform11-a',
+    id: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+  },
+  preview: {
+    name: 'theologai-preview-20260728-transform11-a',
+    id: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+  },
+} as const;
+
+/**
+ * No schema-0009 candidates have been prepared and audited yet.  The canary
+ * workflow calls this local gate before its first Wrangler command, so an
+ * accidental dispatch cannot turn the historical schema-0008 pair into a
+ * live canary baseline.  A future release must replace this sentinel with an
+ * exact reviewed candidate pair and readiness/authority evidence contract.
+ */
+interface Schema0009CanaryGate {
+  state: 'unrecorded' | 'ready';
+  requiredSchema: '0009_candidate_c_sectioned_publications';
+}
+
+export const SCHEMA_0009_CANARY_GATE: Schema0009CanaryGate = {
+  state: 'unrecorded',
+  requiredSchema: '0009_candidate_c_sectioned_publications',
+};
+
 const PRODUCTION = {
   worker: 'theologai', route: 'mcp.theologai.xyz', d1: '53211f50-a893-4b4c-be1e-bc625a595dc7',
   requestNamespace: '361201', operatorNamespace: '361203', version: '3.6.0',
@@ -57,6 +91,34 @@ export function validateCanaryDispatch(input: DispatchInput): void {
   refuse(isSha(input.liveMainSha) && input.liveMainSha === input.sha, 'dispatched SHA must still be the live main SHA');
   refuse(input.confirmation === CANARY_CONFIRMATION, 'confirmation must match exactly');
   assertCommittedConfig(input.configText);
+  assertSchema0009CanaryPrerequisite(input.configText);
+}
+
+/**
+ * The deliberately inert schema-0009 release gate.  It is intentionally
+ * separate from general config validation so recovery can still inspect a
+ * historical config, while a new canary upload cannot begin from one.
+ */
+export function assertSchema0009CanaryPrerequisite(configText: string): void {
+  const root = parseConfig(configText);
+  const preview = recordAt(recordAt(root, 'env'), 'preview');
+  const productionD1 = configuredD1(root, 'production');
+  const previewD1 = configuredD1(preview, 'preview');
+
+  refuse(
+    productionD1.database_name !== LEGACY_SCHEMA_0008_D1.production.name
+      || productionD1.database_id !== LEGACY_SCHEMA_0008_D1.production.id,
+    'recorded schema-0008 production D1 identity is not a canary baseline',
+  );
+  refuse(
+    previewD1.database_name !== LEGACY_SCHEMA_0008_D1.preview.name
+      || previewD1.database_id !== LEGACY_SCHEMA_0008_D1.preview.id,
+    'recorded schema-0008 preview D1 identity is not a canary baseline',
+  );
+  refuse(
+    SCHEMA_0009_CANARY_GATE.state === 'ready',
+    `schema-${SCHEMA_0009_CANARY_GATE.requiredSchema.slice(0, 4)} canary gate is unrecorded: prepare and audit separate preview and production candidates before enabling this workflow`,
+  );
 }
 
 /** Reject all user-supplied Worker IDs before a workflow calls Wrangler. */
@@ -318,7 +380,7 @@ function assertEnvironment(config: JsonRecord, expected: typeof PREVIEW, mode: M
   };
   exactKeys(vars, Object.keys(expectedVars), `${expected.worker} vars`);
   for (const [key, value] of Object.entries(expectedVars)) refuse(vars[key] === value, `${expected.worker} ${key} mismatch`);
-  const d1 = only(arrayAt(config, 'd1_databases').map((entry, index) => asRecord(entry, `D1 ${index}`)), `${expected.worker} D1 binding`);
+  const d1 = configuredD1(config, expected.worker);
   exactKeys(d1, ['binding', 'database_name', 'database_id', 'migrations_dir'], `${expected.worker} D1 binding`);
   refuse(d1.binding === 'THEOLOGAI_DB' && d1.database_id === expected.d1 && d1.migrations_dir === 'migrations', `${expected.worker} D1 binding mismatch`);
   const durable = only(arrayAt(recordAt(config, 'durable_objects'), 'bindings').map((entry, index) => asRecord(entry, `DO ${index}`)), `${expected.worker} DO binding`);
@@ -332,6 +394,13 @@ function assertEnvironment(config: JsonRecord, expected: typeof PREVIEW, mode: M
   assertConfigRate(limits, 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', expected.operatorNamespace, 12);
   uniqueNames([{ name: d1.binding }, durable, ...limits, { name: metadata.binding }], `${expected.worker} critical bindings`);
   if (mode === '000') refuse(expected.live === 'false' && expected.coordinator === 'false' && expected.discovery === 'false', 'production flags must remain 000');
+}
+
+function configuredD1(config: JsonRecord, label: string): JsonRecord & { database_name: string; database_id: string } {
+  const d1 = only(arrayAt(config, 'd1_databases').map((entry, index) => asRecord(entry, `D1 ${index}`)), `${label} D1 binding`);
+  exactKeys(d1, ['binding', 'database_name', 'database_id', 'migrations_dir'], `${label} D1 binding`);
+  refuse(typeof d1.database_name === 'string' && typeof d1.database_id === 'string', `${label} D1 identity is invalid`);
+  return d1 as JsonRecord & { database_name: string; database_id: string };
 }
 
 function assertVersion(version: FullVersion, mode: Mode, requireProductionOperator = false): boolean {

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -37,26 +37,49 @@ export const LEGACY_SCHEMA_0008_D1 = {
  * No schema-0009 candidates have been prepared and audited yet.  The canary
  * workflow calls this local gate before its first Wrangler command, so an
  * accidental dispatch cannot turn the historical schema-0008 pair into a
- * live canary baseline.  A future release must replace this sentinel with an
- * exact reviewed candidate pair and readiness/authority evidence contract.
+ * live canary baseline. A future release must replace this sentinel with a
+ * `ready` branch containing exact candidate identities and pinned evidence.
  */
-interface Schema0009CanaryGate {
-  state: 'unrecorded' | 'ready';
-  requiredSchema: '0009_candidate_c_sectioned_publications';
+export interface Schema0009Evidence {
+  identity: string;
+  sha256: string;
 }
+
+export interface Schema0009CanaryEnvironmentGate {
+  databaseName: string;
+  databaseId: string;
+  readinessEvidence: Schema0009Evidence;
+  authorityEvidence: Schema0009Evidence;
+}
+
+export type Schema0009CanaryGate =
+  | {
+    state: 'unrecorded';
+    requiredSchema: '0009_candidate_c_sectioned_publications';
+  }
+  | {
+    state: 'ready';
+    requiredSchema: '0009_candidate_c_sectioned_publications';
+    preview: Schema0009CanaryEnvironmentGate;
+    production: Schema0009CanaryEnvironmentGate;
+  };
+
+const SCHEMA_0009 = '0009_candidate_c_sectioned_publications';
 
 export const SCHEMA_0009_CANARY_GATE: Schema0009CanaryGate = {
   state: 'unrecorded',
-  requiredSchema: '0009_candidate_c_sectioned_publications',
+  requiredSchema: SCHEMA_0009,
 };
 
 const PRODUCTION = {
-  worker: 'theologai', route: 'mcp.theologai.xyz', d1: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+  worker: 'theologai', route: 'mcp.theologai.xyz',
+  d1Name: 'theologai-production-20260729-transform11-a', d1: '53211f50-a893-4b4c-be1e-bc625a595dc7',
   requestNamespace: '361201', operatorNamespace: '361203', version: '3.6.0',
   discovery: 'false', live: 'false', coordinator: 'false', logs: 'false',
 };
 const PREVIEW = {
-  worker: 'theologai-preview', route: 'preview-mcp.theologai.xyz', d1: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+  worker: 'theologai-preview', route: 'preview-mcp.theologai.xyz',
+  d1Name: 'theologai-preview-20260728-transform11-a', d1: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
   requestNamespace: '361202', operatorNamespace: '361204', version: '3.6.0-preview',
   discovery: 'true', live: 'false', coordinator: 'false', logs: 'true',
 };
@@ -90,8 +113,9 @@ export function validateCanaryDispatch(input: DispatchInput): void {
   refuse(isSha(input.sha) && input.sha === input.expectedSha, 'expected main SHA must equal the dispatched SHA');
   refuse(isSha(input.liveMainSha) && input.liveMainSha === input.sha, 'dispatched SHA must still be the live main SHA');
   refuse(input.confirmation === CANARY_CONFIRMATION, 'confirmation must match exactly');
-  assertCommittedConfig(input.configText);
-  assertSchema0009CanaryPrerequisite(input.configText);
+  const gate = validateSchema0009CanaryGate(SCHEMA_0009_CANARY_GATE);
+  assertCommittedConfig(input.configText, gate);
+  assertSchema0009CanaryPrerequisite(input.configText, gate);
 }
 
 /**
@@ -99,7 +123,8 @@ export function validateCanaryDispatch(input: DispatchInput): void {
  * separate from general config validation so recovery can still inspect a
  * historical config, while a new canary upload cannot begin from one.
  */
-export function assertSchema0009CanaryPrerequisite(configText: string): void {
+export function assertSchema0009CanaryPrerequisite(configText: string, gate: unknown = SCHEMA_0009_CANARY_GATE): void {
+  const reviewedGate = validateSchema0009CanaryGate(gate);
   const root = parseConfig(configText);
   const preview = recordAt(recordAt(root, 'env'), 'preview');
   const productionD1 = configuredD1(root, 'production');
@@ -116,9 +141,34 @@ export function assertSchema0009CanaryPrerequisite(configText: string): void {
     'recorded schema-0008 preview D1 identity is not a canary baseline',
   );
   refuse(
-    SCHEMA_0009_CANARY_GATE.state === 'ready',
-    `schema-${SCHEMA_0009_CANARY_GATE.requiredSchema.slice(0, 4)} canary gate is unrecorded: prepare and audit separate preview and production candidates before enabling this workflow`,
+    reviewedGate.state === 'ready',
+    'schema-0009 canary gate is unrecorded: prepare and audit separate preview and production candidates before enabling this workflow',
   );
+  assertSchema0009EnvironmentMatch(productionD1, reviewedGate.production, 'production');
+  assertSchema0009EnvironmentMatch(previewD1, reviewedGate.preview, 'preview');
+}
+
+/**
+ * Parse the future release record defensively even though checked-in TypeScript
+ * makes incomplete `ready` literals a compile error. This also protects the
+ * command boundary from a malformed JavaScript import or future refactor.
+ */
+export function validateSchema0009CanaryGate(value: unknown): Schema0009CanaryGate {
+  const gate = asRecord(value, 'schema-0009 canary gate');
+  refuse(gate.requiredSchema === SCHEMA_0009, 'schema-0009 canary gate schema mismatch');
+  if (gate.state === 'unrecorded') {
+    exactKeys(gate, ['state', 'requiredSchema'], 'unrecorded schema-0009 canary gate');
+    return gate as Schema0009CanaryGate;
+  }
+  refuse(gate.state === 'ready', 'schema-0009 canary gate state is invalid');
+  exactKeys(gate, ['state', 'requiredSchema', 'preview', 'production'], 'ready schema-0009 canary gate');
+  const preview = parseSchema0009EnvironmentGate(gate.preview, 'preview');
+  const production = parseSchema0009EnvironmentGate(gate.production, 'production');
+  refuse(
+    preview.databaseName !== production.databaseName && preview.databaseId !== production.databaseId,
+    'ready schema-0009 canary gate must use distinct preview and production D1 identities',
+  );
+  return { state: 'ready', requiredSchema: SCHEMA_0009, preview, production };
 }
 
 /** Reject all user-supplied Worker IDs before a workflow calls Wrangler. */
@@ -159,8 +209,8 @@ export function validateEmergencyInputs(ref: string, current: string, target: st
  * Produces a throwaway config with only preview live/coordinator flags changed.
  * It is deliberately an output file, never a tracked configuration edit.
  */
-export function renderCanaryPreviewConfig(configText: string): string {
-  assertCommittedConfig(configText);
+export function renderCanaryPreviewConfig(configText: string, gate: unknown = SCHEMA_0009_CANARY_GATE): string {
+  assertCommittedConfig(configText, gate);
   const start = configText.indexOf('[env.preview.vars]');
   const end = configText.indexOf('\n[', start + 1);
   refuse(start >= 0 && end > start, 'preview vars section is missing or ambiguous');
@@ -172,7 +222,7 @@ export function renderCanaryPreviewConfig(configText: string): string {
     .replace('THEOLOGAI_ENABLE_CCEL_COORDINATOR = "false"', 'THEOLOGAI_ENABLE_CCEL_COORDINATOR = "true"');
   refuse(changed !== section, 'canary flags were not found exactly once');
   const rendered = `${before}${changed}${after}`;
-  assertCanaryConfig(rendered);
+  assertCanaryConfig(rendered, gate);
   return rendered;
 }
 
@@ -336,23 +386,38 @@ export function sanitizedCanaryEvidence(input: {
   };
 }
 
-export function assertCommittedConfig(configText: string): void {
+export function assertCommittedConfig(configText: string, gate: unknown = SCHEMA_0009_CANARY_GATE): void {
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  const { production, preview } = expectedSchema0009Environments(reviewedGate);
   refuse(!configText.includes(OPERATOR_TOKEN), 'operator token must never be stored in Wrangler config');
   const root = parseConfig(configText);
-  assertEnvironment(root, PRODUCTION, '000');
-  const preview = recordAt(recordAt(root, 'env'), 'preview');
-  assertEnvironment(preview, PREVIEW, '100');
-  refuse(PREVIEW.d1 !== PRODUCTION.d1, 'preview and production D1 identities must differ');
+  assertEnvironment(root, production, '000');
+  const previewConfig = recordAt(recordAt(root, 'env'), 'preview');
+  assertEnvironment(previewConfig, preview, '100');
+  refuse(preview.d1 !== production.d1 && preview.d1Name !== production.d1Name,
+    'preview and production D1 identities must differ');
   refuse(PREVIEW.requestNamespace !== PRODUCTION.requestNamespace && PREVIEW.operatorNamespace !== PRODUCTION.operatorNamespace,
     'preview and production rate-limit namespaces must differ');
 }
 
-export function assertCanaryConfig(configText: string): void {
+export function assertCanaryConfig(configText: string, gate: unknown = SCHEMA_0009_CANARY_GATE): void {
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  const { production, preview } = expectedSchema0009Environments(reviewedGate);
   refuse(!configText.includes(OPERATOR_TOKEN), 'operator token must never be stored in canary config');
   const root = parseConfig(configText);
-  assertEnvironment(root, PRODUCTION, '000');
-  const preview = recordAt(recordAt(root, 'env'), 'preview');
-  assertEnvironment(preview, { ...PREVIEW, live: 'true', coordinator: 'true' }, '111');
+  assertEnvironment(root, production, '000');
+  const previewConfig = recordAt(recordAt(root, 'env'), 'preview');
+  assertEnvironment(previewConfig, { ...preview, live: 'true', coordinator: 'true' }, '111');
+}
+
+function expectedSchema0009Environments(gate: Schema0009CanaryGate): { production: typeof PRODUCTION; preview: typeof PREVIEW } {
+  if (gate.state === 'ready') {
+    return {
+      production: { ...PRODUCTION, d1Name: gate.production.databaseName, d1: gate.production.databaseId },
+      preview: { ...PREVIEW, d1Name: gate.preview.databaseName, d1: gate.preview.databaseId },
+    };
+  }
+  return { production: PRODUCTION, preview: PREVIEW };
 }
 
 function assertEnvironment(config: JsonRecord, expected: typeof PREVIEW, mode: Mode): void {
@@ -382,7 +447,8 @@ function assertEnvironment(config: JsonRecord, expected: typeof PREVIEW, mode: M
   for (const [key, value] of Object.entries(expectedVars)) refuse(vars[key] === value, `${expected.worker} ${key} mismatch`);
   const d1 = configuredD1(config, expected.worker);
   exactKeys(d1, ['binding', 'database_name', 'database_id', 'migrations_dir'], `${expected.worker} D1 binding`);
-  refuse(d1.binding === 'THEOLOGAI_DB' && d1.database_id === expected.d1 && d1.migrations_dir === 'migrations', `${expected.worker} D1 binding mismatch`);
+  refuse(d1.binding === 'THEOLOGAI_DB' && d1.database_name === expected.d1Name
+    && d1.database_id === expected.d1 && d1.migrations_dir === 'migrations', `${expected.worker} D1 binding mismatch`);
   const durable = only(arrayAt(recordAt(config, 'durable_objects'), 'bindings').map((entry, index) => asRecord(entry, `DO ${index}`)), `${expected.worker} DO binding`);
   exactKeys(durable, ['name', 'class_name', 'script_name'], `${expected.worker} DO binding`);
   for (const [key, value] of Object.entries({ name: DO.name, class_name: DO.class_name, script_name: DO.script_name })) {
@@ -401,6 +467,34 @@ function configuredD1(config: JsonRecord, label: string): JsonRecord & { databas
   exactKeys(d1, ['binding', 'database_name', 'database_id', 'migrations_dir'], `${label} D1 binding`);
   refuse(typeof d1.database_name === 'string' && typeof d1.database_id === 'string', `${label} D1 identity is invalid`);
   return d1 as JsonRecord & { database_name: string; database_id: string };
+}
+
+function parseSchema0009EnvironmentGate(value: unknown, label: string): Schema0009CanaryEnvironmentGate {
+  const environment = asRecord(value, `${label} schema-0009 canary gate`);
+  exactKeys(environment, ['databaseName', 'databaseId', 'readinessEvidence', 'authorityEvidence'], `${label} schema-0009 canary gate`);
+  refuse(isD1Name(environment.databaseName) && isUuid(environment.databaseId), `${label} schema-0009 D1 identity is invalid`);
+  return {
+    databaseName: environment.databaseName,
+    databaseId: environment.databaseId,
+    readinessEvidence: parseSchema0009Evidence(environment.readinessEvidence, `${label} readiness`),
+    authorityEvidence: parseSchema0009Evidence(environment.authorityEvidence, `${label} authority`),
+  };
+}
+
+function parseSchema0009Evidence(value: unknown, label: string): Schema0009Evidence {
+  const evidence = asRecord(value, `${label} evidence`);
+  exactKeys(evidence, ['identity', 'sha256'], `${label} evidence`);
+  refuse(isEvidenceIdentity(evidence.identity) && isSha256(evidence.sha256), `${label} evidence identity or SHA-256 is invalid`);
+  return { identity: evidence.identity, sha256: evidence.sha256 };
+}
+
+function assertSchema0009EnvironmentMatch(
+  configured: JsonRecord & { database_name: string; database_id: string }, reviewed: Schema0009CanaryEnvironmentGate, label: string,
+): void {
+  refuse(
+    configured.database_name === reviewed.databaseName && configured.database_id === reviewed.databaseId,
+    `${label} D1 identity does not match the reviewed schema-0009 canary gate`,
+  );
 }
 
 function assertVersion(version: FullVersion, mode: Mode, requireProductionOperator = false): boolean {
@@ -549,6 +643,9 @@ function exactKeys(value: JsonRecord, keys: string[], label: string): void { ref
 function isRecord(value: unknown): value is JsonRecord { return typeof value === 'object' && value !== null && !Array.isArray(value); }
 function isUuid(value: unknown): value is string { return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value); }
 function isSha(value: unknown): value is string { return typeof value === 'string' && /^[0-9a-f]{40}$/.test(value); }
+function isSha256(value: unknown): value is string { return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value); }
+function isD1Name(value: unknown): value is string { return typeof value === 'string' && /^theologai-(?:preview|production)-[a-z0-9-]+$/.test(value); }
+function isEvidenceIdentity(value: unknown): value is string { return typeof value === 'string' && /^[a-z0-9][a-z0-9._:-]{2,127}$/.test(value); }
 function stableJson(value: unknown): string { return JSON.stringify(value, (_, nested) => isRecord(nested) ? Object.fromEntries(Object.entries(nested).sort(([a], [b]) => a.localeCompare(b))) : nested); }
 function refuse(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(`CCEL canary refused: ${message}.`); }
 

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -62,9 +62,14 @@ export type Schema0009CanaryGate =
     requiredSchema: '0009_candidate_c_sectioned_publications';
     preview: Schema0009CanaryEnvironmentGate;
     production: Schema0009CanaryEnvironmentGate;
+    environmentIsolationEvidence: Schema0009Evidence;
   };
 
 const SCHEMA_0009 = '0009_candidate_c_sectioned_publications';
+const LEGACY_SCHEMA_0008_D1_IDS = new Set<string>([
+  LEGACY_SCHEMA_0008_D1.production.id,
+  LEGACY_SCHEMA_0008_D1.preview.id,
+]);
 
 export const SCHEMA_0009_CANARY_GATE: Schema0009CanaryGate = {
   state: 'unrecorded',
@@ -130,16 +135,8 @@ export function assertSchema0009CanaryPrerequisite(configText: string, gate: unk
   const productionD1 = configuredD1(root, 'production');
   const previewD1 = configuredD1(preview, 'preview');
 
-  refuse(
-    productionD1.database_name !== LEGACY_SCHEMA_0008_D1.production.name
-      || productionD1.database_id !== LEGACY_SCHEMA_0008_D1.production.id,
-    'recorded schema-0008 production D1 identity is not a canary baseline',
-  );
-  refuse(
-    previewD1.database_name !== LEGACY_SCHEMA_0008_D1.preview.name
-      || previewD1.database_id !== LEGACY_SCHEMA_0008_D1.preview.id,
-    'recorded schema-0008 preview D1 identity is not a canary baseline',
-  );
+  assertNotLegacySchema0008D1(productionD1.database_id, 'production');
+  assertNotLegacySchema0008D1(previewD1.database_id, 'preview');
   refuse(
     reviewedGate.state === 'ready',
     'schema-0009 canary gate is unrecorded: prepare and audit separate preview and production candidates before enabling this workflow',
@@ -161,14 +158,17 @@ export function validateSchema0009CanaryGate(value: unknown): Schema0009CanaryGa
     return gate as Schema0009CanaryGate;
   }
   refuse(gate.state === 'ready', 'schema-0009 canary gate state is invalid');
-  exactKeys(gate, ['state', 'requiredSchema', 'preview', 'production'], 'ready schema-0009 canary gate');
+  exactKeys(gate, ['state', 'requiredSchema', 'preview', 'production', 'environmentIsolationEvidence'], 'ready schema-0009 canary gate');
   const preview = parseSchema0009EnvironmentGate(gate.preview, 'preview');
   const production = parseSchema0009EnvironmentGate(gate.production, 'production');
+  const environmentIsolationEvidence = parseSchema0009Evidence(gate.environmentIsolationEvidence, 'environment isolation');
+  assertNotLegacySchema0008D1(preview.databaseId, 'ready preview');
+  assertNotLegacySchema0008D1(production.databaseId, 'ready production');
   refuse(
     preview.databaseName !== production.databaseName && preview.databaseId !== production.databaseId,
     'ready schema-0009 canary gate must use distinct preview and production D1 identities',
   );
-  return { state: 'ready', requiredSchema: SCHEMA_0009, preview, production };
+  return { state: 'ready', requiredSchema: SCHEMA_0009, preview, production, environmentIsolationEvidence };
 }
 
 /** Reject all user-supplied Worker IDs before a workflow calls Wrangler. */
@@ -233,35 +233,38 @@ export function renderCanaryPreviewConfig(configText: string, gate: unknown = SC
  * before the transaction can upload a candidate.
  */
 export function validatePreviewBaseline(
-  configText: string, deploymentsValue: unknown, versionValue: unknown, expectedVersion: string,
+  configText: string, deploymentsValue: unknown, versionValue: unknown, expectedVersion: string, gate: unknown = SCHEMA_0009_CANARY_GATE,
 ): FullVersion {
-  assertCommittedConfig(configText);
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  assertCommittedConfig(configText, reviewedGate);
   refuse(isUuid(expectedVersion), 'expected preview predecessor must be an exact UUID');
   const version = parseFullVersion(versionValue);
   refuse(version.id === expectedVersion, 'preview predecessor view identity mismatch');
   refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedVersion, 'preview predecessor is not the sole 100% deployment');
-  assertVersion(version, '100');
+  assertVersion(version, '100', false, reviewedGate);
   scriptEtag(version, 'preview predecessor');
   return version;
 }
 
 /** Production is read-only control evidence and must remain v6 / flags 000. */
 export function validateProductionControl(
-  configText: string, deploymentsValue: unknown, versionValue: unknown, expectedVersion: string,
+  configText: string, deploymentsValue: unknown, versionValue: unknown, expectedVersion: string, gate: unknown = SCHEMA_0009_CANARY_GATE,
 ): FullVersion {
-  assertCommittedConfig(configText);
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  assertCommittedConfig(configText, reviewedGate);
   refuse(isUuid(expectedVersion), 'expected production control must be an exact UUID');
   const version = parseFullVersion(versionValue);
   refuse(version.id === expectedVersion, 'production control view identity mismatch');
   refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedVersion, 'production control is not the sole 100% deployment');
-  assertVersion(version, '000', true);
+  assertVersion(version, '000', true, reviewedGate);
   return version;
 }
 
 /** Validate the exact sanitized production binding inventory independently of canary readiness. */
-export function validateProductionBindingInventory(versionValue: unknown): { operatorReady: boolean } {
+export function validateProductionBindingInventory(versionValue: unknown, gate: unknown = SCHEMA_0009_CANARY_GATE): { operatorReady: boolean } {
+  const reviewedGate = validateSchema0009CanaryGate(gate);
   const version = parseFullVersion(versionValue);
-  return { operatorReady: assertVersion(version, '000', false) };
+  return { operatorReady: assertVersion(version, '000', false, reviewedGate) };
 }
 
 /** Uploading must add exactly one undeployed immediately-next version. */
@@ -290,16 +293,17 @@ export function identifyCanaryUpload(
  * predecessor in exactly two flags; code/resource drift remains forbidden.
  */
 export function validateCanaryVersion(
-  configText: string, baselineValue: unknown, canaryValue: unknown, expectedBaseline: string, expectedCanary: string,
+  configText: string, baselineValue: unknown, canaryValue: unknown, expectedBaseline: string, expectedCanary: string, gate: unknown = SCHEMA_0009_CANARY_GATE,
 ): void {
-  assertCommittedConfig(configText);
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  assertCommittedConfig(configText, reviewedGate);
   const baseline = parseFullVersion(baselineValue);
   const canary = parseFullVersion(canaryValue);
   refuse(baseline.id === expectedBaseline && canary.id === expectedCanary, 'canary version identity mismatch');
   refuse(isUuid(expectedBaseline) && isUuid(expectedCanary) && expectedBaseline !== expectedCanary, 'canary and predecessor IDs must be distinct UUIDs');
   refuse(canary.number > baseline.number, 'canary version sequence is invalid');
-  assertVersion(baseline, '100');
-  assertVersion(canary, '111');
+  assertVersion(baseline, '100', false, reviewedGate);
+  assertVersion(canary, '111', false, reviewedGate);
   const baselineScriptEtag = scriptEtag(baseline, 'preview predecessor');
   const canaryScriptEtag = scriptEtag(canary, 'canary');
   refuse(baselineScriptEtag === canaryScriptEtag,
@@ -311,13 +315,14 @@ export function validateCanaryVersion(
 }
 
 export function validateCanaryDeployment(
-  configText: string, deploymentsValue: unknown, canaryValue: unknown, expectedCanary: string,
+  configText: string, deploymentsValue: unknown, canaryValue: unknown, expectedCanary: string, gate: unknown = SCHEMA_0009_CANARY_GATE,
 ): void {
-  assertCommittedConfig(configText);
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  assertCommittedConfig(configText, reviewedGate);
   const canary = parseFullVersion(canaryValue);
   refuse(canary.id === expectedCanary && isUuid(expectedCanary), 'canary deployment identity is invalid');
   refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedCanary, 'canary is not the sole 100% preview deployment');
-  assertVersion(canary, '111');
+  assertVersion(canary, '111', false, reviewedGate);
   scriptEtag(canary, 'canary');
 }
 
@@ -328,26 +333,27 @@ export function validateCanaryDeployment(
  */
 export function planRestore(
   configText: string, deploymentsValue: unknown, currentValue: unknown, targetValue: unknown,
-  expectedCurrent: string, expectedTarget: string,
+  expectedCurrent: string, expectedTarget: string, gate: unknown = SCHEMA_0009_CANARY_GATE,
 ): 'already' | 'deploy' {
-  assertCommittedConfig(configText);
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  assertCommittedConfig(configText, reviewedGate);
   refuse(isUuid(expectedCurrent) && isUuid(expectedTarget), 'restore IDs must be exact UUIDs');
   const current = parseFullVersion(currentValue);
   const target = parseFullVersion(targetValue);
   refuse(target.id === expectedTarget, 'restore target view identity mismatch');
   const active = activeVersion(parseDeployments(deploymentsValue));
-  assertVersion(target, '100');
+  assertVersion(target, '100', false, reviewedGate);
   const targetScriptEtag = scriptEtag(target, 'restore target');
   if (active === expectedTarget) {
     refuse(expectedCurrent === expectedTarget && current.id === expectedTarget, 'active baseline view identity mismatch');
-    assertVersion(current, '100');
+    assertVersion(current, '100', false, reviewedGate);
     refuse(scriptEtag(current, 'active restore baseline') === targetScriptEtag,
       'restore baseline code identity mismatch');
     return 'already';
   }
   refuse(expectedCurrent !== expectedTarget, 'restore candidate and target IDs must differ');
   refuse(active === expectedCurrent && current.id === expectedCurrent, 'active preview version is not the authorized canary');
-  assertVersion(current, '111');
+  assertVersion(current, '111', false, reviewedGate);
   refuse(scriptEtag(current, 'active canary') === targetScriptEtag,
     'restore would overwrite a preview code change');
   refuse(current.annotations?.['workers/tag'] === CANARY_TAG, 'active preview version is not the tagged canary');
@@ -357,13 +363,14 @@ export function planRestore(
 }
 
 export function validateRestoreResult(
-  configText: string, deploymentsValue: unknown, targetValue: unknown, expectedTarget: string,
+  configText: string, deploymentsValue: unknown, targetValue: unknown, expectedTarget: string, gate: unknown = SCHEMA_0009_CANARY_GATE,
 ): void {
-  assertCommittedConfig(configText);
+  const reviewedGate = validateSchema0009CanaryGate(gate);
+  assertCommittedConfig(configText, reviewedGate);
   const target = parseFullVersion(targetValue);
   refuse(target.id === expectedTarget && isUuid(expectedTarget), 'restore target identity is invalid');
   refuse(activeVersion(parseDeployments(deploymentsValue)) === expectedTarget, 'exact preview predecessor was not restored to 100%');
-  assertVersion(target, '100');
+  assertVersion(target, '100', false, reviewedGate);
   scriptEtag(target, 'restored preview predecessor');
 }
 
@@ -472,7 +479,7 @@ function configuredD1(config: JsonRecord, label: string): JsonRecord & { databas
 function parseSchema0009EnvironmentGate(value: unknown, label: string): Schema0009CanaryEnvironmentGate {
   const environment = asRecord(value, `${label} schema-0009 canary gate`);
   exactKeys(environment, ['databaseName', 'databaseId', 'readinessEvidence', 'authorityEvidence'], `${label} schema-0009 canary gate`);
-  refuse(isD1Name(environment.databaseName) && isUuid(environment.databaseId), `${label} schema-0009 D1 identity is invalid`);
+  refuse(isEnvironmentD1Name(environment.databaseName, label) && isUuid(environment.databaseId), `${label} schema-0009 D1 identity is invalid`);
   return {
     databaseName: environment.databaseName,
     databaseId: environment.databaseId,
@@ -497,7 +504,11 @@ function assertSchema0009EnvironmentMatch(
   );
 }
 
-function assertVersion(version: FullVersion, mode: Mode, requireProductionOperator = false): boolean {
+function assertNotLegacySchema0008D1(databaseId: string, label: string): void {
+  refuse(!LEGACY_SCHEMA_0008_D1_IDS.has(databaseId), `${label} D1 identity uses a recorded schema-0008 UUID`);
+}
+
+function assertVersion(version: FullVersion, mode: Mode, requireProductionOperator = false, gate: Schema0009CanaryGate = SCHEMA_0009_CANARY_GATE): boolean {
   const runtime = recordAt(version.resources, 'script_runtime');
   refuse(runtime.compatibility_date === COMPATIBILITY_DATE && stableJson(runtime.compatibility_flags) === stableJson(COMPATIBILITY_FLAGS),
     'version compatibility settings mismatch');
@@ -515,7 +526,8 @@ function assertVersion(version: FullVersion, mode: Mode, requireProductionOperat
   ]);
   refuse(bindings.length === expectedNames.size && bindings.every(binding => expectedNames.has(String(binding.name))),
     'version bindings must be the exact authorized set');
-  const values = mode === '000' ? PRODUCTION : PREVIEW;
+  const environments = expectedSchema0009Environments(gate);
+  const values = mode === '000' ? environments.production : environments.preview;
   assertVersionBinding(bindings, 'THEOLOGAI_DB', 'd1', { id: values.d1 });
   assertVersionBinding(bindings, DO.name, DO.type, { class_name: DO.class_name, script_name: DO.script_name });
   assertVersionRate(bindings, 'THEOLOGAI_RATE_LIMITER', values.requestNamespace, 120);
@@ -644,7 +656,11 @@ function isRecord(value: unknown): value is JsonRecord { return typeof value ===
 function isUuid(value: unknown): value is string { return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value); }
 function isSha(value: unknown): value is string { return typeof value === 'string' && /^[0-9a-f]{40}$/.test(value); }
 function isSha256(value: unknown): value is string { return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value); }
-function isD1Name(value: unknown): value is string { return typeof value === 'string' && /^theologai-(?:preview|production)-[a-z0-9-]+$/.test(value); }
+function isEnvironmentD1Name(value: unknown, environment: string): value is string {
+  return typeof value === 'string'
+    && (environment === 'preview' || environment === 'production')
+    && new RegExp(`^theologai-${environment}-[a-z0-9-]+$`).test(value);
+}
 function isEvidenceIdentity(value: unknown): value is string { return typeof value === 'string' && /^[a-z0-9][a-z0-9._:-]{2,127}$/.test(value); }
 function stableJson(value: unknown): string { return JSON.stringify(value, (_, nested) => isRecord(nested) ? Object.fromEntries(Object.entries(nested).sort(([a], [b]) => a.localeCompare(b))) : nested); }
 function refuse(condition: unknown, message: string): asserts condition { if (!condition) throw new Error(`CCEL canary refused: ${message}.`); }

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -70,6 +70,10 @@ const LEGACY_SCHEMA_0008_D1_IDS = new Set<string>([
   LEGACY_SCHEMA_0008_D1.production.id,
   LEGACY_SCHEMA_0008_D1.preview.id,
 ]);
+const LEGACY_SCHEMA_0008_D1_NAMES = new Set<string>([
+  LEGACY_SCHEMA_0008_D1.production.name,
+  LEGACY_SCHEMA_0008_D1.preview.name,
+]);
 
 export const SCHEMA_0009_CANARY_GATE: Schema0009CanaryGate = {
   state: 'unrecorded',
@@ -135,8 +139,8 @@ export function assertSchema0009CanaryPrerequisite(configText: string, gate: unk
   const productionD1 = configuredD1(root, 'production');
   const previewD1 = configuredD1(preview, 'preview');
 
-  assertNotLegacySchema0008D1(productionD1.database_id, 'production');
-  assertNotLegacySchema0008D1(previewD1.database_id, 'preview');
+  assertNotLegacySchema0008D1(productionD1.database_name, productionD1.database_id, 'production');
+  assertNotLegacySchema0008D1(previewD1.database_name, previewD1.database_id, 'preview');
   refuse(
     reviewedGate.state === 'ready',
     'schema-0009 canary gate is unrecorded: prepare and audit separate preview and production candidates before enabling this workflow',
@@ -162,8 +166,8 @@ export function validateSchema0009CanaryGate(value: unknown): Schema0009CanaryGa
   const preview = parseSchema0009EnvironmentGate(gate.preview, 'preview');
   const production = parseSchema0009EnvironmentGate(gate.production, 'production');
   const environmentIsolationEvidence = parseSchema0009Evidence(gate.environmentIsolationEvidence, 'environment isolation');
-  assertNotLegacySchema0008D1(preview.databaseId, 'ready preview');
-  assertNotLegacySchema0008D1(production.databaseId, 'ready production');
+  assertNotLegacySchema0008D1(preview.databaseName, preview.databaseId, 'ready preview');
+  assertNotLegacySchema0008D1(production.databaseName, production.databaseId, 'ready production');
   refuse(
     preview.databaseName !== production.databaseName && preview.databaseId !== production.databaseId,
     'ready schema-0009 canary gate must use distinct preview and production D1 identities',
@@ -504,8 +508,9 @@ function assertSchema0009EnvironmentMatch(
   );
 }
 
-function assertNotLegacySchema0008D1(databaseId: string, label: string): void {
-  refuse(!LEGACY_SCHEMA_0008_D1_IDS.has(databaseId), `${label} D1 identity uses a recorded schema-0008 UUID`);
+function assertNotLegacySchema0008D1(databaseName: string, databaseId: string, label: string): void {
+  refuse(!LEGACY_SCHEMA_0008_D1_NAMES.has(databaseName) && !LEGACY_SCHEMA_0008_D1_IDS.has(databaseId),
+    `${label} D1 identity uses a recorded schema-0008 name or UUID`);
 }
 
 function assertVersion(version: FullVersion, mode: Mode, requireProductionOperator = false, gate: Schema0009CanaryGate = SCHEMA_0009_CANARY_GATE): boolean {

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -483,12 +483,27 @@ describe('published project contract', () => {
       expect(normalized).toContain('https://www.ccel.org/home3/search');
       expect(normalized).toContain('code/resource-equivalent `100` predecessor');
     }
-    expect(canary).toContain('four separately authorized stages');
+    expect(canary).toContain('five separately authorized stages');
     expect(canary).toContain('Completion or authorization of any stage does not authorize the next stage.');
     expect(canary).toContain('fresh, separate preview and production D1 candidates');
     expect(canary).toContain('schema `0009`');
     expect(canary).toContain('remote readiness and authority audit');
-    expect(canary).toContain('read-only environment-isolation\n   verification');
+    expect(canary).toContain('while both candidates remain unbound');
+    expect(canary).toContain('prepared preview candidate with current-`main` `100` flags');
+    expect(canary).toContain('Only after the preview audit passes');
+    expect(canary).toContain('Then perform a read-only environment-isolation\n   verification');
+    expect(canary).toContain('hard inert schema-`0009` canary gate');
+    expect(canary).toContain('before any\nWrangler command or Cloudflare read');
+    const canaryOrder = [
+      'while both candidates remain unbound',
+      'prepared preview candidate with current-`main` `100` flags',
+      'Only after the preview audit passes',
+      'Then perform a read-only environment-isolation',
+      'Stage the operator credential',
+      'Run this temporary `111` two-request preview canary transaction',
+    ].map(marker => canary.indexOf(marker));
+    expect(canaryOrder.every(index => index >= 0)).toBe(true);
+    expect(canaryOrder).toEqual([...canaryOrder].sort((left, right) => left - right));
     expect(canary).toContain('resources.script.etag');
     expect(canary).toContain('temporary `111` two-request preview canary transaction');
     expect(reconciliation).toContain('protected preview release must safely refresh exact');
@@ -498,8 +513,8 @@ describe('published project contract', () => {
     expect(secret).toContain('Executing staging is a production Worker-version upload mutation');
     expect(secret).toContain('actual production Worker deployment and traffic mutation');
     expect(secret).toContain('Neither staging nor\npromotion authorizes');
-    expect(secret).toContain('separate schema-`0009` D1 gate must have completed for **both** environments');
-    expect(secret).toContain('read-only environment-isolation\nverification');
+    expect(secret).toContain('separate schema-`0009` D1 sequence must have completed in order');
+    expect(secret).toContain('while unbound; the preview candidate bound, deployed, and audited; then the\nproduction candidate bound, deployed, and audited; then a read-only\nenvironment-isolation verification');
     expect(readme).toContain("Current `main` also includes PR #117's Transform-12 schema\n`0009` contract");
     expect(readme).toContain('The deployed preview and production D1 layers remain schema `0008`; current\nmain\'s PR #117 schema `0009` Candidate-C contract is checked out only');
     const normalizedAudit = audit.replace(/\s+/g, ' ');

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -118,7 +118,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/main', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
-    })).toThrow(/production D1 identity uses a recorded schema-0008 UUID/);
+    })).toThrow(/production D1 identity uses a recorded schema-0008 name or UUID/);
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/feature', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
@@ -151,12 +151,12 @@ describe('CCEL live preview canary transaction', () => {
       requiredSchema: '0009_candidate_c_sectioned_publications',
     });
     expect(() => assertSchema0009CanaryPrerequisite(config))
-      .toThrow(/production D1 identity uses a recorded schema-0008 UUID/);
+      .toThrow(/production D1 identity uses a recorded schema-0008 name or UUID/);
     const onlyLegacyPreviewRemaining = config
       .replace('theologai-production-20260729-transform11-a', 'theologai-production-schema0009-candidate')
       .replace('53211f50-a893-4b4c-be1e-bc625a595dc7', '323e4567-e89b-42d3-a456-426614174003');
     expect(() => assertSchema0009CanaryPrerequisite(onlyLegacyPreviewRemaining))
-      .toThrow(/preview D1 identity uses a recorded schema-0008 UUID/);
+      .toThrow(/preview D1 identity uses a recorded schema-0008 name or UUID/);
     const noLegacyIdentityRemaining = onlyLegacyPreviewRemaining
       .replace('theologai-preview-20260728-transform11-a', 'theologai-preview-schema0009-candidate')
       .replace('62b871a6-5b4d-4d9b-8f52-301f6c878f48', '423e4567-e89b-42d3-a456-426614174003');
@@ -195,11 +195,25 @@ describe('CCEL live preview canary transaction', () => {
     expect(() => assertSchema0009CanaryPrerequisite(
       noLegacyIdentityRemaining.replace('423e4567-e89b-42d3-a456-426614174003', LEGACY_SCHEMA_0008_D1.preview.id),
       readyGate,
-    )).toThrow(/preview D1 identity uses a recorded schema-0008 UUID/);
+    )).toThrow(/preview D1 identity uses a recorded schema-0008 name or UUID/);
+    expect(() => assertSchema0009CanaryPrerequisite(
+      noLegacyIdentityRemaining.replace(
+        'theologai-production-schema0009-candidate', LEGACY_SCHEMA_0008_D1.production.name,
+      ),
+      readyGate,
+    )).toThrow(/production D1 identity uses a recorded schema-0008 name or UUID/);
     expect(() => validateSchema0009CanaryGate({
       ...readyGate,
       preview: { ...readyGate.preview, databaseId: LEGACY_SCHEMA_0008_D1.preview.id },
-    })).toThrow(/ready preview D1 identity uses a recorded schema-0008 UUID/);
+    })).toThrow(/ready preview D1 identity uses a recorded schema-0008 name or UUID/);
+    expect(() => validateSchema0009CanaryGate({
+      ...readyGate,
+      production: { ...readyGate.production, databaseName: LEGACY_SCHEMA_0008_D1.production.name },
+    })).toThrow(/ready production D1 identity uses a recorded schema-0008 name or UUID/);
+    expect(() => validateSchema0009CanaryGate({
+      ...readyGate,
+      preview: { ...readyGate.preview, databaseName: LEGACY_SCHEMA_0008_D1.preview.name },
+    })).toThrow(/ready preview D1 identity uses a recorded schema-0008 name or UUID/);
     expect(() => validateSchema0009CanaryGate({
       state: 'ready', requiredSchema: '0009_candidate_c_sectioned_publications', preview: readyGate.preview,
     })).toThrow(/ready schema-0009 canary gate must contain exactly authorized keys/);
@@ -270,6 +284,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(ordered).toEqual([...ordered].sort((left, right) => left - right));
     expect(canaryTransaction).toContain('Do not perform a second preview refresh here.');
     expect(canaryTransaction).toContain('reviewed `ready` record\nfor each environment: exact D1 name/UUID plus separately pinned readiness and\nauthority evidence identities and SHA-256 values, plus one separately pinned\nenvironment-isolation evidence identity and SHA-256');
+    expect(canaryTransaction).toContain('any recorded\nschema-`0008` D1 name or UUID regardless of pairing');
     expect(operatorProvisioning).toContain('it must not be\nrepeated as a second refresh after credential work.');
   });
 

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -50,10 +50,20 @@ const liveBindingShapes = JSON.parse(readFileSync(
   preview: { versionId: string; flags: string; secretTextBindingNames: string[]; operatorReady: boolean };
 };
 
-function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false) {
+interface WorkerD1Ids {
+  preview: string;
+  production: string;
+}
+
+const legacyD1Ids: WorkerD1Ids = {
+  preview: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+  production: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+};
+
+function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false, d1Ids: WorkerD1Ids = legacyD1Ids) {
   const productionMode = mode === '000';
   return [
-    { name: 'THEOLOGAI_DB', type: 'd1', id: productionMode ? '53211f50-a893-4b4c-be1e-bc625a595dc7' : '62b871a6-5b4d-4d9b-8f52-301f6c878f48' },
+    { name: 'THEOLOGAI_DB', type: 'd1', id: productionMode ? d1Ids.production : d1Ids.preview },
     { name: 'THEOLOGAI_CCEL_COORDINATOR', type: 'durable_object_namespace', class_name: 'CcelGlobalCoordinator', script_name: 'theologai-ccel-coordinator' },
     { name: 'THEOLOGAI_RATE_LIMITER', type: 'ratelimit', namespace_id: productionMode ? '361201' : '361202', simple: { limit: 120, period: 60 } },
     { name: 'THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER', type: 'ratelimit', namespace_id: productionMode ? '361203' : '361204', simple: { limit: 12, period: 60 } },
@@ -76,7 +86,7 @@ function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false) {
 
 function view(
   id: string, number: number, mode: '100' | '111' | '000' = '100',
-  options: { message?: string; tag?: string; secret?: boolean; scriptEtag?: string } = {},
+  options: { message?: string; tag?: string; secret?: boolean; scriptEtag?: string; d1Ids?: WorkerD1Ids } = {},
 ) {
   return {
     id, number, metadata: { created_on: '2026-07-29T00:00:00.000Z' },
@@ -84,7 +94,7 @@ function view(
     resources: {
       script: { etag: options.scriptEtag ?? '4f8e2a', handlers: ['fetch'], last_deployed_from: 'wrangler' },
       script_runtime: { compatibility_date: '2026-07-09', compatibility_flags: ['nodejs_compat'] },
-      bindings: bindings(mode, options.secret),
+      bindings: bindings(mode, options.secret, options.d1Ids),
     },
   };
 }
@@ -108,7 +118,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/main', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
-    })).toThrow(/recorded schema-0008 production D1 identity is not a canary baseline/);
+    })).toThrow(/production D1 identity uses a recorded schema-0008 UUID/);
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/feature', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
@@ -141,12 +151,12 @@ describe('CCEL live preview canary transaction', () => {
       requiredSchema: '0009_candidate_c_sectioned_publications',
     });
     expect(() => assertSchema0009CanaryPrerequisite(config))
-      .toThrow(/recorded schema-0008 production D1 identity is not a canary baseline/);
+      .toThrow(/production D1 identity uses a recorded schema-0008 UUID/);
     const onlyLegacyPreviewRemaining = config
       .replace('theologai-production-20260729-transform11-a', 'theologai-production-schema0009-candidate')
       .replace('53211f50-a893-4b4c-be1e-bc625a595dc7', '323e4567-e89b-42d3-a456-426614174003');
     expect(() => assertSchema0009CanaryPrerequisite(onlyLegacyPreviewRemaining))
-      .toThrow(/recorded schema-0008 preview D1 identity is not a canary baseline/);
+      .toThrow(/preview D1 identity uses a recorded schema-0008 UUID/);
     const noLegacyIdentityRemaining = onlyLegacyPreviewRemaining
       .replace('theologai-preview-20260728-transform11-a', 'theologai-preview-schema0009-candidate')
       .replace('62b871a6-5b4d-4d9b-8f52-301f6c878f48', '423e4567-e89b-42d3-a456-426614174003');
@@ -168,6 +178,7 @@ describe('CCEL live preview canary transaction', () => {
         readinessEvidence: { identity: 'remote-d1-readiness.v1', sha256: 'c'.repeat(64) },
         authorityEvidence: { identity: 'transform-8-9-11-12-authority.v1', sha256: 'd'.repeat(64) },
       },
+      environmentIsolationEvidence: { identity: 'environment-isolation.v1', sha256: 'e'.repeat(64) },
     };
     expect(() => validateSchema0009CanaryGate(readyGate)).not.toThrow();
     expect(() => assertCommittedConfig(noLegacyIdentityRemaining, readyGate)).not.toThrow();
@@ -181,6 +192,14 @@ describe('CCEL live preview canary transaction', () => {
       noLegacyIdentityRemaining.replace('theologai-preview-schema0009-candidate', 'theologai-preview-wrong-candidate'),
       readyGate,
     )).toThrow(/preview D1 identity does not match the reviewed schema-0009 canary gate/);
+    expect(() => assertSchema0009CanaryPrerequisite(
+      noLegacyIdentityRemaining.replace('423e4567-e89b-42d3-a456-426614174003', LEGACY_SCHEMA_0008_D1.preview.id),
+      readyGate,
+    )).toThrow(/preview D1 identity uses a recorded schema-0008 UUID/);
+    expect(() => validateSchema0009CanaryGate({
+      ...readyGate,
+      preview: { ...readyGate.preview, databaseId: LEGACY_SCHEMA_0008_D1.preview.id },
+    })).toThrow(/ready preview D1 identity uses a recorded schema-0008 UUID/);
     expect(() => validateSchema0009CanaryGate({
       state: 'ready', requiredSchema: '0009_candidate_c_sectioned_publications', preview: readyGate.preview,
     })).toThrow(/ready schema-0009 canary gate must contain exactly authorized keys/);
@@ -191,6 +210,50 @@ describe('CCEL live preview canary transaction', () => {
         readinessEvidence: { ...readyGate.production.readinessEvidence, sha256: 'not-a-sha256' },
       },
     })).toThrow(/production readiness evidence identity or SHA-256 is invalid/);
+    const { environmentIsolationEvidence: _isolation, ...missingIsolation } = readyGate;
+    expect(() => validateSchema0009CanaryGate(missingIsolation))
+      .toThrow(/ready schema-0009 canary gate must contain exactly authorized keys/);
+    expect(() => validateSchema0009CanaryGate({
+      ...readyGate,
+      environmentIsolationEvidence: { ...readyGate.environmentIsolationEvidence, sha256: 'not-a-sha256' },
+    })).toThrow(/environment isolation evidence identity or SHA-256 is invalid/);
+    expect(() => validateSchema0009CanaryGate({
+      ...readyGate,
+      preview: { ...readyGate.preview, databaseName: 'theologai-production-crossed-candidate' },
+    })).toThrow(/preview schema-0009 D1 identity is invalid/);
+    expect(() => validateSchema0009CanaryGate({
+      ...readyGate,
+      production: { ...readyGate.production, databaseName: 'theologai-preview-crossed-candidate' },
+    })).toThrow(/production schema-0009 D1 identity is invalid/);
+
+    const readyD1Ids: WorkerD1Ids = {
+      preview: readyGate.preview.databaseId,
+      production: readyGate.production.databaseId,
+    };
+    const readyBaseline = view(predecessor, 10, '100', { scriptEtag: 'ready-schema0009', d1Ids: readyD1Ids });
+    const readyCanary = view(canary, 11, '111', {
+      message: CANARY_MESSAGE, tag: CANARY_TAG, scriptEtag: 'ready-schema0009', d1Ids: readyD1Ids,
+    });
+    const readyProduction = view(production, 9, '000', { secret: true, d1Ids: readyD1Ids });
+    expect(() => validatePreviewBaseline(
+      noLegacyIdentityRemaining, deployments(predecessor), readyBaseline, predecessor, readyGate,
+    )).not.toThrow();
+    expect(() => validateProductionControl(
+      noLegacyIdentityRemaining, deployments(production), readyProduction, production, readyGate,
+    )).not.toThrow();
+    expect(validateProductionBindingInventory(readyProduction, readyGate)).toEqual({ operatorReady: true });
+    expect(() => validateCanaryVersion(
+      noLegacyIdentityRemaining, readyBaseline, readyCanary, predecessor, canary, readyGate,
+    )).not.toThrow();
+    expect(() => validateCanaryDeployment(
+      noLegacyIdentityRemaining, deployments(canary), readyCanary, canary, readyGate,
+    )).not.toThrow();
+    expect(planRestore(
+      noLegacyIdentityRemaining, deployments(canary), readyCanary, readyBaseline, canary, predecessor, readyGate,
+    )).toBe('deploy');
+    expect(() => validateRestoreResult(
+      noLegacyIdentityRemaining, deployments(predecessor), readyBaseline, predecessor, readyGate,
+    )).not.toThrow();
     expect(workflow.indexOf('validate-dispatch')).toBeLessThan(workflow.indexOf('npx wrangler'));
   });
 
@@ -206,7 +269,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(ordered.every(index => index >= 0)).toBe(true);
     expect(ordered).toEqual([...ordered].sort((left, right) => left - right));
     expect(canaryTransaction).toContain('Do not perform a second preview refresh here.');
-    expect(canaryTransaction).toContain('reviewed `ready` record\nfor each environment: exact D1 name/UUID plus separately pinned readiness and\nauthority evidence identities and SHA-256 values');
+    expect(canaryTransaction).toContain('reviewed `ready` record\nfor each environment: exact D1 name/UUID plus separately pinned readiness and\nauthority evidence identities and SHA-256 values, plus one separately pinned\nenvironment-isolation evidence identity and SHA-256');
     expect(operatorProvisioning).toContain('it must not be\nrepeated as a second refresh after credential work.');
   });
 

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -25,7 +25,9 @@ import {
   validateProductionBindingInventory,
   validateProductionControl,
   validateRestoreResult,
+  validateSchema0009CanaryGate,
 } from '../../../scripts/ccel-live-preview-canary.js';
+import type { Schema0009CanaryGate } from '../../../scripts/ccel-live-preview-canary.js';
 
 const predecessor = '123e4567-e89b-42d3-a456-426614174000';
 const canary = '123e4567-e89b-42d3-a456-426614174001';
@@ -150,6 +152,45 @@ describe('CCEL live preview canary transaction', () => {
       .replace('62b871a6-5b4d-4d9b-8f52-301f6c878f48', '423e4567-e89b-42d3-a456-426614174003');
     expect(() => assertSchema0009CanaryPrerequisite(noLegacyIdentityRemaining))
       .toThrow(/schema-0009 canary gate is unrecorded/);
+
+    const readyGate: Schema0009CanaryGate = {
+      state: 'ready',
+      requiredSchema: '0009_candidate_c_sectioned_publications',
+      preview: {
+        databaseName: 'theologai-preview-schema0009-candidate',
+        databaseId: '423e4567-e89b-42d3-a456-426614174003',
+        readinessEvidence: { identity: 'remote-d1-readiness.v1', sha256: 'a'.repeat(64) },
+        authorityEvidence: { identity: 'transform-8-9-11-12-authority.v1', sha256: 'b'.repeat(64) },
+      },
+      production: {
+        databaseName: 'theologai-production-schema0009-candidate',
+        databaseId: '323e4567-e89b-42d3-a456-426614174003',
+        readinessEvidence: { identity: 'remote-d1-readiness.v1', sha256: 'c'.repeat(64) },
+        authorityEvidence: { identity: 'transform-8-9-11-12-authority.v1', sha256: 'd'.repeat(64) },
+      },
+    };
+    expect(() => validateSchema0009CanaryGate(readyGate)).not.toThrow();
+    expect(() => assertCommittedConfig(noLegacyIdentityRemaining, readyGate)).not.toThrow();
+    expect(() => renderCanaryPreviewConfig(noLegacyIdentityRemaining, readyGate)).not.toThrow();
+    expect(() => assertSchema0009CanaryPrerequisite(noLegacyIdentityRemaining, readyGate)).not.toThrow();
+    expect(() => assertSchema0009CanaryPrerequisite(
+      noLegacyIdentityRemaining.replace('423e4567-e89b-42d3-a456-426614174003', '423e4567-e89b-42d3-a456-426614174004'),
+      readyGate,
+    )).toThrow(/preview D1 identity does not match the reviewed schema-0009 canary gate/);
+    expect(() => assertSchema0009CanaryPrerequisite(
+      noLegacyIdentityRemaining.replace('theologai-preview-schema0009-candidate', 'theologai-preview-wrong-candidate'),
+      readyGate,
+    )).toThrow(/preview D1 identity does not match the reviewed schema-0009 canary gate/);
+    expect(() => validateSchema0009CanaryGate({
+      state: 'ready', requiredSchema: '0009_candidate_c_sectioned_publications', preview: readyGate.preview,
+    })).toThrow(/ready schema-0009 canary gate must contain exactly authorized keys/);
+    expect(() => validateSchema0009CanaryGate({
+      ...readyGate,
+      production: {
+        ...readyGate.production,
+        readinessEvidence: { ...readyGate.production.readinessEvidence, sha256: 'not-a-sha256' },
+      },
+    })).toThrow(/production readiness evidence identity or SHA-256 is invalid/);
     expect(workflow.indexOf('validate-dispatch')).toBeLessThan(workflow.indexOf('npx wrangler'));
   });
 
@@ -165,6 +206,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(ordered.every(index => index >= 0)).toBe(true);
     expect(ordered).toEqual([...ordered].sort((left, right) => left - right));
     expect(canaryTransaction).toContain('Do not perform a second preview refresh here.');
+    expect(canaryTransaction).toContain('reviewed `ready` record\nfor each environment: exact D1 name/UUID plus separately pinned readiness and\nauthority evidence identities and SHA-256 values');
     expect(operatorProvisioning).toContain('it must not be\nrepeated as a second refresh after credential work.');
   });
 

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -5,8 +5,11 @@ import {
   CANARY_CONFIRMATION,
   CANARY_MESSAGE,
   CANARY_TAG,
+  LEGACY_SCHEMA_0008_D1,
   PRODUCTION_BASE_SECRET_BINDINGS,
+  SCHEMA_0009_CANARY_GATE,
   assertCommittedConfig,
+  assertSchema0009CanaryPrerequisite,
   identifyCanaryUpload,
   planRestore,
   renderCanaryPreviewConfig,
@@ -33,6 +36,8 @@ const workflow = readFileSync(new URL('../../../.github/workflows/ccel-live-prev
 const canarySource = readFileSync(new URL('../../../scripts/ccel-live-preview-canary.ts', import.meta.url), 'utf8');
 const emergencyWorkflow = readFileSync(new URL('../../../.github/workflows/restore-ccel-live-preview-canary.yml', import.meta.url), 'utf8');
 const prWorkflow = readFileSync(new URL('../../../.github/workflows/pr.yml', import.meta.url), 'utf8');
+const canaryTransaction = readFileSync(new URL('../../../docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md', import.meta.url), 'utf8');
+const operatorProvisioning = readFileSync(new URL('../../../docs/CCEL-OPERATOR-SECRET-PROVISIONING.md', import.meta.url), 'utf8');
 const liveBindingShapes = JSON.parse(readFileSync(
   new URL('../../fixtures/wrangler/ccel-canary-live-binding-shapes.json', import.meta.url), 'utf8',
 )) as {
@@ -101,7 +106,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/main', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
-    })).not.toThrow();
+    })).toThrow(/recorded schema-0008 production D1 identity is not a canary baseline/);
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/feature', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
@@ -116,6 +121,51 @@ describe('CCEL live preview canary transaction', () => {
       config.replace('class_name = "CcelGlobalCoordinator"', 'class_name = "WrongCoordinator"'),
       config.replace('namespace_id = "361204"', 'namespace_id = "999999"'),
     ]) expect(() => assertCommittedConfig(tampered)).toThrow();
+  });
+
+  it('keeps the current canary mechanically inert until separately reviewed schema-0009 candidates are recorded', () => {
+    expect(LEGACY_SCHEMA_0008_D1).toEqual({
+      production: {
+        name: 'theologai-production-20260729-transform11-a',
+        id: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+      },
+      preview: {
+        name: 'theologai-preview-20260728-transform11-a',
+        id: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+      },
+    });
+    expect(SCHEMA_0009_CANARY_GATE).toEqual({
+      state: 'unrecorded',
+      requiredSchema: '0009_candidate_c_sectioned_publications',
+    });
+    expect(() => assertSchema0009CanaryPrerequisite(config))
+      .toThrow(/recorded schema-0008 production D1 identity is not a canary baseline/);
+    const onlyLegacyPreviewRemaining = config
+      .replace('theologai-production-20260729-transform11-a', 'theologai-production-schema0009-candidate')
+      .replace('53211f50-a893-4b4c-be1e-bc625a595dc7', '323e4567-e89b-42d3-a456-426614174003');
+    expect(() => assertSchema0009CanaryPrerequisite(onlyLegacyPreviewRemaining))
+      .toThrow(/recorded schema-0008 preview D1 identity is not a canary baseline/);
+    const noLegacyIdentityRemaining = onlyLegacyPreviewRemaining
+      .replace('theologai-preview-20260728-transform11-a', 'theologai-preview-schema0009-candidate')
+      .replace('62b871a6-5b4d-4d9b-8f52-301f6c878f48', '423e4567-e89b-42d3-a456-426614174003');
+    expect(() => assertSchema0009CanaryPrerequisite(noLegacyIdentityRemaining))
+      .toThrow(/schema-0009 canary gate is unrecorded/);
+    expect(workflow.indexOf('validate-dispatch')).toBeLessThan(workflow.indexOf('npx wrangler'));
+  });
+
+  it('documents the single preview-release sequence before production, isolation, credentials, and canary', () => {
+    const unbound = 'while both candidates remain unbound';
+    const preview = 'preview candidate with current-`main` `100` flags';
+    const production = 'Only after the preview audit passes';
+    const isolation = 'Then perform a read-only environment-isolation';
+    const credentials = 'Stage the operator credential';
+    const canary = 'Run this temporary `111` two-request preview canary';
+    const ordered = [unbound, preview, production, isolation, credentials, canary]
+      .map(marker => canaryTransaction.indexOf(marker));
+    expect(ordered.every(index => index >= 0)).toBe(true);
+    expect(ordered).toEqual([...ordered].sort((left, right) => left - right));
+    expect(canaryTransaction).toContain('Do not perform a second preview refresh here.');
+    expect(operatorProvisioning).toContain('it must not be\nrepeated as a second refresh after credential work.');
   });
 
   it('rejects option-like, malformed, or duplicate user IDs and unprovisioned dedicated credentials before Wrangler', () => {


### PR DESCRIPTION
## What changed

- makes the CCEL canary fail locally before any Wrangler command while schema-0009 release evidence is unrecorded
- requires exact preview and production D1 names and UUIDs plus pinned readiness, authority, and environment-isolation evidence before a future canary can be enabled
- rejects retained schema-0008 names or UUIDs, crossed environments, shared identities, malformed evidence, and configuration drift
- propagates reviewed schema-0009 identities through baseline, production-control, canary, deployment, and restore validation
- corrects the release sequence to unbound preparation, preview release/audit, production release/audit, isolation verification, credential work, then canary
- requires matching Worker script etags so only the two canary flags may differ

## Why

The earlier runbook repair described schema 0009 as a prerequisite but did not mechanically prevent the existing schema-0008 bindings from reaching the canary workflow. It also placed production binding before preview verification. This change turns those requirements into fail-closed validation while preserving the current emergency recovery path.

## Current behavior

The checked-in gate remains `unrecorded`, so the live-canary workflow is intentionally inert. This PR does not prepare, bind, deploy, delete, or query any D1 database; stage credentials; make a CCEL request; or change either live environment.

## Verification

- independent Sol release review: pass, no actionable findings
- `npm run test:ccel`: 143/143 passed
- `npm run docs:check`: 12/12 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run test:unit`: 190 files passed; 2,476 passed and 5 skipped
- combined diff whitespace check: passed
