### PR TITLE
test: retire broken legacy command aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,12 +94,7 @@
     "test:e2e:compiled": "tsx scripts/test-node-http-e2e.ts",
     "test:e2e:stdio": "tsx scripts/test-node-stdio-e2e.ts",
     "test:coverage": "vitest run --coverage",
-    "test:ccel": "vitest run test/unit/adapters/commentary/CcelSearchAdapter.test.ts test/unit/services/historical/CcelUpstreamCoordinator.test.ts test/unit/presenters/primarySourceSearchV4Structured.test.ts test/unit/http/worker/ccelOperator.test.ts test/unit/scripts/ccelCoordinatorOperator.test.ts test/unit/scripts/ccelLivePreviewCanary.test.ts",
-    "test:netbible": "tsx test/adapters/netbible-test.ts",
-    "test:bibleapi": "tsx test/adapters/bibleapi-test.ts",
-    "test:commentary": "tsx test/integration/public-commentary-test.ts",
-    "test:all-books": "tsx test/integration/all-books-mapping-test.ts",
-    "test:helloao-bible": "tsx test/adapters/helloao-bible-test.ts"
+    "test:ccel": "vitest run test/unit/adapters/commentary/CcelSearchAdapter.test.ts test/unit/services/historical/CcelUpstreamCoordinator.test.ts test/unit/presenters/primarySourceSearchV4Structured.test.ts test/unit/http/worker/ccelOperator.test.ts test/unit/scripts/ccelCoordinatorOperator.test.ts test/unit/scripts/ccelLivePreviewCanary.test.ts"
   },
   "keywords": [
     "bible",

--- a/test/README.md
+++ b/test/README.md
@@ -42,11 +42,11 @@ The legacy inventory is a quarantine ledger, not deletion authority. Moving,
 executing, migrating, or deleting one of those paths requires a separate
 reviewed change that updates the manifest in the same slice.
 
-## Known unsupported commands
+## Retired legacy commands
 
-The following package scripts are retained temporarily as explicit broken
-compatibility records. They are not supported commands and must not be run or
-silently repointed to tests with different semantics:
+The following former package commands have been removed. They are not runnable
+aliases and must not be reintroduced or silently repointed to maintained tests
+with different semantics:
 
 - `test:bibleapi`
 - `test:netbible`
@@ -54,7 +54,7 @@ silently repointed to tests with different semantics:
 - `test:all-books`
 - `test:helloao-bible`
 
-Their exact targets and failure causes are recorded in
-`test/test-topology.json`. A later command-honesty slice will retire or
-quarantine them explicitly without activating provider, credential, network,
-or legacy code paths.
+Their exact former targets, failure causes, and `retired` status are retained
+as closed provenance in `test/test-topology.json`. The four surviving former
+targets remain quarantined under `legacyOrphan`; the former Bible API target
+is absent. None may be executed, imported, or repointed through this record.

--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -339,31 +339,36 @@
       "owner": "MACULA Gate-1"
     }
   ],
-  "knownBrokenCommands": [
+  "retiredCommands": [
     {
       "name": "test:all-books",
-      "target": "test/integration/all-books-mapping-test.ts",
-      "failureCause": "imports removed src/utils/commentaryMapper.js"
+      "formerTarget": "test/integration/all-books-mapping-test.ts",
+      "failureCause": "imports removed src/utils/commentaryMapper.js",
+      "status": "retired"
     },
     {
       "name": "test:bibleapi",
-      "target": "test/adapters/bibleapi-test.ts",
-      "failureCause": "target file is absent"
+      "formerTarget": "test/adapters/bibleapi-test.ts",
+      "failureCause": "target file is absent",
+      "status": "retired"
     },
     {
       "name": "test:commentary",
-      "target": "test/integration/public-commentary-test.ts",
-      "failureCause": "imports removed commentary adapter, service, and mapper modules"
+      "formerTarget": "test/integration/public-commentary-test.ts",
+      "failureCause": "imports removed commentary adapter, service, and mapper modules",
+      "status": "retired"
     },
     {
       "name": "test:helloao-bible",
-      "target": "test/adapters/helloao-bible-test.ts",
-      "failureCause": "imports removed src/adapters/helloaoBibleAdapter.js"
+      "formerTarget": "test/adapters/helloao-bible-test.ts",
+      "failureCause": "imports removed src/adapters/helloaoBibleAdapter.js",
+      "status": "retired"
     },
     {
       "name": "test:netbible",
-      "target": "test/adapters/netbible-test.ts",
-      "failureCause": "imports removed src/adapters/netBibleApi.js"
+      "formerTarget": "test/adapters/netbible-test.ts",
+      "failureCause": "imports removed src/adapters/netBibleApi.js",
+      "status": "retired"
     }
   ]
 }

