### PR TITLE
fix(deps): patch nanoid security advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5067,9 +5067,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "devOptional": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "hono": "4.12.34",
     "ip-address": "10.3.1",
     "postcss": {
-      "nanoid": "3.3.17"
+      "nanoid": "3.3.18"
     },
     "undici": "7.29.0"
   },


### PR DESCRIPTION
## Security prerequisite for PR #124

Patches the high-severity Nano ID advisory [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8). The first patched Nano ID 3.x release is 3.3.18.

## Surgical scope

This PR changes exactly two files:

- `package.json`: PostCSS's `nanoid` override from 3.3.17 to 3.3.18.
- `package-lock.json`: only the root `node_modules/nanoid` version, tarball URL, and integrity fields.

The resolved path is `agents@0.17.3 → peerOptional vite@8.1.5 → postcss@8.5.23 → nanoid@3.3.18`. The already-patched nested `agents/partyserver` Nano ID 5.1.16 copies are unchanged. Application code has no direct Nano ID import.

An npm 11 lockfile regeneration was deliberately rejected because it normalized unrelated `dev`/optional metadata. This retains only the auditable, content-addressed Nano ID resolution change.

## Validation

Using Node 22.23.1 / npm 10.9.8:

- `npm ci --no-audit`
- `npm run audit:dependencies:high` — 0 vulnerabilities
- `npm audit --package-lock-only --omit=dev --audit-level=high` — 0 vulnerabilities
- `npm ls nanoid --all`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run test:worker-runtime` — 25/25

This is a separate prerequisite for #124; it does not amend or widen that classifier PR.

## Release boundary

This package/lockfile change is deployment-requiring. This draft is not authorization to mark ready, merge, dispatch workflows, approve an environment, or deploy. If an emergency rollback is ever needed, prefer a forward-fix to another patched compatible 3.x; reverting would reintroduce the high advisory and failing audit.