### PR TITLE
Prepare schema-0009 preview release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -464,6 +464,7 @@ jobs:
             --production-active-version-view "$RUNNER_TEMP/final-environment-production-version.json" \
             --preview-deployments "$RUNNER_TEMP/final-environment-preview-deployments.json" \
             --preview-active-version-view "$RUNNER_TEMP/final-environment-preview-version.json" \
+            --production-audited-identity "$RUNNER_TEMP/production-worker-deployment-identity.json" \
             --wrangler-config wrangler.toml \
             --d1-inventory "$RUNNER_TEMP/final-environment-d1-inventory.json" \
             --output "$RUNNER_TEMP/final-environment-isolation-receipt.json"
@@ -485,10 +486,11 @@ jobs:
           observed_active_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
             --deployments "$RUNNER_TEMP/production-worker-deployments-post-mutation.json")"
           npx --no-install wrangler versions view "$observed_active_version" --json > "$RUNNER_TEMP/production-worker-observed-active-version-view.json"
-          npx --no-install tsx scripts/production-release-reconciliation.ts observe-post-mutation \
+          npx --no-install tsx scripts/production-release-reconciliation.ts observe-final-post-audit \
             --predecessor-anchor "$RUNNER_TEMP/production-worker-predecessor-anchor.json" \
             --deployments "$RUNNER_TEMP/production-worker-deployments-post-mutation.json" \
             --observed-active-version-view "$RUNNER_TEMP/production-worker-observed-active-version-view.json" \
+            --production-audited-identity "$RUNNER_TEMP/production-worker-deployment-identity.json" \
             --wrangler-config wrangler.toml \
             --output "$RUNNER_TEMP/production-worker-final-routing-observation.json"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,10 +165,19 @@ jobs:
       - name: Verify candidate production D1 is compatible (read-only)
         run: |
           candidate_d1_name="$(< "$RUNNER_TEMP/production-candidate-d1-name.txt")"
-          npm run d1:remote:check -- --database "$candidate_d1_name"
+          npm run d1:remote:check -- --database "$candidate_d1_name" \
+            --output "$RUNNER_TEMP/production-d1-readiness-receipt.json"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Upload sanitized production D1 readiness receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-d1-readiness-${{ github.sha }}
+          path: ${{ runner.temp }}/production-d1-readiness-receipt.json
+          retention-days: 30
+          if-no-files-found: error
 
       # Retain a read-only predecessor record before deploy. It permits a
       # manual recovery decision if a later step fails; it cannot roll back,
@@ -236,6 +245,28 @@ jobs:
             --output "$RUNNER_TEMP/pre-production-preview-mcp-audit.json"
           test -s "$RUNNER_TEMP/pre-production-preview-mcp-audit.json"
 
+      # A production deploy must leave the independently deployed preview
+      # Worker untouched. Capture its exact sole-active version and binding
+      # before the first mutating step; later verification reuses this record.
+      - name: Capture preview control before production deployment (read-only)
+        id: preview-control-before-production
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/preview-control-d1-inventory-before.json"
+          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-control-deployments-before.json"
+          preview_version="$(npx --no-install tsx scripts/preview-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/preview-control-deployments-before.json")"
+          npx --no-install wrangler versions view "$preview_version" --env preview --json > "$RUNNER_TEMP/preview-control-version-before.json"
+          npx --no-install tsx scripts/preview-release-reconciliation.ts capture-control \
+            --deployments "$RUNNER_TEMP/preview-control-deployments-before.json" \
+            --active-version-view "$RUNNER_TEMP/preview-control-version-before.json" \
+            --wrangler-config wrangler.toml \
+            --d1-inventory "$RUNNER_TEMP/preview-control-d1-inventory-before.json" \
+            --output "$RUNNER_TEMP/preview-control-before-production.json"
+
       - name: Deploy to Cloudflare Workers
         id: production-worker-deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
@@ -269,11 +300,32 @@ jobs:
             --output "$RUNNER_TEMP/production-worker-deployment-pre-audit-identity.json" \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Verify preview control remained unchanged after production deployment (read-only)
+        id: preview-control-after-production-deploy
+        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.preview-control-before-production.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/preview-control-d1-inventory-after-deploy.json"
+          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-control-deployments-after-deploy.json"
+          preview_version="$(npx --no-install tsx scripts/preview-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/preview-control-deployments-after-deploy.json")"
+          npx --no-install wrangler versions view "$preview_version" --env preview --json > "$RUNNER_TEMP/preview-control-version-after-deploy.json"
+          npx --no-install tsx scripts/preview-release-reconciliation.ts verify-control \
+            --control "$RUNNER_TEMP/preview-control-before-production.json" \
+            --deployments "$RUNNER_TEMP/preview-control-deployments-after-deploy.json" \
+            --active-version-view "$RUNNER_TEMP/preview-control-version-after-deploy.json" \
+            --wrangler-config wrangler.toml \
+            --d1-inventory "$RUNNER_TEMP/preview-control-d1-inventory-after-deploy.json" \
+            --output "$RUNNER_TEMP/preview-control-after-production-deploy.json"
+
       # A candidate must be sole-active and attached to the exact D1 that
       # passed readiness before either production black-box audit can begin.
       - name: Require deployed candidate production D1 binding (read-only)
         id: production-worker-candidate-cutover
-        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-pre-audit-identity.outcome == 'success' }}
+        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-pre-audit-identity.outcome == 'success' && steps.preview-control-after-production-deploy.outcome == 'success' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -297,7 +349,7 @@ jobs:
             --output "$RUNNER_TEMP/production-worker-candidate-cutover.json"
 
       - name: Upload production candidate cutover observation