--- a/test/unit/config/testTopology.test.ts
+++ b/test/unit/config/testTopology.test.ts
@@ -12,7 +12,12 @@ interface TopologyManifest {
   partitions: Record<PartitionName, string[]>;
   maintainedTypeScriptEntrypointsOutsideTest: Array<{ path: string; packageScript: string }>;
   separatelyOwnedEntrypoints: Array<{ path: string; packageScript: string; owner: string }>;
-  knownBrokenCommands: Array<{ name: string; target: string; failureCause: string }>;
+  retiredCommands: Array<{
+    name: string;
+    formerTarget: string;
+    failureCause: string;
+    status: 'retired';
+  }>;
 }
 
 const repoRoot = path.resolve(fileURLToPath(new URL('../../../', import.meta.url)));
@@ -127,8 +132,8 @@ describe('test topology manifest', () => {
     ]);
   });
 
-  it('documents exactly five unsupported broken commands without executing legacy targets', () => {
-    expect(manifest.knownBrokenCommands.map(({ name }) => name)).toEqual([
+  it('retires exactly five former commands without executing legacy targets', () => {
+    expect(manifest.retiredCommands.map(({ name }) => name)).toEqual([
       'test:all-books',
       'test:bibleapi',
       'test:commentary',
@@ -136,23 +141,34 @@ describe('test topology manifest', () => {
       'test:netbible',
     ]);
 
-    const expectedCommands: Record<string, string> = {
-      'test:all-books': 'tsx test/integration/all-books-mapping-test.ts',
-      'test:bibleapi': 'tsx test/adapters/bibleapi-test.ts',
-      'test:commentary': 'tsx test/integration/public-commentary-test.ts',
-      'test:helloao-bible': 'tsx test/adapters/helloao-bible-test.ts',
-      'test:netbible': 'tsx test/adapters/netbible-test.ts',
+    const expectedFormerTargets: Record<string, string> = {
+      'test:all-books': 'test/integration/all-books-mapping-test.ts',
+      'test:bibleapi': 'test/adapters/bibleapi-test.ts',
+      'test:commentary': 'test/integration/public-commentary-test.ts',
+      'test:helloao-bible': 'test/adapters/helloao-bible-test.ts',
+      'test:netbible': 'test/adapters/netbible-test.ts',
     };
-    for (const entry of manifest.knownBrokenCommands) {
-      expect(packageJson.scripts[entry.name]).toBe(expectedCommands[entry.name]);
+    for (const entry of manifest.retiredCommands) {
+      expect(Object.keys(entry).sort()).toEqual(['failureCause', 'formerTarget', 'name', 'status']);
+      expect(packageJson.scripts).not.toHaveProperty(entry.name);
+      expect(entry.formerTarget).toBe(expectedFormerTargets[entry.name]);
       expect(entry.failureCause.length).toBeGreaterThan(0);
+      expect(entry.status).toBe('retired');
     }
+
+    const extantFormerTargets = [
+      'test:all-books',
+      'test:commentary',
+      'test:helloao-bible',
+      'test:netbible',
+    ].map((name) => expectedFormerTargets[name]);
+    expect(extantFormerTargets.every((target) => manifest.partitions.legacyOrphan.includes(target))).toBe(true);
+    expect(fs.existsSync(path.join(repoRoot, expectedFormerTargets['test:bibleapi']))).toBe(false);
 
     const allowedTestTargets = new Set([
       ...manifest.partitions.activeVitest,
       ...manifest.partitions.manual,
       ...manifest.partitions.conformance,
-      ...manifest.knownBrokenCommands.map(({ target }) => target),
     ]);
     const scriptedTestTargets = Object.values(packageJson.scripts)
       .flatMap((command) => command.match(/test\/[A-Za-z0-9_./-]+\.ts/g) ?? []);


### PR DESCRIPTION
## Summary

- remove five package scripts whose targets are missing or import retired modules
- record their exact retired-command provenance in the test topology manifest
- enforce that retired commands cannot be reintroduced, aliased, or treated as executable topology
- update the test guide so the commands are no longer advertised as runnable

## Scope

Exactly four files:

- `package.json`
- `test/test-topology.json`
- `test/unit/config/testTopology.test.ts`
- `test/README.md`

No legacy test is executed, migrated, repointed, or deleted. Test topology remains 277 total / 200 active / 22 support, with the immutable D4 source baseline unchanged.

## Verification

- focused topology: 6/6 passed
- unit: 197 files; 2,524 passed; 5 skipped
- coverage: 197 files; 2,524 passed; 5 skipped; 86.71% statements
- standard typecheck passed
- diff check passed

## Release boundary

This package-script change is deploy-required under the repository classifier. Merge and the bundled protected production release require the separate owner gate after ready-state review.
