### PR TITLE
docs: define Phase 3B and reconcile PR122

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,19 +54,28 @@ Remote MCP client configuration:
 ```
 
 Use the preview URL only for explicitly authorized release testing. The current
-live production baseline is PR #108 merge
-`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`: protected workflow
-`30496350408` deployed Cloudflare deployment
-`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, serving Worker
-`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98) as the sole 100% assignment,
-bound to D1 `theologai-production-20260729-transform11-a`
-(`53211f50-a893-4b4c-be1e-bc625a595dc7`). The historical-core audit passed
-8/8, the Transform-11 spine audit passed 10/10, the original-language audit
-passed 11/11, primary-source edge stabilization matched on attempt 4 and
-remained stable, and the independent post-release review returned `SHIP`.
-For this schema-`0009` cutover, the exact captured PR #108 Worker/D1 pair
-above is the immediately preceding primary rollback unit. PR #101 is older
-retained rollback history, not the immediate rollback claim.
+live production baseline is PR #122 merge
+`86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` (tree
+`8150aa29e7e4a22141edbfc9ab568df933f9c9b3`). Protected workflow
+`31631924636` deployed Cloudflare deployment
+`e62698f3-f6b0-4145-97bf-28abdeae0e3a`, serving Worker
+`02174f95-abe2-480b-84bf-3e8c1a3a0320` (#100) as the sole active assignment,
+bound to schema-`0009` D1 `theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). Remote readiness and authority,
+historical core, Transform-11 spine, original-language, edge stabilization,
+final Worker identity, preview-control, and environment-isolation checks all
+passed. CCEL execution remains disabled.
+
+The exact captured PR #108 Worker/D1 pair is the immediately preceding primary
+rollback unit: deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). PR #101 is older retained rollback
+history, not the immediate rollback claim.
+
+The successor delivery program is tracked in
+[Phase 3B](docs/PHASE-3B-PLAN.md). It begins with release hygiene and dual-era
+MCP modernization before the separate historical-research project.
 
 The historical PR #96 `original_language_study` schema-v2 audit passed 11/11
 cases.

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ For a preview-client rollback without changing server state, use the direct prev
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
 
-Production remains on schema `0008`; preview now uses the audited PR #122
-schema-`0009` Candidate-C D1. Earlier local-only and preview-only activation
+Production and preview now use their distinct audited PR #122 schema-`0009`
+Candidate-C D1 databases. Earlier local-only and preview-only activation
 statements are historical. The historical PR #96 public
 `original_language_study` v2 audit does not independently establish the runtime
 path for every later historical transform. The pinned packet's `SOURCE.json`
@@ -223,24 +223,24 @@ candidate, deployed it, proved the active preview binding, and completed its
 audit. It validated the fixed production control against the checked-in
 production D1 name/UUID and fresh inventory before deployment, immediately
 afterward, and again after the final preview audit.
-PR #122 has now completed that protected preview release: source
-`a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree
-`660c06ff31e7d0e2ccbc6fe12204e66c4e793233`) is served solely by preview
-Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` on deployment
-`13393917-fa91-4afc-aeaf-2809db6701a2`; all fixed audits and three production
-control observations passed. The authorization label was removed and revocation
-run `31572924302` succeeded. The detailed sanitized evidence is in
+PR #123 subsequently deployed exact source
+`7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0` (tree
+`28e555808ad3840d145a7ddd7e57934dc30e45c2`) as preview Worker
+`70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144) through deployment
+`4108d59a-4092-4389-824c-fa3820ab66f6`, retaining the same schema-`0009` D1.
+All fixed audits and three production-control observations passed. The
+authorization label was removed and revocation run `31645546905` succeeded.
+PR #122 deployment `13393917-fa91-4afc-aeaf-2809db6701a2` and Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142) are the immediate retained
+same-D1 predecessor. The detailed sanitized evidence is in
 [docs/PREVIEW-RELEASE-RECONCILIATION.md](docs/PREVIEW-RELEASE-RECONCILIATION.md).
-This evidence-only commit postdates the deployed source and makes no new
+This post-release evidence commit postdates the deployed source and makes no new
 runtime claim.
-The checked-in production release target is the separately prepared schema-`0009`
-candidate `theologai-production-20260811-schema0009-a`
-(`9bc79346-338b-439e-a2a5-424f4418eb21`). It remains unbound until the
-protected production workflow proves readiness, the exact active binding,
-post-audit preview control, and final environment isolation. Live production
-remains on its recorded schema-`0008` predecessor until then. The CCEL canary
-gate remains unrecorded and inert. The exact preparation identity, seed
-evidence, and release boundary are recorded in
+Production is separately bound to schema-`0009` D1
+`theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`) by the protected PR #122 release. The
+CCEL canary gate remains unrecorded and inert. The exact preparation identity,
+seed evidence, and release boundary are recorded in
 [docs/D1-DATA-WORKFLOW.md](docs/D1-DATA-WORKFLOW.md).
 
 ## MCP capabilities

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -21,8 +21,10 @@ The retained historical PR #107 preview Worker
 `06b9a603-8339-42b6-a246-ef9238563043` predates PR #115's repository-only,
 unpublished pin to `https://www.ccel.org/home3/search`. It remains valid
 point-in-time predecessor evidence, but it is no longer active. PR #122's
-schema-`0009` Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` is the audited
-current preview `100` baseline.
+schema-`0009` Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` is the retained
+same-D1 predecessor to PR #123. The audited current preview `100` baseline is
+PR #123 Worker `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), deployment
+`4108d59a-4092-4389-824c-fa3820ab66f6`.
 
 Current `main` also includes PR #117's Transform-12 schema `0009` contract.
 PR #107 preview and PR #108 production are retained schema-`0008` predecessor

--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -25,10 +25,10 @@ schema-`0009` Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` is the audited
 current preview `100` baseline.
 
 Current `main` also includes PR #117's Transform-12 schema `0009` contract.
-The retained PR #107 preview and PR #108 production D1 records were prepared
-against schema `0008`. PR #107 is predecessor evidence only; PR #108 remains
-the live production control. The historical `0008` readiness records remain
-evidence for those releases only.
+PR #107 preview and PR #108 production are retained schema-`0008` predecessor
+evidence only. PR #122 completed distinct schema-`0009` preview and production
+releases and the final environment-isolation proof. The historical `0008`
+readiness records remain evidence for those predecessor releases only.
 
 Operational readiness therefore has five separately authorized stages, in this
 order:
@@ -44,12 +44,10 @@ order:
    its protected preview audit. This one release creates the exact-current-main,
    code/resource-equivalent preview predecessor for the later `111` candidate;
    it is the safe preview refresh, not a prerequisite for a second refresh.
-3. Only after the preview audit passes, through a separately approved production
-   release, bind and deploy the exact prepared production candidate and complete
-   its protected production audit. Then perform a read-only environment-isolation
-   verification proving distinct preview and production D1 name/UUID pairs, each
-   active Worker is bound only to its matching environment candidate, and neither
-   retained schema-`0008` D1 was silently reused or crossed.
+3. **Completed by PR #122:** through the separately approved production release,
+   bind and deploy the exact prepared production candidate, complete its
+   protected production audit, and prove distinct preview and production D1
+   name/UUID pairs with no retained schema-`0008` reuse or crossing.
 4. Stage the operator credential as an undeployed production Worker version,
    then separately promote the reviewed version. Promotion is a real
    production Worker deployment and traffic mutation.
@@ -62,13 +60,13 @@ environment binding; the preview audit does not authorize the production release
 and the completed releases/isolation evidence do not authorize credential staging
 or the canary.
 
-The schema-`0009` candidates now have retained unbound preparation evidence:
-the checked-in preview release target is
+The schema-`0009` candidates have retained preparation and release evidence.
+The active preview target is
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`), and the checked-in production target
+(`74f456e2-6951-4003-bb6f-91951342bf8f`), and the active production target is
 `theologai-production-20260811-schema0009-a`