-        if: ${{ always() && steps.production-worker-deploy.outcome == 'success' && steps.production-predecessor.outcome == 'success' }}
+        if: ${{ always() && steps.production-worker-deploy.outcome == 'success' && steps.production-predecessor.outcome == 'success' && steps.production-worker-candidate-cutover.outcome != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: production-candidate-cutover-observation-${{ github.sha }}
@@ -369,6 +421,53 @@ jobs:
             --output "$RUNNER_TEMP/production-worker-deployment-identity.json" \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Verify preview control remained unchanged after production audits (read-only)
+        id: preview-control-after-production-audits
+        if: ${{ steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-deploy.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/preview-control-d1-inventory-after-audits.json"
+          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-control-deployments-after-audits.json"
+          preview_version="$(npx --no-install tsx scripts/preview-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/preview-control-deployments-after-audits.json")"
+          npx --no-install wrangler versions view "$preview_version" --env preview --json > "$RUNNER_TEMP/preview-control-version-after-audits.json"
+          npx --no-install tsx scripts/preview-release-reconciliation.ts verify-control \
+            --control "$RUNNER_TEMP/preview-control-before-production.json" \
+            --deployments "$RUNNER_TEMP/preview-control-deployments-after-audits.json" \
+            --active-version-view "$RUNNER_TEMP/preview-control-version-after-audits.json" \
+            --wrangler-config wrangler.toml \
+            --d1-inventory "$RUNNER_TEMP/preview-control-d1-inventory-after-audits.json" \
+            --output "$RUNNER_TEMP/preview-control-after-production-audits.json"
+
+      - name: Capture final schema-0009 environment isolation receipt (read-only)
+        id: final-environment-isolation
+        if: ${{ steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/final-environment-d1-inventory.json"
+          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/final-environment-production-deployments.json"
+          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/final-environment-preview-deployments.json"
+          production_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/final-environment-production-deployments.json")"
+          preview_version="$(npx --no-install tsx scripts/preview-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/final-environment-preview-deployments.json")"
+          npx --no-install wrangler versions view "$production_version" --json > "$RUNNER_TEMP/final-environment-production-version.json"
+          npx --no-install wrangler versions view "$preview_version" --env preview --json > "$RUNNER_TEMP/final-environment-preview-version.json"
+          npx --no-install tsx scripts/production-release-reconciliation.ts capture-environment-isolation \
+            --production-deployments "$RUNNER_TEMP/final-environment-production-deployments.json" \
+            --production-active-version-view "$RUNNER_TEMP/final-environment-production-version.json" \
+            --preview-deployments "$RUNNER_TEMP/final-environment-preview-deployments.json" \
+            --preview-active-version-view "$RUNNER_TEMP/final-environment-preview-version.json" \
+            --wrangler-config wrangler.toml \
+            --d1-inventory "$RUNNER_TEMP/final-environment-d1-inventory.json" \
+            --output "$RUNNER_TEMP/final-environment-isolation-receipt.json"
+
       # This non-strict observation must run after an attempted deploy even if
       # a secret pre-command or deploy failed. It records current
       # routing/binding state for diagnosis but cannot recover, roll back,
@@ -404,7 +503,7 @@ jobs:
 
       - name: Hash sanitized production audit and reconciliation evidence
         id: production-audit-evidence
-        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.production-final-observation.outcome == 'success' }}
+        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' && steps.final-environment-isolation.outcome == 'success' && steps.production-final-observation.outcome == 'success' }}
         run: |
           edge_stabilization_sha256="$(sha256sum "$RUNNER_TEMP/production-primary-source-edge-stabilization.json" | awk '{print $1}')"
           original_language_audit_sha256="$(sha256sum "$RUNNER_TEMP/original-language-v2-production-audit.json" | awk '{print $1}')"
@@ -413,6 +512,9 @@ jobs:
           identity_sha256="$(sha256sum "$RUNNER_TEMP/production-worker-deployment-identity.json" | awk '{print $1}')"
           candidate_cutover_observation_sha256="$(sha256sum "$RUNNER_TEMP/production-worker-candidate-cutover-observation.json" | awk '{print $1}')"
           final_routing_observation_sha256="$(sha256sum "$RUNNER_TEMP/production-worker-final-routing-observation.json" | awk '{print $1}')"
+          readiness_receipt_sha256="$(sha256sum "$RUNNER_TEMP/production-d1-readiness-receipt.json" | awk '{print $1}')"
+          preview_control_sha256="$(sha256sum "$RUNNER_TEMP/preview-control-after-production-audits.json" | awk '{print $1}')"
+          environment_isolation_sha256="$(sha256sum "$RUNNER_TEMP/final-environment-isolation-receipt.json" | awk '{print $1}')"
           printf 'edge_stabilization_sha256=%s\n' "$edge_stabilization_sha256" >> "$GITHUB_OUTPUT"
           printf 'original_language_audit_sha256=%s\n' "$original_language_audit_sha256" >> "$GITHUB_OUTPUT"
           printf 'historical_audit_sha256=%s\n' "$historical_audit_sha256" >> "$GITHUB_OUTPUT"
@@ -421,6 +523,9 @@ jobs:
           printf 'identity_record_sha256=%s\n' "$identity_sha256" >> "$GITHUB_OUTPUT"
           printf 'candidate_cutover_observation_sha256=%s\n' "$candidate_cutover_observation_sha256" >> "$GITHUB_OUTPUT"
           printf 'final_routing_observation_sha256=%s\n' "$final_routing_observation_sha256" >> "$GITHUB_OUTPUT"
+          printf 'readiness_receipt_sha256=%s\n' "$readiness_receipt_sha256" >> "$GITHUB_OUTPUT"
+          printf 'preview_control_sha256=%s\n' "$preview_control_sha256" >> "$GITHUB_OUTPUT"
+          printf 'environment_isolation_sha256=%s\n' "$environment_isolation_sha256" >> "$GITHUB_OUTPUT"
 
       - name: Upload production reconciliation evidence
         if: ${{ steps.production-audit-evidence.outcome == 'success' }}
@@ -431,6 +536,10 @@ jobs:
             ${{ runner.temp }}/production-worker-candidate-cutover-observation.json
             ${{ runner.temp }}/production-worker-candidate-cutover.json
             ${{ runner.temp }}/production-worker-final-routing-observation.json
+            ${{ runner.temp }}/preview-control-before-production.json
+            ${{ runner.temp }}/preview-control-after-production-deploy.json
+            ${{ runner.temp }}/preview-control-after-production-audits.json
+            ${{ runner.temp }}/final-environment-isolation-receipt.json
           retention-days: 30
           if-no-files-found: error
 
@@ -448,5 +557,10 @@ jobs:
             ${{ runner.temp }}/production-worker-candidate-cutover-observation.json
             ${{ runner.temp }}/production-worker-candidate-cutover.json
             ${{ runner.temp }}/production-worker-final-routing-observation.json
+            ${{ runner.temp }}/production-d1-readiness-receipt.json
+            ${{ runner.temp }}/preview-control-before-production.json
+            ${{ runner.temp }}/preview-control-after-production-deploy.json
+            ${{ runner.temp }}/preview-control-after-production-audits.json
+            ${{ runner.temp }}/final-environment-isolation-receipt.json
           retention-days: 30
           if-no-files-found: error

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -486,11 +486,10 @@ jobs:
           observed_active_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
             --deployments "$RUNNER_TEMP/production-worker-deployments-post-mutation.json")"
           npx --no-install wrangler versions view "$observed_active_version" --json > "$RUNNER_TEMP/production-worker-observed-active-version-view.json"
-          npx --no-install tsx scripts/production-release-reconciliation.ts observe-final-post-audit \
+          npx --no-install tsx scripts/production-release-reconciliation.ts observe-post-mutation \
             --predecessor-anchor "$RUNNER_TEMP/production-worker-predecessor-anchor.json" \
             --deployments "$RUNNER_TEMP/production-worker-deployments-post-mutation.json" \
             --observed-active-version-view "$RUNNER_TEMP/production-worker-observed-active-version-view.json" \
-            --production-audited-identity "$RUNNER_TEMP/production-worker-deployment-identity.json" \
             --wrangler-config wrangler.toml \
             --output "$RUNNER_TEMP/production-worker-final-routing-observation.json"
 
@@ -503,9 +502,32 @@ jobs:
           retention-days: 30
           if-no-files-found: warn
 
+      # The diagnostic observation above remains available after every attempted
+      # deploy. A successful release additionally takes a fresh, strict
+      # post-observation identity record that must match the audited Worker.
+      - name: Verify final production identity after audited release (read-only)
+        id: production-final-post-audit-identity
+        if: ${{ steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' && steps.final-environment-isolation.outcome == 'success' && steps.production-final-observation.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-worker-deployments-final-post-audit.json"
+          final_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/production-worker-deployments-final-post-audit.json")"
+          npx --no-install wrangler versions view "$final_version" --json > "$RUNNER_TEMP/production-worker-final-post-audit-version-view.json"
+          npx --no-install tsx scripts/production-release-reconciliation.ts observe-final-post-audit \
+            --predecessor-anchor "$RUNNER_TEMP/production-worker-predecessor-anchor.json" \
+            --deployments "$RUNNER_TEMP/production-worker-deployments-final-post-audit.json" \
+            --observed-active-version-view "$RUNNER_TEMP/production-worker-final-post-audit-version-view.json" \
+            --production-audited-identity "$RUNNER_TEMP/production-worker-deployment-identity.json" \
+            --wrangler-config wrangler.toml \
+            --output "$RUNNER_TEMP/production-worker-final-post-audit-identity.json"
+
       - name: Hash sanitized production audit and reconciliation evidence
         id: production-audit-evidence
-        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' && steps.final-environment-isolation.outcome == 'success' && steps.production-final-observation.outcome == 'success' }}
+        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' && steps.final-environment-isolation.outcome == 'success' && steps.production-final-observation.outcome == 'success' && steps.production-final-post-audit-identity.outcome == 'success' }}
         run: |
           edge_stabilization_sha256="$(sha256sum "$RUNNER_TEMP/production-primary-source-edge-stabilization.json" | awk '{print $1}')"
           original_language_audit_sha256="$(sha256sum "$RUNNER_TEMP/original-language-v2-production-audit.json" | awk '{print $1}')"
@@ -514,6 +536,7 @@ jobs:
           identity_sha256="$(sha256sum "$RUNNER_TEMP/production-worker-deployment-identity.json" | awk '{print $1}')"
           candidate_cutover_observation_sha256="$(sha256sum "$RUNNER_TEMP/production-worker-candidate-cutover-observation.json" | awk '{print $1}')"
           final_routing_observation_sha256="$(sha256sum "$RUNNER_TEMP/production-worker-final-routing-observation.json" | awk '{print $1}')"
+          final_post_audit_identity_sha256="$(sha256sum "$RUNNER_TEMP/production-worker-final-post-audit-identity.json" | awk '{print $1}')"
           readiness_receipt_sha256="$(sha256sum "$RUNNER_TEMP/production-d1-readiness-receipt.json" | awk '{print $1}')"
           preview_control_sha256="$(sha256sum "$RUNNER_TEMP/preview-control-after-production-audits.json" | awk '{print $1}')"
           environment_isolation_sha256="$(sha256sum "$RUNNER_TEMP/final-environment-isolation-receipt.json" | awk '{print $1}')"
@@ -525,6 +548,7 @@ jobs:
           printf 'identity_record_sha256=%s\n' "$identity_sha256" >> "$GITHUB_OUTPUT"
           printf 'candidate_cutover_observation_sha256=%s\n' "$candidate_cutover_observation_sha256" >> "$GITHUB_OUTPUT"
           printf 'final_routing_observation_sha256=%s\n' "$final_routing_observation_sha256" >> "$GITHUB_OUTPUT"
+          printf 'final_post_audit_identity_sha256=%s\n' "$final_post_audit_identity_sha256" >> "$GITHUB_OUTPUT"
           printf 'readiness_receipt_sha256=%s\n' "$readiness_receipt_sha256" >> "$GITHUB_OUTPUT"
           printf 'preview_control_sha256=%s\n' "$preview_control_sha256" >> "$GITHUB_OUTPUT"
           printf 'environment_isolation_sha256=%s\n' "$environment_isolation_sha256" >> "$GITHUB_OUTPUT"
@@ -538,6 +562,7 @@ jobs:
             ${{ runner.temp }}/production-worker-candidate-cutover-observation.json
             ${{ runner.temp }}/production-worker-candidate-cutover.json
             ${{ runner.temp }}/production-worker-final-routing-observation.json
+            ${{ runner.temp }}/production-worker-final-post-audit-identity.json
             ${{ runner.temp }}/preview-control-before-production.json
             ${{ runner.temp }}/preview-control-after-production-deploy.json
             ${{ runner.temp }}/preview-control-after-production-audits.json
@@ -559,6 +584,7 @@ jobs:
             ${{ runner.temp }}/production-worker-candidate-cutover-observation.json
             ${{ runner.temp }}/production-worker-candidate-cutover.json
             ${{ runner.temp }}/production-worker-final-routing-observation.json
+            ${{ runner.temp }}/production-worker-final-post-audit-identity.json
             ${{ runner.temp }}/production-d1-readiness-receipt.json
             ${{ runner.temp }}/preview-control-before-production.json
             ${{ runner.temp }}/preview-control-after-production-deploy.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -352,6 +352,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
         run: |
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/production-control-d1-inventory-before.json"
           npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-control-deployments-before.json"
           production_control_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
             --deployments "$RUNNER_TEMP/production-control-deployments-before.json")"
@@ -360,6 +361,8 @@ jobs:
           npx --no-install tsx scripts/production-release-reconciliation.ts capture-control \
             --deployments "$RUNNER_TEMP/production-control-deployments-before.json" \
             --active-version-view "$RUNNER_TEMP/production-control-version-before.json" \
+            --wrangler-config wrangler.toml \
+            --d1-inventory "$RUNNER_TEMP/production-control-d1-inventory-before.json" \
             --output "$RUNNER_TEMP/production-control-before.json"
 
       - name: Upload production control before preview deployment
@@ -445,6 +448,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
         run: |
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/production-control-d1-inventory-after-deploy.json"
           npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-control-deployments-after.json"
           production_control_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
             --deployments "$RUNNER_TEMP/production-control-deployments-after.json")"
@@ -454,6 +458,8 @@ jobs:
             --control "$RUNNER_TEMP/production-control-before.json" \
             --deployments "$RUNNER_TEMP/production-control-deployments-after.json" \
             --active-version-view "$RUNNER_TEMP/production-control-version-after.json" \
+            --wrangler-config wrangler.toml \
+            --d1-inventory "$RUNNER_TEMP/production-control-d1-inventory-after-deploy.json" \
             --output "$RUNNER_TEMP/production-control-after.json"
 
       # Do this before either fixed black-box audit: a deployed Worker must be
@@ -595,20 +601,47 @@ jobs:
             --output "$RUNNER_TEMP/preview-worker-deployment-identity.json" \
             --github-output "$GITHUB_OUTPUT"
 
+      # Re-prove the fixed production control after all preview probes and the
+      # final preview Worker identity check. This remains read-only and catches
+      # a production change that happened during the black-box audit window.
+      - name: Verify production control remained unchanged after preview audits (read-only)
+        id: production-control-post-audit
+        if: ${{ steps.preview-primary-source-edge-stabilization-gate.outcome == 'success' && steps.preview-original-language-v2-audit.outcome == 'success' && steps.preview-historical-core-audit.outcome == 'success' && steps.preview-historical-spine-audit.outcome == 'success' && steps.preview-worker-audit-identity.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/production-control-d1-inventory-post-audit.json"
+          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-control-deployments-post-audit.json"
+          production_control_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/production-control-deployments-post-audit.json")"
+          npx --no-install wrangler versions view "$production_control_version" --json \
+            > "$RUNNER_TEMP/production-control-version-post-audit.json"
+          npx --no-install tsx scripts/production-release-reconciliation.ts verify-control \
+            --control "$RUNNER_TEMP/production-control-before.json" \
+            --deployments "$RUNNER_TEMP/production-control-deployments-post-audit.json" \
+            --active-version-view "$RUNNER_TEMP/production-control-version-post-audit.json" \
+            --wrangler-config wrangler.toml \
+            --d1-inventory "$RUNNER_TEMP/production-control-d1-inventory-post-audit.json" \
+            --output "$RUNNER_TEMP/production-control-post-audit.json"
+
       - name: Hash sanitized preview audit evidence
         id: preview-audit-evidence
-        if: ${{ steps.preview-primary-source-edge-stabilization-gate.outcome == 'success' && steps.preview-original-language-v2-audit.outcome == 'success' && steps.preview-historical-core-audit.outcome == 'success' && steps.preview-historical-spine-audit.outcome == 'success' && steps.preview-worker-audit-identity.outcome == 'success' }}
+        if: ${{ steps.production-control-post-audit.outcome == 'success' }}
         run: |
           edge_stabilization_sha256="$(sha256sum "$RUNNER_TEMP/preview-primary-source-edge-stabilization.json" | awk '{print $1}')"
           original_language_audit_sha256="$(sha256sum "$RUNNER_TEMP/original-language-v2-preview-audit.json" | awk '{print $1}')"
           historical_audit_sha256="$(sha256sum "$RUNNER_TEMP/historical-core-preview-audit.json" | awk '{print $1}')"
           historical_spine_audit_sha256="$(sha256sum "$RUNNER_TEMP/historical-spine-preview-audit.json" | awk '{print $1}')"
           identity_sha256="$(sha256sum "$RUNNER_TEMP/preview-worker-deployment-identity.json" | awk '{print $1}')"
+          production_control_post_audit_sha256="$(sha256sum "$RUNNER_TEMP/production-control-post-audit.json" | awk '{print $1}')"
           printf 'edge_stabilization_sha256=%s\n' "$edge_stabilization_sha256" >> "$GITHUB_OUTPUT"
           printf 'original_language_audit_sha256=%s\n' "$original_language_audit_sha256" >> "$GITHUB_OUTPUT"
           printf 'historical_audit_sha256=%s\n' "$historical_audit_sha256" >> "$GITHUB_OUTPUT"
           printf 'historical_spine_audit_sha256=%s\n' "$historical_spine_audit_sha256" >> "$GITHUB_OUTPUT"
           printf 'identity_record_sha256=%s\n' "$identity_sha256" >> "$GITHUB_OUTPUT"
+          printf 'production_control_post_audit_sha256=%s\n' "$production_control_post_audit_sha256" >> "$GITHUB_OUTPUT"
 
       - name: Upload protected preview audit evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -625,6 +658,7 @@ jobs:
             ${{ runner.temp }}/preview-d1-readiness-receipt.json
             ${{ runner.temp }}/production-control-before.json
             ${{ runner.temp }}/production-control-after.json
+            ${{ runner.temp }}/production-control-post-audit.json
           retention-days: 7
           if-no-files-found: error
 
@@ -652,6 +686,7 @@ jobs:
           ORIGINAL_LANGUAGE_AUDIT_SHA256: ${{ steps.preview-audit-evidence.outputs.original_language_audit_sha256 }}
           HISTORICAL_AUDIT_SHA256: ${{ steps.preview-audit-evidence.outputs.historical_audit_sha256 }}
           HISTORICAL_SPINE_AUDIT_SHA256: ${{ steps.preview-audit-evidence.outputs.historical_spine_audit_sha256 }}
+          PRODUCTION_CONTROL_POST_AUDIT_SHA256: ${{ steps.preview-audit-evidence.outputs.production_control_post_audit_sha256 }}
           CANDIDATE_CUTOVER_OBSERVATION_SHA256: ${{ steps.preview-reconciliation-evidence.outputs.candidate_cutover_observation_sha256 }}
           POST_MUTATION_RECONCILIATION_SHA256: ${{ steps.preview-reconciliation-evidence.outputs.post_mutation_reconciliation_sha256 }}
           AUDIT_ARTIFACT: preview-release-audit-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
@@ -666,6 +701,7 @@ jobs:
             const originalLanguageAudit = process.env.ORIGINAL_LANGUAGE_AUDIT_SHA256;
             const historicalAudit = process.env.HISTORICAL_AUDIT_SHA256;
             const historicalSpineAudit = process.env.HISTORICAL_SPINE_AUDIT_SHA256;
+            const productionControlPostAudit = process.env.PRODUCTION_CONTROL_POST_AUDIT_SHA256;
             const candidateCutoverObservation = process.env.CANDIDATE_CUTOVER_OBSERVATION_SHA256;
             const postMutationReconciliation = process.env.POST_MUTATION_RECONCILIATION_SHA256;
             const artifact = process.env.AUDIT_ARTIFACT;
@@ -674,7 +710,8 @@ jobs:
               || !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(deployment)
               || !/^[0-9a-f]{64}$/i.test(workerIdentity) || !/^[0-9a-f]{64}$/i.test(edgeStabilization)
               || !/^[0-9a-f]{64}$/i.test(originalLanguageAudit)
-              || !/^[0-9a-f]{64}$/i.test(historicalAudit) || !/^[0-9a-f]{64}$/i.test(historicalSpineAudit) || !/^[0-9a-f]{64}$/i.test(candidateCutoverObservation)
+              || !/^[0-9a-f]{64}$/i.test(historicalAudit) || !/^[0-9a-f]{64}$/i.test(historicalSpineAudit)
+              || !/^[0-9a-f]{64}$/i.test(productionControlPostAudit) || !/^[0-9a-f]{64}$/i.test(candidateCutoverObservation)
               || !/^[0-9a-f]{64}$/i.test(postMutationReconciliation)
               || !/^preview-release-audit-\d+-[0-9a-f]{40}$/i.test(artifact)) {
               core.setFailed('Preview release evidence is missing or malformed.');
@@ -690,7 +727,7 @@ jobs:
               '',
               `Deployed from checked-out commit \`${commit}\` (tree \`${tree}\`).`,
               `Cloudflare confirms Worker version \`${workerVersion}\` at 100% in deployment \`${deployment}\`.`,
-              `Edge-stabilization SHA-256: \`${edgeStabilization}\`; original-language audit SHA-256: \`${originalLanguageAudit}\`; historical-core audit SHA-256: \`${historicalAudit}\`; Transform-11 historical-spine audit SHA-256: \`${historicalSpineAudit}\`; identity record SHA-256: \`${workerIdentity}\`; candidate-cutover observation SHA-256: \`${candidateCutoverObservation}\`; post-mutation reconciliation SHA-256: \`${postMutationReconciliation}\`; retained artifact: \`${artifact}\` (7 days).`,
+              `Edge-stabilization SHA-256: \`${edgeStabilization}\`; original-language audit SHA-256: \`${originalLanguageAudit}\`; historical-core audit SHA-256: \`${historicalAudit}\`; Transform-11 historical-spine audit SHA-256: \`${historicalSpineAudit}\`; identity record SHA-256: \`${workerIdentity}\`; post-audit production-control SHA-256: \`${productionControlPostAudit}\`; candidate-cutover observation SHA-256: \`${candidateCutoverObservation}\`; post-mutation reconciliation SHA-256: \`${postMutationReconciliation}\`; retained artifact: \`${artifact}\` (7 days).`,
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -298,10 +298,19 @@ jobs:
       - name: Verify candidate preview D1 is compatible (read-only)
         run: |
           candidate_d1_name="$(< "$RUNNER_TEMP/preview-candidate-d1-name.txt")"
-          npm run d1:remote:check -- --database "$candidate_d1_name" --env preview
+          npm run d1:remote:check -- --database "$candidate_d1_name" --env preview \
+            --output "$RUNNER_TEMP/preview-d1-readiness-receipt.json"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Upload sanitized preview D1 readiness receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-d1-readiness-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: ${{ runner.temp }}/preview-d1-readiness-receipt.json
+          retention-days: 7
+          if-no-files-found: error
 
       # This is evidence only. It cannot deploy, roll back, bind, seed, or
       # delete; a later failure/revocation still leaves a manual recovery path.
@@ -330,6 +339,34 @@ jobs:
         with:
           name: preview-release-predecessor-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           path: ${{ runner.temp }}/preview-worker-predecessor-anchor.json
+          retention-days: 7
+          if-no-files-found: error
+
+      # An ordinary preview release may not change production. Capture a fixed
+      # read-only production control before the preview mutation and compare it
+      # again after deployment, before any preview audit can begin.
+      - name: Capture production control before preview deployment (read-only)
+        id: production-control-before
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-control-deployments-before.json"
+          production_control_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/production-control-deployments-before.json")"
+          npx --no-install wrangler versions view "$production_control_version" --json \
+            > "$RUNNER_TEMP/production-control-version-before.json"
+          npx --no-install tsx scripts/production-release-reconciliation.ts capture-control \
+            --deployments "$RUNNER_TEMP/production-control-deployments-before.json" \
+            --active-version-view "$RUNNER_TEMP/production-control-version-before.json" \
+            --output "$RUNNER_TEMP/production-control-before.json"
+
+      - name: Upload production control before preview deployment
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preview-production-control-before-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: ${{ runner.temp }}/production-control-before.json
           retention-days: 7
           if-no-files-found: error
 
@@ -400,10 +437,30 @@ jobs:
             --output "$RUNNER_TEMP/preview-worker-deployment-pre-audit-identity.json" \
             --github-output "$GITHUB_OUTPUT"
 
+      - name: Verify production control remained unchanged (read-only)
+        id: production-control-after
+        if: ${{ always() && steps.preview-worker-deploy.outcome == 'success' && steps.production-control-before.outcome == 'success' }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-control-deployments-after.json"
+          production_control_version="$(npx --no-install tsx scripts/production-release-reconciliation.ts active-version-id \
+            --deployments "$RUNNER_TEMP/production-control-deployments-after.json")"
+          npx --no-install wrangler versions view "$production_control_version" --json \
+            > "$RUNNER_TEMP/production-control-version-after.json"
+          npx --no-install tsx scripts/production-release-reconciliation.ts verify-control \
+            --control "$RUNNER_TEMP/production-control-before.json" \
+            --deployments "$RUNNER_TEMP/production-control-deployments-after.json" \
+            --active-version-view "$RUNNER_TEMP/production-control-version-after.json" \
+            --output "$RUNNER_TEMP/production-control-after.json"
+
       # Do this before either fixed black-box audit: a deployed Worker must be
       # both sole-active and bound to the readiness-tested candidate D1.
       - name: Require deployed candidate preview D1 binding (read-only)
         id: preview-worker-candidate-cutover
+        if: ${{ steps.production-control-after.outcome == 'success' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -429,7 +486,7 @@ jobs:
       # The observation is create-only and deliberately retained even when
       # the following strict candidate-binding gate fails before any audit.
       - name: Upload preview candidate cutover observation
-        if: ${{ always() && steps.preview-worker-deploy.outcome == 'success' && steps.preview-predecessor.outcome == 'success' }}
+        if: ${{ always() && steps.preview-worker-deploy.outcome == 'success' && steps.preview-predecessor.outcome == 'success' && steps.preview-worker-candidate-cutover.outcome != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: preview-candidate-cutover-observation-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
@@ -565,6 +622,9 @@ jobs:
             ${{ runner.temp }}/preview-worker-deployment-identity.json
             ${{ runner.temp }}/preview-worker-candidate-cutover-observation.json
             ${{ runner.temp }}/preview-worker-candidate-cutover.json
+            ${{ runner.temp }}/preview-d1-readiness-receipt.json
+            ${{ runner.temp }}/production-control-before.json
+            ${{ runner.temp }}/production-control-after.json
           retention-days: 7
           if-no-files-found: error
 

--- a/README.md
+++ b/README.md
@@ -206,16 +206,25 @@ remains a historical acquisition-gate snapshot, not deployment evidence.
 Production v6/local-only and preview v7/discovery-only remain deployed with
 CCEL execution disabled before adapter, coordinator, or fetch.
 
-### Schema-0009 preview release pre-state
+### Schema-0009 preview release state
 
-This checked-out release commit targets only the prepared preview D1
+The protected release targeted the prepared preview D1
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`). It is not itself a Cloudflare
-binding or deployment claim: the protected preview workflow must re-check the
-candidate, deploy it, prove the active preview binding, and complete its audit.
-It validates the fixed production control against the checked-in production D1
-name/UUID and fresh inventory before deployment, immediately afterward, and
-again after the final preview audit.
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). The workflow re-checked the
+candidate, deployed it, proved the active preview binding, and completed its
+audit. It validated the fixed production control against the checked-in
+production D1 name/UUID and fresh inventory before deployment, immediately
+afterward, and again after the final preview audit.
+PR #122 has now completed that protected preview release: source
+`a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree
+`660c06ff31e7d0e2ccbc6fe12204e66c4e793233`) is served solely by preview
+Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` on deployment
+`13393917-fa91-4afc-aeaf-2809db6701a2`; all fixed audits and three production
+control observations passed. The authorization label was removed and revocation
+run `31572924302` succeeded. The detailed sanitized evidence is in
+[docs/PREVIEW-RELEASE-RECONCILIATION.md](docs/PREVIEW-RELEASE-RECONCILIATION.md).
+This evidence-only commit postdates the deployed source and makes no new
+runtime claim.
 Production remains configured and live on schema-`0008`
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`); its separately prepared schema-`0009`

--- a/README.md
+++ b/README.md
@@ -220,12 +220,14 @@ run `31572924302` succeeded. The detailed sanitized evidence is in
 [docs/PREVIEW-RELEASE-RECONCILIATION.md](docs/PREVIEW-RELEASE-RECONCILIATION.md).
 This evidence-only commit postdates the deployed source and makes no new
 runtime claim.
-Production remains configured and live on schema-`0008`
-`theologai-production-20260729-transform11-a`
-(`53211f50-a893-4b4c-be1e-bc625a595dc7`); its separately prepared schema-`0009`
-candidate is `9bc79346-338b-439e-a2a5-424f4418eb21` and remains unbound. The
-CCEL canary gate remains unrecorded and inert. The exact preparation identity,
-seed evidence, and release boundary are recorded in
+The checked-in production release target is the separately prepared schema-`0009`
+candidate `theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). It remains unbound until the
+protected production workflow proves readiness, the exact active binding,
+post-audit preview control, and final environment isolation. Live production
+remains on its recorded schema-`0008` predecessor until then. The CCEL canary
+gate remains unrecorded and inert. The exact preparation identity, seed
+evidence, and release boundary are recorded in
 [docs/D1-DATA-WORKFLOW.md](docs/D1-DATA-WORKFLOW.md).
 
 ## MCP capabilities

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ This checked-out release commit targets only the prepared preview D1
 (`74f456e2-6951-4003-bb6f-91951342bf8f`). It is not itself a Cloudflare
 binding or deployment claim: the protected preview workflow must re-check the
 candidate, deploy it, prove the active preview binding, and complete its audit.
+It validates the fixed production control against the checked-in production D1
+name/UUID and fresh inventory before deployment, immediately afterward, and
+again after the final preview audit.
 Production remains configured and live on schema-`0008`
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`); its separately prepared schema-`0009`

--- a/README.md
+++ b/README.md
@@ -196,15 +196,30 @@ For a preview-client rollback without changing server state, use the direct prev
 redirects rather than serving a separate legacy Worker.
 
 The deployed preview and production D1 layers remain schema `0008`; current
-main's PR #117 schema `0009` Candidate-C contract is checked out only and has
-no prepared, bound, or deployed remote-D1 claim. Earlier local-only and
-preview-only activation statements are historical. PR #101 bound the separate
+main's PR #117 schema `0009` Candidate-C contract has prepared, unbound
+candidates but makes no bound or deployed remote-D1 claim. Earlier local-only
+and preview-only activation statements are historical. PR #101 bound the separate
 preview and production D1 databases recorded above. The historical PR #96 public
 `original_language_study` v2 audit does not independently establish the runtime
 path for every later historical transform. The pinned packet's `SOURCE.json`
 remains a historical acquisition-gate snapshot, not deployment evidence.
 Production v6/local-only and preview v7/discovery-only remain deployed with
 CCEL execution disabled before adapter, coordinator, or fetch.
+
+### Schema-0009 preview release pre-state
+
+This checked-out release commit targets only the prepared preview D1
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). It is not itself a Cloudflare
+binding or deployment claim: the protected preview workflow must re-check the
+candidate, deploy it, prove the active preview binding, and complete its audit.
+Production remains configured and live on schema-`0008`
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`); its separately prepared schema-`0009`
+candidate is `9bc79346-338b-439e-a2a5-424f4418eb21` and remains unbound. The
+CCEL canary gate remains unrecorded and inert. The exact preparation identity,
+seed evidence, and release boundary are recorded in
+[docs/D1-DATA-WORKFLOW.md](docs/D1-DATA-WORKFLOW.md).
 
 ## MCP capabilities
 

--- a/README.md
+++ b/README.md
@@ -141,23 +141,20 @@ applied the exact reviewed 49-file, 1,630,259-row seed with corpus identity
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and the complete
 Transform-11 source-pack authority audit (`1/1/1/1/1/1/133/17` pages) passed.
-Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550` now
-serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact
-D1. Production was unchanged by that preview release. Transform-10 hierarchy,
+Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550`
+historically served Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) with
+that exact D1 and is the immediate predecessor to PR #122. Production was
+unchanged by that preview release. Transform-10 hierarchy,
 publication, and Aquinas material remain excluded.
 
-This active PR #107 preview Worker predates PR #115's repository-only,
+That historical PR #107 preview Worker predates PR #115's repository-only,
 unpublished pin to `https://www.ccel.org/home3/search`. It is not a valid
 code/resource-equivalent `100` predecessor for a `111` canary built from
-current `main`. Current `main` also includes PR #117's Transform-12 schema
-`0009` contract, while the retained PR #107/PR #108 D1 records are schema
-`0008`. Before credential staging, separately authorized fresh schema-`0009`
-preview and production D1 preparation and remote readiness/authority audit are
-required while both candidates remain unbound. The reviewed release sequence is
-then preview bind/deploy/audit, production bind/deploy/audit, and read-only
-environment-isolation verification. The preview release is the sole safe
-current-main `100` refresh; it is not repeated later. Those D1 gates do not
-authorize credential work or the canary; see the
+current `main`. PR #122 has since completed the schema-`0009` preview
+bind/deploy/audit stage. The separately prepared schema-`0009` production
+candidate remains unbound; production bind/deploy/audit and read-only
+environment-isolation verification remain separately gated. Completion of the
+preview stage does not authorize credential work or the canary; see the
 [CCEL canary transaction](docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md).
 
 PR #101's former production assignment, retained as the rollback pair, is
@@ -195,11 +192,9 @@ For a preview-client rollback without changing server state, use the direct prev
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
 
-The deployed preview and production D1 layers remain schema `0008`; current
-main's PR #117 schema `0009` Candidate-C contract has prepared, unbound
-candidates but makes no bound or deployed remote-D1 claim. Earlier local-only
-and preview-only activation statements are historical. PR #101 bound the separate
-preview and production D1 databases recorded above. The historical PR #96 public
+Production remains on schema `0008`; preview now uses the audited PR #122
+schema-`0009` Candidate-C D1. Earlier local-only and preview-only activation
+statements are historical. The historical PR #96 public
 `original_language_study` v2 audit does not independently establish the runtime
 path for every later historical transform. The pinned packet's `SOURCE.json`
 remains a historical acquisition-gate snapshot, not deployment evidence.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ bound to D1 `theologai-production-20260729-transform11-a`
 8/8, the Transform-11 spine audit passed 10/10, the original-language audit
 passed 11/11, primary-source edge stabilization matched on attempt 4 and
 remained stable, and the independent post-release review returned `SHIP`.
-The PR #101 production assignment is retained as the matched rollback pair.
+For this schema-`0009` cutover, the exact captured PR #108 Worker/D1 pair
+above is the immediately preceding primary rollback unit. PR #101 is older
+retained rollback history, not the immediate rollback claim.
 
 The historical PR #96 `original_language_study` schema-v2 audit passed 11/11
 cases.
@@ -157,7 +159,7 @@ environment-isolation verification remain separately gated. Completion of the
 preview stage does not authorize credential work or the canary; see the
 [CCEL canary transaction](docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md).
 
-PR #101's former production assignment, retained as the rollback pair, is
+PR #101's former production assignment is older retained rollback history:
 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
@@ -187,7 +189,9 @@ Protected workflow `30496350408` then deployed
 Historical core passed 8/8, Transform-11 spine passed 10/10,
 `original_language_study` passed 11/11, primary-source edge stabilization
 matched on attempt 4 and remained stable, and independent post-release review
-returned `SHIP`. The PR #101 Worker/D1 pair above remains the rollback record.
+returned `SHIP`. The exact PR #108 Worker/D1 pair above is the primary
+immediate rollback unit for this schema-`0009` cutover; PR #101 remains older
+retained rollback history only.
 For a preview-client rollback without changing server state, use the direct preview
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -79,6 +79,13 @@ schema-`0008` D1 name or UUID regardless of pairing, any shared
 preview/production identity, and any mismatch between those reviewed D1 pairs
 and committed configuration.
 
+PR #122 completed the one approved schema-`0009` preview bind/deploy/audit
+stage with its production control unchanged; its release evidence is recorded
+in `PREVIEW-RELEASE-RECONCILIATION.md`. That completion does not authorize the
+production candidate (still unbound), credential staging, or this canary. The
+gate remains `unrecorded` and inert, and the release made no CCEL request or
+secret change.
+
 The only way to create the third row is the main-only, manually dispatched
 `CCEL Live Preview Canary` workflow. It requires all of the following:
 

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -65,8 +65,9 @@ or the canary.
 The schema-`0009` candidates now have retained unbound preparation evidence:
 the checked-in preview release target is
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`), and the production candidate
-`9bc79346-338b-439e-a2a5-424f4418eb21` remains unbound. This does not make the
+(`74f456e2-6951-4003-bb6f-91951342bf8f`), and the checked-in production target
+`theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`) remains unbound. This does not make the
 canary ready. Until a separate reviewed release replaces the hard inert
 schema-`0009` canary gate, the canary workflow rejects both retained schema-`0008`
 D1 identities during its first local validation, before any Wrangler command or

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -17,17 +17,18 @@ Tracked `wrangler.toml` is always the safe baseline:
 | Preview | 1 | 0 | 0 | v7 discovery-contract baseline |
 | Ephemeral canary | 1 | 1 | 1 | preview-only audit candidate; never committed |
 
-The active PR #107 preview Worker
+The retained historical PR #107 preview Worker
 `06b9a603-8339-42b6-a246-ef9238563043` predates PR #115's repository-only,
 unpublished pin to `https://www.ccel.org/home3/search`. It remains valid
-point-in-time evidence, but it is not a code/resource-equivalent `100`
-predecessor for a `111` candidate built from current `main`. The exact-delta
-validator would correctly reject that pairing.
+point-in-time predecessor evidence, but it is no longer active. PR #122's
+schema-`0009` Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` is the audited
+current preview `100` baseline.
 
 Current `main` also includes PR #117's Transform-12 schema `0009` contract.
 The retained PR #107 preview and PR #108 production D1 records were prepared
-against schema `0008`; neither is a current-main-compatible D1 baseline. The
-historical `0008` readiness records remain evidence for those releases only.
+against schema `0008`. PR #107 is predecessor evidence only; PR #108 remains
+the live production control. The historical `0008` readiness records remain
+evidence for those releases only.
 
 Operational readiness therefore has five separately authorized stages, in this
 order:
@@ -38,7 +39,7 @@ order:
    schema/seed **while both candidates remain unbound**. Failure or missing
    evidence is a stop condition; do not reuse, repair, or bind a failed
    candidate.
-2. Through a separately approved preview release, bind and deploy the exact
+2. **Completed by PR #122:** through a separately approved preview release, bind and deploy the exact
    prepared preview candidate with current-`main` `100` flags, then complete
    its protected preview audit. This one release creates the exact-current-main,
    code/resource-equivalent preview predecessor for the later `111` candidate;

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -61,14 +61,18 @@ environment binding; the preview audit does not authorize the production release
 and the completed releases/isolation evidence do not authorize credential staging
 or the canary.
 
-The repository currently records neither schema-`0009` candidate identity nor
-its readiness/authority evidence. Until a separate reviewed release replaces the
-hard inert schema-`0009` canary gate, the canary workflow rejects both retained
-schema-`0008` D1 identities during its first local validation, before any
-Wrangler command or Cloudflare read. Changing only a D1 ID is insufficient: the
-future change must replace the `unrecorded` gate with a reviewed `ready` record
-for each environment: exact D1 name/UUID plus separately pinned readiness and
-authority evidence identities and SHA-256 values, plus one separately pinned
+The schema-`0009` candidates now have retained unbound preparation evidence:
+the checked-in preview release target is
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`), and the production candidate
+`9bc79346-338b-439e-a2a5-424f4418eb21` remains unbound. This does not make the
+canary ready. Until a separate reviewed release replaces the hard inert
+schema-`0009` canary gate, the canary workflow rejects both retained schema-`0008`
+D1 identities during its first local validation, before any Wrangler command or
+Cloudflare read. Changing only a D1 ID is insufficient: the future change must
+replace the `unrecorded` gate with a reviewed `ready` record for each
+environment: exact D1 name/UUID plus separately pinned readiness and authority
+evidence identities and SHA-256 values, plus one separately pinned
 environment-isolation evidence identity and SHA-256. The local validator rejects
 unknown or incomplete `ready` records, malformed evidence, any recorded
 schema-`0008` D1 name or UUID regardless of pairing, any shared

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -337,8 +337,8 @@ This preparer does not change `wrangler.toml`, a Worker binding, deployment,
 or database inventory. It does mutate only the separately named, unbound
 production candidate corpus: migrations and deterministic seed files are
 applied there after the pristine-target guard passes. It never mutates the
-active/bound production corpus. The PR #101 candidate, now the retained
-production rollback,
+active/bound production corpus. The PR #101 candidate is older retained
+rollback history:
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`) was unbound when its one-use operation
 completed with 49/49 seed files, 1,627,474 rows, schema `0008`, corpus identity

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -353,7 +353,7 @@ audits. That PR #101 production assignment—deployment
 `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
-(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`)—is now the matched rollback pair.
+(`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`)—is older retained rollback history.
 The retained PR #101 preview
 predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -384,7 +384,7 @@ resumed, or repaired. Protected preview deployment
 `06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact D1; this preview
 assignment remained unchanged during the later PR #108 production release.
 
-The checked-in root production binding selected the separately prepared,
+The historical checked-in root production binding selected the separately prepared,
 initially unbound Transform-11 candidate
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). It was created once in ENAM from
@@ -403,6 +403,15 @@ Historical core passed 8/8, Transform-11 spine passed 10/10,
 original-language passed 11/11, primary-source edge stabilization matched on
 attempt 4 and remained stable, and independent post-release review returned
 `SHIP`. Retain the PR #101 matched Worker/D1 pair above for rollback.
+
+The next checked-in production target is the separately prepared schema-`0009`
+candidate `theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). This local configuration change makes
+no remote binding or deployment claim. Before a protected production deployment,
+the workflow must emit a sanitized readiness receipt; then it must prove the
+preview control unchanged before deployment, after deployment, and after every
+production audit, followed by a final receipt proving the distinct exact
+schema-`0009` preview/production bindings against fresh inventory.
 
 Approved deploy jobs perform the last compatibility check read-only against
 the candidate name resolved from the checked-in name/UUID pair:

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -358,11 +358,12 @@ The retained PR #101 preview
 predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is
-deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
-`06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
-`theologai-preview-20260728-transform11-a`
-(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). The checked-out Transform-10 Aquinas
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). That former Transform-11 preview
+binding is historical. The current preview baseline is PR #122 deployment
+`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe`, and schema-`0009` D1
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). The checked-out Transform-10 Aquinas
 hierarchy remains local-only and unpublished, with no catalog, runtime, or MCP
 projection. Future production workflows retain the same reconciliation
 contract: re-resolve the checked-in candidate name/UUID, rerun readiness by
@@ -402,7 +403,13 @@ Protected workflow `30496350408` later deployed merge
 Historical core passed 8/8, Transform-11 spine passed 10/10,
 original-language passed 11/11, primary-source edge stabilization matched on
 attempt 4 and remained stable, and independent post-release review returned
-`SHIP`. Retain the PR #101 matched Worker/D1 pair above for rollback.
+`SHIP`. For this schema-`0009` cutover, the exact PR #108 pair is the
+immediately preceding primary rollback unit: deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). PR #101 remains older rollback
+history only and is not the immediate cutover rollback claim.
 
 The next checked-in production target is the separately prepared schema-`0009`
 candidate `theologai-production-20260811-schema0009-a`

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -179,8 +179,9 @@ deploy either Worker, change the root production binding, or activate the
 production candidate. Its protected preview workflow writes a minimal
 sanitized readiness receipt with independently hashable readiness and authority
 outcomes, then captures and compares production deployment, Worker, and D1
