### PR TITLE
refactor: centralize primary source descriptor

### DIFF
--- a/src/mcp/primarySourceSearchDescriptor.ts
+++ b/src/mcp/primarySourceSearchDescriptor.ts
@@ -1,0 +1,94 @@
+import { primarySourceSearchV6OutputSchema, primarySourceSearchV7OutputSchema } from './schemas/primarySourceSearchV4.js';
+import type { ToolHandler } from '../kernel/types.js';
+
+export type PrimarySourceSearchContractVersion = '6' | '7';
+export interface PrimarySourceSearchDescriptor {
+  readonly name: 'primary_source_search';
+  readonly contractVersion: PrimarySourceSearchContractVersion;
+  readonly description: string;
+  readonly inputSchema: ToolHandler['inputSchema'];
+  readonly outputSchema: NonNullable<ToolHandler['outputSchema']>;
+  readonly annotations: { readOnlyHint: true; destructiveHint: false; idempotentHint: true; openWorldHint: boolean };
+}
+
+export function createPrimarySourceSearchDescriptor(contractVersion: PrimarySourceSearchContractVersion = '6'): PrimarySourceSearchDescriptor {
+  const expanded = contractVersion === '7';
+  return {
+    name: 'primary_source_search', contractVersion,
+    description: expanded
+      ? 'Search the curated 35-work historical catalog first. Use searchDepth expanded only when a bounded, separately labeled external-discovery set could help; its unreviewed direct-URL snippets are discovery leads, not evidence. Per-hit edition readiness states the available provenance.'
+      : 'Execute an explicit, bounded query plan against the locally indexed historical-document collection. Supports exact catalog work aliases, exact reviewed creator names, and inclusive overlapping composition-year ranges. Returns catalog scope, snippets, and exact local section locators only; read selected exact resources before quotation or comparison.',
+    inputSchema: inputSchema(expanded),
+    outputSchema: expanded ? primarySourceSearchV7OutputSchema : primarySourceSearchV6OutputSchema,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: expanded },
+  };
+}
+
+function inputSchema(expanded: boolean): ToolHandler['inputSchema'] {
+  return {
+    type: 'object',
+    properties: {
+      queries: {
+        type: 'array', minItems: 1, maxItems: 4,
+        items: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', minLength: 1, maxLength: 40, pattern: '^[A-Za-z0-9][A-Za-z0-9_-]{0,39}$' },
+            text: { type: 'string', minLength: 1, maxLength: 200 },
+            ...(expanded ? {
+              searchDepth: { type: 'string', enum: ['standard', 'expanded'], default: 'standard', description: 'standard searches the curated 35-work catalog. expanded keeps that search and adds one separately labeled bounded external-discovery group; at most one query per call may be expanded.' },
+              expandedLimit: { type: 'integer', minimum: 1, maximum: 5, default: 3, description: 'Expanded-discovery result cap. Valid only with searchDepth expanded.' },
+            } : {
+              providers: { type: 'array', minItems: 1, maxItems: 1, uniqueItems: true, items: { type: 'string', enum: ['local'] }, description: 'Current public provider contract. Only the locally indexed collection is available.' },
+            }),
+            match: { type: 'string', enum: ['all_terms', 'phrase'], default: 'all_terms' },
+            selection: {
+              type: 'string', enum: ['relevance', 'work_diversity'], default: 'relevance',
+              description: expanded
+                ? 'Use relevance for within-work location; use work_diversity for a deterministic curated-catalog survey.'
+                : 'Use relevance for within-work location; use work_diversity for deterministic research bundles that round-robin across matching hosted works.',
+            },
+            author: {
+              type: 'string', minLength: 1, maxLength: 100,
+              description: expanded
+                ? 'One exact reviewed creator name for the catalog search; expanded discovery uses the same literal restriction without treating it as reviewed external metadata.'
+                : 'One exact reviewed creator name. Use separate query-plan items for different creators; creator roles are not relabeled as authorship.',
+            },
+            work: {
+              type: 'string', minLength: 1, maxLength: 160,
+              description: expanded
+                ? 'Exact catalog slug, title, or routing alias; expanded discovery uses the same literal restriction without treating it as reviewed external metadata.'
+                : 'Exact hosted work slug, title, or lookup-only alias.',
+            },
+            startYear: {
+              type: 'integer', minimum: -5000, maximum: 3000,
+              description: expanded
+                ? 'Inclusive catalog composition-overlap lower bound when reviewed dates are available. Expanded discovery deliberately omits it and warns that broader results are not date-filtered.'
+                : 'Inclusive lower bound. A work is eligible when its reviewed composition interval overlaps the requested interval.',
+            },
+            endYear: {
+              type: 'integer', minimum: -5000, maximum: 3000,
+              description: expanded
+                ? 'Inclusive catalog composition-overlap upper bound when reviewed dates are available; must be >= startYear. Expanded discovery deliberately omits it and warns that broader results are not date-filtered.'
+                : 'Inclusive upper bound. Must be greater than or equal to startYear when both are provided.',
+            },
+            page: expanded
+              ? { type: 'integer', const: 1, default: 1, description: 'Curated-catalog page. Page 1 only.' }
+              : { type: 'integer', minimum: 1, maximum: 3, default: 1, description: 'Preserved planner field. The local provider supports only page 1 and reports unsupported_filter otherwise.' },
+            limit: {
+              type: 'integer', minimum: 1, maximum: 8, default: 5,
+              ...(expanded ? { description: 'Curated-catalog maximum is 8. Use expandedLimit for the separately bounded expanded-discovery group.' } : {}),
+            },
+          },
+          required: expanded ? ['id', 'text'] : ['id', 'text', 'providers'],
+          ...(expanded ? { allOf: [
+            { if: { required: ['expandedLimit'] }, then: { required: ['searchDepth'], properties: { searchDepth: { const: 'expanded' } } } },
+            { if: { required: ['searchDepth'], properties: { searchDepth: { const: 'expanded' } } }, then: { properties: { page: { const: 1 } } } },
+          ] } : {}),
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['queries'], additionalProperties: false,
+  };
+}

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -5,8 +5,7 @@ import { parseReference } from '../kernel/reference.js';
 import { parseStrongsIdentity } from '../kernel/strongs.js';
 import { PUBLIC_DONATION_URL } from '../kernel/publicUrls.js';
 import { validatePromptArguments } from './validation.js';
-import type { PrimarySourceContractConfig } from '../kernel/featureFlags.js';
-import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../kernel/featureFlags.js';
+import { createPrimarySourceSearchDescriptor, type PrimarySourceSearchDescriptor } from './primarySourceSearchDescriptor.js';
 
 export interface RecommendedToolCall {
   tool: string;
@@ -59,7 +58,7 @@ function containingChapterReference(value: string): string {
 export function recommendedToolCallsForPrompt(
   name: string,
   args: Record<string, string> | undefined,
-  contract: PrimarySourceContractConfig = DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
+  descriptor: PrimarySourceSearchDescriptor = createPrimarySourceSearchDescriptor(),
 ): RecommendedToolCall[] {
   switch (name) {
     case 'word-study': {
@@ -122,7 +121,7 @@ export function recommendedToolCallsForPrompt(
           queries: [{
             id: 'confession-topic',
             text: topic,
-            ...(contract.contractVersion === '7' ? { searchDepth: 'expanded', expandedLimit: 3 } : { providers: ['local'] }),
+            ...(descriptor.contractVersion === '7' ? { searchDepth: 'expanded', expandedLimit: 3 } : { providers: ['local'] }),
             match: 'all_terms',
             selection: 'work_diversity',
             limit: 5,
@@ -151,17 +150,17 @@ export function recommendedToolCallsForPrompt(
           queries: (authors.length ? authors : [undefined]).map((author, index) => ({
             id: author ? `creator-${index + 1}` : work ? 'exact-local-work' : 'topic-survey',
             text: topic,
-            ...(contract.contractVersion === '7' ? { searchDepth: 'standard' } : { providers: ['local'] }),
+            ...(descriptor.contractVersion === '7' ? { searchDepth: 'standard' } : { providers: ['local'] }),
             match: 'all_terms',
             selection: work ? 'relevance' : 'work_diversity',
             ...scoped,
             ...(author ? { author } : {}),
-            ...(contract.contractVersion === '7' && index === 0 ? { searchDepth: 'expanded', expandedLimit: 3 } : {}),
+            ...(descriptor.contractVersion === '7' && index === 0 ? { searchDepth: 'expanded', expandedLimit: 3 } : {}),
             limit,
           })),
         },
       };
-      if (contract.contractVersion !== '7') return [localCall];
+      if (descriptor.contractVersion !== '7') return [localCall];
       // A prompt materialization may authorize only one expanded-discovery
       // attempt. Additional creator scopes remain standard catalog searches.
       return [localCall];
@@ -179,7 +178,7 @@ function callText(call: RecommendedToolCall): string {
 
 export function registerPromptHandlers(
   server: Server,
-  contract: PrimarySourceContractConfig = DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
+  descriptor: PrimarySourceSearchDescriptor = createPrimarySourceSearchDescriptor(),
 ): void {
   server.setRequestHandler(ListPromptsRequestSchema, async () => ({
     prompts: [
@@ -218,41 +217,41 @@ export function registerPromptHandlers(
       },
       {
         name: 'primary-source-research',
-        description: contract.contractVersion === '7'
+        description: descriptor.contractVersion === '7'
           ? 'Find curated primary-source evidence and optionally broaden discovery without treating snippets as evidence'
           : 'Find and read bounded evidence from the locally indexed historical collection',
         arguments: [
           {
             name: 'topic',
-            description: contract.contractVersion === '7'
+            description: descriptor.contractVersion === '7'
               ? 'Topic or terms for standard catalog research and optional expanded discovery.'
               : 'Topic or terms to find in the local historical collection',
             required: true,
           },
           {
             name: 'work',
-            description: contract.contractVersion === '7'
+            description: descriptor.contractVersion === '7'
               ? 'Optional exact catalog work title/slug. Expanded discovery reuses the literal text as an unreviewed search restriction, not shared reviewed metadata or an author name.'
               : 'Optional exact local work title or slug; not an author name',
             required: false,
           },
           {
             name: 'authors',
-            description: contract.contractVersion === '7'
+            description: descriptor.contractVersion === '7'
               ? 'Optional comma-separated creators. Each becomes a separate exact catalog creator query; only the first scope is broadened immediately, while later scopes remain standard searches. Creator roles remain explicit.'
               : 'Optional comma-separated canonical creator names. Each creator becomes a separate query; creator roles remain explicit.',
             required: false,
           },
           {
             name: 'startYear',
-            description: contract.contractVersion === '7'
+            description: descriptor.contractVersion === '7'
               ? 'Optional inclusive catalog composition-year lower bound as an integer string. Expanded discovery deliberately omits this bound and warns that broader results are not date-filtered.'
               : 'Optional inclusive composition-year lower bound as an integer string.',
             required: false,
           },
           {
             name: 'endYear',
-            description: contract.contractVersion === '7'
+            description: descriptor.contractVersion === '7'
               ? 'Optional inclusive catalog composition-year upper bound as an integer string. Expanded discovery deliberately omits this bound and warns that broader results are not date-filtered.'
               : 'Optional inclusive composition-year upper bound as an integer string.',
             required: false,
@@ -269,7 +268,7 @@ export function registerPromptHandlers(
     validatePromptArguments(name, args);
     // validatePromptArguments narrows both values after the permissive wire boundary.
     if (typeof name !== 'string') throw new Error('Unreachable prompt-name validation state');
-    const calls = recommendedToolCallsForPrompt(name, args, contract);
+    const calls = recommendedToolCallsForPrompt(name, args, descriptor);
 
     let text: string;
     switch (name) {
@@ -328,7 +327,7 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
         const topic = args?.topic ?? '';
         const traditions = args?.traditions;
         const hint = traditions ? ` Focus on: ${traditions.split(',').map(item => item.trim()).join(', ')}.` : '';
-        text = contract.contractVersion === '7'
+        text = descriptor.contractVersion === '7'
           ? `Cross-tradition doctrinal comparison on "${topic}".${hint}
 
 1. **Inspect the curated catalog** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Use each work's returned readiness metadata; do not assume every edition has the same review state.
@@ -369,7 +368,7 @@ Use structured \`passages[]\` when available, compare by its \`translation\`, re
         const externalDateCallInstruction = startYear !== undefined || endYear !== undefined
           ? 'The service retains both year fields for catalog scope and omits them from expanded discovery; do not split or rewrite the plan.'
           : 'Do not add separate date assumptions to expanded results; the broader source cannot enforce reviewed composition years.';
-        text = contract.contractVersion === '7'
+        text = descriptor.contractVersion === '7'
           ? `Research primary-source evidence about "${topic}"${work ? ` within the requested work "${work}"` : ''}${authors.length ? ` for the separately scoped creators ${authors.map(value => `"${value}"`).join(', ')}` : ''}.
 
 1. **Inspect catalog scope** — Read \`theologai://primary-sources/catalog\` with MCP \`resources/read\`. Use its per-work and per-edition readiness metadata as returned; an absent creator is a catalog gap, not evidence that no other source exists.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,7 @@ import { jsonSchemaValidator } from './validation.js';
 import { buildPrimarySourceCatalog, PRIMARY_SOURCE_CATALOG_URI } from './primarySourceCatalog.js';
 import { COMMENTARY_CATALOG } from '../kernel/commentaryCatalog.js';
 import type { PrimarySourceContractConfig } from '../kernel/featureFlags.js';
+import type { PrimarySourceSearchBinding } from '../tools/v2/primarySourceSearch.js';
 
 export interface McpServerServices {
   bibleService: Pick<BibleService, 'getSupportedTranslations'>;
@@ -40,6 +41,7 @@ export interface McpCompositionRoot {
   tools: ToolHandler[];
   services: McpServerServices;
   primarySourceContract: PrimarySourceContractConfig;
+  primarySourceSearch: PrimarySourceSearchBinding;
 }
 
 export interface McpCapabilityProfile {
@@ -297,18 +299,16 @@ export function createTheologAiMcpServer(
     throw resourceNotFound(uri);
   });
 
-  registerPromptHandlers(server, root.primarySourceContract);
+  registerPromptHandlers(server, root.primarySourceSearch.descriptor);
 
   return mcpServer;
 }
 
 function assertPrimarySourceContractParity(root: McpCompositionRoot): void {
-  const tool = root.tools.find(candidate => candidate.name === 'primary_source_search');
-  if (!tool) return;
-  const advertisedVersion = (tool.outputSchema?.properties?.schemaVersion as { const?: unknown } | undefined)?.const;
-  const expectedOpenWorld = root.primarySourceContract.contractVersion === '7';
-  if (advertisedVersion !== root.primarySourceContract.contractVersion
-    || tool.annotations?.openWorldHint !== expectedOpenWorld) {
-    throw new Error('primary_source_search tool and guided-prompt contracts must use the same configuration.');
+  const { descriptor, tool } = root.primarySourceSearch;
+  const named = root.tools.filter(candidate => candidate.name === descriptor.name);
+  if (descriptor.name !== 'primary_source_search' || tool.name !== descriptor.name
+    || named.length !== 1 || named[0] !== tool) {
+    throw new Error('primary_source_search binding must expose its exact named tool exactly once.');
   }
 }

--- a/src/tools/toolRegistry.ts
+++ b/src/tools/toolRegistry.ts
@@ -14,11 +14,9 @@ import { createCrossReferencesHandler } from './v2/crossReferences.js';
 import { createDonationConfigHandler } from './v2/donationConfig.js';
 import { createOriginalLanguageStudyHandler } from './v2/originalLanguageStudy.js';
 import { createParallelPassagesHandler } from './v2/parallelPassages.js';
-import { createPrimarySourceSearchHandler } from './v2/primarySourceSearch.js';
 import { createStrongsLookupHandler } from './v2/strongsLookup.js';
 import { createVerifyDonationHandler } from './v2/verifyDonation.js';
 import { createVerseMorphologyHandler } from './v2/verseMorphology.js';
-import type { PrimarySourceContractConfig } from '../kernel/featureFlags.js';
 
 export interface ToolRegistryDependencies {
   bibleService: Parameters<typeof createBibleLookupHandler>[0];
@@ -26,8 +24,7 @@ export interface ToolRegistryDependencies {
   parallelPassageService: Parameters<typeof createParallelPassagesHandler>[0];
   commentaryService: Parameters<typeof createCommentaryHandler>[0];
   historicalService: Parameters<typeof createClassicTextsHandler>[0];
-  primarySourceSearchService: Parameters<typeof createPrimarySourceSearchHandler>[0];
-  primarySourceContract: PrimarySourceContractConfig;
+  primarySourceSearchTool: ToolHandler;
   strongsService: Parameters<typeof createStrongsLookupHandler>[0];
   morphologyService: Parameters<typeof createVerseMorphologyHandler>[0];
   originalLanguageStudyCoordinator: Parameters<typeof createOriginalLanguageStudyHandler>[0];
@@ -41,7 +38,7 @@ export function createToolRegistry(dependencies: ToolRegistryDependencies): Tool
     createParallelPassagesHandler(dependencies.parallelPassageService),
     createCommentaryHandler(dependencies.commentaryService),
     createClassicTextsHandler(dependencies.historicalService),
-    createPrimarySourceSearchHandler(dependencies.primarySourceSearchService, dependencies.primarySourceContract),
+    dependencies.primarySourceSearchTool,
     createStrongsLookupHandler(dependencies.strongsService),
     createVerseMorphologyHandler(dependencies.morphologyService),
     createOriginalLanguageStudyHandler(dependencies.originalLanguageStudyCoordinator),

--- a/src/tools/v2/index.ts
+++ b/src/tools/v2/index.ts
@@ -41,6 +41,7 @@ import { OriginalLanguageStudyV2ContextProvider } from '../../services/languages
 import { SourceAttestedParallelService } from '../../services/bible/SourceAttestedParallelService.js';
 
 import { createToolRegistry } from '../toolRegistry.js';
+import { bindPrimarySourceSearch, type PrimarySourceSearchBinding } from './primarySourceSearch.js';
 
 // Donation
 import { OnChainVerifier } from '../../adapters/donation/OnChainVerifier.js';
@@ -64,6 +65,7 @@ export interface CompositionRoot {
   tools: ToolHandler[];
   services: ServerServices;
   primarySourceContract: ReturnType<typeof readPrimarySourceFeatureFlags>;
+  primarySourceSearch: PrimarySourceSearchBinding;
 }
 
 export interface CompositionRootOptions {
@@ -123,6 +125,7 @@ export function createCompositionRoot(options: CompositionRootOptions = {}): Com
     primarySourceContract,
     primarySourceContract.liveCcelEnabled ? nodeCcelCoordinator : undefined,
   );
+  const primarySourceSearch = bindPrimarySourceSearch(primarySourceSearchService, primarySourceContract);
   const strongsService = new StrongsService(strongsRepo, morphRepo);
   const morphService = new MorphologyService(morphRepo);
   const originalLanguageStudyService = new OriginalLanguageStudyService(morphRepo, strongsRepo);
@@ -142,8 +145,7 @@ export function createCompositionRoot(options: CompositionRootOptions = {}): Com
     parallelPassageService: parallelService,
     commentaryService,
     historicalService,
-    primarySourceSearchService,
-    primarySourceContract,
+    primarySourceSearchTool: primarySourceSearch.tool,
     strongsService,
     morphologyService: morphService,
     originalLanguageStudyCoordinator,
@@ -154,6 +156,7 @@ export function createCompositionRoot(options: CompositionRootOptions = {}): Com
     tools,
     services: { bibleService, commentaryService, historicalService, strongsService, sourceAttestedParallelService },
     primarySourceContract,
+    primarySourceSearch,
   };
 }
 

--- a/src/tools/v2/primarySourceSearch.ts
+++ b/src/tools/v2/primarySourceSearch.ts
@@ -2,11 +2,11 @@ import type { ToolHandler } from '../../kernel/types.js';
 import { handleToolError } from '../../kernel/errors.js';
 import type { PrimarySourceSearchService } from '../../services/historical/PrimarySourceSearchService.js';
 import { formatPrimarySourceSearchFallback, PRIMARY_SOURCE_FALLBACK_MAX_BYTES } from '../../formatters/primarySourceFormatter.js';
-import { primarySourceSearchV6OutputSchema, primarySourceSearchV7OutputSchema } from '../../mcp/schemas/primarySourceSearchV4.js';
 import { buildLocalDocumentResourceUri } from '../../kernel/documentResource.js';
 import type { ResourceLink } from '@modelcontextprotocol/sdk/types.js';
-import type { PrimarySourceContractConfig } from '../../kernel/featureFlags.js';
 import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../kernel/featureFlags.js';
+import type { PrimarySourceContractConfig } from '../../kernel/featureFlags.js';
+import { createPrimarySourceSearchDescriptor, type PrimarySourceSearchDescriptor } from '../../mcp/primarySourceSearchDescriptor.js';
 import {
   presentPrimarySourceSearchV6,
   type PresentedPrimarySourceSearchV4,
@@ -15,115 +15,37 @@ import {
   PRIMARY_SOURCE_V4_MAX_BYTES,
 } from '../../presenters/primarySourceSearchV4Structured.js';
 
+export interface PrimarySourceSearchBinding {
+  readonly descriptor: PrimarySourceSearchDescriptor;
+  readonly tool: ToolHandler;
+}
+
+export function bindPrimarySourceSearch(
+  service: Pick<PrimarySourceSearchService, 'search'>,
+  contract: Pick<PrimarySourceContractConfig, 'contractVersion'> = DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
+): PrimarySourceSearchBinding {
+  const descriptor = createPrimarySourceSearchDescriptor(contract.contractVersion);
+  return { descriptor, tool: createPrimarySourceSearchHandler(service, descriptor) };
+}
+
 export function createPrimarySourceSearchHandler(
   service: Pick<PrimarySourceSearchService, 'search'>,
-  contract: PrimarySourceContractConfig = DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
+  descriptorOrContract: PrimarySourceSearchDescriptor | Pick<PrimarySourceContractConfig, 'contractVersion'> = createPrimarySourceSearchDescriptor(DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG.contractVersion),
 ): ToolHandler {
-  const v5 = contract.contractVersion === '7';
+  const descriptor = 'inputSchema' in descriptorOrContract
+    ? descriptorOrContract
+    : createPrimarySourceSearchDescriptor(descriptorOrContract.contractVersion);
   return {
-    name: 'primary_source_search',
-    description: v5
-      ? 'Search the curated 35-work historical catalog first. Use searchDepth expanded only when a bounded, separately labeled external-discovery set could help; its unreviewed direct-URL snippets are discovery leads, not evidence. Per-hit edition readiness states the available provenance.'
-      : 'Execute an explicit, bounded query plan against the locally indexed historical-document collection. Supports exact catalog work aliases, exact reviewed creator names, and inclusive overlapping composition-year ranges. Returns catalog scope, snippets, and exact local section locators only; read selected exact resources before quotation or comparison.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        queries: {
-          type: 'array', minItems: 1, maxItems: 4,
-          items: {
-            type: 'object',
-            properties: {
-              id: { type: 'string', minLength: 1, maxLength: 40, pattern: '^[A-Za-z0-9][A-Za-z0-9_-]{0,39}$' },
-              text: { type: 'string', minLength: 1, maxLength: 200 },
-              ...(v5 ? {
-                searchDepth: { type: 'string', enum: ['standard', 'expanded'], default: 'standard', description: 'standard searches the curated 35-work catalog. expanded keeps that search and adds one separately labeled bounded external-discovery group; at most one query per call may be expanded.' },
-                expandedLimit: { type: 'integer', minimum: 1, maximum: 5, default: 3, description: 'Expanded-discovery result cap. Valid only with searchDepth expanded.' },
-              } : {
-                providers: { type: 'array', minItems: 1, maxItems: 1, uniqueItems: true, items: { type: 'string', enum: ['local'] }, description: 'Current public provider contract. Only the locally indexed collection is available.' },
-              }),
-              match: { type: 'string', enum: ['all_terms', 'phrase'], default: 'all_terms' },
-              selection: {
-                type: 'string', enum: ['relevance', 'work_diversity'], default: 'relevance',
-                description: v5
-                  ? 'Use relevance for within-work location; use work_diversity for a deterministic curated-catalog survey.'
-                  : 'Use relevance for within-work location; use work_diversity for deterministic research bundles that round-robin across matching hosted works.',
-              },
-              author: {
-                type: 'string', minLength: 1, maxLength: 100,
-                description: v5
-                  ? 'One exact reviewed creator name for the catalog search; expanded discovery uses the same literal restriction without treating it as reviewed external metadata.'
-                  : 'One exact reviewed creator name. Use separate query-plan items for different creators; creator roles are not relabeled as authorship.',
-              },
-              work: {
-                type: 'string', minLength: 1, maxLength: 160,
-                description: v5
-                  ? 'Exact catalog slug, title, or routing alias; expanded discovery uses the same literal restriction without treating it as reviewed external metadata.'
-                  : 'Exact hosted work slug, title, or lookup-only alias.',
-              },
-              startYear: {
-                type: 'integer', minimum: -5000, maximum: 3000,
-                description: v5
-                  ? 'Inclusive catalog composition-overlap lower bound when reviewed dates are available. Expanded discovery deliberately omits it and warns that broader results are not date-filtered.'
-                  : 'Inclusive lower bound. A work is eligible when its reviewed composition interval overlaps the requested interval.',
-              },
-              endYear: {
-                type: 'integer', minimum: -5000, maximum: 3000,
-                description: v5
-                  ? 'Inclusive catalog composition-overlap upper bound when reviewed dates are available; must be >= startYear. Expanded discovery deliberately omits it and warns that broader results are not date-filtered.'
-                  : 'Inclusive upper bound. Must be greater than or equal to startYear when both are provided.',
-              },
-              page: v5
-                ? {
-                  type: 'integer', const: 1, default: 1,
-                  description: 'Curated-catalog page. Page 1 only.',
-                }
-                : {
-                  type: 'integer', minimum: 1, maximum: 3, default: 1,
-                  description: 'Preserved planner field. The local provider supports only page 1 and reports unsupported_filter otherwise.',
-                },
-              limit: {
-                type: 'integer', minimum: 1, maximum: 8, default: 5,
-                ...(v5 ? { description: 'Curated-catalog maximum is 8. Use expandedLimit for the separately bounded expanded-discovery group.' } : {}),
-              },
-            },
-            required: v5 ? ['id', 'text'] : ['id', 'text', 'providers'],
-            ...(v5 ? {
-              allOf: [
-                {
-                  if: { required: ['expandedLimit'] },
-                  then: {
-                    required: ['searchDepth'],
-                    properties: { searchDepth: { const: 'expanded' } },
-                  },
-                },
-                {
-                  if: {
-                    required: ['searchDepth'],
-                    properties: { searchDepth: { const: 'expanded' } },
-                  },
-                  then: { properties: { page: { const: 1 } } },
-                },
-              ],
-            } : {}),
-            additionalProperties: false,
-          },
-        },
-      },
-      required: ['queries'],
-      additionalProperties: false,
-    },
-    outputSchema: v5 ? primarySourceSearchV7OutputSchema : primarySourceSearchV6OutputSchema,
-    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: v5 },
+    name: descriptor.name, description: descriptor.description, inputSchema: descriptor.inputSchema,
+    outputSchema: descriptor.outputSchema, annotations: descriptor.annotations,
     handler: async params => {
       try {
-        const queries = !v5 && Array.isArray(params.queries)
-          ? params.queries.map(query => ({
-              ...(query as Record<string, unknown>),
-              providers: ['local'],
-            }))
+        const v7 = descriptor.contractVersion === '7';
+        const queries = !v7 && Array.isArray(params.queries)
+          ? params.queries.map(query => ({ ...(query as Record<string, unknown>), providers: ['local'] }))
           : params.queries;
         const result = await service.search({ ...params, queries });
-        const presented = v5 ? presentPrimarySourceSearchV7(result) : presentPrimarySourceSearchV6(result);
+        const presented = v7 ? presentPrimarySourceSearchV7(result) : presentPrimarySourceSearchV6(result);
         const links = localSectionResourceLinks(presented);
         const fallback = formatPrimarySourceSearchFallback(presented);
         const unavailable = presented.planStatus === 'unavailable';

--- a/src/tools/worker/index.ts
+++ b/src/tools/worker/index.ts
@@ -42,6 +42,7 @@ import { OriginalLanguageStudyV2ContextProvider } from '../../services/languages
 import { SourceAttestedParallelService } from '../../services/bible/SourceAttestedParallelService.js';
 
 import { createToolRegistry } from '../toolRegistry.js';
+import { bindPrimarySourceSearch, type PrimarySourceSearchBinding } from '../v2/primarySourceSearch.js';
 
 // Donation
 import { OnChainVerifier } from '../../adapters/donation/OnChainVerifier.js';
@@ -66,6 +67,7 @@ export interface WorkerCompositionRoot {
   tools: ToolHandler[];
   services: WorkerServices;
   primarySourceContract: ReturnType<typeof readPrimarySourceFeatureFlags>;
+  primarySourceSearch: PrimarySourceSearchBinding;
 }
 
 // ── Module-scope singletons (created once per isolate) ──
@@ -145,6 +147,7 @@ export function createWorkerCompositionRoot(env: Env): WorkerCompositionRoot {
     primarySourceContract,
     primarySourceContract.liveCcelEnabled ? createWorkerCcelUpstreamCoordinator(env, primarySourceContract) : undefined,
   );
+  const primarySourceSearch = bindPrimarySourceSearch(primarySourceSearchService, primarySourceContract);
   const strongsService = new StrongsService(strongsRepo, morphRepo);
   const morphService = new MorphologyService(morphRepo);
   const originalLanguageStudyService = new OriginalLanguageStudyService(morphRepo, strongsRepo);
@@ -163,8 +166,7 @@ export function createWorkerCompositionRoot(env: Env): WorkerCompositionRoot {
     parallelPassageService: parallelService,
     commentaryService,
     historicalService,
-    primarySourceSearchService,
-    primarySourceContract,
+    primarySourceSearchTool: primarySourceSearch.tool,
     strongsService,
     morphologyService: morphService,
     originalLanguageStudyCoordinator,
@@ -175,5 +177,6 @@ export function createWorkerCompositionRoot(env: Env): WorkerCompositionRoot {
     tools,
     services: { bibleService, commentaryService, historicalService, strongsService, sourceAttestedParallelService },
     primarySourceContract,
+    primarySourceSearch,
   };
 }

--- a/test/fixtures/mcpCompositionRoot.ts
+++ b/test/fixtures/mcpCompositionRoot.ts
@@ -27,6 +27,7 @@ import { OriginalLanguageStudyService } from '../../src/services/languages/Origi
 import { OriginalLanguageStudyV2Coordinator } from '../../src/services/languages/OriginalLanguageStudyV2Coordinator.js';
 import { OriginalLanguageStudyV2ContextProvider } from '../../src/services/languages/OriginalLanguageStudyV2ContextProvider.js';
 import { createToolRegistry } from '../../src/tools/toolRegistry.js';
+import { bindPrimarySourceSearch } from '../../src/tools/v2/primarySourceSearch.js';
 import type { WorkerCompositionRoot } from '../../src/tools/worker/index.js';
 
 export type DeterministicMcpRoot = McpCompositionRoot & WorkerCompositionRoot;
@@ -178,6 +179,7 @@ export function createDeterministicMcpFixture(): DeterministicMcpFixture {
     ubsSemanticEvidenceBundleRepository,
   );
   const donationService = new DonationService(onChainVerifier);
+  const primarySourceSearch = bindPrimarySourceSearch(primarySourceSearchService, primarySourceContract);
 
   const root = {
     tools: createToolRegistry({
@@ -186,8 +188,7 @@ export function createDeterministicMcpFixture(): DeterministicMcpFixture {
       parallelPassageService,
       commentaryService,
       historicalService,
-      primarySourceSearchService,
-      primarySourceContract,
+      primarySourceSearchTool: primarySourceSearch.tool,
       strongsService,
       morphologyService,
       originalLanguageStudyCoordinator,
@@ -195,6 +196,7 @@ export function createDeterministicMcpFixture(): DeterministicMcpFixture {
     }),
     services: { bibleService, commentaryService, historicalService, strongsService, sourceAttestedParallelService },
     primarySourceContract,
+    primarySourceSearch,
   } satisfies DeterministicMcpRoot;
 
   return { root, biblePassageCalls };

--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -10,8 +10,8 @@
     "conformance": 1
   },
   "current": {
-    "totalTestTypeScript": 276,
-    "activeVitest": 199,
+    "totalTestTypeScript": 277,
+    "activeVitest": 200,
     "support": 22,
     "manual": 4,
     "legacyOrphan": 50,
@@ -98,6 +98,7 @@
       "test/unit/mcp/outputValidation.test.ts",
       "test/unit/mcp/parallelPassagesOutputValidation.test.ts",
       "test/unit/mcp/primarySourceCatalog.test.ts",
+      "test/unit/mcp/primarySourceSearchDescriptor.test.ts",
       "test/unit/mcp/promptContracts.test.ts",
       "test/unit/mcp/server.test.ts",
       "test/unit/mcp/validation.test.ts",

--- a/test/unit/http/nodeHttpServer.test.ts
+++ b/test/unit/http/nodeHttpServer.test.ts
@@ -18,6 +18,8 @@ import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../../src/kernel/feat
 import { BibleMCPServer } from '../../../src/server.js';
 import { BibleService } from '../../../src/services/bible/BibleService.js';
 import { createBibleLookupHandler } from '../../../src/tools/v2/bibleLookup.js';
+import { createPrimarySourceSearchHandler } from '../../../src/tools/v2/primarySourceSearch.js';
+import { createPrimarySourceSearchDescriptor } from '../../../src/mcp/primarySourceSearchDescriptor.js';
 
 const TEST_MAX_BODY_BYTES = 1024;
 
@@ -335,9 +337,11 @@ function makeRoot(): McpCompositionRoot {
     getCopyright: () => 'Test fixture',
   };
   const bibleService = new BibleService([adapter]);
+  const descriptor = createPrimarySourceSearchDescriptor();
+  const primarySourceSearchTool = createPrimarySourceSearchHandler({ search: vi.fn() } as never, descriptor);
 
   return {
-    tools: [createBibleLookupHandler(bibleService)],
+    tools: [createBibleLookupHandler(bibleService), primarySourceSearchTool],
     services: {
       bibleService,
       commentaryService: { getAvailableCommentators: () => [] },
@@ -357,6 +361,7 @@ function makeRoot(): McpCompositionRoot {
       },
     },
     primarySourceContract: DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
+    primarySourceSearch: { descriptor, tool: primarySourceSearchTool },
   };
 }
 

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -19,6 +19,7 @@ import { classicTextsOutputSchema } from '../../../src/mcp/schemas/classicTexts.
 import { validateClassicTextsOutputSemantics } from '../../../src/presenters/classicTextsStructured.js';
 import { primarySourceSearchV6OutputSchema, primarySourceSearchV7OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
 import { validatorFor } from '../../../src/mcp/validation.js';
+import { createPrimarySourceSearchDescriptor } from '../../../src/mcp/primarySourceSearchDescriptor.js';
 
 const connected: Array<{ client: Client; server: Server }> = [];
 type LogMessage = { level: string; logger?: string; data: unknown };
@@ -28,8 +29,11 @@ async function connect(
   logs?: LogMessage[],
   primarySourceContract = DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
 ): Promise<Client> {
+  const descriptor = createPrimarySourceSearchDescriptor(primarySourceContract.contractVersion);
+  const primarySourceSearchTool = tools.find(tool => tool.name === 'primary_source_search')
+    ?? createPrimarySourceSearchHandler({ search: vi.fn() } as never, descriptor);
   const root = {
-    tools,
+    tools: tools.includes(primarySourceSearchTool) ? tools : [...tools, primarySourceSearchTool],
     services: {
       bibleService: { getSupportedTranslations: () => ['ESV'] },
       commentaryService: { getAvailableCommentators: () => ['Test'] },
@@ -41,6 +45,7 @@ async function connect(
       strongsService: { lookup: async () => undefined },
     },
     primarySourceContract,
+    primarySourceSearch: { descriptor, tool: primarySourceSearchTool },
   };
   const server = createTheologAiMcpServer(root, 'output-validation-test').server;
   const client = new Client({ name: 'output-validation-client', version: '1.0.0' }, { capabilities: {} });

--- a/test/unit/mcp/primarySourceSearchDescriptor.test.ts
+++ b/test/unit/mcp/primarySourceSearchDescriptor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { createPrimarySourceSearchDescriptor } from '../../../src/mcp/primarySourceSearchDescriptor.js';
+
+describe('primary-source search descriptor', () => {
+  it('owns the public v6 contract without execution configuration', () => {
+    const descriptor = createPrimarySourceSearchDescriptor();
+    expect(descriptor).toMatchObject({
+      name: 'primary_source_search', contractVersion: '6',
+      annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    });
+    expect(JSON.stringify(descriptor)).not.toMatch(/ccel|liveCcel|coordinator/i);
+    expect(functionValues(descriptor)).toEqual([]);
+  });
+
+  it('switches only public v7 contract facts', () => {
+    const descriptor = createPrimarySourceSearchDescriptor('7');
+    expect(descriptor.contractVersion).toBe('7');
+    expect(descriptor.annotations.openWorldHint).toBe(true);
+    expect(functionValues(descriptor)).toEqual([]);
+  });
+});
+
+function functionValues(value: unknown, path = '$'): string[] {
+  if (typeof value === 'function') return [path];
+  if (!value || typeof value !== 'object') return [];
+  return Reflect.ownKeys(value).flatMap(key => functionValues(
+    Reflect.get(value, key), `${path}.${String(key)}`,
+  ));
+}

--- a/test/unit/mcp/promptContracts.test.ts
+++ b/test/unit/mcp/promptContracts.test.ts
@@ -12,6 +12,7 @@ import { createStrongsLookupHandler } from '../../../src/tools/v2/strongsLookup.
 import { createVerseMorphologyHandler } from '../../../src/tools/v2/verseMorphology.js';
 import { createOriginalLanguageStudyHandler } from '../../../src/tools/v2/originalLanguageStudy.js';
 import { createPrimarySourceSearchHandler } from '../../../src/tools/v2/primarySourceSearch.js';
+import { createPrimarySourceSearchDescriptor } from '../../../src/mcp/primarySourceSearchDescriptor.js';
 
 const unused = {} as never;
 const tools: ToolHandler[] = [
@@ -30,6 +31,11 @@ const tools: ToolHandler[] = [
 const toolByName = new Map(tools.map(tool => [tool.name, tool]));
 
 describe('prompt-recommended tool-call contracts', () => {
+  it('derives guided primary-source calls from descriptor facts', () => {
+    const descriptor = createPrimarySourceSearchDescriptor('7');
+    expect(recommendedToolCallsForPrompt('confession-study', { topic: 'justification' }, descriptor)[0]!.arguments)
+      .toMatchObject({ queries: [{ searchDepth: 'expanded', expandedLimit: 3 }] });
+  });
   it.each([
     ['word-study', { word: 'G26' }],
     ['word-study', { word: 'love', testament: 'NT' }],

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -17,6 +17,7 @@ import { createParallelPassagesHandler } from '../../../src/tools/v2/parallelPas
 import { formatLocalDocumentResource, formatLocalDocumentSectionResourceWithIdentity } from '../../../src/formatters/historicalFormatter.js';
 import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../../src/kernel/featureFlags.js';
 import { primarySourceSearchV6OutputSchema } from '../../../src/mcp/schemas/primarySourceSearchV4.js';
+import { createPrimarySourceSearchDescriptor } from '../../../src/mcp/primarySourceSearchDescriptor.js';
 
 const TOOL_NAMES = [
   'bible_lookup',
@@ -54,8 +55,9 @@ function makeMockTool(name: string): ToolHandler {
 }
 
 function makeMockRoot(): McpCompositionRoot {
+  const tools = TOOL_NAMES.map(makeMockTool);
   return {
-    tools: TOOL_NAMES.map(makeMockTool),
+    tools,
     services: {
       bibleService: {
         getSupportedTranslations: () => ['ESV', 'KJV', 'NET'],
@@ -130,6 +132,7 @@ function makeMockRoot(): McpCompositionRoot {
       },
     },
     primarySourceContract: DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG,
+    primarySourceSearch: { descriptor: createPrimarySourceSearchDescriptor(), tool: tools[5]! },
   };
 }
 
@@ -181,6 +184,37 @@ afterEach(async () => {
 });
 
 describe('shared MCP registration', () => {
+  it('requires the exact bound primary-source tool exactly once', () => {
+    const root = makeMockRoot();
+    root.tools = root.tools.filter(tool => tool.name !== 'primary_source_search');
+    expect(() => createTheologAiMcpServer(root, 'binding-test')).toThrow('exact named tool exactly once');
+
+    const duplicate = makeMockRoot();
+    duplicate.tools = [...duplicate.tools, duplicate.primarySourceSearch.tool];
+    expect(() => createTheologAiMcpServer(duplicate, 'binding-test')).toThrow('exact named tool exactly once');
+
+    const structuralClone = makeMockRoot();
+    const cloned = { ...structuralClone.primarySourceSearch.tool };
+    structuralClone.tools = structuralClone.tools.map(tool => tool.name === 'primary_source_search' ? cloned : tool);
+    expect(() => createTheologAiMcpServer(structuralClone, 'binding-test')).toThrow('exact named tool exactly once');
+
+    const wrongName = makeMockRoot();
+    wrongName.primarySourceSearch = {
+      ...wrongName.primarySourceSearch,
+      descriptor: { ...wrongName.primarySourceSearch.descriptor, name: 'wrong_name' } as never,
+    };
+    expect(() => createTheologAiMcpServer(wrongName, 'binding-test')).toThrow('exact named tool exactly once');
+
+    const secondNamedClone = makeMockRoot();
+    secondNamedClone.tools = [...secondNamedClone.tools, { ...secondNamedClone.primarySourceSearch.tool }];
+    expect(() => createTheologAiMcpServer(secondNamedClone, 'binding-test')).toThrow('exact named tool exactly once');
+
+    const rootWithClone = makeMockRoot();
+    const replacementClone = { ...rootWithClone.primarySourceSearch.tool };
+    rootWithClone.tools = [...rootWithClone.tools.filter(tool => tool.name !== 'primary_source_search'), replacementClone];
+    expect(() => createTheologAiMcpServer(rootWithClone, 'binding-test')).toThrow('exact named tool exactly once');
+  });
+
   it('advertises the stable server identity and four capabilities', async () => {
     const client = await connect(createTheologAiMcpServer(makeMockRoot(), '1.0.0-test').server);
 
@@ -590,6 +624,7 @@ describe('shared MCP registration', () => {
         coverage: { localAttempted: true, localStatus: 'ok', localHitCount: 1, ccelAttempted: false, ccelHitCount: 0, notices: [] },
       }) } as any)
       : tool);
+    root.primarySourceSearch = { descriptor: createPrimarySourceSearchDescriptor(), tool: root.tools.find(tool => tool.name === 'primary_source_search')! };
     const client = await connect(createTheologAiMcpServer(root, '1.0.0-test').server);
 
     const result = await client.callTool({
@@ -979,6 +1014,7 @@ describe('shared MCP registration', () => {
     root.tools = root.tools.map(tool => tool.name === 'primary_source_search'
       ? createPrimarySourceSearchHandler({ search: vi.fn() } as any, root.primarySourceContract)
       : tool);
+    root.primarySourceSearch = { descriptor: createPrimarySourceSearchDescriptor('7'), tool: root.tools.find(tool => tool.name === 'primary_source_search')! };
     const client = await connect(createTheologAiMcpServer(root, '1.0.0-v7-test').server);
     const listed = await client.listPrompts();
     const primaryDefinition = listed.prompts.find(prompt => prompt.name === 'primary-source-research')!;
@@ -1039,14 +1075,13 @@ describe('shared MCP registration', () => {
     expect(confessionText).toContain('Name any disabled, unavailable, or unsupported provider');
   });
 
-  it('rejects tool/prompt contract divergence at server construction', () => {
+  it('requires the bound descriptor rather than probing mutable tool metadata', () => {
     const root = makeMockRoot();
     root.primarySourceContract = {
       exposeCcelDiscovery: true, ccelLiveSearch: false, ccelCoordinator: false,
       contractVersion: '7', liveCcelEnabled: false,
     };
-    expect(() => createTheologAiMcpServer(root, 'mismatched-contract-test'))
-      .toThrow('tool and guided-prompt contracts must use the same configuration');
+    expect(() => createTheologAiMcpServer(root, 'mismatched-contract-test')).not.toThrow();
   });
 
   it('advertises and executes the exact v7 tool contract through MCP', async () => {
@@ -1072,6 +1107,7 @@ describe('shared MCP registration', () => {
     const root = makeMockRoot();
     root.primarySourceContract = contract;
     root.tools = root.tools.map(tool => tool.name === 'primary_source_search' ? handler : tool);
+    root.primarySourceSearch = { descriptor: createPrimarySourceSearchDescriptor('7'), tool: handler };
     const client = await connect(createTheologAiMcpServer(root, '1.0.0-v7-tool-test').server);
 
     const listed = await client.listTools();

--- a/test/unit/scripts/historicalCorePreviewAudit.test.ts
+++ b/test/unit/scripts/historicalCorePreviewAudit.test.ts
@@ -23,6 +23,7 @@ import { primarySourceSearchV6OutputSchema, primarySourceSearchV7OutputSchema } 
 import { registerToolHandlers } from '../../../src/mcp/tools.js';
 import { createClassicTextsHandler } from '../../../src/tools/v2/classicTexts.js';
 import { createPrimarySourceSearchHandler } from '../../../src/tools/v2/primarySourceSearch.js';
+import { createPrimarySourceSearchDescriptor } from '../../../src/mcp/primarySourceSearchDescriptor.js';
 
 const root = new URL('../../../', import.meta.url);
 const fixtureUrl = new URL('test/fixtures/historical-core-preview-audit.json', root);
@@ -310,10 +311,7 @@ describe('historical core preview audit contract', () => {
 
   it('proves a v6 CCEL provider is rejected by input validation before the primary-source handler can execute', async () => {
     const search = vi.fn();
-    const handler = createPrimarySourceSearchHandler({ search } as never, {
-      exposeCcelDiscovery: false, ccelLiveSearch: false, ccelCoordinator: false,
-      contractVersion: '6', liveCcelEnabled: false,
-    });
+    const handler = createPrimarySourceSearchHandler({ search } as never, createPrimarySourceSearchDescriptor());
     const server = new Server({ name: 'historical-v6-input-boundary-test', version: '1.0.0' }, { capabilities: { tools: {} } });
     registerToolHandlers(server, [handler], false);
     const client = new Client({ name: 'historical-v6-input-boundary-client', version: '1.0.0' }, { capabilities: {} });

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createPrimarySourceSearchHandler } from '../../../../src/tools/v2/primarySourceSearch.js';
+import { createPrimarySourceSearchDescriptor } from '../../../../src/mcp/primarySourceSearchDescriptor.js';
 import { validatorFor } from '../../../../src/mcp/validation.js';
 import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
 
@@ -11,6 +12,10 @@ function schemaTerms(value: unknown): string[] {
 }
 
 describe('primary_source_search handler', () => {
+  it('uses the runtime-neutral descriptor for isolated v6 handler construction', () => {
+    const handler = createPrimarySourceSearchHandler({ search: vi.fn() } as any, createPrimarySourceSearchDescriptor());
+    expect(handler.name).toBe('primary_source_search');
+  });
   const scope = {
     status: 'matched' as const, requested: {}, eligibleDocumentCount: 1,
     eligibleDocuments: [{ id: 'institutes', title: 'Institutes', metadataStatus: 'reviewed' as const }],


### PR DESCRIPTION
## Purpose

Make `primary_source_search` public descriptor ownership explicit and shared without changing its public MCP contract or CCEL execution policy.

## Scope

This PR changes exactly 16 paths relative to main `8440ebb57b6f9e6b8e5c00370e1c327702dd03cf`: seven runtime paths and nine test/topology paths. It adds the runtime-neutral descriptor and its focused unit test, then updates the existing handler, roots, registry, server, prompts, fixtures, contract owners, and topology manifest.

## Architecture

- The new descriptor is recursively data-only and owns the exact v6/v7 advertised metadata and prompt-relevant public facts.
- Node and Worker roots retain the full `PrimarySourceContractConfig` for service and CCEL execution gates, while atomically exposing one typed `{ descriptor, tool }` binding.
- The registry accepts the already-bound primary tool and preserves the canonical 11-tool order.
- The MCP server requires the exact bound tool identity exactly once and rejects missing, cloned, duplicated, second-named, or wrong-name bindings without schema or annotation probing.
- Prompts consume descriptor facts rather than independently branching on execution configuration.
- Handler-owned normalization, presentation, delivery, error behavior, and the public v6/v7 wire contract remain unchanged.

The topology manifest advances from 276/199/22 to 277 total test TypeScript files / 200 active Vitest files / 22 support files. Its immutable source baseline is unchanged.

## Verification

Pinned Node 22.23.1 / npm 10.9.8:

- focused descriptor/server/prompt/handler/root/audit tests: PASS
- `test:unit`: 197 files, 2,524 passed / 5 skipped
- `test:coverage`: PASS (90.89% lines, 80.94% branches, 92.04% functions)
- Node, Worker, release, fixture, and E2E typechecks: PASS
- current integration, compiled stdio, compiled HTTP, production-like Worker v6, real Workerd preview v7, and MCP conformance: PASS
- topology validator and `git diff --check`: PASS

Independent review found and verified repairs for two pre-publication issues: executable normalization/presentation callbacks were removed from the descriptor, and the complete server identity/uniqueness rejection matrix was added.

## Release boundary

This is deploy-required because runtime source changes. PR checks must pass and Deploy Preview must skip. Merge and the protected production release require a separate owner gate. This PR does not authorize preview or D1 mutation, a secret-value change, rollback, manual dispatch, or cleanup.
