### PR TITLE
test: isolate Node unit environment defaults

### DIFF
--- a/test/setup.ts
+++ b/test/setup.ts
@@ -6,14 +6,10 @@
  */
 
 import { vi } from 'vitest';
-import * as dotenv from 'dotenv';
-
-// Load environment variables for tests
-dotenv.config();
 
 // Set test environment variables
 process.env.NODE_ENV = 'test';
-process.env.ESV_API_KEY = process.env.ESV_API_KEY || 'test-esv-api-key';
+process.env.ESV_API_KEY = 'test-esv-api-key';
 
 // Global test timeout
 vi.setConfig({ testTimeout: 30000 });

--- a/test/unit/config/unitTestEnvironmentIsolation.test.ts
+++ b/test/unit/config/unitTestEnvironmentIsolation.test.ts
@@ -1,0 +1,135 @@
+import { spawn } from 'node:child_process';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url)))));
+const setupPath = join(repositoryRoot, 'test', 'setup.ts');
+const vitestCliPath = join(repositoryRoot, 'node_modules', 'vitest', 'vitest.mjs');
+const childTimeoutMs = 20_000;
+const childOutputLimitBytes = 8 * 1024;
+
+const hostileKeys = [
+  'ESV_API_KEY',
+  'THEOLOGAI_TEST_DOTENV_SENTINEL',
+  'THEOLOGAI_TEST_DATABASE_PATH',
+  'WRANGLER_BIN',
+  'CI',
+  'THEOLOGAI_TEST_GENERIC_API_TOKEN',
+  'CLOUDFLARE_API_TOKEN',
+  'THEOLOGAI_TEST_FEATURE_FLAG',
+  'DOTENV_CONFIG_PATH',
+  'DOTENV_CONFIG_OVERRIDE',
+] as const;
+
+const hostileKeysThatMustRemainAbsent = hostileKeys.filter((key) => key !== 'ESV_API_KEY');
+
+type ChildResult = 'passed' | 'child-config' | 'child-setup' | 'child-module' | 'child-no-probe' | 'child-exit' | 'child-error' | 'child-timeout' | 'child-output-limit';
+
+function boundedChildFailureCode(output: string): ChildResult {
+  if (output.includes('Failed to load config')) return 'child-config';
+  if (output.includes('setup.ts')) return 'child-setup';
+  if (output.includes('Cannot find module') || output.includes("Cannot find package 'vitest'")) return 'child-module';
+  if (output.includes('No test files found')) return 'child-no-probe';
+  return 'child-exit';
+}
+
+function minimalChildEnvironment(inheritedEsv: boolean): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    TMPDIR: process.env.TMPDIR,
+  };
+
+  if (inheritedEsv) environment.ESV_API_KEY = 'inherited-synthetic-esv';
+  return environment;
+}
+
+async function runHostileDotenvCase(name: string, inheritedEsv: boolean): Promise<ChildResult> {
+  const root = await mkdtemp(join(tmpdir(), 'theologai-d4-unit-env-'));
+  const configPath = join(root, 'vitest.config.mts');
+  const probePath = join(root, 'environment-isolation.probe.test.ts');
+  const dotenvPath = join(root, '.env');
+
+  try {
+    await writeFile(dotenvPath, [
+      'ESV_API_KEY=hostile-synthetic-esv',
+      'THEOLOGAI_TEST_DOTENV_SENTINEL=hostile',
+      'THEOLOGAI_TEST_DATABASE_PATH=hostile.sqlite',
+      'WRANGLER_BIN=hostile-wrangler',
+      'CI=hostile-ci',
+      'THEOLOGAI_TEST_GENERIC_API_TOKEN=hostile-token',
+      'CLOUDFLARE_API_TOKEN=hostile-cloudflare-token',
+      'THEOLOGAI_TEST_FEATURE_FLAG=hostile-feature',
+      'DOTENV_CONFIG_PATH=hostile-dotenv-path',
+      'DOTENV_CONFIG_OVERRIDE=true',
+      '',
+    ].join('\n'), { mode: 0o600 });
+    await chmod(dotenvPath, 0o600);
+
+    await writeFile(configPath, [
+      `export default { test: { environment: 'node', globals: true, setupFiles: [${JSON.stringify(setupPath)}], include: ['environment-isolation.probe.test.ts'], pool: 'threads', minWorkers: 1, maxWorkers: 1, fileParallelism: false, testTimeout: 10000, hookTimeout: 10000 } };`,
+      '',
+    ].join('\n'));
+
+    await writeFile(probePath, [
+      `const hostileKeys = ${JSON.stringify(hostileKeysThatMustRemainAbsent)};`,
+      "test('real Node-unit setup ignores cwd dotenv values', () => {",
+      '  for (const key of hostileKeys) expect(process.env[key]).toBeUndefined();',
+      "  expect(process.env.NODE_ENV).toBe('test');",
+      "  expect(process.env.ESV_API_KEY).toBe('test-esv-api-key');",
+      '});',
+      '',
+    ].join('\n'));
+
+    return await new Promise<ChildResult>((resolve) => {
+      const child = spawn(process.execPath, [vitestCliPath, 'run', '--config', configPath, '--root', root], {
+        cwd: root,
+        env: minimalChildEnvironment(inheritedEsv),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let outputBytes = 0;
+      let boundedOutput = '';
+      let settled = false;
+      let terminalResult: ChildResult | undefined;
+      const settle = (result: ChildResult) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve(result);
+      };
+      const onOutput = (chunk: Buffer) => {
+        outputBytes += chunk.length;
+        if (boundedOutput.length < childOutputLimitBytes) {
+          boundedOutput += chunk.toString('utf8', 0, Math.min(chunk.length, childOutputLimitBytes - boundedOutput.length));
+        }
+        if (outputBytes > childOutputLimitBytes) {
+          terminalResult = 'child-output-limit';
+          child.kill('SIGKILL');
+        }
+      };
+      const timeout = setTimeout(() => {
+        terminalResult = 'child-timeout';
+        child.kill('SIGKILL');
+      }, childTimeoutMs);
+
+      child.stdout.on('data', onOutput);
+      child.stderr.on('data', onOutput);
+      child.on('error', () => settle('child-error'));
+      child.on('close', (code) => settle(terminalResult ?? (code === 0 ? 'passed' : boundedChildFailureCode(boundedOutput))));
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe('Node-unit environment isolation', () => {
+  it.each([
+    ['replaces an inherited synthetic ESV key', true],
+    ['sets the test ESV key without an inherited key', false],
+  ])('%s while ignoring a hostile cwd dotenv file', async (_name, inheritedEsv) => {
+    await expect(runHostileDotenvCase(_name, inheritedEsv)).resolves.toBe('passed');
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

Make Node-unit test setup deterministic and independent of a developer or repository `.env` file. `test/setup.ts` no longer loads dotenv and always sets `NODE_ENV=test` and the synthetic `ESV_API_KEY` test value.

## Scope

Exactly two test files change: the Node-unit setup and a bounded child-Vitest isolation test. The new test exercises the real setup from a temporary cwd in two cases—one with a synthetic inherited ESV key and one without—while a hostile synthetic `.env` attempts to set ESV, CI, D1, Wrangler, token, feature-flag, and dotenv-control values. It verifies fixed test defaults and absent hostile values without emitting environment or `.env` contents.

## Validation

- Focused isolation, ESV adapter, and config tests: 15 passed.
- Unit and coverage suites: 192 files, 2,489 passed, 5 skipped; thresholds met.
- Typecheck, build, current integration, and Worker runtime passed under Node 22.23.1 / npm 10.9.8.

This test-path change is deploy-required by the production classifier. It does not change runtime behavior, workflows, dependencies, data, or Cloudflare/D1 configuration.