-(`9bc79346-338b-439e-a2a5-424f4418eb21`) remains unbound. This does not make the
-canary ready. Until a separate reviewed release replaces the hard inert
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). This does not make the canary ready.
+Until a separate reviewed release replaces the hard inert
 schema-`0009` canary gate, the canary workflow rejects both retained schema-`0008`
 D1 identities during its first local validation, before any Wrangler command or
 Cloudflare read. Changing only a D1 ID is insufficient: the future change must
@@ -81,11 +79,13 @@ schema-`0008` D1 name or UUID regardless of pairing, any shared
 preview/production identity, and any mismatch between those reviewed D1 pairs
 and committed configuration.
 
-PR #122 completed the one approved schema-`0009` preview bind/deploy/audit
-stage with its production control unchanged; its release evidence is recorded
-in `PREVIEW-RELEASE-RECONCILIATION.md`. That completion does not authorize the
-production candidate (still unbound), credential staging, or this canary. The
-gate remains `unrecorded` and inert, and the release made no CCEL request or
+PR #122 completed both approved schema-`0009` bind/deploy/audit stages. Preview
+evidence is recorded in `PREVIEW-RELEASE-RECONCILIATION.md`; production
+workflow `31631924636` deployed Worker
+`02174f95-abe2-480b-84bf-3e8c1a3a0320` through deployment
+`e62698f3-f6b0-4145-97bf-28abdeae0e3a` and emitted the final isolation receipt.
+Those completions do not authorize credential staging or this canary. The gate
+remains `unrecorded` and inert, and neither release made a CCEL request or
 secret change.
 
 The only way to create the third row is the main-only, manually dispatched

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -411,14 +411,16 @@ immediately preceding primary rollback unit: deployment
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). PR #101 remains older rollback
 history only and is not the immediate cutover rollback claim.
 
-The next checked-in production target is the separately prepared schema-`0009`
-candidate `theologai-production-20260811-schema0009-a`
-(`9bc79346-338b-439e-a2a5-424f4418eb21`). This local configuration change makes
-no remote binding or deployment claim. Before a protected production deployment,
-the workflow must emit a sanitized readiness receipt; then it must prove the
-preview control unchanged before deployment, after deployment, and after every
-production audit, followed by a final receipt proving the distinct exact
-schema-`0009` preview/production bindings against fresh inventory.
+PR #122 promoted the separately prepared schema-`0009` candidate
+`theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). Protected workflow `31631924636`
+deployed Worker `02174f95-abe2-480b-84bf-3e8c1a3a0320` through deployment
+`e62698f3-f6b0-4145-97bf-28abdeae0e3a`. It emitted the sanitized readiness
+receipt, proved preview unchanged before deployment, after deployment, and
+after every production audit, pinned the final production Worker to the exact
+audited identity, and emitted the final receipt proving the distinct exact
+schema-`0009` preview/production bindings against fresh inventory. The PR #108
+pair above is retained as the immediate matched rollback unit.
 
 Approved deploy jobs perform the last compatibility check read-only against
 the candidate name resolved from the checked-in name/UUID pair:

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -359,11 +359,13 @@ predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
 (`51890e12-1c3f-421f-b661-9a5ea9637e43`). That former Transform-11 preview
-binding is historical. The current preview baseline is PR #122 deployment
-`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
-`b2c62527-5759-4c1d-a9a3-8c1d43dddabe`, and schema-`0009` D1
+binding is historical. The current preview baseline is PR #123 deployment
+`4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
+`70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`). The checked-out Transform-10 Aquinas
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). Its same-D1 PR #122 predecessor was
+deployment `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142). The checked-out Transform-10 Aquinas
 hierarchy remains local-only and unpublished, with no catalog, runtime, or MCP
 projection. Future production workflows retain the same reconciliation
 contract: re-resolve the checked-in candidate name/UUID, rerun readiness by

