### PR TITLE
docs: add current release snapshot canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ absent; it adds no document or catalog projection and is not wired into runtime 
 
 <!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,classic_text_lookup,commentary_lookup,donation_config,original_language_lookup,original_language_study,parallel_passages,primary_source_search,verify_donation -->
 
+## Current release snapshot
+
+The [current release snapshot](docs/CURRENT-RELEASE.md) is the designated
+current snapshot for this entry document and the named reconciliation documents.
+The historical release records below preserve point-in-time evidence; they are
+not current identity authority.
+
 ## Public website and remote endpoints
 
 The public website is [theologai.xyz](https://theologai.xyz). The hosted
@@ -53,8 +60,8 @@ Remote MCP client configuration:
 }
 ```
 
-Use the preview URL only for explicitly authorized release testing. The current
-live production baseline is PR #122 merge
+Use the preview URL only for explicitly authorized release testing. The
+following is the historical PR #122 production baseline, not current today:
 `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` (tree
 `8150aa29e7e4a22141edbfc9ab568df933f9c9b3`). Protected workflow
 `31631924636` deployed Cloudflare deployment
@@ -67,7 +74,8 @@ final Worker identity, preview-control, and environment-isolation checks all
 passed. CCEL execution remains disabled.
 
 The exact captured PR #108 Worker/D1 pair is the immediately preceding primary
-rollback unit: deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+rollback unit in that dated release record; it is not current today: deployment
+`3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
 `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6`, and D1
 `theologai-production-20260729-transform11-a`
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). PR #101 is older retained rollback

