### PR TITLE
test: centralize workflow topology ownership

### DIFF
--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -10,8 +10,8 @@
     "conformance": 1
   },
   "current": {
-    "totalTestTypeScript": 274,
-    "activeVitest": 197,
+    "totalTestTypeScript": 275,
+    "activeVitest": 198,
     "support": 22,
     "manual": 4,
     "legacyOrphan": 50,
@@ -56,6 +56,7 @@
       "test/unit/config/npmPublicationPolicy.test.ts",
       "test/unit/config/testTopology.test.ts",
       "test/unit/config/unitTestEnvironmentIsolation.test.ts",
+      "test/unit/config/workflowTopology.test.ts",
       "test/unit/docs/publicContract.test.ts",
       "test/unit/formatters/bibleFormatter.test.ts",
       "test/unit/formatters/commentaryFormatter.test.ts",

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -39,7 +39,7 @@ describe('custom-domain infrastructure contract', () => {
     }
   });
 
-  it('publishes canonical deployment URLs without weakening preview authorization', async () => {
+  it('publishes canonical deployment URLs and preserves release-context detector ordering', async () => {
     const [productionWorkflow, previewWorkflow] = await Promise.all([
       readProjectFile('.github/workflows/deploy.yml'),
       readProjectFile('.github/workflows/pr.yml'),
@@ -47,7 +47,6 @@ describe('custom-domain infrastructure contract', () => {
 
     expect(productionWorkflow).toContain('name: production');
     expect(productionWorkflow).toContain('url: https://mcp.theologai.xyz/mcp');
-    expect(productionWorkflow).toContain('fetch-depth: 0');
     const releaseContextStart = productionWorkflow.indexOf('- name: Resolve production release comparison context');
     const detectorStart = productionWorkflow.indexOf('- name: Detect production custom-domain declaration change');
     const prerequisiteStart = productionWorkflow.indexOf('- name: Require live website and audited preview custom domain');
@@ -93,26 +92,8 @@ describe('custom-domain infrastructure contract', () => {
 
     expect(previewWorkflow).toContain('name: preview');
     expect(previewWorkflow).toContain('url: https://preview-mcp.theologai.xyz/mcp');
-    expect(previewWorkflow).toContain('contains(github.event.pull_request.labels.*.name, \'deploy-preview\')');
-    expect(previewWorkflow).toContain("if (!labels.includes('deploy-preview')) failures.push('the deploy-preview label is absent')");
-    expect(previewWorkflow.match(/github\.rest\.pulls\.get/g)).toHaveLength(2);
-    const previewJob = previewWorkflow.slice(previewWorkflow.indexOf('  preview-deploy:'));
-    const previewCheckoutStart = previewJob.indexOf('- uses: actions/checkout@');
-    const previewCheckoutEnd = previewJob.indexOf('- uses: actions/setup-node@', previewCheckoutStart);
-    const previewCheckout = previewJob.slice(previewCheckoutStart, previewCheckoutEnd);
-    expect(previewCheckout).toContain('ref: ${{ github.event.pull_request.head.sha }}');
-    expect(previewCheckout).toContain('- name: Verify preview checkout identity');
-    expect(previewCheckout).toContain('EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}');
-    expect(previewCheckout).toContain('git rev-parse HEAD');
-    expect(previewCheckout).toContain('git rev-parse HEAD^{tree}');
-    expect(previewCheckout).toContain('Preview checkout does not match the authorized pull-request head');
-    expect(previewCheckout).toContain("printf 'commit=%s\\n' \"$checked_out_commit\" >> \"$GITHUB_OUTPUT\"");
-    expect(previewCheckout).toContain("printf 'tree=%s\\n' \"$checked_out_tree\" >> \"$GITHUB_OUTPUT\"");
     expect(previewWorkflow).toContain('**Canonical MCP Endpoint:** `https://preview-mcp.theologai.xyz/mcp`');
     expect(previewWorkflow).toContain('**Compatibility MCP endpoint:** `https://theologai-preview.tjfrederick.workers.dev/mcp`');
-    expect(previewWorkflow).toContain('CHECKED_OUT_COMMIT: ${{ steps.preview-checkout.outputs.commit }}');
-    expect(previewWorkflow).toContain('CHECKED_OUT_TREE: ${{ steps.preview-checkout.outputs.tree }}');
-    expect(previewWorkflow).toContain('Deployed from checked-out commit \\`${commit}\\` (tree \\`${tree}\\`).');
   });
 
   it('keeps fallback origin behavior on the legacy Pages site during the staged cutover', () => {

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -1,0 +1,179 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+async function readWorkflow(name: string): Promise<string> {
+  return readFile(new URL(`../../../.github/workflows/${name}`, import.meta.url), 'utf8');
+}
+
+function occurrences(source: string, exactLine: string): number {
+  return source.split('\n').filter(line => line === exactLine).length;
+}
+
+function uniqueBlock(source: string, exactAnchor: string): string {
+  expect(occurrences(source, exactAnchor), `unique workflow anchor: ${exactAnchor}`).toBe(1);
+  const lines = source.split('\n');
+  const start = lines.indexOf(exactAnchor);
+  const indent = exactAnchor.length - exactAnchor.trimStart().length;
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (line.trim() === '') continue;
+    const lineIndent = line.length - line.trimStart().length;
+    if (lineIndent <= indent) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+function normalized(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+const REVOCATION_PREDICATE = normalized(`
+  github.event.action == 'closed' ||
+  (github.event.action == 'unlabeled' && github.event.label.name == 'deploy-preview') ||
+  github.event.action == 'converted_to_draft' ||
+  (
+    github.event.action == 'edited' &&
+    github.event.changes.base.ref.from == 'main' &&
+    github.event.pull_request.base.ref != 'main'
+  )
+`);
+
+describe('workflow topology', () => {
+  it('keeps production classification isolated and deployment fail-open behind production', async () => {
+    const workflow = await readWorkflow('deploy.yml');
+    const trigger = uniqueBlock(workflow, 'on:');
+    const concurrency = uniqueBlock(workflow, 'concurrency:');
+    const classifier = uniqueBlock(workflow, '  classify-deployment:');
+    const deploy = uniqueBlock(workflow, '  deploy:');
+    const outputs = uniqueBlock(classifier, '    outputs:');
+
+    expect(normalized(trigger)).toBe(normalized(`
+      on:
+        push:
+          branches: [main]
+        workflow_dispatch:
+          inputs:
+            reason:
+              description: Short reason for the manual production deployment
+              required: true
+              type: string
+    `));
+    expect(normalized(concurrency)).toBe('concurrency: group: deploy-production cancel-in-progress: false');
+    expect(occurrences(workflow, '  classify-deployment:')).toBe(1);
+    expect(occurrences(workflow, '  deploy:')).toBe(1);
+
+    expect(classifier).toContain('name: Classify Production Deployment');
+    expect(classifier).toContain('permissions:\n      contents: read');
+    expect(classifier).toContain('fetch-depth: 0');
+    expect(classifier).not.toMatch(/\n\s+environment:|secrets\.|wrangler|cloudflare/i);
+    expect(normalized(outputs)).toBe(normalized(`
+      outputs:
+        classification_succeeded: \${{ steps.classify.outputs.classification_succeeded }}
+        deploy_required: \${{ steps.classify.outputs.deploy_required }}
+        decision: \${{ steps.classify.outputs.decision }}
+        reason: \${{ steps.classify.outputs.reason }}
+        base: \${{ steps.classify.outputs.base }}
+        head: \${{ steps.classify.outputs.head }}
+        changed_path_evidence_json: \${{ steps.classify.outputs.changed_path_evidence_json }}
+    `));
+    expect(classifier).toContain('if [ "$GITHUB_EVENT_NAME" = \'workflow_dispatch\' ]; then');
+    expect(classifier).toContain('if [ "$GITHUB_REF" != \'refs/heads/main\' ]; then');
+    expect(classifier).toContain('before="$(git rev-parse HEAD^1)"');
+    expect(classifier).toContain("grep -Eq '^[0-9a-fA-F]{40}$'");
+    expect(classifier).toContain('git cat-file -e "${before}^{commit}"');
+    expect(classifier).toContain('git merge-base --is-ancestor "$before" HEAD');
+    expect(classifier).not.toMatch(/run:\s*\|[\s\S]*?\$\{\{\s*github\.ref\s*\}\}/);
+    expect(classifier).not.toContain('${{ inputs.reason }}');
+
+    expect(deploy).toContain('needs: classify-deployment');
+    expect(deploy).toContain("if: ${{ always() && github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.classify-deployment.result != 'success' || needs.classify-deployment.outputs.classification_succeeded != 'true' || needs.classify-deployment.outputs.deploy_required != 'false') }}");
+    expect(deploy).toContain('environment:\n      name: production\n      url: https://mcp.theologai.xyz/mcp');
+    expect(deploy).toContain('permissions:\n      contents: read');
+    expect(occurrences(workflow, '      name: production')).toBe(1);
+  });
+
+  it('keeps the five PR checks and preview authorization boundary exact', async () => {
+    const workflow = await readWorkflow('pr.yml');
+    const trigger = uniqueBlock(workflow, 'on:');
+    const permissions = uniqueBlock(workflow, 'permissions:');
+    const expectedJobs = [
+      ['  test-and-build:', 'Test & Build'],
+      ['  fresh-checkout-data:', 'Fresh Checkout & Data'],
+      ['  worker-runtime:', 'Worker Runtime & D1'],
+      ['  node-http-e2e:', 'Node HTTP E2E'],
+      ['  mcp-conformance:', 'Applicable MCP Conformance'],
+    ] as const;
+
+    expect(normalized(trigger)).toBe(normalized(`
+      on:
+        pull_request:
+          branches: [main]
+          types: [opened, synchronize, reopened, labeled, ready_for_review]
+    `));
+    expect(normalized(permissions)).toBe('permissions: contents: read');
+    expect([...workflow.matchAll(/^  ([a-z][a-z0-9-]+):$/gm)].map(match => match[1])).toEqual([
+      'test-and-build', 'fresh-checkout-data', 'worker-runtime', 'node-http-e2e', 'mcp-conformance', 'preview-deploy',
+    ]);
+    for (const [anchor, name] of expectedJobs) {
+      expect(uniqueBlock(workflow, anchor)).toContain(`name: ${name}`);
+    }
+
+    const freshCheckout = uniqueBlock(workflow, '  fresh-checkout-data:');
+    expect(freshCheckout).toContain('fetch-depth: 2');
+    expect(occurrences(freshCheckout, '      - name: Verify historical section-key lineage')).toBe(1);
+
+    const preview = uniqueBlock(workflow, '  preview-deploy:');
+    expect(preview).toContain('name: Deploy Preview');
+    expect(preview).toContain('needs: [test-and-build, fresh-checkout-data, worker-runtime, node-http-e2e, mcp-conformance]');
+    expect(normalized(preview)).toContain(normalized(`
+      if: >-
+        github.event.pull_request.state == 'open' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+    `));
+    expect(preview).toContain('group: theologai-shared-preview-mutation\n      cancel-in-progress: false');
+    expect(preview).toContain('environment:\n      name: preview\n      url: https://preview-mcp.theologai.xyz/mcp');
+    expect(preview).toContain('permissions:\n      contents: read\n      pull-requests: write');
+    const authorization = preview.indexOf('- name: Confirm live preview authorization before using environment secrets');
+    const checkout = preview.indexOf('- uses: actions/checkout@');
+    const setup = preview.indexOf('- uses: actions/setup-node@');
+    expect(authorization).toBeGreaterThan(0);
+    expect(checkout).toBeGreaterThan(authorization);
+    expect(setup).toBeGreaterThan(checkout);
+    expect(preview.slice(authorization, checkout)).toContain('github.rest.pulls.get');
+    expect(preview.slice(authorization, checkout)).toContain("if (!labels.includes('deploy-preview'))");
+    expect(preview.slice(checkout, setup)).toContain('ref: ${{ github.event.pull_request.head.sha }}');
+    expect(preview.slice(checkout, setup)).toContain('- name: Verify preview checkout identity');
+  });
+
+  it('characterizes preview revocation without inventing a routing oracle', async () => {
+    const workflow = await readWorkflow('preview-revocation.yml');
+    const trigger = uniqueBlock(workflow, 'on:');
+    const permissions = uniqueBlock(workflow, 'permissions: {}');
+    const concurrency = uniqueBlock(workflow, 'concurrency:');
+    const job = uniqueBlock(workflow, '  acknowledge-revocation:');
+
+    expect(normalized(trigger)).toContain('pull_request: types: [closed, unlabeled, converted_to_draft, edited]');
+    expect(trigger).not.toContain('branches:');
+    expect(trigger).not.toContain('ready_for_review');
+    expect(normalized(permissions)).toBe('permissions: {}');
+    expect(normalized(concurrency)).toContain(REVOCATION_PREDICATE);
+    expect(normalized(concurrency)).toContain("format('pr-{0}', github.event.pull_request.number)");
+    expect(normalized(concurrency)).toContain("format('preview-revocation-noop-{0}', github.run_id)");
+    expect(normalized(concurrency)).toContain('cancel-in-progress: >- ${{ ' + REVOCATION_PREDICATE + ' }}');
+
+    expect(normalized(job)).toContain(`if: >- ${REVOCATION_PREDICATE}`);
+    expect(job).toContain('name: Record Preview Revocation');
+    expect(job).toContain('runs-on: ubuntu-latest');
+    expect(job).toContain('timeout-minutes: 1');
+    expect(job).not.toMatch(/environment:|secrets\.|upload-artifact/i);
+    expect(occurrences(job, '      - name: Confirm active preview cancellation')).toBe(1);
+    expect(job).toContain('run: echo "Preview authorization was revoked; matching in-flight PR Checks runs were canceled."');
+  });
+});

--- a/test/unit/scripts/classifyProductionDeployment.test.ts
+++ b/test/unit/scripts/classifyProductionDeployment.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { classifyProductionDeployment, collectGitClassification, parseNameStatusNul } from '../../../scripts/classify-production-deployment.mjs';
-import { readFile } from 'node:fs/promises';
 
 const before = 'a'.repeat(40);
 const after = 'b'.repeat(40);
@@ -65,50 +64,4 @@ describe('production deployment classifier', () => {
     ]);
   });
 
-  it('keeps the workflow fail-safe, manual-deploy defaults, and classifier isolation wired', async () => {
-    const workflow = await readFile(new URL('../../../.github/workflows/deploy.yml', import.meta.url), 'utf8');
-    const prWorkflow = await readFile(new URL('../../../.github/workflows/pr.yml', import.meta.url), 'utf8');
-    expect(workflow).toContain('workflow_dispatch:');
-    expect(workflow).toContain('reason:');
-    expect(workflow).toContain('required: true');
-    expect(workflow).toContain('classify-deployment:');
-    expect(workflow).toContain('fetch-depth: 0');
-    const classifier = workflow.slice(workflow.indexOf('  classify-deployment:'), workflow.indexOf('\n  deploy:'));
-    const deploy = workflow.slice(workflow.indexOf('  deploy:'));
-    expect(classifier).toContain('if [ "$GITHUB_EVENT_NAME" = \'workflow_dispatch\' ]; then');
-    expect(classifier).toContain('if [ "$GITHUB_REF" != \'refs/heads/main\' ]; then');
-    expect(classifier).not.toMatch(/run:\s*\|[\s\S]*?github\.ref/);
-    expect(classifier).toContain('exit 1');
-    expect(classifier).toContain('manual-main-dispatch');
-    expect(classifier).toContain('before="$(git rev-parse HEAD^1)"');
-    expect(classifier).toContain("grep -Eq '^[0-9a-fA-F]{40}$'");
-    expect(classifier).toContain("echo 'decision=deploy'");
-    expect(classifier).toContain('echo "base=$before"');
-    expect(classifier).toContain('>> "$GITHUB_STEP_SUMMARY"');
-    expect(workflow).toContain('decision: ${{ steps.classify.outputs.decision }}');
-    expect(deploy).toContain('needs: classify-deployment');
-    expect(deploy).toContain("if: ${{ always() && github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.classify-deployment.result != 'success' || needs.classify-deployment.outputs.classification_succeeded != 'true' || needs.classify-deployment.outputs.deploy_required != 'false') }}");
-    // This exact truth table is the workflow condition above: only an
-    // explicit successful push classifier result of false skips deployment.
-    const runs = (event: 'push' | 'workflow_dispatch', ref: string, result: string, succeeded: string | undefined, required: string | undefined) =>
-      ref === 'refs/heads/main' && (event === 'workflow_dispatch' || result !== 'success' || succeeded !== 'true' || required !== 'false');
-    expect(runs('push', 'refs/heads/main', 'success', 'true', 'false')).toBe(false);
-    expect(runs('push', 'refs/heads/main', 'failure', undefined, undefined)).toBe(true);
-    expect(runs('push', 'refs/heads/main', 'success', undefined, undefined)).toBe(true);
-    expect(runs('push', 'refs/heads/main', 'success', 'true', 'malformed')).toBe(true);
-    expect(runs('workflow_dispatch', 'refs/heads/main', 'success', 'true', 'false')).toBe(true);
-    expect(runs('workflow_dispatch', 'refs/heads/feature', 'failure', undefined, undefined)).toBe(false);
-    expect(runs('workflow_dispatch', 'refs/tags/v3.6.0', 'failure', undefined, undefined)).toBe(false);
-    expect(workflow).toContain('Resolve production release comparison context');
-    expect(workflow).toContain('before="$(git rev-parse HEAD^1)"');
-    expect(workflow).toContain('custom_domain_required=true');
-    // Push preserves its exact event base only while resolving the shared
-    // context; later production guards consume that context output instead.
-    expect(deploy.match(/github\.event\.before/g)).toHaveLength(1);
-    expect(deploy).toContain('PREVIOUS_MAIN_SHA: ${{ steps.production-release-context.outputs.before }}');
-    expect(deploy).toContain('before="${{ steps.production-release-context.outputs.before }}"');
-    for (const check of ['Test & Build', 'Fresh Checkout & Data', 'Worker Runtime & D1', 'Node HTTP E2E', 'Applicable MCP Conformance']) {
-      expect(prWorkflow).toContain(`name: ${check}`);
-    }
-  });
 });


### PR DESCRIPTION
## Purpose

Centralize static GitHub Actions topology characterization in one executable owner without changing any workflow or runtime behavior.

## Scope

- add `test/unit/config/workflowTopology.test.ts` as the unique-anchor static owner for `deploy.yml`, `pr.yml`, and `preview-revocation.yml` topology;
- keep classifier tests focused on parser/classifier/CLI behavior;
- keep custom-domain tests focused on routes, D1/configuration, canonical URLs, and release-context detector ordering;
- update the topology manifest from 274/197/22 to 275 test TypeScript files / 198 active Vitest files / 22 support files.

No workflow, source, runtime, package, lock, configuration, data, or generated file changes.

## Verification

Pinned Node 22.23.1/npm 10.9.8:

- focused topology/classifier/custom-domain/release-guard/lineage suite: 6 files, 47 tests passed;
- unit: 195 files, 2,508 passed, 5 skipped;
- coverage: 90.89% lines, 80.94% branches, 92.03% functions;
- Node/Worker/release typechecks passed;
- manifest validation and `git diff --check` passed.

This test-only slice is deployment-required under the production classifier. No deployment or release action is part of this draft PR.