--- a/docs/PHASE-3B-PLAN.md
+++ b/docs/PHASE-3B-PLAN.md
@@ -15,7 +15,7 @@ passed. Protected production workflow `31631924636` completed successfully.
 | Surface | Active release | D1 | Product profile |
 | --- | --- | --- | --- |
 | Production | deployment `e62698f3-f6b0-4145-97bf-28abdeae0e3a`; Worker `02174f95-abe2-480b-84bf-3e8c1a3a0320` (#100) | `theologai-production-20260811-schema0009-a` (`9bc79346-338b-439e-a2a5-424f4418eb21`) | v6 local-only; CCEL execution disabled |
-| Preview | deployment `13393917-fa91-4afc-aeaf-2809db6701a2`; Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142) | `theologai-preview-20260811-schema0009-a` (`74f456e2-6951-4003-bb6f-91951342bf8f`) | v7 discovery-aware; CCEL execution disabled |
+| Preview | deployment `4108d59a-4092-4389-824c-fa3820ab66f6`; Worker `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144) | `theologai-preview-20260811-schema0009-a` (`74f456e2-6951-4003-bb6f-91951342bf8f`) | v7 discovery-aware; CCEL execution disabled |
 
 Production readiness, Transform-8/9 authority, edge stabilization,
 original-language v2, historical-core, and Transform-11 historical-spine
@@ -30,11 +30,13 @@ deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). Retain both databases. Any rollback
 or deletion remains separately authorized.
 
-The production Worker is the exact `main` merge. Preview predates the
-documentation, release-evidence, production-guard, and production-binding
-commits in PR #122, but its executable Worker source, data, packages, and
-preview configuration are equivalent to `main`. No application refresh is
-currently required in either environment.
+The production Worker is the exact PR #122 `main` merge. PR #123 subsequently
+deployed its exact reviewed head `7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0`
+(tree `28e555808ad3840d145a7ddd7e57934dc30e45c2`) to preview without changing
+the D1 binding. Its readiness, edge, original-language, historical-core, and
+historical-spine audits passed; production remained unchanged. This
+post-release evidence update is documentation-only and is not itself a new
+runtime claim.
 
 ## Current product boundary
 

--- a/docs/PHASE-3B-PLAN.md
+++ b/docs/PHASE-3B-PLAN.md
@@ -1,0 +1,181 @@
+# Phase 3B plan
+
+This document defines the next TheologAI delivery program after the protected
+schema-`0009` preview and production releases completed by PR #122. Earlier
+roadmap sections use "Phase 3" for already-shipped work; **Phase 3B** is the
+unambiguous name for this successor program.
+
+## Known-good starting point
+
+GitHub `main` is PR #122 merge
+`86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2`, exact tree
+`8150aa29e7e4a22141edbfc9ab568df933f9c9b3`. Its five required CI checks
+passed. Protected production workflow `31631924636` completed successfully.
+
+| Surface | Active release | D1 | Product profile |
+| --- | --- | --- | --- |
+| Production | deployment `e62698f3-f6b0-4145-97bf-28abdeae0e3a`; Worker `02174f95-abe2-480b-84bf-3e8c1a3a0320` (#100) | `theologai-production-20260811-schema0009-a` (`9bc79346-338b-439e-a2a5-424f4418eb21`) | v6 local-only; CCEL execution disabled |
+| Preview | deployment `13393917-fa91-4afc-aeaf-2809db6701a2`; Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142) | `theologai-preview-20260811-schema0009-a` (`74f456e2-6951-4003-bb6f-91951342bf8f`) | v7 discovery-aware; CCEL execution disabled |
+
+Production readiness, Transform-8/9 authority, edge stabilization,
+original-language v2, historical-core, and Transform-11 historical-spine
+audits passed. The final isolation receipt proved the exact distinct
+production and preview Worker/D1 pairs. Preview did not change during the
+production release.
+
+The immediate production rollback unit is the captured PR #108 matched pair:
+deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). Retain both databases. Any rollback
+or deletion remains separately authorized.
+
+The production Worker is the exact `main` merge. Preview predates the
+documentation, release-evidence, production-guard, and production-binding
+commits in PR #122, but its executable Worker source, data, packages, and
+preview configuration are equivalent to `main`. No application refresh is
+currently required in either environment.
+
+## Current product boundary
+
+TheologAI exposes eleven tools and six guided prompts across local stdio/HTTP
+and hosted Worker transports. It provides eight Bible translations, six
+commentary sources, 35 locally indexed historical works, UBS-attested parallel
+passages, Strong's and morphology evidence, contextual original-language
+study, local primary-source research, and donation support.
+
+The following boundaries remain deliberate:
+
+- production primary-source research is local-only;
+- preview exposes the discovery-aware contract but cannot execute CCEL before
+  adapter, coordinator, or fetch;
+- CCEL bodies are never mirrored or durably stored;
+- the partial Aquinas packet and Norton packet are not public corpus members;
+- npm distribution is unsupported; local execution and hosted Cloudflare
+  deployment remain the supported forms.
+
+## Phase 3B sequencing
+
+### 3B.0 — Rebaseline and simplify
+
+1. Use a clean branch from `origin/main`; do not treat the dirty historical
+   primary checkout as a release source.
+2. Inventory the primary checkout and stale/prunable worktree registrations.
+   Preserve them until the owner separately authorizes any deletion.
+3. Add a narrowly reviewed mechanism that prevents evidence-only or
+   documentation-only merges from causing an unnecessary production deploy.
+4. Merge the post-PR-#122 evidence record only after that mechanism is proven.
+5. Consolidate current release identity into one authoritative record and keep
+   historical records explicitly time-scoped.
+6. Rehearse the matched PR #108 Worker/D1 rollback without changing live
+   traffic, then define a retention policy before any predecessor cleanup.
+
+### 3B.1 — Dual-era MCP modernization
+
+The current server uses `@modelcontextprotocol/sdk` v1 and negotiates the
+legacy `2025-11-25` protocol. The current MCP specification is `2026-07-28`,
+and the official TypeScript v2 packages support both legacy and modern eras.
+
+Implement this as a behavior-neutral infrastructure release:
+
+1. Spike the official TypeScript SDK v2 and current Cloudflare Agents SDK in
+   isolation; record bundle, runtime, and compatibility findings before
+   selecting versions.
+2. Preserve `2025-11-25` stdio and Streamable HTTP compatibility while adding
+   `2026-07-28` negotiation on the same endpoints.
+3. Add `server/discover`, per-request protocol/client capability metadata,
+   required `resultType`, cache metadata, deterministic list ordering, modern
+   request headers, and matching CORS policy.
+4. Keep all eleven tool schemas, six prompts, resources, data, and product
+   behavior unchanged during this migration.
+5. Replace new uses of deprecated MCP Logging with stderr or OpenTelemetry;
+   retain only the compatibility behavior required by legacy clients.
+6. Add separate legacy and modern protocol fixtures, conformance coverage, and
+   black-box audits. Preview must prove both eras before production.
+
+Do not add Tasks, MCP Apps, or Skills-over-MCP merely because they exist. Add
+an extension only when it solves a defined product workflow. Tasks are not
+currently justified by the server's bounded calls. MCP Apps may later help
+with interlinear, parallel-passage, or source-comparison presentation.
+
+Authoritative protocol references:
+
+- <https://modelcontextprotocol.io/specification/2026-07-28>
+- <https://modelcontextprotocol.io/specification/2026-07-28/changelog>
+- <https://github.com/modelcontextprotocol/typescript-sdk/blob/main/docs/protocol-versions.md>
+
+### 3B.2 — Historical research project
+
+Treat broad historical research as one product workflow rather than unrelated
+"add documents" and "turn on CCEL" features. Start from natural research
+requests such as topical surveys, locating a passage in one work, and
+comparing two historical authors.
+
+The target workflow is:
+
+1. turn the user's question into a bounded query plan;
+2. search rights-reviewed local texts first;
+3. use approved external providers only for missing discovery coverage;
+4. keep reviewed local evidence separate from unreviewed discovery results;
+5. return exact locators and short attributed snippets;
+6. track searched, read, deferred, unavailable, and not-searched coverage;
+7. read selected exact local sections before synthesis; and
+8. disclose when an external result has not been read.
+
+The retained CCEL path remains discovery-only: clean links, at most five short
+attributed 240-character snippets, no body retrieval, mirroring,
+republication, or durable CCEL content storage. A current interface,
+robots/policy, and operational review plus a separately authorized preview
+canary remain prerequisites to any live request.
+
+In parallel, run a rights-reviewed local-corpus program. The first candidates
+are one complete defensible English edition of Aquinas rather than presenting
+the partial packet as the whole *Summa*, and the approved Norton translation of
+Calvin. Reuse the generic part/question/article hierarchy, retain explicit
+edition provenance, and prefer one edition per work unless a second edition
+has a defined scholarly purpose.
+
+### 3B.3 — Original-language experience
+
+Preserve the existing evidence boundary while making one tool useful at
+multiple levels:
+
+- beginner: explain a likely nuance missed in English and the limits of the
+  evidence;
+- intermediate: lemma, morphology, translation range, and local context;
+- technical: source identity, attested semantic candidates, ambiguity, and
+  bounded occurrence windows.
+
+Update guided prompts to choose an appropriate depth. Evaluate MACULA
+discourse/context data only after a separate source, license, and product-scope
+review.
+
+### 3B.4 — Public operations
+
+1. Add privacy-safe custom-domain traffic observability before changing access
+   policy.
+2. Diagnose the sustained anonymous Frankfurt/AWS traffic and then consider a
+   narrow WAF or limiter response that keeps the MCP publicly usable.
+3. Revisit the production `workers.dev` compatibility alias only with separate
+   authorization.
+4. Optionally configure `www.theologai.xyz` as an apex redirect; it currently
+   has no DNS record.
+5. Continue consolidating release workflows and sanitized evidence retention.
+
+## Release order
+
+The default critical path is:
+
+```text
+3B.0 rebaseline and release hygiene
+  -> 3B.1 dual-era MCP preview and production
+  -> 3B.2 historical-research specification
+  -> local corpus and CCEL canary workstreams
+  -> unified historical-research preview audit
+  -> separately authorized production hard cutover
+```
+
+Original-language experience and public-edge observability may proceed in
+parallel after the MCP modernization has passed preview. No Phase 3B item
+authorizes a deployment, D1 operation, secret change, CCEL request, WAF change,
+or deletion merely by appearing in this plan.

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -9,13 +9,51 @@ The record intentionally distinguishes two D1 identities:
 
 The generic release workflow permits both code-only releases (`d1Changed: false`) and data cutovers (`d1Changed: true`); it never infers freshness from a different ID alone. Wrangler 4.107.0’s D1 binding response is accepted only when the sole `THEOLOGAI_DB` binding has canonical UUID `id` and `database_id` fields that agree exactly. After deployment, the sole active Worker version must bind the candidate ID before either fixed audit begins; a retained-old-D1 deployment is refused even if its Worker version otherwise looks new.
 
-## PR #122 schema-0009 preview release — passed
+## PR #123 current schema-0009 preview release — passed
+
+The protected preview workflow deployed exact source
+`7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0` (tree
+`28e555808ad3840d145a7ddd7e57934dc30e45c2`) through Actions run
+`31644218683` and GitHub deployment `5878053561`. Cloudflare deployment
+`4108d59a-4092-4389-824c-fa3820ab66f6` serves Worker
+`70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144) as the sole 100% preview
+assignment, bound to `theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). Its immediate retained predecessor
+is the same-D1 PR #122 deployment `13393917-fa91-4afc-aeaf-2809db6701a2`,
+Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142).
+
+Edge stabilization passed on attempt 2; original-language v2 passed 11/11,
+historical core passed 8/8, and the Transform-11 spine passed 10/10. Sanitized
+evidence SHA-256 values are respectively
+`fcdb34bd0327969faa3d6d15d315aa9e69c3800b9dd4821205bed617742301d2`,
+`c1652a64075e4087ac2c1a02e6ccd177ca8a6ad48749d5e5407dd03acd3842b9`,
+`5a79ecd9baed504209d79c4bddc067d31f5d8b1f0c9611792dbadebe134dbe52`, and
+`f02d387b60b898793c1868f4d4716863af75c7e9130c8f3603c1a9f4c9f12e58`.
+The readiness receipt hash is
+`24e6cf53ac8de7d2e17903faf56a145d8dd7ef7c49b27e628878353484cfaee2`;
+the final Worker identity hash is
+`514dfbb6f0a15aa30560990c2d4f7850424c17d40c3afa951848cb04679e906e`;
+and candidate reconciliation is
+`4bf0d0f463738f61a27f6b0fcf72c357a53ee148e261a17a8daa448e1f6f456c`.
+
+Production remained deployment `e62698f3-f6b0-4145-97bf-28abdeae0e3a`,
+Worker `02174f95-abe2-480b-84bf-3e8c1a3a0320`, and D1
+`theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`) before deployment, immediately after
+deployment, and after all preview audits. The final production-control hash is
+`584652da1316af9862e381e8bef2cc2944c6c2dc66559d28dd299e01c35a8aff`.
+The `deploy-preview` label was removed and Preview Revocation run `31645546905`
+passed. No production mutation, CCEL request, credential staging, canary, D1
+write, or deletion occurred. This post-release documentation update is not
+itself deployed and makes no later runtime claim.
+
+## Historical PR #122 schema-0009 preview release — passed
 
 The protected preview release deployed source
 `a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree
 `660c06ff31e7d0e2ccbc6fe12204e66c4e793233`) through Actions run
 `31568581322` and GitHub deployment `5864161923`. Cloudflare deployment