-identities around the preview mutation. Any production identity drift fails the
-preview release before black-box audits.
+identities against the checked-in production D1 name/UUID and fresh inventory.
+It re-proves that control immediately after deployment and after the final
+preview audit; any drift blocks release evidence.
 
 ## Optional local D1 rehearsal
 

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -151,6 +151,37 @@ read-only inventory/check. If retention or compatibility has not been verified,
 document the target as candidate/unverified. Database deletion remains a later,
 separately authorized operation after the retention window and rollback review.
 
+### Schema-0009 preview-release preparation record
+
+The reviewed pre-release baseline is commit
+`e1baa04fecbb066860d06f262142e3450823b7d0`, tree
+`673af4a75c770c541a8be3c84e77d8f91033bd07`. Both schema-`0009` candidates
+were prepared and audited while unbound. The preview candidate is
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`); the separately prepared production
+candidate is `9bc79346-338b-439e-a2a5-424f4418eb21` and is not this release's
+binding target.
+
+The deterministic seed identity was manifest
+`ecbd23bb3c692665c7031a8c1fa7733e17a56fbc7e3a167ba4011f6c1cca62d8`, sourced
+from data manifest `14e30a32f316f1c7a954a9641f7d1b8bd6608d8e0f4bdc2eaba4c565f472f83d`,
+with D1 materialization identity
+`66c148a206b9b0eb1bf7552572570c42dabfd0ba591b63e0cf0d02adda35aa07` and
+migration-`0009` identity
+`989dd945ac633ecb1ba83cc80a1b88234cac31d78b3d905ae0242eb66c533eb3`. It
+contained 49 ordered files, 1,630,260 rows, and 177,923,082 bytes. Each
+candidate passed the read-only readiness plus Transform-8 and Transform-9
+authority audits with 60 tables, 307,617,792 bytes, 35 documents, 4,111
+sections, zero `historical_sectioned_publications` rows, and one corpus seal.
+
+This commit changes only the checked-in preview binding. It does not bind or
+deploy either Worker, change the root production binding, or activate the
+production candidate. Its protected preview workflow writes a minimal
+sanitized readiness receipt with independently hashable readiness and authority
+outcomes, then captures and compares production deployment, Worker, and D1
+identities around the preview mutation. Any production identity drift fails the
+preview release before black-box audits.
+
 ## Optional local D1 rehearsal
 
 Wrangler defaults D1 commands to local state, but specify `--local` explicitly

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -9,7 +9,51 @@ The record intentionally distinguishes two D1 identities:
 
 The generic release workflow permits both code-only releases (`d1Changed: false`) and data cutovers (`d1Changed: true`); it never infers freshness from a different ID alone. Wrangler 4.107.0’s D1 binding response is accepted only when the sole `THEOLOGAI_DB` binding has canonical UUID `id` and `database_id` fields that agree exactly. After deployment, the sole active Worker version must bind the candidate ID before either fixed audit begins; a retained-old-D1 deployment is refused even if its Worker version otherwise looks new.
 
-The schema-`0009` preview release pre-state targets
+## PR #122 schema-0009 preview release — passed
+
+The protected preview release deployed source
+`a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree
+`660c06ff31e7d0e2ccbc6fe12204e66c4e793233`) through Actions run
+`31568581322` and GitHub deployment `5864161923`. Cloudflare deployment
+`13393917-fa91-4afc-aeaf-2809db6701a2` now serves Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142) as the sole 100% preview
+assignment, bound to `theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). Its retained predecessor is
+deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
+`06b9a603-8339-42b6-a246-ef9238563043`, and D1
+`theologai-preview-20260728-transform11-a`
+(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`).
+
+Edge stabilization, original-language v2, historical core, and the complete
+Transform-11 spine passed. Their sanitized evidence SHA-256 values are,
+respectively, `efa907bc99f05d4a9bbc7800caa3502f52774101bd131a01fb53ec588d98f49d`,
+`9d3f0fe27f3129f0955d42ddcd5aebd9f8d89de96a752a14eeff3418d9031651`,
+`7832ff8e6cff3492664ada1851e01536e1897226720c9e1e9bec6bc4f6af2ad6`, and
+`bd2851f4623ea2e919d2296986e862bab8fd0e316e027f31e0cc3324a723602e`.
+The final preview identity hash is
+`6c3b717562c8fc2bcb8c5f5374a0827bba2391ee105d86ed1d492a3e8bef5a82`;
+the readiness receipt hash is
+`24e6cf53ac8de7d2e17903faf56a145d8dd7ef7c49b27e628878353484cfaee2`;
+and the candidate reconciliation hash is
+`2765288114abf37b3ea78879d5e62e3e6df44dd3d10af466bd5ed65286d1b557`.
+
+The pre-deploy, immediate post-deploy, and post-audit controls proved production
+unchanged at deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). The final production-control hash is
+`481900a3eec516fe06d3252175b63e318783c7230f70311235e4a1dd73198889`.
+The `deploy-preview` label was removed immediately afterward; Preview Revocation
+run `31572924302` passed and the PR remains open and unmerged. The separately
+prepared production candidate `9bc79346-338b-439e-a2a5-424f4418eb21` remains
+unbound. The schema-0009 canary gate remains `unrecorded` and inert; no CCEL
+request, credential staging, canary, or production mutation was authorized.
+This evidence-only documentation commit postdates the deployed head. It does
+not claim that a later documentation commit was deployed.
+
+### Pre-release record
+
+The schema-`0009` preview release pre-state targeted
 `theologai-preview-20260811-schema0009-a`
 (`74f456e2-6951-4003-bb6f-91951342bf8f`) in checked-in configuration only.
 It has no live binding or deployment claim until this protected workflow passes.

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -123,20 +123,18 @@ Transform-11 authority read; an explicitly authorized read-only rerun then
 passed primary readiness, Transform-8 (`1/12/12` pages), and the complete
 Transform-11 audit (`1/1/1/1/1/1/133/17` pages). No seed, migration, repair, or
 resume was repeated. The candidate was unbound during that preparation.
-Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550` now
-serves PR #107 head `1105b75cd8537632bdb20e598092f6ba94a6adc0` as Worker
-`06b9a603-8339-42b6-a246-ef9238563043` (#140), the sole active preview
-assignment bound to that exact candidate D1. It remains v7/discovery-only with
-CCEL execution disabled before adapter, coordinator, or fetch. Production
-remains unchanged.
+Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550`
+historically served PR #107 head `1105b75cd8537632bdb20e598092f6ba94a6adc0` as
+Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140), bound to that exact
+candidate D1. It is PR #122's retained immediate predecessor, not the current
+preview assignment.
 
-That active PR #107 Worker predates PR #115's repository-only, unpublished
+That historical PR #107 Worker predates PR #115's repository-only, unpublished
 change pinning the candidate CCEL endpoint to
 `https://www.ccel.org/home3/search`. It is not a code/resource-equivalent `100`
-predecessor for a `111` canary built from current `main`. Before any canary is
-authorized, a separate protected preview release must safely refresh exact
-current-`main` code and resources with the `100` flags and pass its preview
-audit. That refresh does not authorize credential provisioning or the canary.
+predecessor for a `111` canary built from current `main`. PR #122 completed the
+required current-main schema-`0009` preview refresh and audit. That completion
+does not authorize production release, credential provisioning, or the canary.
 
 At the reconciliation cutoff immediately after PR #113, `main` was
 `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
@@ -149,8 +147,10 @@ provisional Norton capacity evidence that remains subject to local and release
 gates. Production runs for PRs #109–#113 were cancelled and preview jobs
 skipped, so they make no runtime, Worker, deployment, binding, remote-D1, or
 corpus claim.
-Preview therefore remains the PR #107 assignment above. Production remains PR
-#108 merge `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`, deployment
+At that cutoff, preview remained the PR #107 assignment above; PR #122 has
+since superseded it with the audited schema-`0009` preview assignment. CCEL
+execution remains disabled before adapter, coordinator, or fetch. Production
+remains PR #108 merge `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`, deployment
 `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
 `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
 `53211f50-a893-4b4c-be1e-bc625a595dc7`, with v6/local-only behavior and CCEL

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -14,8 +14,12 @@ The schema-`0009` preview release pre-state targets
 (`74f456e2-6951-4003-bb6f-91951342bf8f`) in checked-in configuration only.
 It has no live binding or deployment claim until this protected workflow passes.
 Before the preview deployment, the workflow captures a fixed read-only
-production control snapshot; after the deployment it must prove the same
-production deployment UUID, Worker UUID, and D1 UUID before any preview audit.
+production control snapshot, proving its observed D1 UUID against the exact
+checked-in production name/UUID and a fresh read-only D1 inventory. It proves
+the same production deployment UUID, Worker UUID, and D1 UUID immediately
+after deployment before any preview audit, then again after every fixed preview
+audit and the final preview Worker identity check. The hash-only final control
+record is retained with the preview audit evidence.
 The separately prepared production candidate
 `9bc79346-338b-439e-a2a5-424f4418eb21` remains unbound, while production stays
 on `theologai-production-20260729-transform11-a`

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -65,11 +65,13 @@ after deployment before any preview audit, then again after every fixed preview
 audit and the final preview Worker identity check. The hash-only final control
 record is retained with the preview audit evidence.
 The separately prepared production candidate
-`9bc79346-338b-439e-a2a5-424f4418eb21` remains unbound, while production stays
-on `theologai-production-20260729-transform11-a`
-(`53211f50-a893-4b4c-be1e-bc625a595dc7`). The readiness artifact retains only
-database/environment identifiers and independently hashable readiness and
-authority results—never raw Wrangler output or diagnostics.
+`theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`) is now the checked-in production
+target but remains unbound. Live production stays on its recorded schema-`0008`
+predecessor until the separate protected production workflow succeeds. Its
+sanitized readiness receipt, pre/post/post-audit preview-control records, and
+final environment-isolation receipt retain only independently hashable
+identities and results—never raw Wrangler output or diagnostics.
 
 The historical read-only observation from approximately 2026-07-25T19:13Z
 recorded preview deployment `4148bfb5-dd03-447f-b656-9daa0aee4380`, serving

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -9,6 +9,20 @@ The record intentionally distinguishes two D1 identities:
 
 The generic release workflow permits both code-only releases (`d1Changed: false`) and data cutovers (`d1Changed: true`); it never infers freshness from a different ID alone. Wrangler 4.107.0’s D1 binding response is accepted only when the sole `THEOLOGAI_DB` binding has canonical UUID `id` and `database_id` fields that agree exactly. After deployment, the sole active Worker version must bind the candidate ID before either fixed audit begins; a retained-old-D1 deployment is refused even if its Worker version otherwise looks new.
 
+The schema-`0009` preview release pre-state targets
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`) in checked-in configuration only.
+It has no live binding or deployment claim until this protected workflow passes.
+Before the preview deployment, the workflow captures a fixed read-only
+production control snapshot; after the deployment it must prove the same
+production deployment UUID, Worker UUID, and D1 UUID before any preview audit.
+The separately prepared production candidate
+`9bc79346-338b-439e-a2a5-424f4418eb21` remains unbound, while production stays
+on `theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). The readiness artifact retains only
+database/environment identifiers and independently hashable readiness and
+authority results—never raw Wrangler output or diagnostics.
+
 The historical read-only observation from approximately 2026-07-25T19:13Z
 recorded preview deployment `4148bfb5-dd03-447f-b656-9daa0aee4380`, serving
 Worker version `ca1376bb-05cc-403b-a396-d2e89403abec` and bound to

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -37,12 +37,13 @@ PR95's Transform-9 normal preview release is historical, having used
 predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is
-deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
-`06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
-`theologai-preview-20260728-transform11-a`
-(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`). The retained PR #101 production
-rollback is deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). That former Transform-11 preview
+binding is historical. The current preview baseline is PR #122 deployment
+`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe`, and schema-`0009` D1
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). The retained PR #101 production
+rollback is older history: deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
 (`f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395`). This schema-`0008` database was
@@ -90,8 +91,13 @@ protected workflow `30496350408` subsequently deployed merge
 `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98), bound to this D1. Historical
 core passed 8/8, Transform-11 spine passed 10/10, original-language passed
 11/11, edge stabilization matched attempt 4 and remained stable, and the
-independent post-release review returned `SHIP`. Retain the PR #101 Worker/D1
-pair above as rollback.
+independent post-release review returned `SHIP`. For this schema-`0009`
+cutover, the exact PR #108 pair is the immediately preceding primary rollback
+unit: deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). PR #101 is older rollback history,
+not the immediate rollback claim for this cutover.
 
 ## Source and materialization
 

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -42,11 +42,12 @@ audit all passed. The retained PR #101 preview predecessor was
 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is
-deployment `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
-`06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
-`theologai-preview-20260728-transform11-a`
-(`62b871a6-5b4d-4d9b-8f52-301f6c878f48`).
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The PR #107 preview assignment is
+the immediate retained predecessor. The current preview baseline is PR #122
+deployment `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142), and schema-`0009` D1
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`).
 
 The checked-in root production target was separately prepared unbound as
 Transform-11 candidate `theologai-production-20260729-transform11-a`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -360,12 +360,16 @@ binding—at merge `72a8ee5eef9b909a373b085d1a4f193484ddfe8a`, deployment
   reconciliation cutoff immediately after PR #113, `main` was
   `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
   `9922aedb74c690e7a3fcb926b3d621f28fa44535`), and that revision was not
-  deployed. Preview remains
+  deployed. At that cutoff, preview remained
   PR #107 head `1105b75cd8537632bdb20e598092f6ba94a6adc0`, deployment
   `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
   `06b9a603-8339-42b6-a246-ef9238563043`, and D1
   `62b871a6-5b4d-4d9b-8f52-301f6c878f48`, with v7/discovery-only behavior and
-  CCEL execution disabled before adapter, coordinator, or fetch. Production
+  CCEL execution disabled before adapter, coordinator, or fetch. PR #122 has
+  since superseded that preview assignment with deployment
+  `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+  `b2c62527-5759-4c1d-a9a3-8c1d43dddabe`, and schema-`0009` D1
+  `74f456e2-6951-4003-bb6f-91951342bf8f`. Production
   remains PR #108 merge `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`, deployment
   `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
   `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
@@ -700,11 +704,16 @@ Code readiness and operational readiness are deliberately separate:
   predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
   `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
   `theologai-preview-20260728-hierarchy-a`
-  (`51890e12-1c3f-421f-b661-9a5ea9637e43`). Preview now serves deployment
+  (`51890e12-1c3f-421f-b661-9a5ea9637e43`). PR #107 deployment
   `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
   `06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
   `theologai-preview-20260728-transform11-a`
-  (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`) with the v7/discovery-only
+  (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`) are the immediate retained
+  predecessor. Preview now serves PR #122 deployment
+  `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+  `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142), and schema-`0009` D1
+  `theologai-preview-20260811-schema0009-a`
+  (`74f456e2-6951-4003-bb6f-91951342bf8f`) with the v7/discovery-only
   contract; CCEL execution remains disabled before adapter, coordinator, or
   fetch. The schema-`0008` production database was
   unbound when remote readiness and Transform-8/9 authority audits passed and

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -3,7 +3,8 @@
 > **Current status:** exposure-only preview record. Production remains deployed
 > v6/local-only. Preview is deployed and audited on the v7/discovery-only
 > contract, with CCEL execution disabled before adapter, coordinator, or fetch.
-> The active PR #107 Worker predates the current-main endpoint pin below.
+> PR #122's audited schema-`0009` preview Worker now contains the current-main
+> endpoint pin below; the retained PR #107 Worker is historical predecessor evidence.
 > TheologAI does not retrieve or republish CCEL
 > document bodies. Live discovery still requires a fresh operational preflight
 > and separate explicit release review.
@@ -23,10 +24,10 @@ The live-search and coordinator flags remain off in production and preview.
   interface guarantee. No HTML, query, result, or snippet evidence is retained.
   There is no endpoint configuration, root/alternate-path probing, or fallback
   host/path in the adapter.
-  PR #115 introduced this pin in repository code only and was not deployed;
-  the active PR #107 preview predecessor is not evidence that `/home3/search`
-  is deployed. A protected safe-`100` current-main preview refresh and audit is
-  required before it can become a canary predecessor.
+  PR #115 introduced this pin in repository code only. PR #122 subsequently
+  deployed and audited it in the safe-`100` schema-`0009` preview baseline;
+  this proves the configured endpoint-bearing code is deployed, not that a
+  live CCEL result query succeeds or is authorized.
 - Search contract reviewed: [CCEL Search Help](https://www.ccel.org/help/search), including the documented `author`, `authorID`, `title`, and `bookID` fields.
 - Exact locator shape reviewed: `https://ccel.org/ccel/{author}/{work}/{section}.html`.
 - Product boundary approved by the owner on 2026-07-16: retain the existing

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -16,19 +16,28 @@ and the independent post-release review returned `SHIP`. This is not a
 hierarchy/publication activation; CCEL execution remains disabled and Aquinas
 remains inactive.
 
-### Schema-0009 preview-release pre-state
+### Schema-0009 preview release state
 
-The checked-in preview configuration now targets the separately prepared,
-unbound schema-`0009` D1 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`). This is a release candidate, not a
-claim that preview traffic has changed: the protected preview workflow must
-prove the candidate binding and complete its audit. It also captures production
-against its checked-in D1 name/UUID and fresh inventory before preview mutation,
-immediately after deployment, and again after final preview audit; it fails if
-its deployment, Worker, or D1 UUID changes. Production remains configured and live on
+The checked-in preview configuration targets schema-`0009` D1
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). The protected preview workflow
+proved that binding and completed its audit. It captured production against its
+checked-in D1 name/UUID and fresh inventory before preview mutation,
+immediately after deployment, and again after final preview audit. Production
+remains configured and live on
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`); prepared candidate
 `9bc79346-338b-439e-a2a5-424f4418eb21` is unbound and is not configured here.
+
+PR #122 completed the protected preview release from
+`a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree
+`660c06ff31e7d0e2ccbc6fe12204e66c4e793233`): Cloudflare deployment
+`13393917-fa91-4afc-aeaf-2809db6701a2` assigns Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` solely to the schema-`0009` preview D1.
+All bounded audits and production-control comparisons passed. The preview
+authorization has been revoked (run `31572924302`); PR #122 remains open and
+unmerged. This evidence-only commit postdates that deployment and does not
+change production, CCEL execution, or secrets.
 
 The former PR #101 production assignment is the matched rollback pair:
 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -23,11 +23,13 @@ The checked-in preview configuration targets schema-`0009` D1
 (`74f456e2-6951-4003-bb6f-91951342bf8f`). The protected preview workflow
 proved that binding and completed its audit. It captured production against its
 checked-in D1 name/UUID and fresh inventory before preview mutation,
