### PR TITLE
ci: verify PR merge-ref lineage

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,9 +88,28 @@ jobs:
 
       - name: Verify historical section-key lineage
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EXPECTED_MERGE_SHA: ${{ github.sha }}
+          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          test "$(git rev-parse HEAD^1)" = "$BASE_SHA"
+          for sha in "$EXPECTED_MERGE_SHA" "$EXPECTED_HEAD_SHA"; do
+            printf '%s\n' "$sha" | grep -Eq '^[0-9a-fA-F]{40}$'
+            git cat-file -e "$sha^{commit}"
+          done
+
+          checked_out_sha="$(git rev-parse HEAD)"
+          test "$checked_out_sha" = "$EXPECTED_MERGE_SHA"
+          set -- $(git rev-list --parents -n 1 HEAD)
+          test "$#" -eq 3
+          test "$1" = "$checked_out_sha"
+          BASE_SHA="$2"
+          CANDIDATE_HEAD_SHA="$3"
+
+          for sha in "$BASE_SHA" "$CANDIDATE_HEAD_SHA"; do
+            printf '%s\n' "$sha" | grep -Eq '^[0-9a-fA-F]{40}$'
+            git cat-file -e "$sha^{commit}"
+          done
+          test "$CANDIDATE_HEAD_SHA" = "$EXPECTED_HEAD_SHA"
+
           if git cat-file -e "$BASE_SHA:data/historical-section-key-plan.json"; then
             git show "$BASE_SHA:data/historical-section-key-plan.json" > "$RUNNER_TEMP/historical-section-key-plan.previous.json"
             npm run data:verify-section-keys -- --previous-plan "$RUNNER_TEMP/historical-section-key-plan.previous.json"

--- a/test/unit/scripts/historicalSectionKeyPlan.test.ts
+++ b/test/unit/scripts/historicalSectionKeyPlan.test.ts
@@ -394,12 +394,32 @@ describe('migration-free historical section-key plan', () => {
     expect(exactSuccessor.status, exactSuccessor.stderr).toBe(0);
   });
 
-  it('keeps production ancestry and PR merge-parent lineage gates distinct', () => {
+  it('keeps production ancestry and exact PR merge-ref lineage gates distinct', () => {
+    const lineageStart = prWorkflow.indexOf('      - name: Verify historical section-key lineage');
+    const lineageEnd = prWorkflow.indexOf('      - name: Build SQLite database from tracked sources');
+    const lineageStep = prWorkflow.slice(lineageStart, lineageEnd);
+
+    expect(lineageStart).toBeGreaterThanOrEqual(0);
+    expect(lineageEnd).toBeGreaterThan(lineageStart);
     expect(deployWorkflow).toContain('fetch-depth: 0');
     expect(deployWorkflow).toContain('git merge-base --is-ancestor "$PREVIOUS_MAIN_SHA" HEAD');
     expect(deployWorkflow).toContain('git show "$PREVIOUS_MAIN_SHA:data/historical-section-key-plan.json"');
     expect(deployWorkflow).not.toContain('git rev-parse HEAD^1)" = "$PREVIOUS_MAIN_SHA"');
     expect(prWorkflow).toContain('fetch-depth: 2');
-    expect(prWorkflow).toContain('test "$(git rev-parse HEAD^1)" = "$BASE_SHA"');
+    expect(lineageStep).not.toContain('github.event.pull_request.base.sha');
+    expect(lineageStep).toContain('EXPECTED_MERGE_SHA: ${{ github.sha }}');
+    expect(lineageStep).toContain('EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}');
+    expect(lineageStep).not.toMatch(/run:\s*\|[\s\S]*github\.(?:sha|event\.pull_request\.head\.sha)/);
+    expect(lineageStep).toContain('for sha in "$EXPECTED_MERGE_SHA" "$EXPECTED_HEAD_SHA"; do');
+    expect(lineageStep).toContain('git cat-file -e "$sha^{commit}"');
+    expect(lineageStep).toContain('checked_out_sha="$(git rev-parse HEAD)"');
+    expect(lineageStep).toContain('test "$checked_out_sha" = "$EXPECTED_MERGE_SHA"');
+    expect(lineageStep).toContain('set -- $(git rev-list --parents -n 1 HEAD)');
+    expect(lineageStep).toContain('test "$#" -eq 3');
+    expect(lineageStep).toContain('BASE_SHA="$2"');
+    expect(lineageStep).toContain('CANDIDATE_HEAD_SHA="$3"');
+    expect(lineageStep).toContain('for sha in "$BASE_SHA" "$CANDIDATE_HEAD_SHA"; do');
+    expect(lineageStep).toContain('test "$CANDIDATE_HEAD_SHA" = "$EXPECTED_HEAD_SHA"');
+    expect(lineageStep).toContain('git show "$BASE_SHA:data/historical-section-key-plan.json"');
   });
 });


### PR DESCRIPTION
## Purpose

Fixes the PR workflow's historical section-key lineage guard when an older PR is evaluated against a newer generated merge ref.

## Root cause and fail-safe behavior

`github.event.pull_request.base.sha` can remain the PR's original base while `github.sha` and the default checkout point to GitHub's current `refs/pull/<n>/merge` commit. The prior guard incorrectly required those identities to be equal.

The lineage step now verifies the checked-out merge ref itself: expected merge and head identities are passed through step environment variables, validated as commit SHAs, the checkout must match `github.sha`, and it must have exactly two parents. Parent 2 must match the PR head; parent 1 is the sole predecessor used for the prior-plan lookup or genesis fallback. Non-merge, missing-parent, and octopus shapes fail closed. No `pull_request.base.sha` is used in this step, and no flexible context is interpolated into shell source.

## Scope and validation

Only `.github/workflows/pr.yml` and `test/unit/scripts/historicalSectionKeyPlan.test.ts` change.

- Focused lineage test: 24 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run test:coverage`: 2,479 passed, 5 skipped
- `git diff --check`: passed

## Sequencing

This is a separate prerequisite for PR #124; it does not alter #124's approved four-file head. Hosted Actions remain the final proof. Deploy Preview is expected to skip because this PR is draft and has no `deploy-preview` label.

Because this changes a workflow and any merge to `main` is deploy-requiring under the current production workflow, ready-state, merge, environment approval, and protected production release are intentionally not authorized by this PR.