-`13393917-fa91-4afc-aeaf-2809db6701a2` now serves Worker
+`13393917-fa91-4afc-aeaf-2809db6701a2` historically served Worker
 `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142) as the sole 100% preview
 assignment, bound to `theologai-preview-20260811-schema0009-a`
 (`74f456e2-6951-4003-bb6f-91951342bf8f`). Its retained predecessor is
@@ -44,12 +82,11 @@ unchanged at deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). The final production-control hash is
 `481900a3eec516fe06d3252175b63e318783c7230f70311235e4a1dd73198889`.
 The `deploy-preview` label was removed immediately afterward; Preview Revocation
-run `31572924302` passed and the PR remains open and unmerged. The separately
-prepared production candidate `9bc79346-338b-439e-a2a5-424f4418eb21` remains
-unbound. The schema-0009 canary gate remains `unrecorded` and inert; no CCEL
-request, credential staging, canary, or production mutation was authorized.
-This evidence-only documentation commit postdates the deployed head. It does
-not claim that a later documentation commit was deployed.
+run `31572924302` passed. PR #122 later merged and completed its separately
+protected production release. The schema-0009 canary gate remained `unrecorded`
+and inert; no CCEL request, credential staging, or canary was authorized by the
+preview release. This section is historical evidence superseded for current
+preview identity by the PR #123 record above.
 
 ### Pre-release record
 

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -14,8 +14,8 @@ edition-scoped authority hierarchy packet and standalone materializer. Normal
 release builds deliberately exclude its hierarchy rows and shared lineage. It
 is unpublished and has no document or catalog projection, runtime composition
 dependency, or MCP surface. It leaves the active historical catalog boundary
-unchanged through preparation: preview and production now serve the
-Transform-11 35-work corpus after the protected PR #108 D1 cutover.
+unchanged through preparation: preview and production serve the Transform-11
+35-work corpus, now on their distinct schema-`0009` PR #122 D1 releases.
 
 Transform 11 retains migration `0006_historical_source_packs` and schema
 `0008`, but expands the manifest allowlist to three checked-in packs, 18 works,

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -38,11 +38,13 @@ predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
 (`51890e12-1c3f-421f-b661-9a5ea9637e43`). That former Transform-11 preview
-binding is historical. The current preview baseline is PR #122 deployment
-`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
-`b2c62527-5759-4c1d-a9a3-8c1d43dddabe`, and schema-`0009` D1
+binding is historical. The current preview baseline is PR #123 deployment
+`4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
+`70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`). The retained PR #101 production
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). Its same-D1 PR #122 predecessor was
+deployment `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142). The retained PR #101 production
 rollback is older history: deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), and D1
 `theologai-production-20260728-hierarchy-a`

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -90,12 +90,14 @@ audit all passed. The retained PR #101 preview predecessor was
 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The PR #107 preview assignment is