-immediately after deployment, and again after final preview audit. Production
-remains configured and live on
-`theologai-production-20260729-transform11-a`
-(`53211f50-a893-4b4c-be1e-bc625a595dc7`); prepared candidate
-`9bc79346-338b-439e-a2a5-424f4418eb21` is unbound and is not configured here.
+immediately after deployment, and again after final preview audit. The
+checked-in production target is now the separately prepared schema-`0009`
+candidate `theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`), which remains unbound. Live
+production stays on its recorded schema-`0008` predecessor until the protected
+production workflow proves the active binding, re-proves preview control after
+deployment and audits, and emits the final environment-isolation receipt.
 
 PR #122 completed the protected preview release from
 `a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -16,6 +16,19 @@ and the independent post-release review returned `SHIP`. This is not a
 hierarchy/publication activation; CCEL execution remains disabled and Aquinas
 remains inactive.
 
+### Schema-0009 preview-release pre-state
+
+The checked-in preview configuration now targets the separately prepared,
+unbound schema-`0009` D1 `theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). This is a release candidate, not a
+claim that preview traffic has changed: the protected preview workflow must
+prove the candidate binding and complete its audit. It also captures production
+before and after the preview mutation and fails if its deployment, Worker, or
+D1 UUID changes. Production remains configured and live on
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`); prepared candidate
+`9bc79346-338b-439e-a2a5-424f4418eb21` is unbound and is not configured here.
+
 The former PR #101 production assignment is the matched rollback pair:
 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -63,9 +63,9 @@ identity `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed while
 unbound. Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550`
-now serves Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) as the sole
-active preview assignment bound to that exact D1. This preview assignment
-remained unchanged during the PR #108 production release.
+historically served Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) with
+that exact D1. It remained unchanged during the PR #108 production release and
+is now PR #122's retained immediate predecessor, not the active preview.
 
 The checked-in root production target was prepared unbound as the Transform-11
 candidate `theologai-production-20260729-transform11-a`

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -16,6 +16,10 @@ and the independent post-release review returned `SHIP`. This is not a
 hierarchy/publication activation; CCEL execution remains disabled and Aquinas
 remains inactive.
 
+For the schema-`0009` cutover, the exact captured PR #108 Worker/D1 pair above
+is the immediately preceding primary rollback unit. PR #101 is older retained
+rollback history, not the immediate rollback claim.
+
 ### Schema-0009 preview release state
 
 The checked-in preview configuration targets schema-`0009` D1
@@ -41,7 +45,7 @@ authorization has been revoked (run `31572924302`); PR #122 remains open and
 unmerged. This evidence-only commit postdates that deployment and does not
 change production, CCEL execution, or secrets.
 
-The former PR #101 production assignment is the matched rollback pair:
+The former PR #101 production assignment is older retained rollback history:
 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`
@@ -79,8 +83,9 @@ merge `501ae7840a71ceb589dc3b1ae9863aef83e3586f`, exact tree
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed. The
 protected PR #108 workflow `30496350408` subsequently proved and activated its
-exact Worker/D1 assignment. The PR #101 Worker/D1 pair above is retained as
-rollback.
+exact Worker/D1 assignment. That PR #108 pair is the immediate primary rollback
+unit for the schema-`0009` cutover; the PR #101 pair above is older retained
+rollback history only.
 
 Historical PR #96 production evidence is source-attested to checked-out commit
 `ac4b5ed774302fbfc86bf846b6ee77a07beed456` and exact tree

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -23,8 +23,9 @@ unbound schema-`0009` D1 `theologai-preview-20260811-schema0009-a`
 (`74f456e2-6951-4003-bb6f-91951342bf8f`). This is a release candidate, not a
 claim that preview traffic has changed: the protected preview workflow must
 prove the candidate binding and complete its audit. It also captures production
-before and after the preview mutation and fails if its deployment, Worker, or
-D1 UUID changes. Production remains configured and live on
+against its checked-in D1 name/UUID and fresh inventory before preview mutation,
+immediately after deployment, and again after final preview audit; it fails if
+its deployment, Worker, or D1 UUID changes. Production remains configured and live on
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`); prepared candidate
 `9bc79346-338b-439e-a2a5-424f4418eb21` is unbound and is not configured here.

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -88,7 +88,7 @@ const PRODUCTION = {
 };
 const PREVIEW = {
   worker: 'theologai-preview', route: 'preview-mcp.theologai.xyz',
-  d1Name: 'theologai-preview-20260728-transform11-a', d1: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+  d1Name: 'theologai-preview-20260811-schema0009-a', d1: '74f456e2-6951-4003-bb6f-91951342bf8f',
   requestNamespace: '361202', operatorNamespace: '361204', version: '3.6.0-preview',
   discovery: 'true', live: 'false', coordinator: 'false', logs: 'true',
 };

--- a/scripts/ccel-live-preview-canary.ts
+++ b/scripts/ccel-live-preview-canary.ts
@@ -82,7 +82,7 @@ export const SCHEMA_0009_CANARY_GATE: Schema0009CanaryGate = {
 
 const PRODUCTION = {
   worker: 'theologai', route: 'mcp.theologai.xyz',
-  d1Name: 'theologai-production-20260729-transform11-a', d1: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+  d1Name: 'theologai-production-20260811-schema0009-a', d1: '9bc79346-338b-439e-a2a5-424f4418eb21',
   requestNamespace: '361201', operatorNamespace: '361203', version: '3.6.0',
   discovery: 'false', live: 'false', coordinator: 'false', logs: 'false',
 };

--- a/scripts/ccel-operator-secret-release.ts
+++ b/scripts/ccel-operator-secret-release.ts
@@ -4,9 +4,9 @@ import { parse as parseToml } from 'smol-toml';
 
 export const CCEL_OPERATOR_SECRET = 'THEOLOGAI_CCEL_OPERATOR_TOKEN';
 export const PRODUCTION_WORKER = 'theologai';
-/** Prepared Transform-11 candidate; it was unbound during readiness and config alone does not prove live traffic. */
-export const PRODUCTION_D1_NAME = 'theologai-production-20260729-transform11-a';
-export const PRODUCTION_D1_ID = '53211f50-a893-4b4c-be1e-bc625a595dc7';
+/** Reviewed schema-0009 production candidate; config alone does not bind it. */
+export const PRODUCTION_D1_NAME = 'theologai-production-20260811-schema0009-a';
+export const PRODUCTION_D1_ID = '9bc79346-338b-439e-a2a5-424f4418eb21';
 /** The reviewed schema-0009 preview candidate; config alone does not bind it. */
 export const PREVIEW_D1_NAME = 'theologai-preview-20260811-schema0009-a';
 export const PREVIEW_D1_ID = '74f456e2-6951-4003-bb6f-91951342bf8f';

--- a/scripts/ccel-operator-secret-release.ts
+++ b/scripts/ccel-operator-secret-release.ts
@@ -7,9 +7,9 @@ export const PRODUCTION_WORKER = 'theologai';
 /** Prepared Transform-11 candidate; it was unbound during readiness and config alone does not prove live traffic. */
 export const PRODUCTION_D1_NAME = 'theologai-production-20260729-transform11-a';
 export const PRODUCTION_D1_ID = '53211f50-a893-4b4c-be1e-bc625a595dc7';
-/** The reviewed, prepared preview candidate; config alone does not bind it. */
-export const PREVIEW_D1_NAME = 'theologai-preview-20260728-transform11-a';
-export const PREVIEW_D1_ID = '62b871a6-5b4d-4d9b-8f52-301f6c878f48';
+/** The reviewed schema-0009 preview candidate; config alone does not bind it. */
+export const PREVIEW_D1_NAME = 'theologai-preview-20260811-schema0009-a';
+export const PREVIEW_D1_ID = '74f456e2-6951-4003-bb6f-91951342bf8f';
 export const STAGE_CONFIRMATION = 'I AUTHORIZE PROVISIONING THE PROTECTED CCEL OPERATOR SECRET';
 export const PROMOTE_CONFIRMATION = 'PROMOTE THEOLOGAI CCEL OPERATOR SECRET';
 export const ROLLBACK_CONFIRMATION = 'ROLL BACK THEOLOGAI TO THE EXACT SECRETLESS BASELINE';

--- a/scripts/check-remote-d1-readiness.ts
+++ b/scripts/check-remote-d1-readiness.ts
@@ -2,7 +2,8 @@
 /** Read-only remote D1 compatibility gate used only inside approved deploy jobs. */
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { genesisOneOneLemmaReadinessPredicate, johnOneOneReadinessPredicate } from './data-integrity.js';
@@ -24,10 +25,12 @@ import {
 import {
   auditHistoricalTransform8Authority,
   parseHistoricalTransform8D1Page,
+  type HistoricalTransform8AuthorityAuditResult,
 } from './historical-transform8-authority-audit.js';
 import {
   auditHistoricalTransform9Authority,
   parseHistoricalTransform9D1Page,
+  type HistoricalTransform9AuthorityAuditResult,
 } from './historical-transform9-authority-audit.js';
 import {
   normalAquinasHierarchyExclusionChecks,
@@ -135,6 +138,24 @@ interface RemoteD1ReadinessOptions {
    * workflows continue to use their reviewed configuration.
    */
   configPath?: string;
+}
+
+interface ReadinessReceiptComponent {
+  identitySha256: string;
+  result: 'passed';
+  resultSha256: string;
+}
+
+/**
+ * Minimal, publishable result of a successful remote gate. It deliberately
+ * excludes SQL, Wrangler JSON, diagnostics, request metadata, and source text.
+ */
+export interface RemoteD1ReadinessReceipt {
+  schemaVersion: 'theologai-remote-d1-readiness-receipt.v1';
+  database: string;
+  environment: string | null;
+  readiness: ReadinessReceiptComponent;
+  authority: ReadinessReceiptComponent;
 }
 
 type ReadinessCommandExecutor = (
@@ -633,26 +654,73 @@ function assertD1ReadinessSqlByteBound(kind: 'primary' | 'diagnostic', sql: stri
   return sql;
 }
 
-function parseArguments(argv: string[]): { database: string; env?: string; printOnly: boolean } {
+function parseArguments(argv: string[]): { database: string; env?: string; output?: string; printOnly: boolean } {
   let database: string | undefined;
   let env: string | undefined;
+  let output: string | undefined;
   let printOnly = false;
   for (let index = 0; index < argv.length; index++) {
     const argument = argv[index];
     if (argument === '--database') database = argv[++index];
     else if (argument === '--env') env = argv[++index];
+    else if (argument === '--output') output = argv[++index];
     else if (argument === '--print') printOnly = true;
     else throw new Error(`Unknown argument: ${argument}`);
   }
   if (!database || database.startsWith('--')) throw new Error('--database is required');
   if (env?.startsWith('--')) throw new Error('--env requires a value');
-  return { database, env, printOnly };
+  if (output?.startsWith('--')) throw new Error('--output requires a path');
+  if (printOnly && output) throw new Error('--print and --output cannot be combined');
+  return { database, env, output, printOnly };
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function receiptComponent(identity: unknown): ReadinessReceiptComponent {
+  const identitySha256 = sha256(JSON.stringify(identity));
+  const result = 'passed' as const;
+  return { identitySha256, result, resultSha256: sha256(JSON.stringify({ identitySha256, result })) };
+}
+
+export function createRemoteD1ReadinessReceipt(input: {
+  database: string;
+  env?: string;
+  transform8: HistoricalTransform8AuthorityAuditResult;
+  transform9: HistoricalTransform9AuthorityAuditResult;
+}): RemoteD1ReadinessReceipt {
+  return {
+    schemaVersion: 'theologai-remote-d1-readiness-receipt.v1',
+    database: input.database,
+    environment: input.env ?? null,
+    readiness: receiptComponent({
+      kind: 'd1-readiness.v1', schemaVersion: MANIFEST.schemaVersion,
+      corpusIdentity: D1_CORPUS_IDENTITY,
+      checkCount: buildD1ReadinessQueryContract(MANIFEST.expectedCounts).checks.length,
+    }),
+    authority: receiptComponent({
+      kind: 'historical-transform8-9-authority.v1',
+      transform8: {
+        attestationSha256: input.transform8.attestationSha256,
+        profilesSha256: input.transform8.profilesSha256,
+        identitiesSha256: input.transform8.identitiesSha256,
+        aliasesSha256: input.transform8.aliasesSha256,
+        bodyFtsSampleSha256: input.transform8.bodyFtsSampleSha256,
+      },
+      transform9: input.transform9.hashes,
+    }),
+  };
+}
+
+function writeReadinessReceipt(path: string, receipt: RemoteD1ReadinessReceipt): void {
+  writeFileSync(path, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
 }
 
 export function runRemoteD1ReadinessCheck(
   options: RemoteD1ReadinessOptions,
   execute: ReadinessCommandExecutor = execFileSync,
-): void {
+): RemoteD1ReadinessReceipt {
   const wrangler = options.wrangler ?? join(ROOT, 'node_modules', 'wrangler', 'bin', 'wrangler.js');
   const cwd = options.cwd ?? ROOT;
   const executeSql = (sql: string, capture = false): unknown => {
@@ -678,6 +746,9 @@ export function runRemoteD1ReadinessCheck(
       );
     });
     process.stderr.write(`Transform-9 D1 authority audit passed (${transform9Audit.pages.packs}/${transform9Audit.pages.works}/${transform9Audit.pages.editions}/${transform9Audit.pages.artifacts}/${transform9Audit.pages.documents}/${transform9Audit.pages.profiles}/${transform9Audit.pages.sections}/${transform9Audit.pages.projections} pages).\n`);
+    return createRemoteD1ReadinessReceipt({
+      database: options.database, env: options.env, transform8: audit, transform9: transform9Audit,
+    });
   } catch (primaryError) {
     process.stderr.write('Primary D1 readiness gate failed; requesting failed-check diagnostics.\n');
     try {
@@ -690,14 +761,15 @@ export function runRemoteD1ReadinessCheck(
 }
 
 function main(): void {
-  const { database, env, printOnly } = parseArguments(process.argv.slice(2));
+  const { database, env, output, printOnly } = parseArguments(process.argv.slice(2));
   const sql = buildD1ReadinessSql(MANIFEST.expectedCounts);
   if (printOnly) {
     process.stdout.write(`${sql}\n`);
     return;
   }
 
-  runRemoteD1ReadinessCheck({ database, env });
+  const receipt = runRemoteD1ReadinessCheck({ database, env });
+  if (output) writeReadinessReceipt(output, receipt);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/scripts/preview-release-reconciliation.ts
+++ b/scripts/preview-release-reconciliation.ts
@@ -9,6 +9,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parse as parseToml } from 'smol-toml';
+import { LEGACY_SCHEMA_0008_D1 } from './ccel-live-preview-canary.js';
 
 type RecordValue = Record<string, unknown>;
 /** The checked-in binding that the preceding readiness gate tested. */
@@ -104,6 +105,27 @@ export interface ProductionControlIdentity {
   d1: ObservedD1Binding;
   /** Exact checked-in production binding proved against a fresh D1 inventory. */
   configuredD1: CandidateD1Binding;
+  wranglerConfigSha256: string;
+  d1InventorySha256: string;
+}
+
+/** A fixed preview snapshot used to prove a production release did not touch preview. */
+export interface PreviewControlIdentity {
+  schemaVersion: 1;
+  worker: 'theologai-preview';
+  deploymentId: string;
+  workerVersionId: string;
+  d1: ObservedD1Binding;
+  configuredD1: CandidateD1Binding;
+  wranglerConfigSha256: string;
+  d1InventorySha256: string;
+}
+
+/** Final read-only proof that both current environments are distinct schema-0009 targets. */
+export interface EnvironmentIsolationReceipt {
+  schemaVersion: 1;
+  production: { worker: 'theologai'; deploymentId: string; workerVersionId: string; d1: CandidateD1Binding };
+  preview: { worker: 'theologai-preview'; deploymentId: string; workerVersionId: string; d1: CandidateD1Binding };
   wranglerConfigSha256: string;
   d1InventorySha256: string;
 }
@@ -340,6 +362,110 @@ export function verifyProductionControlUnchanged(input: {
   return observed;
 }
 
+export function capturePreviewControlIdentity(input: {
+  deploymentsText: string;
+  activeVersionViewText: string;
+  wranglerConfigText: string;
+  d1InventoryText: string;
+}): PreviewControlIdentity {
+  const configuredD1 = checkedOutCandidateD1(input.wranglerConfigText);
+  assertCandidateD1Inventory(configuredD1, input.d1InventoryText, 'preview');
+  const active = currentSoleDeployment(input.deploymentsText, 'preview control deployments');
+  const d1 = observedD1FromAuthoritativeVersionView(input.activeVersionViewText, active.versionId, 'preview control');
+  assertObservedD1MatchesCandidate(d1, configuredD1, 'preview control');
+  return {
+    schemaVersion: 1, worker: 'theologai-preview', deploymentId: active.id, workerVersionId: active.versionId, d1, configuredD1,
+    wranglerConfigSha256: sha256(input.wranglerConfigText), d1InventorySha256: sha256(input.d1InventoryText),
+  };
+}
+
+function parsePreviewControlIdentity(value: unknown): PreviewControlIdentity {
+  const control = object(value, 'preview control identity');
+  exactKeys(control, ['schemaVersion', 'worker', 'deploymentId', 'workerVersionId', 'd1', 'configuredD1', 'wranglerConfigSha256', 'd1InventorySha256'], 'preview control identity');
+  const d1 = object(control.d1, 'preview control D1');
+  const configuredD1 = object(control.configuredD1, 'preview control configured D1');
+  exactKeys(d1, ['binding', 'databaseId'], 'preview control D1');
+  exactKeys(configuredD1, ['binding', 'databaseName', 'databaseId'], 'preview control configured D1');
+  assert(control.schemaVersion === 1 && control.worker === 'theologai-preview'
+    && isUuid(control.deploymentId) && isUuid(control.workerVersionId)
+    && d1.binding === 'THEOLOGAI_DB' && isUuid(d1.databaseId)
+    && configuredD1.binding === 'THEOLOGAI_DB' && typeof configuredD1.databaseName === 'string'
+    && configuredD1.databaseName.length > 0 && isUuid(configuredD1.databaseId)
+    && d1.databaseId.toLowerCase() === configuredD1.databaseId.toLowerCase()
+    && isSha256(control.wranglerConfigSha256) && isSha256(control.d1InventorySha256),
+  'preview control identity is not canonical');
+  return {
+    schemaVersion: 1, worker: 'theologai-preview', deploymentId: control.deploymentId.toLowerCase(), workerVersionId: control.workerVersionId.toLowerCase(),
+    d1: { binding: 'THEOLOGAI_DB', databaseId: d1.databaseId.toLowerCase() },
+    configuredD1: { binding: 'THEOLOGAI_DB', databaseName: configuredD1.databaseName, databaseId: configuredD1.databaseId.toLowerCase() },
+    wranglerConfigSha256: control.wranglerConfigSha256.toLowerCase(), d1InventorySha256: control.d1InventorySha256.toLowerCase(),
+  };
+}
+
+/** Fail closed if a production release changes any preview routing, version, or binding identity. */
+export function verifyPreviewControlUnchanged(input: {
+  controlText: string;
+  deploymentsText: string;
+  activeVersionViewText: string;
+  wranglerConfigText: string;
+  d1InventoryText: string;
+}): PreviewControlIdentity {
+  const control = parsePreviewControlIdentity(parseJson(input.controlText, 'preview control identity'));
+  const observed = capturePreviewControlIdentity({
+    deploymentsText: input.deploymentsText, activeVersionViewText: input.activeVersionViewText,
+    wranglerConfigText: input.wranglerConfigText, d1InventoryText: input.d1InventoryText,
+  });
+  assert(observed.deploymentId === control.deploymentId, 'preview deployment changed during production release');
+  assert(observed.workerVersionId === control.workerVersionId, 'preview Worker version changed during production release');
+  assert(observed.d1.databaseId === control.d1.databaseId, 'preview D1 binding changed during production release');
+  assert(observed.configuredD1.databaseName === control.configuredD1.databaseName
+    && observed.configuredD1.databaseId === control.configuredD1.databaseId
+    && observed.wranglerConfigSha256 === control.wranglerConfigSha256,
+  'checked-out preview D1 configuration changed during production release');
+  return observed;
+}
+
+function assertCurrentSchema0009D1(candidate: CandidateD1Binding, environment: 'preview' | 'production'): void {
+  const retained = Object.values(LEGACY_SCHEMA_0008_D1);
+  assert(!retained.some(legacy => candidate.databaseId === legacy.id || candidate.databaseName === legacy.name),
+    `${environment} D1 uses a recorded schema-0008 name or UUID`);
+}
+
+/**
+ * Capture a sanitized final receipt. It proves each active Worker binds its
+ * exact checked-in D1, both mappings exist in one fresh inventory, and neither
+ * environment crosses into the other or retained schema-0008 identities.
+ */
+export function captureEnvironmentIsolationReceipt(input: {
+  productionDeploymentsText: string;
+  productionActiveVersionViewText: string;
+  previewDeploymentsText: string;
+  previewActiveVersionViewText: string;
+  wranglerConfigText: string;
+  d1InventoryText: string;
+}): EnvironmentIsolationReceipt {
+  const productionD1 = checkedOutProductionCandidateD1(input.wranglerConfigText);
+  const previewD1 = checkedOutCandidateD1(input.wranglerConfigText);
+  assertCurrentSchema0009D1(productionD1, 'production');
+  assertCurrentSchema0009D1(previewD1, 'preview');
+  assert(productionD1.databaseId !== previewD1.databaseId && productionD1.databaseName !== previewD1.databaseName,
+    'production and preview D1 identities must be distinct');
+  assertCandidateD1Inventory(productionD1, input.d1InventoryText, 'production');
+  assertCandidateD1Inventory(previewD1, input.d1InventoryText, 'preview');
+  const production = currentSoleDeployment(input.productionDeploymentsText, 'environment isolation production deployments');
+  const preview = currentSoleDeployment(input.previewDeploymentsText, 'environment isolation preview deployments');
+  const observedProductionD1 = observedD1FromAuthoritativeVersionView(input.productionActiveVersionViewText, production.versionId, 'environment isolation production');
+  const observedPreviewD1 = observedD1FromAuthoritativeVersionView(input.previewActiveVersionViewText, preview.versionId, 'environment isolation preview');
+  assertObservedD1MatchesCandidate(observedProductionD1, productionD1, 'environment isolation production');
+  assertObservedD1MatchesCandidate(observedPreviewD1, previewD1, 'environment isolation preview');
+  return {
+    schemaVersion: 1,
+    production: { worker: 'theologai', deploymentId: production.id, workerVersionId: production.versionId, d1: productionD1 },
+    preview: { worker: 'theologai-preview', deploymentId: preview.id, workerVersionId: preview.versionId, d1: previewD1 },
+    wranglerConfigSha256: sha256(input.wranglerConfigText), d1InventorySha256: sha256(input.d1InventoryText),
+  };
+}
+
 export function capturePreviewPredecessorAnchor(input: {
   deploymentsText: string;
   predecessorVersionViewText: string;
@@ -527,7 +653,7 @@ function exactArgs(argv: string[], command: string, expected: string[]): Map<str
   return values;
 }
 
-async function writeRecord(record: PreviewPredecessorAnchor | PreviewPostMutationObservation | ProductionPredecessorAnchor | ProductionPostMutationObservation | ProductionControlIdentity, output: string): Promise<void> {
+async function writeRecord(record: PreviewPredecessorAnchor | PreviewPostMutationObservation | ProductionPredecessorAnchor | ProductionPostMutationObservation | ProductionControlIdentity | PreviewControlIdentity | EnvironmentIsolationReceipt, output: string): Promise<void> {
   await writeFile(output, `${JSON.stringify(record, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
 }
 
@@ -544,6 +670,24 @@ export async function runCli(argv: string[]): Promise<void> {
   if (command === 'active-version-id') {
     const values = exactArgs(argv.slice(1), command, ['--deployments']);
     process.stdout.write(`${activePreviewVersionId(await readFile(values.get('--deployments')!, 'utf8'))}\n`);
+    return;
+  }
+  if (command === 'capture-control') {
+    const values = exactArgs(argv.slice(1), command, ['--deployments', '--active-version-view', '--wrangler-config', '--d1-inventory', '--output']);
+    const [deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
+      readFile(values.get('--deployments')!, 'utf8'), readFile(values.get('--active-version-view')!, 'utf8'),
+      readFile(values.get('--wrangler-config')!, 'utf8'), readFile(values.get('--d1-inventory')!, 'utf8'),
+    ]);
+    await writeRecord(capturePreviewControlIdentity({ deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText }), values.get('--output')!);
+    return;
+  }
+  if (command === 'verify-control') {
+    const values = exactArgs(argv.slice(1), command, ['--control', '--deployments', '--active-version-view', '--wrangler-config', '--d1-inventory', '--output']);
+    const [controlText, deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
+      readFile(values.get('--control')!, 'utf8'), readFile(values.get('--deployments')!, 'utf8'),
+      readFile(values.get('--active-version-view')!, 'utf8'), readFile(values.get('--wrangler-config')!, 'utf8'), readFile(values.get('--d1-inventory')!, 'utf8'),
+    ]);
+    await writeRecord(verifyPreviewControlUnchanged({ controlText, deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText }), values.get('--output')!);
     return;
   }
   if (command === 'capture-predecessor') {
@@ -570,7 +714,7 @@ export async function runCli(argv: string[]): Promise<void> {
     await writeRecord(observePreviewPostMutation({ predecessorAnchorText, postMutationDeploymentsText, observedActiveVersionViewText, wranglerConfigText }), values.get('--output')!);
     return;
   }
-  fail('command must be candidate-d1-name, active-version-id, capture-predecessor, reconcile-post-mutation, or observe-post-mutation');
+  fail('command must be candidate-d1-name, active-version-id, capture-control, verify-control, capture-predecessor, reconcile-post-mutation, or observe-post-mutation');
 }
 
 /** Fixed production CLI wrapper: it has no environment or Worker-name option. */