--- a/docs/CURRENT-RELEASE.md
+++ b/docs/CURRENT-RELEASE.md
@@ -1,0 +1,78 @@
+# Current release snapshot
+
+This dated, sanitized record is the **designated current snapshot for these
+entry/reconciliation documents**: the README, production and preview release
+reconciliations, Worker operations, the Phase 3B plan, and primary-source
+catalog scope. It was observed through protected run `32165010129`, completed
+`2026-08-18T17:44:52Z`; it is not a timeless guarantee or the sole authority
+for every historical document in this repository.
+
+## Active production assignment
+
+PR #124 merged as source `7f567ef0d050c91ac24e02e9798ac68cf448f8ff` with tree
+`a61e76014037a59d53db6ab92cf9d27707bf2059`. Protected run `32165010129`
+recorded GitHub production deployment `5967750549` and the active Cloudflare
+assignment: deployment `dec913dc-1c1e-4bb0-b616-8cdb4bb14822`, Worker
+`815b6e78-3dfc-435f-bcb4-5715802fd9aa` (version #108), and
+`THEOLOGAI_DB` `theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). The numbered Worker version is not
+PR #108.
+
+The immediate same-D1 predecessor is retained only as predecessor evidence:
+deployment `b2541421-17eb-4cf2-9f35-e16d4e243038`, Worker
+`43ec9518-446e-4a26-bd34-ac4b647f0f51` (version #106), on the same production
+D1. It is not the active assignment.
+
+## Preview control
+
+The preview control observed with that release remains deployment
+`4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
+`70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (version #144), and D1
+`theologai-preview-20260811-schema0009-a`
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). It is a control identity, not a
+claim that later release activity cannot change it.
+
+## Rollback boundary and evidence
+
+The separately retained PR #108 matched rollback record is historical
+evidence: deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (version #98), and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). Do not mix a Worker from that pair
+with a different D1. Any rollback requires owner authorization plus fresh
+compatibility and readiness evidence for the complete matched pair.
+
+Run `32165010129` uploaded seven sanitized evidence artifacts: audit
+`9335870200` (`e401a9e6139ef3503780261806890d3cebaf3de04682f08d6b32453e1f8e1651`),
+reconciliation `9335869860`
+(`86d586ff75cd32893c48501ae6bc5cce2a0f6dc9098701bd0040c3102143c647`),
+final routing `9335867356`
+(`c5eaec43f82d2571bef3e449c52ff0181f3742de536cee015f7e03dac5b1a283`),
+edge `9335841157`
+(`be8cc4c98ec86daa193c4113dc2a4166148e2dd733b3bb0b6766253c27597d7b`),
+candidate cutover `9335834854`
+(`5dc6672e60d0ef3ef4d5c9a5f07a2574b557076b1e94ec0c2ec623825ff4e43a`),
+predecessor `9335818590`
+(`a0d78b84fbd35ffdf3c87c4513d3558d5d1c9e70b683dbd624c6add3029a2d81`),
+and D1 readiness `9335816004`
+(`b177d9e0970ff23711059ba74acab2ef9024361cb458a58b47ba95aced297955`).
+They retain bounded identities, counts, and hashes rather than request bodies,
+tool output, source text, or credentials.
+
+## Scope and deferred authority work
+
+This snapshot intentionally does not reconcile every release claim in the
+repository. Confirmed deferred authority debt is in `CLAUDE.md`,
+`test/unit/docs/publicContract.test.ts`, `CHANGELOG.md`,
+`docs/CUSTOM-DOMAIN-MIGRATION.md`, `docs/D1-DATA-WORKFLOW.md`,
+`docs/ROADMAP.md`, `docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md`,
+`docs/UBS-HEBREW-V0.9.2-DERIVED-NOTICE.md`, and
+`docs/UBS-SEMANTICS-FOUNDATION.md`. The touched entry/reconciliation documents
+also retain contextually scoped legacy fixture literals as temporary debt. CCEL,
+architecture, development, and `NOTICE` documents are further-audit candidates,
+not confirmed stale claims.
+
+This document makes no no-deployment-canary result claim; only the post-merge
+main workflow establishes that result. On a successful documentation-only skip,
+Git main advances while the deployed source/tree remains the recorded assignment
+until a later protected production release changes it.

--- a/docs/PHASE-3B-PLAN.md
+++ b/docs/PHASE-3B-PLAN.md
@@ -5,7 +5,11 @@ schema-`0009` preview and production releases completed by PR #122. Earlier
 roadmap sections use "Phase 3" for already-shipped work; **Phase 3B** is the
 unambiguous name for this successor program.
 
-## Known-good starting point
+For the active assignment in these entry/reconciliation documents, see the
+[current release snapshot](CURRENT-RELEASE.md). The release facts in this plan
+are historical planning baselines, not current identity authority.
+
+## Historical known-good starting point
 
 GitHub `main` is PR #122 merge
 `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2`, exact tree
@@ -67,8 +71,9 @@ The following boundaries remain deliberate:
 3. Add a narrowly reviewed mechanism that prevents evidence-only or
    documentation-only merges from causing an unnecessary production deploy.
 4. Merge the post-PR-#122 evidence record only after that mechanism is proven.
-5. Consolidate current release identity into one authoritative record and keep
-   historical records explicitly time-scoped.
+5. Establish a designated current snapshot for entry/reconciliation documents
+   and keep historical records explicitly time-scoped; repository-wide
+   authority cleanup remains separate work.
 6. Rehearse the matched PR #108 Worker/D1 rollback without changing live
    traffic, then define a retention policy before any predecessor cleanup.
 

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -1,5 +1,9 @@
 # Preview Release Reconciliation
 
+For the active assignment in these entry/reconciliation documents, see the
+[designated current snapshot](CURRENT-RELEASE.md). The records below retain
+dated release evidence and are not current identity authority.
+
 The protected preview workflow records and uploads a predecessor anchor before it mutates the preview Worker, proves the newly deployed Worker binds the candidate before either black-box audit, and records the active deployment again after the release gate. These are evidence, not a deployment mechanism. Uploading the predecessor first preserves a manual recovery target even if a later job cancellation prevents a post-mutation observation.
 
 The record intentionally distinguishes two D1 identities:
@@ -9,9 +13,13 @@ The record intentionally distinguishes two D1 identities:
 
 The generic release workflow permits both code-only releases (`d1Changed: false`) and data cutovers (`d1Changed: true`); it never infers freshness from a different ID alone. Wrangler 4.107.0’s D1 binding response is accepted only when the sole `THEOLOGAI_DB` binding has canonical UUID `id` and `database_id` fields that agree exactly. After deployment, the sole active Worker version must bind the candidate ID before either fixed audit begins; a retained-old-D1 deployment is refused even if its Worker version otherwise looks new.
 
-## PR #123 current schema-0009 preview release — passed
+## Historical PR #123 schema-0009 preview release — passed
 
-The protected preview workflow deployed exact source
+The legacy fixture phrase `PR #123 current schema-0009 preview release` labels
+this dated record only; it is not current today. The active assignment is in
+the [current snapshot](CURRENT-RELEASE.md).
+
+At that protected preview release, the workflow deployed exact source
 `7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0` (tree
 `28e555808ad3840d145a7ddd7e57934dc30e45c2`) through Actions run
 `31644218683` and GitHub deployment `5878053561`. Cloudflare deployment

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -1,5 +1,9 @@
 # Primary-source catalog scope
 
+For the active assignment in these entry/reconciliation documents, see the
+[designated current snapshot](CURRENT-RELEASE.md). The release bindings below
+are historical catalog and audit evidence, not current identity authority.
+
 ## Historical Transform 6 catalog slice
 
 The historical Transform 6 slice materializes the reviewed catalog manifest
@@ -7,7 +11,7 @@ for the 17 legacy hosted works. It adds no document bodies and grants no new
 rights; it makes that already-hosted collection's work identities,
 composition-date scope, and explicitly attributed creators machine-readable.
 
-## Checked-out Transform 11 candidate and deployed Transform 9 baseline
+## Historical checked-out Transform 11 candidate and deployed Transform 9 baseline
 
 The checked-out Transform 10 candidate retains an inactive Aquinas
 edition-scoped authority hierarchy packet and standalone materializer. Normal
@@ -38,7 +42,7 @@ predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
 (`51890e12-1c3f-421f-b661-9a5ea9637e43`). That former Transform-11 preview
-binding is historical. The current preview baseline is PR #123 deployment
+binding is historical. The historical PR #123 preview baseline is deployment
 `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
 `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
 `theologai-preview-20260811-schema0009-a`
@@ -74,7 +78,8 @@ PR #107's Transform-11 preview candidate
 `29a4a7faec2a960f06bfc026a319df8c08b495bb7ad82831fb62d3a3586643a4`.
 Primary readiness, Transform-8 authority (`1/12/12` pages), and complete
 Transform-11 source-pack authority (`1/1/1/1/1/1/133/17` pages) passed while
-unbound. Protected preview deployment now proves the current binding above;
+unbound. The protected preview deployment proved the binding described above at
+that historical release;
 production was unchanged by that preview release, and Transform-10
 hierarchy/publication/Aquinas rows remain excluded.
 

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -1,12 +1,17 @@
 # Production Release Reconciliation
 
+For the active assignment, see the [designated current snapshot](CURRENT-RELEASE.md).
 This document records the completed PR #122 schema-`0009` production cutover,
 its immediate PR #108 rollback pair, older PR #101 history, and the safeguards
 required for later releases.
 
-## Current PR #122 production release
+## Historical PR #122 production release
 
-PR #122 merged as `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` with exact tree
+The legacy fixture phrase `Current PR #122 production release` is retained
+solely as dated point-in-time evidence; it is not current today. The active
+assignment is recorded in the [current snapshot](CURRENT-RELEASE.md).
+
+At that release, PR #122 merged as `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` with exact tree
 `8150aa29e7e4a22141edbfc9ab568df933f9c9b3`. Protected production workflow
 `31631924636` deployed `e62698f3-f6b0-4145-97bf-28abdeae0e3a`, Worker
 `02174f95-abe2-480b-84bf-3e8c1a3a0320` (#100), as the sole active production
@@ -90,7 +95,7 @@ audit all passed. The retained PR #101 preview predecessor was
 deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
-(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The current preview baseline is PR #123
+(`51890e12-1c3f-421f-b661-9a5ea9637e43`). The historical PR #123 preview baseline is
 deployment `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
 `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
 `theologai-preview-20260811-schema0009-a`

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -1,10 +1,14 @@
 # Worker operations
 
-## Current live baseline
+The [current release snapshot](CURRENT-RELEASE.md) is the designated current
+snapshot for this operations document. The dated records below retain release
+evidence and are not current identity authority.
+
+## Historical PR #122 live baseline
 
 The integrated checked-out normal build excludes the Transform-10 Aquinas
 hierarchy from all normal D1 corpora: it has no catalog, runtime, or MCP
-projection. Production is PR #122 merge
+projection. In this dated record, Production is PR #122 merge
 `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` (tree
 `8150aa29e7e4a22141edbfc9ab568df933f9c9b3`). Protected workflow
 `31631924636` deployed `e62698f3-f6b0-4145-97bf-28abdeae0e3a`, serving Worker
@@ -32,15 +36,17 @@ The checked-in preview configuration targets schema-`0009` D1
 proved that binding and completed its audit. It captured production against its
 checked-in D1 name/UUID and fresh inventory before preview mutation,
 immediately after deployment, and again after final preview audit. The
-checked-in and active production target is the separately prepared
-schema-`0009` candidate `theologai-production-20260811-schema0009-a`
-(`9bc79346-338b-439e-a2a5-424f4418eb21`). PR #122's protected production
-workflow proved the active binding, re-proved preview control after deployment
-and audits, and emitted the final environment-isolation receipt.
+separately prepared schema-`0009` candidate
+`theologai-production-20260811-schema0009-a`
+(`9bc79346-338b-439e-a2a5-424f4418eb21`) is the production D1 also recorded in
+today's [current release snapshot](CURRENT-RELEASE.md). PR #122's protected
+production binding observation is dated historical evidence, not current today;
+it proved the active binding, re-proved preview control after deployment and
+audits, and emitted the final environment-isolation receipt.
 
-PR #123 completed the current protected preview release from
+In the dated release record, PR #123 completed the current protected preview release from
 `7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0` (tree
-`28e555808ad3840d145a7ddd7e57934dc30e45c2`): Cloudflare deployment
+`28e555808ad3840d145a7ddd7e57934dc30e45c2`); it is not current today. Cloudflare deployment
 `4108d59a-4092-4389-824c-fa3820ab66f6` assigns Worker
 `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144) solely to the schema-`0009`
 preview D1. All bounded audits and production-control comparisons passed. The


### PR DESCRIPTION
## Purpose

Add a narrow Markdown-only production-classifier canary and an additive designated current-snapshot reader path. This does not claim repository-wide release-authority cleanup and does not claim the classifier/no-deployment behavior has yet been proved in GitHub Actions.

## Exact scope

Relative to main 7f567ef0d050c91ac24e02e9798ac68cf448f8ff, this draft changes exactly seven Markdown paths: adds docs/CURRENT-RELEASE.md and modifies README.md, docs/PRODUCTION-RELEASE-RECONCILIATION.md, docs/worker-operations.md, docs/PHASE-3B-PLAN.md, docs/PREVIEW-RELEASE-RECONCILIATION.md, and docs/PRIMARY-SOURCE-CATALOG-SCOPE.md.

SHA-256: README e907ec190d55f97c5857886722918204ab963756fb84ca8a329784b7761c56f5; CURRENT-RELEASE 207d2f19b2f6a8511123db7cd7df0a435e08a0a1c2d2d0f215e08acfa0f55faf; production reconciliation 33e901929686733855301d3242c36c8a2c82d9fe4b9a1b1a02b127c6ef421eaa; worker operations 077377bf82a0e6a89230205f98bd4fbac5a742d4e891eb2a605b85a47a0ac203; Phase 3B plan 66d887b180854638840a8b0313a01a9530deecd21f660a309a24497b3be890be; preview reconciliation 9987f6d98e4cac7ea53e2dd1ecb7858a402c3c9850f6d65efedae8ab727fdc1d; primary-source catalog scope 01edce9b48891cb6a674dba34ffc71a0d443fa0a011cfd5446a2b1799ea044f7.

## Snapshot and authority boundary

CURRENT-RELEASE is a dated, sanitized designated snapshot for these entry/reconciliation documents, observed through #124 protected run 32165010129 completed 2026-08-18T17:44:52Z. It records active #124 source/tree, production deployment/Worker #108/D1, unchanged preview control, #106 as immediate same-D1 predecessor, and the distinct PR #108 Worker #98/Transform11-D1 rollback pair. It forbids mixed Worker/D1 rollback and requires owner authorization plus fresh compatibility/readiness evidence.

#122/#123 facts remain as dated evidence; required legacy literals are contextually scoped as not current today. Confirmed deferred authority debt remains CLAUDE.md, test/unit/docs/publicContract.test.ts, CHANGELOG.md, docs/CUSTOM-DOMAIN-MIGRATION.md, docs/D1-DATA-WORKFLOW.md, docs/ROADMAP.md, docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md, docs/UBS-HEBREW-V0.9.2-DERIVED-NOTICE.md, and docs/UBS-SEMANTICS-FOUNDATION.md. CCEL/architecture/development/NOTICE docs remain audit candidates, not asserted stale claims.

## Local verification

Pinned Node 22.23.1/npm 10.9.8: npm ci --no-audit; docs:check (13/13); focused classifier/endpoint tests (9/9); test:unit (191 files, 2487 passed/5 skipped); typecheck Node/Worker/release; and git diff --check all passed. The pure exact A+6M classifier simulation returned classificationSucceeded=true, deployRequired=false, decision=skip, reason=markdown-documentation-only, with seven ordered records.

## Release boundary

This is a draft documentation-only PR. PR checks must pass five required jobs and Deploy Preview must skip; they do not prove the production classifier. Only a later separately authorized merge may produce the one main-push deployment workflow that must prove the classifier skip before any production environment, secret, Cloudflare, Worker, D1, preview, or artifact mutation. A successful documentation-only skip advances Git main while the deployed source/tree remains the documented active assignment until a later protected production release.