-the immediate retained predecessor. The current preview baseline is PR #122
-deployment `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
-`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142), and schema-`0009` D1
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is PR #123
+deployment `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
+`70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`).
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). Its immediate retained predecessor
+is the same-D1 PR #122 deployment `13393917-fa91-4afc-aeaf-2809db6701a2`,
+Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142); PR #107 is the earlier
+schema-`0008` predecessor.
 
 The checked-in root production target was separately prepared unbound as
 Transform-11 candidate `theologai-production-20260729-transform11-a`

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -1,7 +1,55 @@
 # Production Release Reconciliation
 
-This document records the completed PR #108 protected production cutover, its
-PR #101 rollback pair, and the safeguards required for later releases.
+This document records the completed PR #122 schema-`0009` production cutover,
+its immediate PR #108 rollback pair, older PR #101 history, and the safeguards
+required for later releases.
+
+## Current PR #122 production release
+
+PR #122 merged as `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` with exact tree
+`8150aa29e7e4a22141edbfc9ab568df933f9c9b3`. Protected production workflow
+`31631924636` deployed `e62698f3-f6b0-4145-97bf-28abdeae0e3a`, Worker
+`02174f95-abe2-480b-84bf-3e8c1a3a0320` (#100), as the sole active production
+assignment bound to schema-`0009` D1
+`theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`).
+
+Remote readiness and Transform authority passed. Edge stabilization matched
+twice, original-language v2 passed all 13 logical operations, historical core
+passed all 54 logical operations across eight works, and Transform-11
+historical spine passed all 82 logical operations across ten works, with zero
+audit retries. Final production identity remained the exact audited deployment
+and Worker. Preview remained deployment
+`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe`, and D1
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`) before deployment, after deployment,
+and after the audits. The final environment-isolation receipt proved the two
+exact distinct Worker/D1 pairs.
+
+Sanitized authoritative workflow evidence includes these SHA-256 identities:
+
+- production D1 readiness receipt:
+  `f112b33785a6c1953625c395954bd952db6f0224ad389c52996881b76973d112`;
+- edge stabilization:
+  `552f455683eb67ef1cd20a4355c338e448f6a6df3f2eff972987fc6f26b07b82`;
+- original-language v2 audit:
+  `30781505a0b1e26417e7d018fdea1060e490a53aab71ad295886c3291333bcc9`;
+- historical-core audit:
+  `7c397cd7ce73f11a151aff25fba3026764fc4981f51dd4d19fd40a3d2a38106c`;
+- Transform-11 historical-spine audit:
+  `a25a01b87e65ce3f391e4a131edc277411ba52a59a366313c622628351fd74a4`;
+- final environment-isolation receipt:
+  `a2daa145b6e4cbf6545fdcacb38f7e9939ba9c7b33db2141c86e7a8a54b834a5`.
+
+The immediate rollback unit is PR #108 deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). No rollback, database cleanup,
+credential operation, or CCEL request was part of PR #122.
+
+## Historical PR #108 and PR #101 records
 At the reconciliation cutoff immediately after PR #113, `main` was
 `2f12262c9a37d3588bee9b5071954823c15cbd12` (tree
 `9922aedb74c690e7a3fcb926b3d621f28fa44535`), and that revision was not

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,6 +3,9 @@
 This is the tracked source of truth for delivery status and sequencing. The
 ignored [dated architecture and roadmap assessment](../test-output/ARCHITECTURE_AND_ROADMAP_ASSESSMENT.md)
 is local source context only and does not define the current product contract.
+The successor program after PR #122 is defined in
+[Phase 3B](./PHASE-3B-PLAN.md); earlier uses of "Phase 3" below are historical
+names for already-shipped work.
 
 ## Shipped baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -368,11 +368,13 @@ binding—at merge `72a8ee5eef9b909a373b085d1a4f193484ddfe8a`, deployment
   `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
   `06b9a603-8339-42b6-a246-ef9238563043`, and D1
   `62b871a6-5b4d-4d9b-8f52-301f6c878f48`, with v7/discovery-only behavior and
-  CCEL execution disabled before adapter, coordinator, or fetch. PR #122 has
+  CCEL execution disabled before adapter, coordinator, or fetch. PR #123 has
   since superseded that preview assignment with deployment
-  `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
-  `b2c62527-5759-4c1d-a9a3-8c1d43dddabe`, and schema-`0009` D1
-  `74f456e2-6951-4003-bb6f-91951342bf8f`. Production
+  `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
+  `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
+  `74f456e2-6951-4003-bb6f-91951342bf8f`. Its immediate same-D1 predecessor
+  is PR #122 deployment `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+  `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142). Production
   remains PR #108 merge `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`, deployment
   `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
   `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