@@ -602,6 +746,22 @@ export async function runProductionCli(argv: string[]): Promise<void> {
     ]);
     await writeRecord(verifyProductionControlUnchanged({ controlText, deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText }), values.get('--output')!); return;
   }
+  if (command === 'capture-environment-isolation') {
+    const values = exactArgs(argv.slice(1), command, [
+      '--production-deployments', '--production-active-version-view', '--preview-deployments', '--preview-active-version-view',
+      '--wrangler-config', '--d1-inventory', '--output',
+    ]);
+    const [productionDeploymentsText, productionActiveVersionViewText, previewDeploymentsText, previewActiveVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
+      readFile(values.get('--production-deployments')!, 'utf8'), readFile(values.get('--production-active-version-view')!, 'utf8'),
+      readFile(values.get('--preview-deployments')!, 'utf8'), readFile(values.get('--preview-active-version-view')!, 'utf8'),
+      readFile(values.get('--wrangler-config')!, 'utf8'), readFile(values.get('--d1-inventory')!, 'utf8'),
+    ]);
+    await writeRecord(captureEnvironmentIsolationReceipt({
+      productionDeploymentsText, productionActiveVersionViewText, previewDeploymentsText, previewActiveVersionViewText,
+      wranglerConfigText, d1InventoryText,
+    }), values.get('--output')!);
+    return;
+  }
   if (command === 'capture-predecessor') {
     const values = exactArgs(argv.slice(1), command, ['--deployments', '--predecessor-version-view', '--wrangler-config', '--d1-inventory', '--output']);
     const [deploymentsText, predecessorVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
@@ -619,7 +779,7 @@ export async function runProductionCli(argv: string[]): Promise<void> {
     const input = { predecessorAnchorText, postMutationDeploymentsText, observedActiveVersionViewText, wranglerConfigText };
     await writeRecord(command === 'observe-post-mutation' ? observeProductionPostMutation(input) : reconcileProductionPostMutation(input), values.get('--output')!); return;
   }
-  fail('production command must be candidate-d1-name, active-version-id, capture-control, verify-control, capture-predecessor, reconcile-post-mutation, or observe-post-mutation');
+  fail('production command must be candidate-d1-name, active-version-id, capture-control, verify-control, capture-environment-isolation, capture-predecessor, reconcile-post-mutation, or observe-post-mutation');
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {

--- a/scripts/preview-release-reconciliation.ts
+++ b/scripts/preview-release-reconciliation.ts
@@ -130,6 +130,22 @@ export interface EnvironmentIsolationReceipt {
   d1InventorySha256: string;
 }
 
+/** The post-audit production identity emitted by the fixed Worker verifier. */
+interface AuditedProductionWorkerIdentity {
+  schemaVersion: 2;
+  worker: 'theologai';
+  deployedVersionId: string;
+  deployedVersionNumber: number;
+  deploymentId: string;
+  beforeVersionsSha256: string;
+  afterVersionsSha256: string;
+  deploymentsSha256: string;
+  commandOutputSha256: string;
+  commandReportedVersionId: string;
+  addedVersionIds: string[];
+  postAuditDeploymentsSha256: string;
+}
+
 function fail(message: string): never { throw new Error(`Worker release reconciliation refused: ${message}.`); }
 function assert(value: unknown, message: string): asserts value { if (!value) fail(message); }
 function object(value: unknown, label: string): RecordValue {
@@ -334,6 +350,45 @@ function parseProductionControlIdentity(value: unknown): ProductionControlIdenti
   };
 }
 
+function parseAuditedProductionWorkerIdentity(value: unknown): AuditedProductionWorkerIdentity {
+  const identity = object(value, 'audited production Worker identity');
+  exactKeys(identity, [
+    'schemaVersion', 'worker', 'deployedVersionId', 'deployedVersionNumber', 'deploymentId',
+    'beforeVersionsSha256', 'afterVersionsSha256', 'deploymentsSha256', 'commandOutputSha256',
+    'commandReportedVersionId', 'addedVersionIds', 'postAuditDeploymentsSha256',
+  ], 'audited production Worker identity');
+  assert(identity.schemaVersion === 2 && identity.worker === 'theologai'
+    && isUuid(identity.deployedVersionId) && Number.isSafeInteger(identity.deployedVersionNumber)
+    && (identity.deployedVersionNumber as number) > 0 && isUuid(identity.deploymentId)
+    && isUuid(identity.commandReportedVersionId)
+    && identity.commandReportedVersionId.toLowerCase() === identity.deployedVersionId.toLowerCase()
+    && Array.isArray(identity.addedVersionIds) && (identity.addedVersionIds.length === 1 || identity.addedVersionIds.length === 2)
+    && identity.addedVersionIds.every(isUuid) && new Set(identity.addedVersionIds.map(value => value.toLowerCase())).size === identity.addedVersionIds.length
+    && identity.addedVersionIds.at(-1)?.toLowerCase() === identity.deployedVersionId.toLowerCase()
+    && ['beforeVersionsSha256', 'afterVersionsSha256', 'deploymentsSha256', 'commandOutputSha256', 'postAuditDeploymentsSha256']
+      .every(key => isSha256(identity[key])),
+  'audited production Worker identity is not canonical');
+  return {
+    schemaVersion: 2, worker: 'theologai', deployedVersionId: identity.deployedVersionId.toLowerCase(),
+    deployedVersionNumber: identity.deployedVersionNumber as number, deploymentId: identity.deploymentId.toLowerCase(),
+    beforeVersionsSha256: (identity.beforeVersionsSha256 as string).toLowerCase(), afterVersionsSha256: (identity.afterVersionsSha256 as string).toLowerCase(),
+    deploymentsSha256: (identity.deploymentsSha256 as string).toLowerCase(), commandOutputSha256: (identity.commandOutputSha256 as string).toLowerCase(),
+    commandReportedVersionId: identity.commandReportedVersionId.toLowerCase(),
+    addedVersionIds: identity.addedVersionIds.map(value => value.toLowerCase()),
+    postAuditDeploymentsSha256: (identity.postAuditDeploymentsSha256 as string).toLowerCase(),
+  };
+}
+
+function assertProductionMatchesAuditedIdentity(
+  production: Deployment,
+  auditedProduction: AuditedProductionWorkerIdentity,
+): void {
+  assert(production.id === auditedProduction.deploymentId,
+    'production deployment changed after audited production identity');
+  assert(production.versionId === auditedProduction.deployedVersionId,
+    'production Worker version changed after audited production identity');
+}
+
 /** Fail closed if an ordinary preview release observed any production identity drift. */
 export function verifyProductionControlUnchanged(input: {
   controlText: string;
@@ -439,11 +494,15 @@ function assertCurrentSchema0009D1(candidate: CandidateD1Binding, environment: '
 export function captureEnvironmentIsolationReceipt(input: {
   productionDeploymentsText: string;
   productionActiveVersionViewText: string;
+  productionAuditedIdentityText: string;
   previewDeploymentsText: string;
   previewActiveVersionViewText: string;
   wranglerConfigText: string;
   d1InventoryText: string;
 }): EnvironmentIsolationReceipt {
+  const auditedProduction = parseAuditedProductionWorkerIdentity(
+    parseJson(input.productionAuditedIdentityText, 'audited production Worker identity'),
+  );
   const productionD1 = checkedOutProductionCandidateD1(input.wranglerConfigText);
   const previewD1 = checkedOutCandidateD1(input.wranglerConfigText);
   assertCurrentSchema0009D1(productionD1, 'production');
@@ -456,6 +515,7 @@ export function captureEnvironmentIsolationReceipt(input: {
   const preview = currentSoleDeployment(input.previewDeploymentsText, 'environment isolation preview deployments');
   const observedProductionD1 = observedD1FromAuthoritativeVersionView(input.productionActiveVersionViewText, production.versionId, 'environment isolation production');
   const observedPreviewD1 = observedD1FromAuthoritativeVersionView(input.previewActiveVersionViewText, preview.versionId, 'environment isolation preview');
+  assertProductionMatchesAuditedIdentity(production, auditedProduction);
   assertObservedD1MatchesCandidate(observedProductionD1, productionD1, 'environment isolation production');
   assertObservedD1MatchesCandidate(observedPreviewD1, previewD1, 'environment isolation preview');
   return {
@@ -610,10 +670,16 @@ export function observeProductionPostMutation(input: {
   postMutationDeploymentsText: string;
   observedActiveVersionViewText: string;
   wranglerConfigText: string;
+  auditedProductionIdentityText?: string;
 }): ProductionPostMutationObservation {
   const predecessor = parseProductionAnchor(parseJson(input.predecessorAnchorText, 'production predecessor anchor'));
   const candidateD1 = checkedOutProductionCandidateD1(input.wranglerConfigText);
   const active = currentSoleDeployment(input.postMutationDeploymentsText, 'post-mutation production deployments');
+  if (input.auditedProductionIdentityText !== undefined) {
+    assertProductionMatchesAuditedIdentity(active, parseAuditedProductionWorkerIdentity(
+      parseJson(input.auditedProductionIdentityText, 'audited production Worker identity'),
+    ));
+  }
   const observedActiveD1 = observedD1FromAuthoritativeVersionView(input.observedActiveVersionViewText, active.versionId, 'post-mutation production active');
   return {
     schemaVersion: 3, worker: 'theologai', predecessorVersionId: predecessor.predecessorVersionId,
@@ -749,16 +815,17 @@ export async function runProductionCli(argv: string[]): Promise<void> {
   if (command === 'capture-environment-isolation') {
     const values = exactArgs(argv.slice(1), command, [
       '--production-deployments', '--production-active-version-view', '--preview-deployments', '--preview-active-version-view',
-      '--wrangler-config', '--d1-inventory', '--output',
+      '--production-audited-identity', '--wrangler-config', '--d1-inventory', '--output',
     ]);
-    const [productionDeploymentsText, productionActiveVersionViewText, previewDeploymentsText, previewActiveVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
+    const [productionDeploymentsText, productionActiveVersionViewText, previewDeploymentsText, previewActiveVersionViewText, productionAuditedIdentityText, wranglerConfigText, d1InventoryText] = await Promise.all([
       readFile(values.get('--production-deployments')!, 'utf8'), readFile(values.get('--production-active-version-view')!, 'utf8'),
       readFile(values.get('--preview-deployments')!, 'utf8'), readFile(values.get('--preview-active-version-view')!, 'utf8'),
+      readFile(values.get('--production-audited-identity')!, 'utf8'),
       readFile(values.get('--wrangler-config')!, 'utf8'), readFile(values.get('--d1-inventory')!, 'utf8'),
     ]);
     await writeRecord(captureEnvironmentIsolationReceipt({
       productionDeploymentsText, productionActiveVersionViewText, previewDeploymentsText, previewActiveVersionViewText,
-      wranglerConfigText, d1InventoryText,
+      productionAuditedIdentityText, wranglerConfigText, d1InventoryText,
     }), values.get('--output')!);
     return;
   }
@@ -779,7 +846,19 @@ export async function runProductionCli(argv: string[]): Promise<void> {
     const input = { predecessorAnchorText, postMutationDeploymentsText, observedActiveVersionViewText, wranglerConfigText };
     await writeRecord(command === 'observe-post-mutation' ? observeProductionPostMutation(input) : reconcileProductionPostMutation(input), values.get('--output')!); return;
   }
-  fail('production command must be candidate-d1-name, active-version-id, capture-control, verify-control, capture-environment-isolation, capture-predecessor, reconcile-post-mutation, or observe-post-mutation');
+  if (command === 'observe-final-post-audit') {
+    const values = exactArgs(argv.slice(1), command, ['--predecessor-anchor', '--deployments', '--observed-active-version-view', '--production-audited-identity', '--wrangler-config', '--output']);
+    const [predecessorAnchorText, postMutationDeploymentsText, observedActiveVersionViewText, auditedProductionIdentityText, wranglerConfigText] = await Promise.all([
+      readFile(values.get('--predecessor-anchor')!, 'utf8'), readFile(values.get('--deployments')!, 'utf8'),
+      readFile(values.get('--observed-active-version-view')!, 'utf8'), readFile(values.get('--production-audited-identity')!, 'utf8'),
+      readFile(values.get('--wrangler-config')!, 'utf8'),
+    ]);
+    await writeRecord(observeProductionPostMutation({
+      predecessorAnchorText, postMutationDeploymentsText, observedActiveVersionViewText, auditedProductionIdentityText, wranglerConfigText,
+    }), values.get('--output')!);
+    return;
+  }
+  fail('production command must be candidate-d1-name, active-version-id, capture-control, verify-control, capture-environment-isolation, capture-predecessor, reconcile-post-mutation, observe-post-mutation, or observe-final-post-audit');
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {

--- a/scripts/preview-release-reconciliation.ts
+++ b/scripts/preview-release-reconciliation.ts
@@ -92,6 +92,18 @@ export interface ProductionPostMutationObservation {
 
 export type ProductionPostMutationReconciliation = ProductionPostMutationObservation;
 
+/**
+ * A fixed production control snapshot used to prove an ordinary preview
+ * release did not alter production. It has no caller-selected Worker target.
+ */
+export interface ProductionControlIdentity {
+  schemaVersion: 1;
+  worker: 'theologai';
+  deploymentId: string;
+  workerVersionId: string;
+  d1: ObservedD1Binding;
+}
+
 function fail(message: string): never { throw new Error(`Worker release reconciliation refused: ${message}.`); }
 function assert(value: unknown, message: string): asserts value { if (!value) fail(message); }
 function object(value: unknown, label: string): RecordValue {
@@ -242,6 +254,54 @@ export function activePreviewVersionId(deploymentsText: string): string {
 
 export function activeProductionVersionId(deploymentsText: string): string {
   return currentSoleDeployment(deploymentsText, 'production deployments').versionId;
+}
+
+export function captureProductionControlIdentity(input: {
+  deploymentsText: string;
+  activeVersionViewText: string;
+}): ProductionControlIdentity {
+  const active = currentSoleDeployment(input.deploymentsText, 'production control deployments');
+  const d1 = observedD1FromAuthoritativeVersionView(input.activeVersionViewText, active.versionId, 'production control');
+  return {
+    schemaVersion: 1,
+    worker: 'theologai',
+    deploymentId: active.id,
+    workerVersionId: active.versionId,
+    d1,
+  };
+}
+
+function parseProductionControlIdentity(value: unknown): ProductionControlIdentity {
+  const control = object(value, 'production control identity');
+  exactKeys(control, ['schemaVersion', 'worker', 'deploymentId', 'workerVersionId', 'd1'], 'production control identity');
+  const d1 = object(control.d1, 'production control D1');
+  exactKeys(d1, ['binding', 'databaseId'], 'production control D1');
+  assert(control.schemaVersion === 1 && control.worker === 'theologai'
+    && isUuid(control.deploymentId) && isUuid(control.workerVersionId)
+    && d1.binding === 'THEOLOGAI_DB' && isUuid(d1.databaseId),
+  'production control identity is not canonical');
+  return {
+    schemaVersion: 1, worker: 'theologai', deploymentId: control.deploymentId.toLowerCase(),
+    workerVersionId: control.workerVersionId.toLowerCase(),
+    d1: { binding: 'THEOLOGAI_DB', databaseId: d1.databaseId.toLowerCase() },
+  };
+}
+
+/** Fail closed if an ordinary preview release observed any production identity drift. */
+export function verifyProductionControlUnchanged(input: {
+  controlText: string;
+  deploymentsText: string;
+  activeVersionViewText: string;
+}): ProductionControlIdentity {
+  const control = parseProductionControlIdentity(parseJson(input.controlText, 'production control identity'));
+  const observed = captureProductionControlIdentity({
+    deploymentsText: input.deploymentsText,
+    activeVersionViewText: input.activeVersionViewText,
+  });
+  assert(observed.deploymentId === control.deploymentId, 'production deployment changed during preview release');
+  assert(observed.workerVersionId === control.workerVersionId, 'production Worker version changed during preview release');
+  assert(observed.d1.databaseId === control.d1.databaseId, 'production D1 binding changed during preview release');
+  return observed;
 }
 
 export function capturePreviewPredecessorAnchor(input: {
@@ -431,7 +491,7 @@ function exactArgs(argv: string[], command: string, expected: string[]): Map<str
   return values;
 }
 
-async function writeRecord(record: PreviewPredecessorAnchor | PreviewPostMutationObservation | ProductionPredecessorAnchor | ProductionPostMutationObservation, output: string): Promise<void> {
+async function writeRecord(record: PreviewPredecessorAnchor | PreviewPostMutationObservation | ProductionPredecessorAnchor | ProductionPostMutationObservation | ProductionControlIdentity, output: string): Promise<void> {
   await writeFile(output, `${JSON.stringify(record, null, 2)}\n`, { encoding: 'utf8', flag: 'wx' });
 }
 
@@ -489,6 +549,21 @@ export async function runProductionCli(argv: string[]): Promise<void> {
     const values = exactArgs(argv.slice(1), command, ['--deployments']);
     process.stdout.write(`${activeProductionVersionId(await readFile(values.get('--deployments')!, 'utf8'))}\n`); return;
   }
+  if (command === 'capture-control') {
+    const values = exactArgs(argv.slice(1), command, ['--deployments', '--active-version-view', '--output']);
+    const [deploymentsText, activeVersionViewText] = await Promise.all([
+      readFile(values.get('--deployments')!, 'utf8'), readFile(values.get('--active-version-view')!, 'utf8'),
+    ]);
+    await writeRecord(captureProductionControlIdentity({ deploymentsText, activeVersionViewText }), values.get('--output')!); return;
+  }
+  if (command === 'verify-control') {
+    const values = exactArgs(argv.slice(1), command, ['--control', '--deployments', '--active-version-view', '--output']);
+    const [controlText, deploymentsText, activeVersionViewText] = await Promise.all([
+      readFile(values.get('--control')!, 'utf8'), readFile(values.get('--deployments')!, 'utf8'),
+      readFile(values.get('--active-version-view')!, 'utf8'),
+    ]);
+    await writeRecord(verifyProductionControlUnchanged({ controlText, deploymentsText, activeVersionViewText }), values.get('--output')!); return;
+  }
   if (command === 'capture-predecessor') {
     const values = exactArgs(argv.slice(1), command, ['--deployments', '--predecessor-version-view', '--wrangler-config', '--d1-inventory', '--output']);
     const [deploymentsText, predecessorVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
@@ -506,7 +581,7 @@ export async function runProductionCli(argv: string[]): Promise<void> {
     const input = { predecessorAnchorText, postMutationDeploymentsText, observedActiveVersionViewText, wranglerConfigText };
     await writeRecord(command === 'observe-post-mutation' ? observeProductionPostMutation(input) : reconcileProductionPostMutation(input), values.get('--output')!); return;
   }
-  fail('production command must be candidate-d1-name, active-version-id, capture-predecessor, reconcile-post-mutation, or observe-post-mutation');
+  fail('production command must be candidate-d1-name, active-version-id, capture-control, verify-control, capture-predecessor, reconcile-post-mutation, or observe-post-mutation');
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {

--- a/scripts/preview-release-reconciliation.ts
+++ b/scripts/preview-release-reconciliation.ts
@@ -97,11 +97,15 @@ export type ProductionPostMutationReconciliation = ProductionPostMutationObserva
  * release did not alter production. It has no caller-selected Worker target.
  */
 export interface ProductionControlIdentity {
-  schemaVersion: 1;
+  schemaVersion: 2;
   worker: 'theologai';
   deploymentId: string;
   workerVersionId: string;
   d1: ObservedD1Binding;
+  /** Exact checked-in production binding proved against a fresh D1 inventory. */
+  configuredD1: CandidateD1Binding;
+  wranglerConfigSha256: string;
+  d1InventorySha256: string;
 }
 
 function fail(message: string): never { throw new Error(`Worker release reconciliation refused: ${message}.`); }
@@ -259,31 +263,52 @@ export function activeProductionVersionId(deploymentsText: string): string {
 export function captureProductionControlIdentity(input: {
   deploymentsText: string;
   activeVersionViewText: string;
+  wranglerConfigText: string;
+  d1InventoryText: string;
 }): ProductionControlIdentity {
+  const configuredD1 = checkedOutProductionCandidateD1(input.wranglerConfigText);
+  assertCandidateD1Inventory(configuredD1, input.d1InventoryText, 'production');
   const active = currentSoleDeployment(input.deploymentsText, 'production control deployments');
   const d1 = observedD1FromAuthoritativeVersionView(input.activeVersionViewText, active.versionId, 'production control');
+  assertObservedD1MatchesCandidate(d1, configuredD1, 'production control');
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     worker: 'theologai',
     deploymentId: active.id,
     workerVersionId: active.versionId,
     d1,
+    configuredD1,
+    wranglerConfigSha256: sha256(input.wranglerConfigText),
+    d1InventorySha256: sha256(input.d1InventoryText),
   };
 }
 
 function parseProductionControlIdentity(value: unknown): ProductionControlIdentity {
   const control = object(value, 'production control identity');
-  exactKeys(control, ['schemaVersion', 'worker', 'deploymentId', 'workerVersionId', 'd1'], 'production control identity');
+  exactKeys(control, ['schemaVersion', 'worker', 'deploymentId', 'workerVersionId', 'd1', 'configuredD1', 'wranglerConfigSha256', 'd1InventorySha256'], 'production control identity');
   const d1 = object(control.d1, 'production control D1');
+  const configuredD1 = object(control.configuredD1, 'production control configured D1');
   exactKeys(d1, ['binding', 'databaseId'], 'production control D1');
-  assert(control.schemaVersion === 1 && control.worker === 'theologai'
+  exactKeys(configuredD1, ['binding', 'databaseName', 'databaseId'], 'production control configured D1');
+  assert(control.schemaVersion === 2 && control.worker === 'theologai'
     && isUuid(control.deploymentId) && isUuid(control.workerVersionId)
     && d1.binding === 'THEOLOGAI_DB' && isUuid(d1.databaseId),
   'production control identity is not canonical');
+  assert(configuredD1.binding === 'THEOLOGAI_DB' && typeof configuredD1.databaseName === 'string'
+    && configuredD1.databaseName.length > 0 && isUuid(configuredD1.databaseId)
+    && d1.databaseId.toLowerCase() === configuredD1.databaseId.toLowerCase()
+    && isSha256(control.wranglerConfigSha256) && isSha256(control.d1InventorySha256),
+  'production control configured D1 proof is not canonical');
   return {
-    schemaVersion: 1, worker: 'theologai', deploymentId: control.deploymentId.toLowerCase(),
+    schemaVersion: 2, worker: 'theologai', deploymentId: control.deploymentId.toLowerCase(),
     workerVersionId: control.workerVersionId.toLowerCase(),
     d1: { binding: 'THEOLOGAI_DB', databaseId: d1.databaseId.toLowerCase() },
+    configuredD1: {
+      binding: 'THEOLOGAI_DB', databaseName: configuredD1.databaseName,
+      databaseId: configuredD1.databaseId.toLowerCase(),
+    },
+    wranglerConfigSha256: control.wranglerConfigSha256.toLowerCase(),
+    d1InventorySha256: control.d1InventorySha256.toLowerCase(),
   };
 }
 
@@ -292,15 +317,26 @@ export function verifyProductionControlUnchanged(input: {
   controlText: string;
   deploymentsText: string;
   activeVersionViewText: string;
+  wranglerConfigText: string;
+  d1InventoryText: string;
 }): ProductionControlIdentity {
   const control = parseProductionControlIdentity(parseJson(input.controlText, 'production control identity'));
+  const active = currentSoleDeployment(input.deploymentsText, 'production control deployments');
+  const observedD1 = observedD1FromAuthoritativeVersionView(input.activeVersionViewText, active.versionId, 'production control');
+  assert(active.id === control.deploymentId, 'production deployment changed during preview release');
+  assert(active.versionId === control.workerVersionId, 'production Worker version changed during preview release');
+  assert(observedD1.databaseId === control.d1.databaseId, 'production D1 binding changed during preview release');
   const observed = captureProductionControlIdentity({
-    deploymentsText: input.deploymentsText,
-    activeVersionViewText: input.activeVersionViewText,
+    deploymentsText: input.deploymentsText, activeVersionViewText: input.activeVersionViewText,
+    wranglerConfigText: input.wranglerConfigText, d1InventoryText: input.d1InventoryText,
   });
   assert(observed.deploymentId === control.deploymentId, 'production deployment changed during preview release');
   assert(observed.workerVersionId === control.workerVersionId, 'production Worker version changed during preview release');
   assert(observed.d1.databaseId === control.d1.databaseId, 'production D1 binding changed during preview release');
+  assert(observed.configuredD1.databaseName === control.configuredD1.databaseName
+    && observed.configuredD1.databaseId === control.configuredD1.databaseId
+    && observed.wranglerConfigSha256 === control.wranglerConfigSha256,
+  'checked-out production D1 configuration changed during preview release');
   return observed;
 }
 
@@ -550,19 +586,21 @@ export async function runProductionCli(argv: string[]): Promise<void> {
     process.stdout.write(`${activeProductionVersionId(await readFile(values.get('--deployments')!, 'utf8'))}\n`); return;
   }
   if (command === 'capture-control') {
-    const values = exactArgs(argv.slice(1), command, ['--deployments', '--active-version-view', '--output']);
-    const [deploymentsText, activeVersionViewText] = await Promise.all([
+    const values = exactArgs(argv.slice(1), command, ['--deployments', '--active-version-view', '--wrangler-config', '--d1-inventory', '--output']);
+    const [deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
       readFile(values.get('--deployments')!, 'utf8'), readFile(values.get('--active-version-view')!, 'utf8'),
+      readFile(values.get('--wrangler-config')!, 'utf8'), readFile(values.get('--d1-inventory')!, 'utf8'),
     ]);
-    await writeRecord(captureProductionControlIdentity({ deploymentsText, activeVersionViewText }), values.get('--output')!); return;
+    await writeRecord(captureProductionControlIdentity({ deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText }), values.get('--output')!); return;
   }
   if (command === 'verify-control') {
-    const values = exactArgs(argv.slice(1), command, ['--control', '--deployments', '--active-version-view', '--output']);
-    const [controlText, deploymentsText, activeVersionViewText] = await Promise.all([
+    const values = exactArgs(argv.slice(1), command, ['--control', '--deployments', '--active-version-view', '--wrangler-config', '--d1-inventory', '--output']);
+    const [controlText, deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText] = await Promise.all([
       readFile(values.get('--control')!, 'utf8'), readFile(values.get('--deployments')!, 'utf8'),
       readFile(values.get('--active-version-view')!, 'utf8'),
+      readFile(values.get('--wrangler-config')!, 'utf8'), readFile(values.get('--d1-inventory')!, 'utf8'),
     ]);
-    await writeRecord(verifyProductionControlUnchanged({ controlText, deploymentsText, activeVersionViewText }), values.get('--output')!); return;
+    await writeRecord(verifyProductionControlUnchanged({ controlText, deploymentsText, activeVersionViewText, wranglerConfigText, d1InventoryText }), values.get('--output')!); return;
   }
   if (command === 'capture-predecessor') {
     const values = exactArgs(argv.slice(1), command, ['--deployments', '--predecessor-version-view', '--wrangler-config', '--d1-inventory', '--output']);

--- a/test/fixtures/wrangler/baseline-version-view.json
+++ b/test/fixtures/wrangler/baseline-version-view.json
@@ -20,7 +20,7 @@
       "compatibility_flags": ["nodejs_compat"]
     },
     "bindings": [
-      { "name": "THEOLOGAI_DB", "type": "d1", "id": "53211f50-a893-4b4c-be1e-bc625a595dc7" },
+      { "name": "THEOLOGAI_DB", "type": "d1", "id": "9bc79346-338b-439e-a2a5-424f4418eb21" },
       { "name": "THEOLOGAI_CCEL_COORDINATOR", "type": "durable_object_namespace", "class_name": "CcelGlobalCoordinator", "script_name": "theologai-ccel-coordinator" },
       { "name": "THEOLOGAI_RATE_LIMITER", "type": "ratelimit", "namespace_id": "361201", "simple": { "limit": 120, "period": 60 } },
       { "name": "THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER", "type": "ratelimit", "namespace_id": "361203", "simple": { "limit": 12, "period": 60 } },

--- a/test/fixtures/wrangler/staged-version-view.json
+++ b/test/fixtures/wrangler/staged-version-view.json
@@ -21,7 +21,7 @@
       "compatibility_flags": ["nodejs_compat"]
     },
     "bindings": [
-      { "name": "THEOLOGAI_DB", "type": "d1", "id": "53211f50-a893-4b4c-be1e-bc625a595dc7" },
+      { "name": "THEOLOGAI_DB", "type": "d1", "id": "9bc79346-338b-439e-a2a5-424f4418eb21" },
       { "name": "THEOLOGAI_CCEL_COORDINATOR", "type": "durable_object_namespace", "class_name": "CcelGlobalCoordinator", "script_name": "theologai-ccel-coordinator" },
       { "name": "THEOLOGAI_RATE_LIMITER", "type": "ratelimit", "namespace_id": "361201", "simple": { "limit": 120, "period": 60 } },
       { "name": "THEOLOGAI_CCEL_OPERATOR_AUTH_LIMITER", "type": "ratelimit", "namespace_id": "361203", "simple": { "limit": 12, "period": 60 } },

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -26,8 +26,8 @@ describe('custom-domain infrastructure contract', () => {
     expect(preview).toContain('workers_dev = true');
     expect(preview).toContain('{ pattern = "preview-mcp.theologai.xyz", custom_domain = true }');
     expect(preview).not.toContain('{ pattern = "mcp.theologai.xyz", custom_domain = true }');
-    expect(preview).toContain('database_name = "theologai-preview-20260728-transform11-a"');
-    expect(preview).toContain('database_id = "62b871a6-5b4d-4d9b-8f52-301f6c878f48"');
+    expect(preview).toContain('database_name = "theologai-preview-20260811-schema0009-a"');
+    expect(preview).toContain('database_id = "74f456e2-6951-4003-bb6f-91951342bf8f"');
     expect(preview).toContain('namespace_id = "361202"');
 
     for (const environment of [production, preview]) {

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -19,8 +19,8 @@ describe('custom-domain infrastructure contract', () => {
     expect(production).toContain('workers_dev = true');
     expect(production).toContain('{ pattern = "mcp.theologai.xyz", custom_domain = true }');
     expect(production).not.toContain('preview-mcp.theologai.xyz');
-    expect(production).toContain('database_name = "theologai-production-20260729-transform11-a"');
-    expect(production).toContain('database_id = "53211f50-a893-4b4c-be1e-bc625a595dc7"');
+    expect(production).toContain('database_name = "theologai-production-20260811-schema0009-a"');
+    expect(production).toContain('database_id = "9bc79346-338b-439e-a2a5-424f4418eb21"');
     expect(production).toContain('namespace_id = "361201"');
 
     expect(preview).toContain('workers_dev = true');

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -516,7 +516,7 @@ describe('published project contract', () => {
     expect(secret).toContain('separate schema-`0009` D1 sequence must have completed in order');
     expect(secret).toContain('while unbound; the preview candidate bound, deployed, and audited; then the\nproduction candidate bound, deployed, and audited; then a read-only\nenvironment-isolation verification');
     expect(readme).toContain("Current `main` also includes PR #117's Transform-12 schema\n`0009` contract");
-    expect(readme).toContain('This checked-out release commit targets only the prepared preview D1');
+    expect(readme).toContain('The protected release targeted the prepared preview D1');
     const normalizedAudit = audit.replace(/\s+/g, ' ');
     expect(normalizedAudit).toContain('schema observations prove v6 local-only versus v7 CCEL exposure; they do not prove which endpoint-bearing code revision is deployed');
     expect(normalizedAudit).toContain("does not prove PR #115's repository-only `/home3/search` pin is active");
@@ -573,5 +573,19 @@ describe('published project contract', () => {
     expect(workflow).toContain('scripts/production-release-reconciliation.ts verify-control');
     expect(reconciliation).toContain('checked-in production name/UUID and a fresh read-only D1 inventory');
     expect(reconciliation).toContain('again after every fixed preview\naudit and the final preview Worker identity check');
+    expect(reconciliation).toContain('a0f13b5bdbf3ca071dbb7524dea9c6ce80770404');
+    expect(reconciliation).toContain('660c06ff31e7d0e2ccbc6fe12204e66c4e793233');
+    expect(reconciliation).toContain('31568581322');
+    expect(reconciliation).toContain('5864161923');
+    expect(reconciliation).toContain('13393917-fa91-4afc-aeaf-2809db6701a2');
+    expect(reconciliation).toContain('b2c62527-5759-4c1d-a9a3-8c1d43dddabe');
+    expect(reconciliation).toContain('06b9a603-8339-42b6-a246-ef9238563043');
+    expect(reconciliation).toContain('5e812152-355b-4a5f-a123-2485e89f1550');
+    expect(reconciliation).toContain('481900a3eec516fe06d3252175b63e318783c7230f70311235e4a1dd73198889');
+    expect(reconciliation).toContain('31572924302');
+    expect(reconciliation).toContain('This evidence-only documentation commit postdates the deployed head.');
+    expect(readme).toContain('This evidence-only commit postdates the deployed source');
+    expect(operations).toContain('This evidence-only commit postdates that deployment');
+    expect(canary).toMatch(/The\s+gate remains `unrecorded` and inert/);
   });
 });

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -492,8 +492,8 @@ describe('published project contract', () => {
     expect(canary).toContain('prepared preview candidate with current-`main` `100` flags');
     expect(canary).toContain('Only after the preview audit passes');
     expect(canary).toContain('Then perform a read-only environment-isolation\n   verification');
-    expect(canary).toContain('hard inert schema-`0009` canary gate');
-    expect(canary).toContain('before any\nWrangler command or Cloudflare read');
+    expect(canary).toMatch(/hard inert\s+schema-`0009` canary gate/);
+    expect(canary).toMatch(/before any\s+Wrangler command or\s+Cloudflare read/);
     const canaryOrder = [
       'while both candidates remain unbound',
       'prepared preview candidate with current-`main` `100` flags',
@@ -516,12 +516,56 @@ describe('published project contract', () => {
     expect(secret).toContain('separate schema-`0009` D1 sequence must have completed in order');
     expect(secret).toContain('while unbound; the preview candidate bound, deployed, and audited; then the\nproduction candidate bound, deployed, and audited; then a read-only\nenvironment-isolation verification');
     expect(readme).toContain("Current `main` also includes PR #117's Transform-12 schema\n`0009` contract");
-    expect(readme).toContain('The deployed preview and production D1 layers remain schema `0008`; current\nmain\'s PR #117 schema `0009` Candidate-C contract is checked out only');
+    expect(readme).toContain('This checked-out release commit targets only the prepared preview D1');
     const normalizedAudit = audit.replace(/\s+/g, ' ');
     expect(normalizedAudit).toContain('schema observations prove v6 local-only versus v7 CCEL exposure; they do not prove which endpoint-bearing code revision is deployed');
     expect(normalizedAudit).toContain("does not prove PR #115's repository-only `/home3/search` pin is active");
     expect(coordinator).toContain('The current v7 discovery application contract');
     expect(coordinator).toContain('The historical v5 release selected production v4/local-only');
     expect(coordinator).not.toContain('The v5 discovery application contract is exposed only by');
+  });
+
+  it('records the schema-0009 preview-only release boundary and production control', async () => {
+    const [readme, workflow, reconciliation, canary, operations, config, dataWorkflow, canaryScript] = await Promise.all([
+      readProjectFile('README.md'),
+      readProjectFile('.github/workflows/pr.yml'),
+      readProjectFile('docs/PREVIEW-RELEASE-RECONCILIATION.md'),
+      readProjectFile('docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md'),
+      readProjectFile('docs/worker-operations.md'),
+      readProjectFile('wrangler.toml'),
+      readProjectFile('docs/D1-DATA-WORKFLOW.md'),
+      readProjectFile('scripts/ccel-live-preview-canary.ts'),
+    ]);
+    const previewName = 'theologai-preview-20260811-schema0009-a';
+    const previewId = '74f456e2-6951-4003-bb6f-91951342bf8f';
+    const productionId = '53211f50-a893-4b4c-be1e-bc625a595dc7';
+    const productionCandidateId = '9bc79346-338b-439e-a2a5-424f4418eb21';
+
+    for (const document of [readme, reconciliation, canary, operations, dataWorkflow]) {
+      expect(document).toContain(previewName);
+      expect(document).toContain(previewId);
+      expect(document).toContain(productionCandidateId);
+      expect(document).toContain('unbound');
+    }
+    expect(config).toContain(`database_name = "${previewName}"`);
+    expect(config).toContain(`database_id = "${previewId}"`);
+    expect(config).toContain(`database_id = "${productionId}"`);
+    expect(config).not.toContain(productionCandidateId);
+    expect(dataWorkflow).toContain('e1baa04fecbb066860d06f262142e3450823b7d0');
+    expect(dataWorkflow).toContain('673af4a75c770c541a8be3c84e77d8f91033bd07');
+    expect(dataWorkflow).toContain('ecbd23bb3c692665c7031a8c1fa7733e17a56fbc7e3a167ba4011f6c1cca62d8');
+    expect(dataWorkflow).toContain('14e30a32f316f1c7a954a9641f7d1b8bd6608d8e0f4bdc2eaba4c565f472f83d');
+    expect(dataWorkflow).toContain('66c148a206b9b0eb1bf7552572570c42dabfd0ba591b63e0cf0d02adda35aa07');
+    expect(dataWorkflow).toContain('989dd945ac633ecb1ba83cc80a1b88234cac31d78b3d905ae0242eb66c533eb3');
+    expect(dataWorkflow).toContain('49 ordered files, 1,630,260 rows, and 177,923,082 bytes');
+    expect(dataWorkflow).toContain('60 tables, 307,617,792 bytes, 35 documents, 4,111');
+    expect(dataWorkflow).toContain('zero `historical_sectioned_publications` rows, and one corpus seal');
+    expect(canaryScript).toContain("state: 'unrecorded'");
+    expect(workflow).toContain('preview-d1-readiness-receipt.json');
+    expect(workflow).toContain('Capture production control before preview deployment (read-only)');
+    expect(workflow).toContain('Verify production control remained unchanged (read-only)');
+    expect(workflow).toContain('production-control-after.outcome == \'success\'');
+    expect(workflow).toContain('scripts/production-release-reconciliation.ts capture-control');
+    expect(workflow).toContain('scripts/production-release-reconciliation.ts verify-control');
   });
 });

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -356,12 +356,15 @@ describe('published project contract', () => {
       d1Id: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
     };
 
-    for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
+    const productionCutoverDocuments = [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap];
+    for (const document of productionCutoverDocuments) {
       for (const value of Object.values(liveProduction)) expect(document).toContain(value);
       for (const value of Object.values(rollbackProduction)) expect(document).toContain(value);
-      for (const value of Object.values(livePreview)) expect(document).toContain(value);
       expect(document).toContain('30496350408');
       expect(document).toContain('8da99fd0a161b90a4bd90ab29bde1abf796b3bf6');
+    }
+    for (const document of [readme, dataWorkflow, reconciliation, operations, roadmap]) {
+      for (const value of Object.values(livePreview)) expect(document).toContain(value);
     }
     expect(reconciliation).toContain('completed PR #108 protected production cutover');
     expect(reconciliation).toContain('a59d9a062b2e6c7884de97fd97309878e1cbdc23');
@@ -379,6 +382,14 @@ describe('published project contract', () => {
     expect(roadmap).toContain('independent post-release review returned `SHIP`');
     expect(reconciliation).toContain('primary-source edge stabilization');
     expect(reconciliation).toContain('Transform-11 historical-spine audit');
+    expect(dataWorkflow).toContain('PR #122 deployment\n`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker');
+    expect(catalogScope).toContain('PR #122 deployment\n`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker');
+    expect(dataWorkflow).toContain('immediately preceding primary rollback unit');
+    expect(catalogScope).toContain('immediately preceding primary rollback\nunit');
+    expect(dataWorkflow).not.toContain('The current preview baseline is\ndeployment `5e812152');
+    expect(catalogScope).not.toContain('The current preview baseline is\ndeployment `5e812152');
+    expect(dataWorkflow).not.toContain('Retain the PR #101 matched Worker/D1 pair above for rollback.');
+    expect(catalogScope).not.toContain('Retain the PR #101 Worker/D1\npair above as rollback.');
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
       expect(document).not.toContain('Transform-8/9/10 authority');
       expect(document).toContain('Aquinas');

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -467,7 +467,7 @@ describe('published project contract', () => {
   });
 
   it('separates the current schema-0009 preview from historical PR107 evidence', async () => {
-    const [canary, reconciliation, readme, preflight, secret, audit, coordinator, operations] = await Promise.all([
+    const [canary, reconciliation, readme, preflight, secret, audit, coordinator, operations, productionReconciliation, roadmap] = await Promise.all([
       readProjectFile('docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md'),
       readProjectFile('docs/PREVIEW-RELEASE-RECONCILIATION.md'),
       readProjectFile('README.md'),
@@ -476,6 +476,8 @@ describe('published project contract', () => {
       readProjectFile('docs/CCEL-LIVE-PREVIEW-AUDIT.md'),
       readProjectFile('docs/CCEL-UPSTREAM-COORDINATOR.md'),
       readProjectFile('docs/worker-operations.md'),
+      readProjectFile('docs/PRODUCTION-RELEASE-RECONCILIATION.md'),
+      readProjectFile('docs/ROADMAP.md'),
     ]);
     for (const document of [canary, reconciliation, readme]) {
       const normalized = document.replace(/\s+/g, ' ');
@@ -509,7 +511,7 @@ describe('published project contract', () => {
     expect(canary).toContain('temporary `111` two-request preview canary transaction');
     expect(reconciliation).toContain('PR #122 completed the\nrequired current-main schema-`0009` preview refresh and audit');
     expect(preflight).toContain('fixed current-main candidate endpoint');
-    expect(preflight).toContain('PR #115 introduced this pin in repository code only and was not deployed');
+    expect(preflight).toContain('PR #115 introduced this pin in repository code only. PR #122 subsequently');
     expect(preflight).toContain('The v7\ncandidate contract does not supersede');
     expect(secret).toContain('Executing staging is a production Worker-version upload mutation');
     expect(secret).toContain('actual production Worker deployment and traffic mutation');
@@ -528,6 +530,11 @@ describe('published project contract', () => {
     expect(readme).not.toContain('The deployed preview and production D1 layers remain schema `0008`');
     expect(reconciliation).not.toContain('the sole active preview\nassignment bound to that exact candidate D1');
     expect(operations).not.toContain('as the sole\nactive preview assignment bound to that exact D1');
+    expect(preflight).not.toContain('The active PR #107 Worker');
+    expect(preflight).not.toContain('current-main preview refresh and audit is\n  required');
+    expect(productionReconciliation).not.toContain('The current preview baseline is\ndeployment `5e812152');
+    expect(roadmap).not.toContain('Preview remains\n  PR #107');
+    expect(roadmap).not.toContain('Preview now serves deployment\n  `5e812152');
   });
 
   it('records the schema-0009 preview-only release boundary and production control', async () => {

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -550,19 +550,19 @@ describe('published project contract', () => {
     ]);
     const previewName = 'theologai-preview-20260811-schema0009-a';
     const previewId = '74f456e2-6951-4003-bb6f-91951342bf8f';
-    const productionId = '53211f50-a893-4b4c-be1e-bc625a595dc7';
-    const productionCandidateId = '9bc79346-338b-439e-a2a5-424f4418eb21';
+    const productionId = '9bc79346-338b-439e-a2a5-424f4418eb21';
+    const productionName = 'theologai-production-20260811-schema0009-a';
 
     for (const document of [readme, reconciliation, canary, operations, dataWorkflow]) {
       expect(document).toContain(previewName);
       expect(document).toContain(previewId);
-      expect(document).toContain(productionCandidateId);
+      expect(document).toContain(productionId);
       expect(document).toContain('unbound');
     }
     expect(config).toContain(`database_name = "${previewName}"`);
     expect(config).toContain(`database_id = "${previewId}"`);
+    expect(config).toContain(`database_name = "${productionName}"`);
     expect(config).toContain(`database_id = "${productionId}"`);
-    expect(config).not.toContain(productionCandidateId);
     expect(dataWorkflow).toContain('e1baa04fecbb066860d06f262142e3450823b7d0');
     expect(dataWorkflow).toContain('673af4a75c770c541a8be3c84e77d8f91033bd07');
     expect(dataWorkflow).toContain('ecbd23bb3c692665c7031a8c1fa7733e17a56fbc7e3a167ba4011f6c1cca62d8');

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -390,6 +390,20 @@ describe('published project contract', () => {
     expect(catalogScope).not.toContain('The current preview baseline is\ndeployment `5e812152');
     expect(dataWorkflow).not.toContain('Retain the PR #101 matched Worker/D1 pair above for rollback.');
     expect(catalogScope).not.toContain('Retain the PR #101 Worker/D1\npair above as rollback.');
+    for (const document of [readme, dataWorkflow, operations]) {
+      const normalized = document.replace(/\s+/g, ' ');
+      expect(normalized).toContain('immediately preceding primary rollback unit');
+    }
+    expect(readme.replace(/\s+/g, ' ')).toContain('PR #101 is older retained rollback history');
+    expect(operations.replace(/\s+/g, ' ')).toContain('PR #101 is older retained rollback history');
+    expect(dataWorkflow).toContain('older retained rollback history');
+    expect(readme).not.toContain('The PR #101 production assignment is retained as the matched rollback pair.');
+    expect(readme).not.toContain("PR #101's former production assignment, retained as the rollback pair");
+    expect(readme).not.toContain('The PR #101 Worker/D1 pair above remains the rollback record.');
+    expect(operations).not.toContain('The former PR #101 production assignment is the matched rollback pair:');
+    expect(operations).not.toContain('The PR #101 Worker/D1 pair above is retained as\nrollback.');
+    expect(dataWorkflow).not.toContain('—is now the matched rollback pair.');
+    expect(dataWorkflow).not.toContain('The PR #101 candidate, now the retained\nproduction rollback,');
     for (const document of [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap]) {
       expect(document).not.toContain('Transform-8/9/10 authority');
       expect(document).toContain('Aquinas');

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -564,8 +564,14 @@ describe('published project contract', () => {
     expect(workflow).toContain('preview-d1-readiness-receipt.json');
     expect(workflow).toContain('Capture production control before preview deployment (read-only)');
     expect(workflow).toContain('Verify production control remained unchanged (read-only)');
+    expect(workflow).toContain('Verify production control remained unchanged after preview audits (read-only)');
     expect(workflow).toContain('production-control-after.outcome == \'success\'');
+    expect(workflow).toContain('production-control-d1-inventory-before.json');
+    expect(workflow).toContain('production-control-d1-inventory-post-audit.json');
+    expect(workflow).toContain('production_control_post_audit_sha256');
     expect(workflow).toContain('scripts/production-release-reconciliation.ts capture-control');
     expect(workflow).toContain('scripts/production-release-reconciliation.ts verify-control');
+    expect(reconciliation).toContain('checked-in production name/UUID and a fresh read-only D1 inventory');
+    expect(reconciliation).toContain('again after every fixed preview\naudit and the final preview Worker identity check');
   });
 });

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -292,7 +292,7 @@ describe('published project contract', () => {
     expect(reconciliation).toContain('This is the retained compatible\npreview predecessor');
     expect(reconciliation).toContain('evidence remains authoritative for that predecessor');
     expect(operations).toContain('The retained PR #101 preview predecessor was deployment');
-    expect(operations).toContain('active preview assignment bound to that exact D1');
+    expect(operations).toContain("PR #122's retained immediate predecessor, not the active preview");
   });
 
   it('records the completed Transform 11 preview release and unpublished hardening boundary', async () => {
@@ -325,7 +325,7 @@ describe('published project contract', () => {
     expect(documents[6]).toContain('30419373527');
     expect(documents[6]).toContain('30420256210');
     expect(documents[6]).toContain('Production was unchanged by that preview release');
-    expect(documents[5]).toContain('preview assignment\nremained unchanged during the PR #108 production release');
+    expect(documents[5]).toContain('remained unchanged during the PR #108 production release and\nis now PR #122');
   });
 
   it('documents the completed PR #108 Transform 11 production cutover and rollback', async () => {
@@ -431,7 +431,7 @@ describe('published project contract', () => {
     for (const document of [roadmap, production, preview]) {
       for (const value of Object.values(durableProduction)) expect(document).toContain(value);
     }
-    expect(preview).toContain('CCEL execution disabled before adapter, coordinator, or fetch');
+    expect(preview.replace(/\s+/g, ' ')).toContain('CCEL execution remains disabled before adapter, coordinator, or fetch');
     expect(production).toContain('PR #108 v6/local-only release');
   });
 
@@ -466,8 +466,8 @@ describe('published project contract', () => {
     expect(preflight).toContain('No HTML, query, result, or snippet evidence is retained.');
   });
 
-  it('separates the current-main CCEL canary prerequisites from active PR107 evidence', async () => {
-    const [canary, reconciliation, readme, preflight, secret, audit, coordinator] = await Promise.all([
+  it('separates the current schema-0009 preview from historical PR107 evidence', async () => {
+    const [canary, reconciliation, readme, preflight, secret, audit, coordinator, operations] = await Promise.all([
       readProjectFile('docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md'),
       readProjectFile('docs/PREVIEW-RELEASE-RECONCILIATION.md'),
       readProjectFile('README.md'),
@@ -475,13 +475,14 @@ describe('published project contract', () => {
       readProjectFile('docs/CCEL-OPERATOR-SECRET-PROVISIONING.md'),
       readProjectFile('docs/CCEL-LIVE-PREVIEW-AUDIT.md'),
       readProjectFile('docs/CCEL-UPSTREAM-COORDINATOR.md'),
+      readProjectFile('docs/worker-operations.md'),
     ]);
     for (const document of [canary, reconciliation, readme]) {
       const normalized = document.replace(/\s+/g, ' ');
       expect(normalized).toContain('06b9a603-8339-42b6-a246-ef9238563043');
       expect(normalized).toContain("PR #115's repository-only");
       expect(normalized).toContain('https://www.ccel.org/home3/search');
-      expect(normalized).toContain('code/resource-equivalent `100` predecessor');
+      expect(normalized).toMatch(/code\/resource-equivalent (?:`100` )?preview predecessor|code\/resource-equivalent `100` predecessor/);
     }
     expect(canary).toContain('five separately authorized stages');
     expect(canary).toContain('Completion or authorization of any stage does not authorize the next stage.');
@@ -506,7 +507,7 @@ describe('published project contract', () => {
     expect(canaryOrder).toEqual([...canaryOrder].sort((left, right) => left - right));
     expect(canary).toContain('resources.script.etag');
     expect(canary).toContain('temporary `111` two-request preview canary transaction');
-    expect(reconciliation).toContain('protected preview release must safely refresh exact');
+    expect(reconciliation).toContain('PR #122 completed the\nrequired current-main schema-`0009` preview refresh and audit');
     expect(preflight).toContain('fixed current-main candidate endpoint');
     expect(preflight).toContain('PR #115 introduced this pin in repository code only and was not deployed');
     expect(preflight).toContain('The v7\ncandidate contract does not supersede');
@@ -515,7 +516,7 @@ describe('published project contract', () => {
     expect(secret).toContain('Neither staging nor\npromotion authorizes');
     expect(secret).toContain('separate schema-`0009` D1 sequence must have completed in order');
     expect(secret).toContain('while unbound; the preview candidate bound, deployed, and audited; then the\nproduction candidate bound, deployed, and audited; then a read-only\nenvironment-isolation verification');
-    expect(readme).toContain("Current `main` also includes PR #117's Transform-12 schema\n`0009` contract");
+    expect(readme).toContain('PR #122 has since completed the schema-`0009` preview');
     expect(readme).toContain('The protected release targeted the prepared preview D1');
     const normalizedAudit = audit.replace(/\s+/g, ' ');
     expect(normalizedAudit).toContain('schema observations prove v6 local-only versus v7 CCEL exposure; they do not prove which endpoint-bearing code revision is deployed');
@@ -523,6 +524,10 @@ describe('published project contract', () => {
     expect(coordinator).toContain('The current v7 discovery application contract');
     expect(coordinator).toContain('The historical v5 release selected production v4/local-only');
     expect(coordinator).not.toContain('The v5 discovery application contract is exposed only by');
+    expect(readme).not.toContain('This active PR #107 preview Worker');
+    expect(readme).not.toContain('The deployed preview and production D1 layers remain schema `0008`');
+    expect(reconciliation).not.toContain('the sole active preview\nassignment bound to that exact candidate D1');
+    expect(operations).not.toContain('as the sole\nactive preview assignment bound to that exact D1');
   });
 
   it('records the schema-0009 preview-only release boundary and production control', async () => {

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -57,7 +57,7 @@ interface WorkerD1Ids {
 
 const currentD1Ids: WorkerD1Ids = {
   preview: '74f456e2-6951-4003-bb6f-91951342bf8f',
-  production: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+  production: '9bc79346-338b-439e-a2a5-424f4418eb21',
 };
 
 function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false, d1Ids: WorkerD1Ids = currentD1Ids) {
@@ -118,7 +118,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/main', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
-    })).toThrow(/production D1 identity uses a recorded schema-0008 name or UUID/);
+    })).toThrow(/schema-0009 canary gate is unrecorded/);
     expect(() => validateCanaryDispatch({
       ref: 'refs/heads/feature', sha: 'a'.repeat(40), expectedSha: 'a'.repeat(40), liveMainSha: 'a'.repeat(40),
       confirmation: CANARY_CONFIRMATION, configText: config,
@@ -154,15 +154,15 @@ describe('CCEL live preview canary transaction', () => {
       .replace('theologai-preview-20260811-schema0009-a', LEGACY_SCHEMA_0008_D1.preview.name)
       .replace('74f456e2-6951-4003-bb6f-91951342bf8f', LEGACY_SCHEMA_0008_D1.preview.id);
     expect(() => assertSchema0009CanaryPrerequisite(legacyConfig))
-      .toThrow(/production D1 identity uses a recorded schema-0008 name or UUID/);
+      .toThrow(/preview D1 identity uses a recorded schema-0008 name or UUID/);
     const onlyLegacyPreviewRemaining = legacyConfig
-      .replace('theologai-production-20260729-transform11-a', 'theologai-production-schema0009-candidate')
-      .replace('53211f50-a893-4b4c-be1e-bc625a595dc7', '323e4567-e89b-42d3-a456-426614174003');
+      .replace('theologai-production-20260811-schema0009-a', 'theologai-production-schema0009-candidate')
+      .replace('9bc79346-338b-439e-a2a5-424f4418eb21', '323e4567-e89b-42d3-a456-426614174003');
     expect(() => assertSchema0009CanaryPrerequisite(onlyLegacyPreviewRemaining))
       .toThrow(/preview D1 identity uses a recorded schema-0008 name or UUID/);
     const noLegacyIdentityRemaining = onlyLegacyPreviewRemaining
-      .replace('theologai-preview-20260728-transform11-a', 'theologai-preview-schema0009-candidate')
-      .replace('62b871a6-5b4d-4d9b-8f52-301f6c878f48', '423e4567-e89b-42d3-a456-426614174003');
+      .replace(LEGACY_SCHEMA_0008_D1.preview.name, 'theologai-preview-schema0009-candidate')
+      .replace(LEGACY_SCHEMA_0008_D1.preview.id, '423e4567-e89b-42d3-a456-426614174003');
     expect(() => assertSchema0009CanaryPrerequisite(noLegacyIdentityRemaining))
       .toThrow(/schema-0009 canary gate is unrecorded/);
 

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -55,12 +55,12 @@ interface WorkerD1Ids {
   production: string;
 }
 
-const legacyD1Ids: WorkerD1Ids = {
-  preview: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+const currentD1Ids: WorkerD1Ids = {
+  preview: '74f456e2-6951-4003-bb6f-91951342bf8f',
   production: '53211f50-a893-4b4c-be1e-bc625a595dc7',
 };
 
-function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false, d1Ids: WorkerD1Ids = legacyD1Ids) {
+function bindings(mode: '100' | '111' | '000', includeOperatorSecret = false, d1Ids: WorkerD1Ids = currentD1Ids) {
   const productionMode = mode === '000';
   return [
     { name: 'THEOLOGAI_DB', type: 'd1', id: productionMode ? d1Ids.production : d1Ids.preview },
@@ -129,7 +129,7 @@ describe('CCEL live preview canary transaction', () => {
     })).toThrow();
     for (const tampered of [
       config.replace('preview-mcp.theologai.xyz', 'wrong.example'),
-      config.replace('62b871a6-5b4d-4d9b-8f52-301f6c878f48', '11111111-1111-4111-8111-111111111111'),
+      config.replace('74f456e2-6951-4003-bb6f-91951342bf8f', '11111111-1111-4111-8111-111111111111'),
       config.replace('class_name = "CcelGlobalCoordinator"', 'class_name = "WrongCoordinator"'),
       config.replace('namespace_id = "361204"', 'namespace_id = "999999"'),
     ]) expect(() => assertCommittedConfig(tampered)).toThrow();
@@ -150,9 +150,12 @@ describe('CCEL live preview canary transaction', () => {
       state: 'unrecorded',
       requiredSchema: '0009_candidate_c_sectioned_publications',
     });
-    expect(() => assertSchema0009CanaryPrerequisite(config))
+    const legacyConfig = config
+      .replace('theologai-preview-20260811-schema0009-a', LEGACY_SCHEMA_0008_D1.preview.name)
+      .replace('74f456e2-6951-4003-bb6f-91951342bf8f', LEGACY_SCHEMA_0008_D1.preview.id);
+    expect(() => assertSchema0009CanaryPrerequisite(legacyConfig))
       .toThrow(/production D1 identity uses a recorded schema-0008 name or UUID/);
-    const onlyLegacyPreviewRemaining = config
+    const onlyLegacyPreviewRemaining = legacyConfig
       .replace('theologai-production-20260729-transform11-a', 'theologai-production-schema0009-candidate')
       .replace('53211f50-a893-4b4c-be1e-bc625a595dc7', '323e4567-e89b-42d3-a456-426614174003');
     expect(() => assertSchema0009CanaryPrerequisite(onlyLegacyPreviewRemaining))
@@ -283,7 +286,7 @@ describe('CCEL live preview canary transaction', () => {
     expect(ordered.every(index => index >= 0)).toBe(true);
     expect(ordered).toEqual([...ordered].sort((left, right) => left - right));
     expect(canaryTransaction).toContain('Do not perform a second preview refresh here.');
-    expect(canaryTransaction).toContain('reviewed `ready` record\nfor each environment: exact D1 name/UUID plus separately pinned readiness and\nauthority evidence identities and SHA-256 values, plus one separately pinned\nenvironment-isolation evidence identity and SHA-256');
+    expect(canaryTransaction.replace(/\s+/g, ' ')).toContain('reviewed `ready` record for each environment: exact D1 name/UUID plus separately pinned readiness and authority evidence identities and SHA-256 values, plus one separately pinned environment-isolation evidence identity and SHA-256');
     expect(canaryTransaction).toContain('any recorded\nschema-`0008` D1 name or UUID regardless of pairing');
     expect(operatorProvisioning).toContain('it must not be\nrepeated as a second refresh after credential work.');
   });

--- a/test/unit/scripts/checkRemoteD1Readiness.test.ts
+++ b/test/unit/scripts/checkRemoteD1Readiness.test.ts
@@ -297,10 +297,20 @@ describe('remote D1 readiness query', () => {
   it('runs primary readiness, then bounded authority pages, and requests diagnostics only after failure', () => {
     const remote = remoteAuthorityExecutor();
     try {
-      runRemoteD1ReadinessCheck({
+      const receipt = runRemoteD1ReadinessCheck({
         database: 'preview', env: 'preview', wrangler: '/tmp/wrangler',
         configPath: '/tmp/generated-candidate/wrangler.candidate.toml',
       }, remote.execute);
+      expect(receipt).toMatchObject({
+        schemaVersion: 'theologai-remote-d1-readiness-receipt.v1',
+        database: 'preview', environment: 'preview',
+        readiness: { result: 'passed' }, authority: { result: 'passed' },
+      });
+      for (const component of [receipt.readiness, receipt.authority]) {
+        expect(component.identitySha256).toMatch(/^[a-f0-9]{64}$/);
+        expect(component.resultSha256).toMatch(/^[a-f0-9]{64}$/);
+      }
+      expect(JSON.stringify(receipt)).not.toMatch(/(?:sql|resources|diagnostic|content)/i);
       expect(remote.calls).toHaveLength(183); // readiness plus Transform 8 and complete three-pack authority pages
       expect(remote.calls[0]).toContain('--json');
       expect(remote.calls[0]).toContain('--env');

--- a/test/unit/scripts/previewReleaseReconciliation.test.ts
+++ b/test/unit/scripts/previewReleaseReconciliation.test.ts
@@ -75,37 +75,64 @@ describe('preview release reconciliation evidence', () => {
     })).toThrow('does not match the checked-out readiness-tested candidate D1');
   });
 
-  it('fails closed when a preview release changes any production control identity', () => {
+  it('proves the initial production control against config and fresh name/UUID inventory, then fails closed for post-audit drift', async () => {
+    const config = await readFile(new URL('wrangler.toml', root), 'utf8');
+    const productionInventory = inventory(productionCandidateD1Id, productionCandidateD1Name);
     const productionControl = captureProductionControlIdentity({
       deploymentsText: deployments(predecessorDeployment, predecessorVersion),
       activeVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      wranglerConfigText: config,
+      d1InventoryText: productionInventory,
     });
-    expect(productionControl).toEqual({
-      schemaVersion: 1,
+    expect(productionControl).toMatchObject({
+      schemaVersion: 2,
       worker: 'theologai',
       deploymentId: predecessorDeployment,
       workerVersionId: predecessorVersion,
       d1: { binding: 'THEOLOGAI_DB', databaseId: productionCandidateD1Id },
+      configuredD1: { binding: 'THEOLOGAI_DB', databaseName: productionCandidateD1Name, databaseId: productionCandidateD1Id },
     });
+    expect(productionControl.wranglerConfigSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(productionControl.d1InventorySha256).toMatch(/^[0-9a-f]{64}$/);
     expect(verifyProductionControlUnchanged({
       controlText: JSON.stringify(productionControl),
       deploymentsText: deployments(predecessorDeployment, predecessorVersion),
       activeVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      wranglerConfigText: config,
+      d1InventoryText: productionInventory,
     })).toEqual(productionControl);
+    expect(() => captureProductionControlIdentity({
+      deploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      activeVersionViewText: versionView(predecessorVersion, predecessorD1Id),
+      wranglerConfigText: config,
+      d1InventoryText: productionInventory,
+    })).toThrow('does not match the checked-out readiness-tested candidate D1');
+    expect(() => captureProductionControlIdentity({
+      deploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      activeVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      wranglerConfigText: config,
+      d1InventoryText: inventory(productionCandidateD1Id, 'unexpected-production-name'),
+    })).toThrow('does not match the read-only inventory ID/name mapping');
     expect(() => verifyProductionControlUnchanged({
       controlText: JSON.stringify(productionControl),
       deploymentsText: deployments(candidateDeployment, predecessorVersion),
       activeVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      wranglerConfigText: config,
+      d1InventoryText: productionInventory,
     })).toThrow('production deployment changed during preview release');
     expect(() => verifyProductionControlUnchanged({
       controlText: JSON.stringify(productionControl),
       deploymentsText: deployments(predecessorDeployment, candidateVersion),
       activeVersionViewText: versionView(candidateVersion, productionCandidateD1Id),
+      wranglerConfigText: config,
+      d1InventoryText: productionInventory,
     })).toThrow('production Worker version changed during preview release');
     expect(() => verifyProductionControlUnchanged({
       controlText: JSON.stringify(productionControl),
       deploymentsText: deployments(predecessorDeployment, predecessorVersion),
       activeVersionViewText: versionView(predecessorVersion, predecessorD1Id),
+      wranglerConfigText: config,
+      d1InventoryText: productionInventory,
     })).toThrow('production D1 binding changed during preview release');
   });
 
@@ -265,12 +292,18 @@ describe('preview release reconciliation evidence', () => {
     const candidateCutover = workflow.indexOf('Require deployed candidate preview D1 binding (read-only)');
     const originalLanguageAudit = workflow.indexOf('Audit original-language v2 contract on preview');
     const historicalAudit = workflow.indexOf('Audit Transform-9 historical core contract on preview');
+    const previewAuditIdentity = workflow.indexOf('Verify preview Worker remained active through audit (read-only)');
+    const postAuditProductionControl = workflow.indexOf('Verify production control remained unchanged after preview audits (read-only)');
+    const evidenceHash = workflow.indexOf('Hash sanitized preview audit evidence');
     expect(mapping).toBeGreaterThan(-1);
     expect(readiness).toBeGreaterThan(mapping);
     expect(predecessor).toBeGreaterThan(readiness);
     expect(candidateCutover).toBeGreaterThan(predecessor);
     expect(originalLanguageAudit).toBeGreaterThan(candidateCutover);
     expect(historicalAudit).toBeGreaterThan(candidateCutover);
+    expect(previewAuditIdentity).toBeGreaterThan(historicalAudit);
+    expect(postAuditProductionControl).toBeGreaterThan(previewAuditIdentity);
+    expect(evidenceHash).toBeGreaterThan(postAuditProductionControl);
     expect(workflow).toContain('npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/preview-d1-inventory.json"');
     expect(workflow).toContain('--database "$candidate_d1_name" --env preview');
     expect(workflow).toContain('observe-post-mutation');
@@ -278,5 +311,11 @@ describe('preview release reconciliation evidence', () => {
     expect(workflow).toContain('Hash sanitized preview reconciliation evidence');
     expect(workflow).toContain('candidate_cutover_observation_sha256');
     expect(workflow).toContain('post_mutation_reconciliation_sha256');
+    expect(workflow).toContain('production-control-d1-inventory-before.json');
+    expect(workflow).toContain('production-control-d1-inventory-after-deploy.json');
+    expect(workflow).toContain('production-control-d1-inventory-post-audit.json');
+    expect(workflow).toContain('--wrangler-config wrangler.toml');
+    expect(workflow).toContain('production_control_post_audit_sha256');
+    expect(workflow).toContain('production-control-post-audit.json');
   });
 });

--- a/test/unit/scripts/previewReleaseReconciliation.test.ts
+++ b/test/unit/scripts/previewReleaseReconciliation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   activeProductionVersionId,
   candidateProductionD1DatabaseName,
+  captureProductionControlIdentity,
   captureProductionPredecessorAnchor,
   reconcileProductionPostMutation,
   activePreviewVersionId,
@@ -10,6 +11,7 @@ import {
   capturePreviewPredecessorAnchor,
   observePreviewPostMutation,
   reconcilePreviewPostMutation,
+  verifyProductionControlUnchanged,
 } from '../../../scripts/preview-release-reconciliation.js';
 
 const root = new URL('../../../', import.meta.url);
@@ -18,8 +20,8 @@ const candidateVersion = '223e4567-e89b-42d3-a456-426614174000';
 const predecessorDeployment = '323e4567-e89b-42d3-a456-426614174000';
 const candidateDeployment = '423e4567-e89b-42d3-a456-426614174000';
 const predecessorD1Id = '94c4938b-7800-4d68-9097-0df33c31fdc1';
-const candidateD1Id = '62b871a6-5b4d-4d9b-8f52-301f6c878f48';
-const candidateD1Name = 'theologai-preview-20260728-transform11-a';
+const candidateD1Id = '74f456e2-6951-4003-bb6f-91951342bf8f';
+const candidateD1Name = 'theologai-preview-20260811-schema0009-a';
 const productionCandidateD1Id = '53211f50-a893-4b4c-be1e-bc625a595dc7';
 const productionCandidateD1Name = 'theologai-production-20260729-transform11-a';
 
@@ -71,6 +73,40 @@ describe('preview release reconciliation evidence', () => {
       predecessorAnchorText: JSON.stringify(anchor), postMutationDeploymentsText: deployments(candidateDeployment, candidateVersion),
       observedActiveVersionViewText: versionView(candidateVersion, predecessorD1Id), wranglerConfigText: config,
     })).toThrow('does not match the checked-out readiness-tested candidate D1');
+  });
+
+  it('fails closed when a preview release changes any production control identity', () => {
+    const productionControl = captureProductionControlIdentity({
+      deploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      activeVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+    });
+    expect(productionControl).toEqual({
+      schemaVersion: 1,
+      worker: 'theologai',
+      deploymentId: predecessorDeployment,
+      workerVersionId: predecessorVersion,
+      d1: { binding: 'THEOLOGAI_DB', databaseId: productionCandidateD1Id },
+    });
+    expect(verifyProductionControlUnchanged({
+      controlText: JSON.stringify(productionControl),
+      deploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      activeVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+    })).toEqual(productionControl);
+    expect(() => verifyProductionControlUnchanged({
+      controlText: JSON.stringify(productionControl),
+      deploymentsText: deployments(candidateDeployment, predecessorVersion),
+      activeVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+    })).toThrow('production deployment changed during preview release');
+    expect(() => verifyProductionControlUnchanged({
+      controlText: JSON.stringify(productionControl),
+      deploymentsText: deployments(predecessorDeployment, candidateVersion),
+      activeVersionViewText: versionView(candidateVersion, productionCandidateD1Id),
+    })).toThrow('production Worker version changed during preview release');
+    expect(() => verifyProductionControlUnchanged({
+      controlText: JSON.stringify(productionControl),
+      deploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      activeVersionViewText: versionView(predecessorVersion, predecessorD1Id),
+    })).toThrow('production D1 binding changed during preview release');
   });
 
   it('captures distinct observed predecessor and readiness-tested candidate D1 identities', async () => {

--- a/test/unit/scripts/previewReleaseReconciliation.test.ts
+++ b/test/unit/scripts/previewReleaseReconciliation.test.ts
@@ -7,6 +7,7 @@ import {
   capturePreviewControlIdentity,
   captureProductionControlIdentity,
   captureProductionPredecessorAnchor,
+  observeProductionPostMutation,
   reconcileProductionPostMutation,
   activePreviewVersionId,
   candidatePreviewD1DatabaseName,
@@ -48,6 +49,18 @@ function inventory(id = candidateD1Id, name = candidateD1Name): string {
   return JSON.stringify([{ uuid: id, name }]);
 }
 
+function auditedProductionIdentity(
+  deploymentId = predecessorDeployment,
+  deployedVersionId = predecessorVersion,
+): string {
+  return JSON.stringify({
+    schemaVersion: 2, worker: 'theologai', deploymentId, deployedVersionId, deployedVersionNumber: 42,
+    beforeVersionsSha256: 'a'.repeat(64), afterVersionsSha256: 'b'.repeat(64), deploymentsSha256: 'c'.repeat(64),
+    commandOutputSha256: 'd'.repeat(64), commandReportedVersionId: deployedVersionId, addedVersionIds: [deployedVersionId],
+    postAuditDeploymentsSha256: 'e'.repeat(64),
+  });
+}
+
 function predecessorConfig(config: string): string {
   return config
     .replace(`database_name = "${candidateD1Name}"`, 'database_name = "theologai-preview-20260722-b"')
@@ -76,6 +89,11 @@ describe('preview release reconciliation evidence', () => {
       predecessorAnchorText: JSON.stringify(anchor), postMutationDeploymentsText: deployments(candidateDeployment, candidateVersion),
       observedActiveVersionViewText: versionView(candidateVersion, predecessorD1Id), wranglerConfigText: config,
     })).toThrow('does not match the checked-out readiness-tested candidate D1');
+    expect(() => observeProductionPostMutation({
+      predecessorAnchorText: JSON.stringify(anchor), postMutationDeploymentsText: deployments(predecessorDeployment, candidateVersion),
+      observedActiveVersionViewText: versionView(candidateVersion, productionCandidateD1Id), wranglerConfigText: config,
+      auditedProductionIdentityText: auditedProductionIdentity(candidateDeployment, candidateVersion),
+    })).toThrow('production deployment changed after audited production identity');
   });
 
   it('proves the initial production control against config and fresh name/UUID inventory, then fails closed for post-audit drift', async () => {
@@ -163,6 +181,7 @@ describe('preview release reconciliation evidence', () => {
       productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
       previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
       previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      productionAuditedIdentityText: auditedProductionIdentity(),
       wranglerConfigText: config, d1InventoryText: allInventory,
     })).toMatchObject({
       production: { worker: 'theologai', d1: { databaseName: productionCandidateD1Name, databaseId: productionCandidateD1Id } },
@@ -173,6 +192,7 @@ describe('preview release reconciliation evidence', () => {
       productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
       previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
       previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      productionAuditedIdentityText: auditedProductionIdentity(),
       wranglerConfigText: config.replace(`database_name = "${productionCandidateD1Name}"`, 'database_name = "theologai-production-20260729-transform11-a"'),
       d1InventoryText: allInventory,
     })).toThrow('production D1 uses a recorded schema-0008 name or UUID');
@@ -181,6 +201,7 @@ describe('preview release reconciliation evidence', () => {
       productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
       previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
       previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      productionAuditedIdentityText: auditedProductionIdentity(),
       wranglerConfigText: config.replace(`database_id = "${candidateD1Id}"`, `database_id = "${productionCandidateD1Id}"`),
       d1InventoryText: allInventory,
     })).toThrow('production and preview D1 identities must be distinct');
@@ -189,9 +210,26 @@ describe('preview release reconciliation evidence', () => {
       productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
       previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
       previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      productionAuditedIdentityText: auditedProductionIdentity(),
       wranglerConfigText: config.replace(`database_id = "${productionCandidateD1Id}"`, 'database_id = "62b871a6-5b4d-4d9b-8f52-301f6c878f48"'),
       d1InventoryText: allInventory,
     })).toThrow('production D1 uses a recorded schema-0008 name or UUID');
+    expect(() => captureEnvironmentIsolationReceipt({
+      productionDeploymentsText: deployments(candidateDeployment, candidateVersion),
+      productionActiveVersionViewText: versionView(candidateVersion, productionCandidateD1Id),
+      previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
+      previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      productionAuditedIdentityText: auditedProductionIdentity(),
+      wranglerConfigText: config, d1InventoryText: allInventory,
+    })).toThrow('production deployment changed after audited production identity');
+    expect(() => captureEnvironmentIsolationReceipt({
+      productionDeploymentsText: deployments(predecessorDeployment, candidateVersion),
+      productionActiveVersionViewText: versionView(candidateVersion, productionCandidateD1Id),
+      previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
+      previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      productionAuditedIdentityText: auditedProductionIdentity(),
+      wranglerConfigText: config, d1InventoryText: allInventory,
+    })).toThrow('production Worker version changed after audited production identity');
   });
 
   it('captures distinct observed predecessor and readiness-tested candidate D1 identities', async () => {

--- a/test/unit/scripts/previewReleaseReconciliation.test.ts
+++ b/test/unit/scripts/previewReleaseReconciliation.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   activeProductionVersionId,
   candidateProductionD1DatabaseName,
+  captureEnvironmentIsolationReceipt,
+  capturePreviewControlIdentity,
   captureProductionControlIdentity,
   captureProductionPredecessorAnchor,
   reconcileProductionPostMutation,
@@ -11,6 +13,7 @@ import {
   capturePreviewPredecessorAnchor,
   observePreviewPostMutation,
   reconcilePreviewPostMutation,
+  verifyPreviewControlUnchanged,
   verifyProductionControlUnchanged,
 } from '../../../scripts/preview-release-reconciliation.js';
 
@@ -22,8 +25,8 @@ const candidateDeployment = '423e4567-e89b-42d3-a456-426614174000';
 const predecessorD1Id = '94c4938b-7800-4d68-9097-0df33c31fdc1';
 const candidateD1Id = '74f456e2-6951-4003-bb6f-91951342bf8f';
 const candidateD1Name = 'theologai-preview-20260811-schema0009-a';
-const productionCandidateD1Id = '53211f50-a893-4b4c-be1e-bc625a595dc7';
-const productionCandidateD1Name = 'theologai-production-20260729-transform11-a';
+const productionCandidateD1Id = '9bc79346-338b-439e-a2a5-424f4418eb21';
+const productionCandidateD1Name = 'theologai-production-20260811-schema0009-a';
 
 function deployments(id = predecessorDeployment, version = predecessorVersion): string {
   return JSON.stringify([{
@@ -134,6 +137,61 @@ describe('preview release reconciliation evidence', () => {
       wranglerConfigText: config,
       d1InventoryText: productionInventory,
     })).toThrow('production D1 binding changed during preview release');
+  });
+
+  it('proves preview remains exact and distinct throughout a production release', async () => {
+    const config = await readFile(new URL('wrangler.toml', root), 'utf8');
+    const allInventory = JSON.stringify([
+      { uuid: candidateD1Id, name: candidateD1Name },
+      { uuid: productionCandidateD1Id, name: productionCandidateD1Name },
+    ]);
+    const previewControl = capturePreviewControlIdentity({
+      deploymentsText: deployments(candidateDeployment, candidateVersion),
+      activeVersionViewText: versionView(candidateVersion, candidateD1Id),
+      wranglerConfigText: config, d1InventoryText: allInventory,
+    });
+    expect(verifyPreviewControlUnchanged({
+      controlText: JSON.stringify(previewControl), deploymentsText: deployments(candidateDeployment, candidateVersion),
+      activeVersionViewText: versionView(candidateVersion, candidateD1Id), wranglerConfigText: config, d1InventoryText: allInventory,
+    })).toEqual(previewControl);
+    expect(() => verifyPreviewControlUnchanged({
+      controlText: JSON.stringify(previewControl), deploymentsText: deployments(predecessorDeployment, candidateVersion),
+      activeVersionViewText: versionView(candidateVersion, candidateD1Id), wranglerConfigText: config, d1InventoryText: allInventory,
+    })).toThrow('preview deployment changed during production release');
+    expect(captureEnvironmentIsolationReceipt({
+      productionDeploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
+      previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      wranglerConfigText: config, d1InventoryText: allInventory,
+    })).toMatchObject({
+      production: { worker: 'theologai', d1: { databaseName: productionCandidateD1Name, databaseId: productionCandidateD1Id } },
+      preview: { worker: 'theologai-preview', d1: { databaseName: candidateD1Name, databaseId: candidateD1Id } },
+    });
+    expect(() => captureEnvironmentIsolationReceipt({
+      productionDeploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
+      previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      wranglerConfigText: config.replace(`database_name = "${productionCandidateD1Name}"`, 'database_name = "theologai-production-20260729-transform11-a"'),
+      d1InventoryText: allInventory,
+    })).toThrow('production D1 uses a recorded schema-0008 name or UUID');
+    expect(() => captureEnvironmentIsolationReceipt({
+      productionDeploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
+      previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      wranglerConfigText: config.replace(`database_id = "${candidateD1Id}"`, `database_id = "${productionCandidateD1Id}"`),
+      d1InventoryText: allInventory,
+    })).toThrow('production and preview D1 identities must be distinct');
+    expect(() => captureEnvironmentIsolationReceipt({
+      productionDeploymentsText: deployments(predecessorDeployment, predecessorVersion),
+      productionActiveVersionViewText: versionView(predecessorVersion, productionCandidateD1Id),
+      previewDeploymentsText: deployments(candidateDeployment, candidateVersion),
+      previewActiveVersionViewText: versionView(candidateVersion, candidateD1Id),
+      wranglerConfigText: config.replace(`database_id = "${productionCandidateD1Id}"`, 'database_id = "62b871a6-5b4d-4d9b-8f52-301f6c878f48"'),
+      d1InventoryText: allInventory,
+    })).toThrow('production D1 uses a recorded schema-0008 name or UUID');
   });
 
   it('captures distinct observed predecessor and readiness-tested candidate D1 identities', async () => {

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -83,7 +83,7 @@ describe('production release guards', () => {
     expect(observationBlock).toContain("steps.production-worker-deploy.outcome != 'skipped'");
     expect(observationBlock).toContain("steps.production-predecessor.outcome == 'success'");
     expect(observationBlock).not.toContain('continue-on-error');
-    expect(observationBlock).toContain('observe-post-mutation');
+    expect(observationBlock).toContain('observe-final-post-audit');
     expect(observationBlock).not.toContain('reconcile-post-mutation');
     expect(finalArtifactBlock).toContain("steps.production-worker-deploy.outcome != 'skipped'");
     expect(finalArtifactBlock).toContain('if-no-files-found: warn');
@@ -97,6 +97,8 @@ describe('production release guards', () => {
     expect(workflow).toContain('Verify preview control remained unchanged after production audits (read-only)');
     expect(workflow).toContain('Capture final schema-0009 environment isolation receipt (read-only)');
     expect(workflow).toContain('production-d1-readiness-receipt.json');
+    expect(workflow).toContain('--production-audited-identity "$RUNNER_TEMP/production-worker-deployment-identity.json"');
+    expect(workflow).toContain('scripts/production-release-reconciliation.ts observe-final-post-audit');
     expect(historicalAuditScript).toContain('${profile.label} expanded-discovery/catalog execution invariant drifted');
     expect(historicalAuditScript).not.toContain('preview expanded-discovery/catalog execution invariant drifted');
 

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -75,6 +75,7 @@ describe('production release guards', () => {
     const historicalAuditScript = await readFile(new URL('../../../scripts/audit-historical-core-preview.ts', import.meta.url), 'utf8');
     const finalObservation = workflow.indexOf('Capture final production routing/binding observation (read-only)');
     const finalArtifact = workflow.indexOf('Upload final production routing/binding observation');
+    const finalPostAuditIdentity = workflow.indexOf('Verify final production identity after audited release (read-only)');
     const protectedEvidence = workflow.indexOf('Upload protected production audit evidence');
     const observationBlock = workflow.slice(finalObservation, finalArtifact);
     const finalArtifactBlock = workflow.slice(finalArtifact, protectedEvidence);
@@ -88,6 +89,8 @@ describe('production release guards', () => {
     expect(observationBlock).not.toContain('reconcile-post-mutation');
     expect(finalArtifactBlock).toContain("steps.production-worker-deploy.outcome != 'skipped'");
     expect(finalArtifactBlock).toContain('if-no-files-found: warn');
+    expect(finalPostAuditIdentity).toBeGreaterThan(finalArtifact);
+    expect(finalPostAuditIdentity).toBeLessThan(protectedEvidence);
 
     // A failed deploy never becomes green because its action failed. A deploy
     // that otherwise passed its strict gates is also terminal if final
@@ -102,6 +105,7 @@ describe('production release guards', () => {
     expect(workflow).toContain('Verify final production identity after audited release (read-only)');
     expect(workflow).toContain('scripts/production-release-reconciliation.ts observe-final-post-audit');
     expect(workflow).toContain("steps.production-final-post-audit-identity.outcome == 'success'");
+    expect(workflow).toContain('production-worker-final-post-audit-identity.json');
     expect(historicalAuditScript).toContain('${profile.label} expanded-discovery/catalog execution invariant drifted');
     expect(historicalAuditScript).not.toContain('preview expanded-discovery/catalog execution invariant drifted');
 

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -91,14 +91,19 @@ describe('production release guards', () => {
     // A failed deploy never becomes green because its action failed. A deploy
     // that otherwise passed its strict gates is also terminal if final
     // routing/binding evidence could not be captured or hashed.
-    expect(workflow).toContain("id: production-audit-evidence\n        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.production-final-observation.outcome == 'success' }}");
+    expect(workflow).toContain("id: production-audit-evidence\n        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' && steps.final-environment-isolation.outcome == 'success' && steps.production-final-observation.outcome == 'success' }}");
+    expect(workflow).toContain('Capture preview control before production deployment (read-only)');
+    expect(workflow).toContain('Verify preview control remained unchanged after production deployment (read-only)');
+    expect(workflow).toContain('Verify preview control remained unchanged after production audits (read-only)');
+    expect(workflow).toContain('Capture final schema-0009 environment isolation receipt (read-only)');
+    expect(workflow).toContain('production-d1-readiness-receipt.json');
     expect(historicalAuditScript).toContain('${profile.label} expanded-discovery/catalog execution invariant drifted');
     expect(historicalAuditScript).not.toContain('preview expanded-discovery/catalog execution invariant drifted');
 
     // Strict cutover, fixed audits, audit-stability proof, and protected
     // evidence remain unavailable unless the deploy action itself succeeded.
     expect(workflow).toContain("id: production-worker-pre-audit-identity\n        if: ${{ steps.production-worker-deploy.outcome == 'success' }}");
-    expect(workflow).toContain("id: production-worker-candidate-cutover\n        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-pre-audit-identity.outcome == 'success' }}");
+    expect(workflow).toContain("id: production-worker-candidate-cutover\n        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-pre-audit-identity.outcome == 'success' && steps.preview-control-after-production-deploy.outcome == 'success' }}");
     expect(workflow).toContain("id: production-primary-source-edge-stabilization-gate\n        if: ${{ always() && steps.production-worker-candidate-cutover.outcome == 'success' }}");
     expect(workflow).toContain("id: production-original-language-v2-audit\n        if: ${{ steps.production-primary-source-edge-stabilization-gate.outcome == 'success' }}");
     expect(workflow).toContain("id: production-historical-core-audit\n        if: ${{ steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' }}");

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -83,7 +83,8 @@ describe('production release guards', () => {
     expect(observationBlock).toContain("steps.production-worker-deploy.outcome != 'skipped'");
     expect(observationBlock).toContain("steps.production-predecessor.outcome == 'success'");
     expect(observationBlock).not.toContain('continue-on-error');
-    expect(observationBlock).toContain('observe-final-post-audit');
+    expect(observationBlock).toContain('observe-post-mutation');
+    expect(observationBlock).not.toContain('production-audited-identity');
     expect(observationBlock).not.toContain('reconcile-post-mutation');
     expect(finalArtifactBlock).toContain("steps.production-worker-deploy.outcome != 'skipped'");
     expect(finalArtifactBlock).toContain('if-no-files-found: warn');
@@ -91,14 +92,16 @@ describe('production release guards', () => {
     // A failed deploy never becomes green because its action failed. A deploy
     // that otherwise passed its strict gates is also terminal if final
     // routing/binding evidence could not be captured or hashed.
-    expect(workflow).toContain("id: production-audit-evidence\n        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' && steps.final-environment-isolation.outcome == 'success' && steps.production-final-observation.outcome == 'success' }}");
+    expect(workflow).toContain("id: production-audit-evidence\n        if: ${{ steps.production-worker-deploy.outcome == 'success' && steps.production-worker-candidate-cutover.outcome == 'success' && steps.production-primary-source-edge-stabilization-gate.outcome == 'success' && steps.production-original-language-v2-audit.outcome == 'success' && steps.production-historical-core-audit.outcome == 'success' && steps.production-historical-spine-audit.outcome == 'success' && steps.production-worker-audit-identity.outcome == 'success' && steps.preview-control-after-production-audits.outcome == 'success' && steps.final-environment-isolation.outcome == 'success' && steps.production-final-observation.outcome == 'success' && steps.production-final-post-audit-identity.outcome == 'success' }}");
     expect(workflow).toContain('Capture preview control before production deployment (read-only)');
     expect(workflow).toContain('Verify preview control remained unchanged after production deployment (read-only)');
     expect(workflow).toContain('Verify preview control remained unchanged after production audits (read-only)');
     expect(workflow).toContain('Capture final schema-0009 environment isolation receipt (read-only)');
     expect(workflow).toContain('production-d1-readiness-receipt.json');
     expect(workflow).toContain('--production-audited-identity "$RUNNER_TEMP/production-worker-deployment-identity.json"');
+    expect(workflow).toContain('Verify final production identity after audited release (read-only)');
     expect(workflow).toContain('scripts/production-release-reconciliation.ts observe-final-post-audit');
+    expect(workflow).toContain("steps.production-final-post-audit-identity.outcome == 'success'");
     expect(historicalAuditScript).toContain('${profile.label} expanded-discovery/catalog execution invariant drifted');
     expect(historicalAuditScript).not.toContain('preview expanded-discovery/catalog execution invariant drifted');
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -112,11 +112,11 @@ script_name = "theologai-ccel-coordinator"
 
 [[env.preview.d1_databases]]
 binding = "THEOLOGAI_DB"
-# PR #107's prepared Transform-11 candidate. This checked-in declaration is not a remote
-# binding change; protected preview deployment must prove the active Worker
-# binds this exact D1 before it may run release audits.
-database_name = "theologai-preview-20260728-transform11-a"
-database_id = "62b871a6-5b4d-4d9b-8f52-301f6c878f48"
+# Prepared schema-0009 Candidate-C preview target. This checked-in declaration
+# is not a remote binding change; protected preview deployment must prove the
+# active Worker binds this exact D1 before it may run release audits.
+database_name = "theologai-preview-20260811-schema0009-a"
+database_id = "74f456e2-6951-4003-bb6f-91951342bf8f"
 migrations_dir = "migrations"
 
 # Preview uses a distinct namespace so load tests and PR validation cannot

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,11 +45,11 @@ script_name = "theologai-ccel-coordinator"
 # For multi-environment setups, use [env.staging] / [env.production] sections.
 [[d1_databases]]
 binding = "THEOLOGAI_DB"
-# PR #107's prepared Transform-11 candidate. This declaration selects the
+# Prepared schema-0009 candidate. This declaration selects the
 # release target only; the protected production workflow must prove the active
 # Worker binding before audits establish any live-state claim.
-database_name = "theologai-production-20260729-transform11-a"
-database_id = "53211f50-a893-4b4c-be1e-bc625a595dc7"
+database_name = "theologai-production-20260811-schema0009-a"
+database_id = "9bc79346-338b-439e-a2a5-424f4418eb21"
 migrations_dir = "migrations"
 
 # Anonymous abuse control. Counters are intentionally local to each Cloudflare


### PR DESCRIPTION
## Summary

- Select the separately prepared schema-0009 D1 candidate for preview only.
- Keep production on its existing schema-0008 D1 and keep the CCEL canary hard-inert.
- Add sanitized readiness receipts and strict production identity checks before and after the complete preview audit.
- Record the unbound preparation evidence and release boundaries in current operational documentation.

## Prepared candidates

- Preview: `theologai-preview-20260811-schema0009-a` (`74f456e2-6951-4003-bb6f-91951342bf8f`)
- Production, still unbound: `theologai-production-20260811-schema0009-a` (`9bc79346-338b-439e-a2a5-424f4418eb21`)
- Both completed the one-use 49-file / 1,630,260-row import, remote readiness, Transform-8 authority, and Transform-9/11 authority audits.

## Safety boundaries

- This PR does not authorize or perform production deployment, CCEL requests, secret staging, database deletion, migration retry, or canary activation.
- Do not add `deploy-preview` until normal CI and independent review pass.
- Preview deployment must be revoked after the protected audit.

## Verification

- Focused release suite: 52 passed, 2 intentionally skipped
- Follow-up targeted suite: 41 passed
- CCEL suite: 143 passed
- Documentation contracts: 13 passed
- Typecheck, build, YAML parse, and diff checks passed
- Independent release review: PASS