@@ -711,14 +713,16 @@ Code readiness and operational readiness are deliberately separate:
   `5e812152-355b-4a5f-a123-2485e89f1550`, Worker
   `06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
   `theologai-preview-20260728-transform11-a`
-  (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`) are the immediate retained
-  predecessor. Preview now serves PR #122 deployment
-  `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
-  `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142), and schema-`0009` D1
+  (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`) are an earlier retained
+  predecessor. Preview now serves PR #123 deployment
+  `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
+  `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
   `theologai-preview-20260811-schema0009-a`
   (`74f456e2-6951-4003-bb6f-91951342bf8f`) with the v7/discovery-only
-  contract; CCEL execution remains disabled before adapter, coordinator, or
-  fetch. The schema-`0008` production database was
+  contract; its immediate same-D1 predecessor is PR #122 deployment
+  `13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+  `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142). CCEL execution remains
+  disabled before adapter, coordinator, or fetch. The schema-`0008` production database was
   unbound when remote readiness and Transform-8/9 authority audits passed and
   Transform-10 normal-corpus exclusion predicates proved hierarchy,
   publication, and Aquinas-lineage rows empty. Protected workflow

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -38,17 +38,17 @@ schema-`0009` candidate `theologai-production-20260811-schema0009-a`
 workflow proved the active binding, re-proved preview control after deployment
 and audits, and emitted the final environment-isolation receipt.
 
-PR #122 completed the protected preview release from
-`a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree
-`660c06ff31e7d0e2ccbc6fe12204e66c4e793233`): Cloudflare deployment
-`13393917-fa91-4afc-aeaf-2809db6701a2` assigns Worker
-`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` solely to the schema-`0009` preview D1.
-All bounded audits and production-control comparisons passed. The preview
-authorization has been revoked (run `31572924302`); PR #122 later merged and
-completed the separately protected production release above. Preview's
-executable Worker inputs remain equivalent to current `main`; the later commits
-change documentation, release evidence and guards, and the production-only D1
-binding, not preview application behavior.
+PR #123 completed the current protected preview release from
+`7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0` (tree
+`28e555808ad3840d145a7ddd7e57934dc30e45c2`): Cloudflare deployment
+`4108d59a-4092-4389-824c-fa3820ab66f6` assigns Worker
+`70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144) solely to the schema-`0009`
+preview D1. All bounded audits and production-control comparisons passed. The
+preview authorization was revoked by run `31645546905`. The immediate retained
+same-D1 predecessor is PR #122 deployment
+`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker
+`b2c62527-5759-4c1d-a9a3-8c1d43dddabe` (#142). This post-release evidence
+update makes no new runtime claim.
 
 The former PR #101 production assignment is older retained rollback history:
 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker
@@ -76,7 +76,8 @@ Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed while
 unbound. Protected preview deployment `5e812152-355b-4a5f-a123-2485e89f1550`
 historically served Worker `06b9a603-8339-42b6-a246-ef9238563043` (#140) with
 that exact D1. It remained unchanged during the PR #108 production release and
-is now PR #122's retained immediate predecessor, not the active preview.
+is an earlier retained predecessor, not the active preview. PR #122's
+schema-`0009` Worker above is the immediate same-D1 predecessor to PR #123.
 
 The checked-in root production target was prepared unbound as the Transform-11
 candidate `theologai-production-20260729-transform11-a`

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -4,23 +4,27 @@
 
 The integrated checked-out normal build excludes the Transform-10 Aquinas
 hierarchy from all normal D1 corpora: it has no catalog, runtime, or MCP
-projection. Production is PR #108 merge
-`8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`. Protected workflow
-`30496350408` deployed `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, serving
-Worker `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (#98) as the sole 100%
-assignment, bound to `theologai-production-20260729-transform11-a`
-(`53211f50-a893-4b4c-be1e-bc625a595dc7`). Historical core passed 8/8,
-Transform-11 spine passed 10/10, original-language passed 11/11,
-primary-source edge stabilization matched on attempt 4 and remained stable,
-and the independent post-release review returned `SHIP`. This is not a
-hierarchy/publication activation; CCEL execution remains disabled and Aquinas
-remains inactive.
+projection. Production is PR #122 merge
+`86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` (tree
+`8150aa29e7e4a22141edbfc9ab568df933f9c9b3`). Protected workflow
+`31631924636` deployed `e62698f3-f6b0-4145-97bf-28abdeae0e3a`, serving Worker
+`02174f95-abe2-480b-84bf-3e8c1a3a0320` (#100) as the sole active assignment,
+bound to `theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). Readiness, authority, historical
+core, Transform-11 spine, original-language, edge stabilization, final Worker
+identity, preview-control, and environment-isolation checks passed. This is not
+a hierarchy/publication activation; CCEL execution remains disabled and
+Aquinas remains inactive.
 
-For the schema-`0009` cutover, the exact captured PR #108 Worker/D1 pair above
-is the immediately preceding primary rollback unit. PR #101 is older retained
-rollback history, not the immediate rollback claim.
+For the schema-`0009` cutover, the exact captured PR #108 pair is the
+immediately preceding primary rollback unit: deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). PR #101 is older retained rollback
+history, not the immediate rollback claim.
 
-### Schema-0009 preview release state
+### Schema-0009 release state
 
 The checked-in preview configuration targets schema-`0009` D1
 `theologai-preview-20260811-schema0009-a`
@@ -28,12 +32,11 @@ The checked-in preview configuration targets schema-`0009` D1
 proved that binding and completed its audit. It captured production against its
 checked-in D1 name/UUID and fresh inventory before preview mutation,
 immediately after deployment, and again after final preview audit. The
-checked-in production target is now the separately prepared schema-`0009`
-candidate `theologai-production-20260811-schema0009-a`
-(`9bc79346-338b-439e-a2a5-424f4418eb21`), which remains unbound. Live
-production stays on its recorded schema-`0008` predecessor until the protected
-production workflow proves the active binding, re-proves preview control after
-deployment and audits, and emits the final environment-isolation receipt.
+checked-in and active production target is the separately prepared
+schema-`0009` candidate `theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). PR #122's protected production
+workflow proved the active binding, re-proved preview control after deployment
+and audits, and emitted the final environment-isolation receipt.
 
 PR #122 completed the protected preview release from
 `a0f13b5bdbf3ca071dbb7524dea9c6ce80770404` (tree
@@ -41,9 +44,11 @@ PR #122 completed the protected preview release from
 `13393917-fa91-4afc-aeaf-2809db6701a2` assigns Worker
 `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` solely to the schema-`0009` preview D1.
 All bounded audits and production-control comparisons passed. The preview
-authorization has been revoked (run `31572924302`); PR #122 remains open and
-unmerged. This evidence-only commit postdates that deployment and does not
-change production, CCEL execution, or secrets.
+authorization has been revoked (run `31572924302`); PR #122 later merged and
+completed the separately protected production release above. Preview's
+executable Worker inputs remain equivalent to current `main`; the later commits
+change documentation, release evidence and guards, and the production-only D1
+binding, not preview application behavior.
 
 The former PR #101 production assignment is older retained rollback history:
 deployment `71b76d24-bf5f-490e-adc4-31cf63fb046e`, Worker

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -184,7 +184,7 @@ describe('published project contract', () => {
 
     expect(readme).toContain('Production v6/local-only and preview v7/discovery-only currently search and\nretrieve the 35-work Transform-11 collection');
     expect(operations).toContain('current preview Transform-11 / 35-work release');
-    expect(operations).toContain('Production is PR #108 merge');
+    expect(operations).toContain('Production is PR #122 merge');
     expect(developerGuide).toContain('both deployed 35-work catalogs');
     expect(developerGuide).toContain('PR #108 is the current production release record');
   });
@@ -283,7 +283,7 @@ describe('published project contract', () => {
     expect(operations).toContain('protected PR95 preview release deployed Cloudflare deployment');
     expect(operations).toContain('black-box audit passed with no P0-P3 findings');
     expect(operations).toContain('Transform-10 Aquinas\nhierarchy from all normal D1 corpora');
-    expect(operations).toContain('CCEL execution remains disabled and Aquinas\nremains inactive');
+    expect(operations.replace(/\s+/g, ' ')).toContain('CCEL execution remains disabled and Aquinas remains inactive');
     expect(operations).not.toContain('prepared but unbound preview\ncandidate retains that inactive authority data');
     expect(operations).toContain(`Its historical Cloudflare deployment\n\`${historicalDeployment}\` served Worker`);
     expect(operations).toContain('This historical release is neither\nthe current preview identity nor the immediate retained predecessor');
@@ -328,7 +328,7 @@ describe('published project contract', () => {
     expect(documents[5]).toContain('remained unchanged during the PR #108 production release and\nis now PR #122');
   });
 
-  it('documents the completed PR #108 Transform 11 production cutover and rollback', async () => {
+  it('documents the current PR #122 schema-0009 production release and PR #108 rollback', async () => {
     const [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('docs/D1-DATA-WORKFLOW.md'),
@@ -337,36 +337,50 @@ describe('published project contract', () => {
       readProjectFile('docs/worker-operations.md'),
       readProjectFile('docs/ROADMAP.md'),
     ]);
-    const liveProduction = {
+    const immediateRollback = {
       deployment: '3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8',
       worker: '291f3292-3fa9-44fc-bf6f-b68fd2f4cef6',
       d1: 'theologai-production-20260729-transform11-a',
       d1Id: '53211f50-a893-4b4c-be1e-bc625a595dc7',
     };
-    const rollbackProduction = {
+    const olderProduction = {
       deployment: '71b76d24-bf5f-490e-adc4-31cf63fb046e',
       worker: 'bae58cd3-cad7-4663-879d-408accf061b0',
       d1: 'theologai-production-20260728-hierarchy-a',
       d1Id: 'f93c3b02-a0bd-4ca1-9697-8ecb4bcf9395',
     };
+    const liveProduction = {
+      deployment: 'e62698f3-f6b0-4145-97bf-28abdeae0e3a',
+      worker: '02174f95-abe2-480b-84bf-3e8c1a3a0320',
+      d1: 'theologai-production-20260811-schema0009-a',
+      d1Id: '9bc79346-338b-439e-a2a5-424f4418eb21',
+    };
     const livePreview = {
-      deployment: '5e812152-355b-4a5f-a123-2485e89f1550',
-      worker: '06b9a603-8339-42b6-a246-ef9238563043',
-      d1: 'theologai-preview-20260728-transform11-a',
-      d1Id: '62b871a6-5b4d-4d9b-8f52-301f6c878f48',
+      deployment: '13393917-fa91-4afc-aeaf-2809db6701a2',
+      worker: 'b2c62527-5759-4c1d-a9a3-8c1d43dddabe',
+      d1: 'theologai-preview-20260811-schema0009-a',
+      d1Id: '74f456e2-6951-4003-bb6f-91951342bf8f',
     };
 
     const productionCutoverDocuments = [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap];
     for (const document of productionCutoverDocuments) {
-      for (const value of Object.values(liveProduction)) expect(document).toContain(value);
-      for (const value of Object.values(rollbackProduction)) expect(document).toContain(value);
+      for (const value of Object.values(immediateRollback)) expect(document).toContain(value);
+      for (const value of Object.values(olderProduction)) expect(document).toContain(value);
       expect(document).toContain('30496350408');
+    }
+    for (const document of [readme, dataWorkflow, catalogScope, reconciliation, roadmap]) {
       expect(document).toContain('8da99fd0a161b90a4bd90ab29bde1abf796b3bf6');
+    }
+    for (const document of [readme, dataWorkflow, reconciliation, operations]) {
+      for (const value of Object.values(liveProduction)) expect(document).toContain(value);
+    }
+    for (const document of [readme, reconciliation, operations]) {
+      expect(document).toContain('86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2');
     }
     for (const document of [readme, dataWorkflow, reconciliation, operations, roadmap]) {
       for (const value of Object.values(livePreview)) expect(document).toContain(value);
     }
-    expect(reconciliation).toContain('completed PR #108 protected production cutover');
+    expect(reconciliation).toContain('Current PR #122 production release');
     expect(reconciliation).toContain('a59d9a062b2e6c7884de97fd97309878e1cbdc23');
     expect(reconciliation).toContain('5665940735');
     expect(reconciliation).toContain('8742223883');
@@ -378,7 +392,7 @@ describe('published project contract', () => {
     expect(reconciliation).toContain('77da8832ab4139a769aae7d87716a3d581407cc2d036b6f7939e306d9b865de5');
     expect(dataWorkflow).toContain('Historical core passed 8/8');
     expect(catalogScope).toContain('Transform-11 spine passed 10/10');
-    expect(operations).toContain('primary-source edge stabilization matched on attempt 4');
+    expect(operations).toContain('edge stabilization');
     expect(roadmap).toContain('independent post-release review returned `SHIP`');
     expect(reconciliation).toContain('primary-source edge stabilization');
     expect(reconciliation).toContain('Transform-11 historical-spine audit');
@@ -518,15 +532,15 @@ describe('published project contract', () => {
     expect(canary).toContain('remote readiness and authority audit');
     expect(canary).toContain('while both candidates remain unbound');
     expect(canary).toContain('prepared preview candidate with current-`main` `100` flags');
-    expect(canary).toContain('Only after the preview audit passes');
-    expect(canary).toContain('Then perform a read-only environment-isolation\n   verification');
+    expect(canary).toContain('Completed by PR #122');
+    expect(canary).toContain('no retained schema-`0008` reuse or crossing');
     expect(canary).toMatch(/hard inert\s+schema-`0009` canary gate/);
     expect(canary).toMatch(/before any\s+Wrangler command or\s+Cloudflare read/);
     const canaryOrder = [
       'while both candidates remain unbound',
       'prepared preview candidate with current-`main` `100` flags',
-      'Only after the preview audit passes',
-      'Then perform a read-only environment-isolation',
+      '3. **Completed by PR #122',
+      'no retained schema-`0008` reuse or crossing',
       'Stage the operator credential',
       'Run this temporary `111` two-request preview canary transaction',
     ].map(marker => canary.indexOf(marker));
@@ -562,7 +576,7 @@ describe('published project contract', () => {
     expect(roadmap).not.toContain('Preview now serves deployment\n  `5e812152');
   });
 
-  it('records the schema-0009 preview-only release boundary and production control', async () => {
+  it('records the completed schema-0009 preview and production releases', async () => {
     const [readme, workflow, reconciliation, canary, operations, config, dataWorkflow, canaryScript] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('.github/workflows/pr.yml'),
@@ -582,7 +596,6 @@ describe('published project contract', () => {
       expect(document).toContain(previewName);
       expect(document).toContain(previewId);
       expect(document).toContain(productionId);
-      expect(document).toContain('unbound');
     }
     expect(config).toContain(`database_name = "${previewName}"`);
     expect(config).toContain(`database_id = "${previewId}"`);
@@ -622,7 +635,7 @@ describe('published project contract', () => {
     expect(reconciliation).toContain('31572924302');
     expect(reconciliation).toContain('This evidence-only documentation commit postdates the deployed head.');
     expect(readme).toContain('This evidence-only commit postdates the deployed source');
-    expect(operations).toContain('This evidence-only commit postdates that deployment');
-    expect(canary).toMatch(/The\s+gate remains `unrecorded` and inert/);
+    expect(operations).toContain("PR #122 later merged and\ncompleted the separately protected production release");
+    expect(canary.replace(/\s+/g, ' ')).toContain('The gate remains `unrecorded` and inert');
   });
 });

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -292,7 +292,8 @@ describe('published project contract', () => {
     expect(reconciliation).toContain('This is the retained compatible\npreview predecessor');
     expect(reconciliation).toContain('evidence remains authoritative for that predecessor');
     expect(operations).toContain('The retained PR #101 preview predecessor was deployment');
-    expect(operations).toContain("PR #122's retained immediate predecessor, not the active preview");
+    expect(operations).toContain('is an earlier retained predecessor, not the active preview');
+    expect(operations).toContain("PR #122's\nschema-`0009` Worker above is the immediate same-D1 predecessor to PR #123");
   });
 
   it('records the completed Transform 11 preview release and unpublished hardening boundary', async () => {
@@ -325,17 +326,19 @@ describe('published project contract', () => {
     expect(documents[6]).toContain('30419373527');
     expect(documents[6]).toContain('30420256210');
     expect(documents[6]).toContain('Production was unchanged by that preview release');
-    expect(documents[5]).toContain('remained unchanged during the PR #108 production release and\nis now PR #122');
+    expect(documents[5]).toContain('remained unchanged during the PR #108 production release and\nis an earlier retained predecessor');
+    expect(documents[5]).toContain('immediate same-D1 predecessor to PR #123');
   });
 
   it('documents the current PR #122 schema-0009 production release and PR #108 rollback', async () => {
-    const [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap] = await Promise.all([
+    const [readme, dataWorkflow, catalogScope, reconciliation, operations, roadmap, phasePlan] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('docs/D1-DATA-WORKFLOW.md'),
       readProjectFile('docs/PRIMARY-SOURCE-CATALOG-SCOPE.md'),
       readProjectFile('docs/PRODUCTION-RELEASE-RECONCILIATION.md'),
       readProjectFile('docs/worker-operations.md'),
       readProjectFile('docs/ROADMAP.md'),
+      readProjectFile('docs/PHASE-3B-PLAN.md'),
     ]);
     const immediateRollback = {
       deployment: '3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8',
@@ -356,8 +359,8 @@ describe('published project contract', () => {
       d1Id: '9bc79346-338b-439e-a2a5-424f4418eb21',
     };
     const livePreview = {
-      deployment: '13393917-fa91-4afc-aeaf-2809db6701a2',
-      worker: 'b2c62527-5759-4c1d-a9a3-8c1d43dddabe',
+      deployment: '4108d59a-4092-4389-824c-fa3820ab66f6',
+      worker: '70bbbecf-3fe6-4a04-8c34-babc3df09ad0',
       d1: 'theologai-preview-20260811-schema0009-a',
       d1Id: '74f456e2-6951-4003-bb6f-91951342bf8f',
     };
@@ -380,6 +383,13 @@ describe('published project contract', () => {
     for (const document of [readme, dataWorkflow, reconciliation, operations, roadmap]) {
       for (const value of Object.values(livePreview)) expect(document).toContain(value);
     }
+    for (const value of Object.values(livePreview)) expect(phasePlan).toContain(value);
+    expect(phasePlan).toContain('7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0');
+    expect(phasePlan).toContain('28e555808ad3840d145a7ddd7e57934dc30e45c2');
+    for (const document of [dataWorkflow, catalogScope, reconciliation, operations, roadmap, phasePlan]) {
+      expect(document).not.toContain('current preview baseline is PR #122');
+      expect(document).not.toContain('Preview now serves PR #122');
+    }
     expect(reconciliation).toContain('Current PR #122 production release');
     expect(reconciliation).toContain('a59d9a062b2e6c7884de97fd97309878e1cbdc23');
     expect(reconciliation).toContain('5665940735');
@@ -396,8 +406,8 @@ describe('published project contract', () => {
     expect(roadmap).toContain('independent post-release review returned `SHIP`');
     expect(reconciliation).toContain('primary-source edge stabilization');
     expect(reconciliation).toContain('Transform-11 historical-spine audit');
-    expect(dataWorkflow).toContain('PR #122 deployment\n`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker');
-    expect(catalogScope).toContain('PR #122 deployment\n`13393917-fa91-4afc-aeaf-2809db6701a2`, Worker');
+    expect(dataWorkflow).toContain('same-D1 PR #122 predecessor');
+    expect(catalogScope).toContain('same-D1 PR #122 predecessor');
     expect(dataWorkflow).toContain('immediately preceding primary rollback unit');
     expect(catalogScope).toContain('immediately preceding primary rollback\nunit');
     expect(dataWorkflow).not.toContain('The current preview baseline is\ndeployment `5e812152');
@@ -633,9 +643,16 @@ describe('published project contract', () => {
     expect(reconciliation).toContain('5e812152-355b-4a5f-a123-2485e89f1550');
     expect(reconciliation).toContain('481900a3eec516fe06d3252175b63e318783c7230f70311235e4a1dd73198889');
     expect(reconciliation).toContain('31572924302');
-    expect(reconciliation).toContain('This evidence-only documentation commit postdates the deployed head.');
-    expect(readme).toContain('This evidence-only commit postdates the deployed source');
-    expect(operations).toContain("PR #122 later merged and\ncompleted the separately protected production release");
+    expect(reconciliation).toContain('PR #123 current schema-0009 preview release');
+    expect(reconciliation).toContain('31644218683');
+    expect(reconciliation).toContain('5878053561');
+    expect(reconciliation).toContain('4108d59a-4092-4389-824c-fa3820ab66f6');
+    expect(reconciliation).toContain('70bbbecf-3fe6-4a04-8c34-babc3df09ad0');
+    expect(reconciliation).toContain('31645546905');
+    expect(reconciliation).toContain('This post-release documentation update is not\nitself deployed');
+    expect(readme).toContain('This post-release evidence commit postdates the deployed source');
+    expect(operations).toContain('PR #123 completed the current protected preview release');
+    expect(operations).toContain('immediate retained\nsame-D1 predecessor is PR #122');
     expect(canary.replace(/\s+/g, ' ')).toContain('The gate remains `unrecorded` and inert');
   });
 });

--- a/test/unit/scripts/ccelLivePreviewCanary.test.ts
+++ b/test/unit/scripts/ccelLivePreviewCanary.test.ts
@@ -274,11 +274,11 @@ describe('CCEL live preview canary transaction', () => {
     expect(workflow.indexOf('validate-dispatch')).toBeLessThan(workflow.indexOf('npx wrangler'));
   });
 
-  it('documents the single preview-release sequence before production, isolation, credentials, and canary', () => {
+  it('documents the completed preview-production sequence before gated credentials and canary', () => {
     const unbound = 'while both candidates remain unbound';
-    const preview = 'preview candidate with current-`main` `100` flags';
-    const production = 'Only after the preview audit passes';
-    const isolation = 'Then perform a read-only environment-isolation';
+    const preview = 'prepared preview candidate with current-`main` `100` flags';
+    const production = 'through the separately approved production release';
+    const isolation = 'prove distinct preview and production D1';
     const credentials = 'Stage the operator credential';
     const canary = 'Run this temporary `111` two-request preview canary';
     const ordered = [unbound, preview, production, isolation, credentials, canary]


### PR DESCRIPTION
## Summary
- record PR #122 as the current schema-0009 production baseline and retain exact rollback identities
- add the Phase 3B roadmap covering release hygiene, dual-era MCP modernization, historical research, original-language UX, and public operations
- update operator-facing status documents and strengthen their public contract tests

## Scope
Documentation and documentation-contract tests only. No runtime, Worker configuration, database, binding, workflow, secret, or production changes.

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run docs:check`
- `git diff --check`

## Preview release
This PR is intended for the protected preview workflow after initial CI passes. Production remains untouched.