### PR TITLE
ci: verify deployment plan before production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      classification_succeeded: ${{ steps.classify.outputs.classification_succeeded }}
-      deploy_required: ${{ steps.classify.outputs.deploy_required }}
-      decision: ${{ steps.classify.outputs.decision }}
-      reason: ${{ steps.classify.outputs.reason }}
-      base: ${{ steps.classify.outputs.base }}
-      head: ${{ steps.classify.outputs.head }}
-      changed_path_evidence_json: ${{ steps.classify.outputs.changed_path_evidence_json }}
+      artifact_name: ${{ steps.production-deployment-plan.outputs.artifact_name }}
+      plan_sha256: ${{ steps.production-deployment-plan.outputs.plan_sha256 }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -74,6 +69,7 @@ jobs:
           printf '%s' "$before" | grep -Eq '^[0-9a-f]{40}$'
           git cat-file -e "${before}^{commit}"
           git merge-base --is-ancestor "$before" HEAD
+          echo "release_context_json=$release_context" >> "$GITHUB_OUTPUT"
           if [ "$mode" = 'manual' ]; then
             test "$PRODUCTION_RELEASE_EVENT_NAME" = 'workflow_dispatch'
             test "$force_deploy" = 'true'
@@ -89,18 +85,6 @@ jobs:
               echo "head=$head"
               echo 'changed_path_evidence_json=[]'
             } >> "$GITHUB_OUTPUT"
-            {
-              echo '## Production deployment classification'
-              echo
-              echo '- Decision: **deploy required**'
-              echo '- Classification succeeded: `true`'
-              echo "- Reason: \`$selection_reason\`"
-              echo "- Base: \`$before\`"
-              echo "- Head: \`$head\`"
-              echo
-              echo 'Changed paths:'
-              echo '- _(manual dispatch; no push diff)_'
-            } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           test "$mode" = 'push'
@@ -108,15 +92,159 @@ jobs:
           test "$force_deploy" = 'false'
           test "$custom_domain_required" = 'false'
           test "$selection_reason" = 'push-before'
-          node scripts/classify-production-deployment.mjs \
+          GITHUB_STEP_SUMMARY='' node scripts/classify-production-deployment.mjs \
             --before "$before" \
             --after "$PRODUCTION_RELEASE_HEAD" \
             --head "$(git rev-parse HEAD)"
 
+      - name: Create canonical production deployment plan
+        id: production-deployment-plan
+        env:
+          PRODUCTION_PLAN_ARTIFACT_NAME: production-deployment-plan-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          PRODUCTION_PLAN_RUN_ID: ${{ github.run_id }}
+          PRODUCTION_PLAN_RUN_ATTEMPT: ${{ github.run_attempt }}
+          PRODUCTION_PLAN_EVENT_NAME: ${{ github.event_name }}
+          PRODUCTION_PLAN_REF: ${{ github.ref }}
+          PRODUCTION_PLAN_HEAD: ${{ github.sha }}
+          PRODUCTION_PLAN_RELEASE_CONTEXT_JSON: ${{ steps.classify.outputs.release_context_json }}
+          PRODUCTION_PLAN_CLASSIFICATION_SUCCEEDED: ${{ steps.classify.outputs.classification_succeeded }}
+          PRODUCTION_PLAN_DEPLOY_REQUIRED: ${{ steps.classify.outputs.deploy_required }}
+          PRODUCTION_PLAN_DECISION: ${{ steps.classify.outputs.decision }}
+          PRODUCTION_PLAN_CLASSIFICATION_REASON: ${{ steps.classify.outputs.reason }}
+          PRODUCTION_PLAN_BASE: ${{ steps.classify.outputs.base }}
+          PRODUCTION_PLAN_CLASSIFICATION_HEAD: ${{ steps.classify.outputs.head }}
+          PRODUCTION_PLAN_CHANGED_PATH_EVIDENCE_JSON: ${{ steps.classify.outputs.changed_path_evidence_json }}
+        run: |
+          plan_directory="$RUNNER_TEMP/production-deployment-plan"
+          mkdir -p "$plan_directory"
+          node scripts/production-deployment-plan.mjs create > "$plan_directory/production-deployment-plan.json"
+          plan_sha256="$(sha256sum "$plan_directory/production-deployment-plan.json" | awk '{print $1}')"
+          printf '%s\n' "$plan_sha256" > "$plan_directory/production-deployment-plan.sha256"
+          printf 'artifact_name=%s\n' "$PRODUCTION_PLAN_ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+          printf 'plan_sha256=%s\n' "$plan_sha256" >> "$GITHUB_OUTPUT"
+          evidence_count="$(node --input-type=module -e '
+            const value = JSON.parse(process.argv[1]);
+            if (!Array.isArray(value)) throw new Error("invalid changed-path evidence");
+            process.stdout.write(String(value.length));
+          ' "$PRODUCTION_PLAN_CHANGED_PATH_EVIDENCE_JSON")"
+          {
+            echo '## Production deployment plan'
+            echo
+            echo "- Decision: \`$PRODUCTION_PLAN_DECISION\`"
+            echo "- Classification succeeded: \`$PRODUCTION_PLAN_CLASSIFICATION_SUCCEEDED\`"
+            echo "- Reason: \`$PRODUCTION_PLAN_CLASSIFICATION_REASON\`"
+            echo "- Base: \`$PRODUCTION_PLAN_BASE\`"
+            echo "- Head: \`$PRODUCTION_PLAN_CLASSIFICATION_HEAD\`"
+            echo "- Gate artifact: \`$PRODUCTION_PLAN_ARTIFACT_NAME\`"
+            echo "- Plan SHA-256: \`$plan_sha256\`"
+            echo "- Changed-path evidence records: \`$evidence_count\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload production deployment plan gate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.production-deployment-plan.outputs.artifact_name }}
+          path: |
+            ${{ runner.temp }}/production-deployment-plan/production-deployment-plan.json
+            ${{ runner.temp }}/production-deployment-plan/production-deployment-plan.sha256
+          retention-days: 1
+          if-no-files-found: error
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false
+
+  verify-deployment-plan:
+    name: Verify Production Deployment Plan
+    needs: classify-deployment
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      artifact_name: ${{ steps.verify.outputs.artifact_name }}
+      plan_sha256: ${{ steps.verify.outputs.plan_sha256 }}
+      deploy_required: ${{ steps.verify.outputs.deploy_required }}
+      decision: ${{ steps.verify.outputs.decision }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Download exact production deployment plan gate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.classify-deployment.outputs.artifact_name }}
+          path: ${{ runner.temp }}/production-deployment-plan-verifier
+          merge-multiple: false
+          digest-mismatch: error
+
+      - name: Verify production deployment plan before environment routing
+        id: verify
+        env:
+          EXPECTED_ARTIFACT_NAME: ${{ needs.classify-deployment.outputs.artifact_name }}
+          EXPECTED_SHA256: ${{ needs.classify-deployment.outputs.plan_sha256 }}
+          EXPECTED_RUN_ID: ${{ github.run_id }}
+          EXPECTED_RUN_ATTEMPT: ${{ github.run_attempt }}
+          EXPECTED_EVENT_NAME: ${{ github.event_name }}
+          EXPECTED_REF: ${{ github.ref }}
+          EXPECTED_HEAD: ${{ github.sha }}
+          PRODUCTION_RELEASE_EVENT_NAME: ${{ github.event_name }}
+          PRODUCTION_RELEASE_REF: ${{ github.ref }}
+          PRODUCTION_RELEASE_PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          PRODUCTION_RELEASE_FIRST_PARENT=''
+          if [ "$PRODUCTION_RELEASE_EVENT_NAME" = 'workflow_dispatch' ]; then
+            PRODUCTION_RELEASE_FIRST_PARENT="$(git rev-parse HEAD^1)"
+          fi
+          export PRODUCTION_RELEASE_FIRST_PARENT
+          EXPECTED_RELEASE_CONTEXT_JSON="$(node scripts/resolve-production-release-context.mjs)"
+          export EXPECTED_RELEASE_CONTEXT_JSON
+          verified="$(node scripts/production-deployment-plan.mjs verify \
+            --directory "$RUNNER_TEMP/production-deployment-plan-verifier")"
+          node --input-type=module -e '
+            const value = JSON.parse(process.argv[1]);
+            const keys = ["artifactName", "planSha256", "classificationSucceeded", "deployRequired", "decision", "reason", "base", "head", "changedPathEvidenceCount"];
+            if (
+              typeof value !== "object" || value === null || Array.isArray(value) ||
+              Object.keys(value).length !== keys.length || keys.some(key => !Object.hasOwn(value, key)) ||
+              typeof value.artifactName !== "string" || !/^[0-9a-f]{64}$/.test(value.planSha256) ||
+              value.classificationSucceeded !== true || typeof value.deployRequired !== "boolean" ||
+              value.decision !== (value.deployRequired ? "deploy" : "skip") ||
+              typeof value.reason !== "string" || !/^[0-9a-f]{40}$/.test(value.base) ||
+              !/^[0-9a-f]{40}$/.test(value.head) || !Number.isSafeInteger(value.changedPathEvidenceCount) ||
+              value.changedPathEvidenceCount < 0
+            ) throw new Error("invalid verified production deployment plan record");
+          ' "$verified"
+          artifact_name="$(node --input-type=module -e 'const value=JSON.parse(process.argv[1]);process.stdout.write(value.artifactName)' "$verified")"
+          plan_sha256="$(node --input-type=module -e 'const value=JSON.parse(process.argv[1]);process.stdout.write(value.planSha256)' "$verified")"
+          deploy_required="$(node --input-type=module -e 'const value=JSON.parse(process.argv[1]);process.stdout.write(String(value.deployRequired))' "$verified")"
+          decision="$(node --input-type=module -e 'const value=JSON.parse(process.argv[1]);process.stdout.write(value.decision)' "$verified")"
+          reason="$(node --input-type=module -e 'const value=JSON.parse(process.argv[1]);process.stdout.write(value.reason)' "$verified")"
+          evidence_count="$(node --input-type=module -e 'const value=JSON.parse(process.argv[1]);process.stdout.write(String(value.changedPathEvidenceCount))' "$verified")"
+          {
+            printf 'artifact_name=%s\n' "$artifact_name"
+            printf 'plan_sha256=%s\n' "$plan_sha256"
+            printf 'deploy_required=%s\n' "$deploy_required"
+            printf 'decision=%s\n' "$decision"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo '## Verified production deployment plan'
+            echo
+            echo "- Decision: \`$decision\`"
+            echo "- Reason: \`$reason\`"
+            echo "- Gate artifact: \`$artifact_name\`"
+            echo "- Plan SHA-256: \`$plan_sha256\`"
+            echo "- Changed-path evidence records: \`$evidence_count\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   deploy:
     name: Test, Build & Deploy
-    needs: classify-deployment
-    if: ${{ always() && github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.classify-deployment.result != 'success' || needs.classify-deployment.outputs.classification_succeeded != 'true' || needs.classify-deployment.outputs.deploy_required != 'false') }}
+    needs: verify-deployment-plan
+    if: ${{ github.ref == 'refs/heads/main' && needs.verify-deployment-plan.outputs.deploy_required == 'true' && needs.verify-deployment-plan.outputs.decision == 'deploy' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
@@ -124,6 +252,12 @@ jobs:
       url: https://mcp.theologai.xyz/mcp
     permissions:
       contents: read
+    env:
+      EXPECTED_RUN_ID: ${{ github.run_id }}
+      EXPECTED_RUN_ATTEMPT: ${{ github.run_attempt }}
+      EXPECTED_EVENT_NAME: ${{ github.event_name }}
+      EXPECTED_REF: ${{ github.ref }}
+      EXPECTED_HEAD: ${{ github.sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -133,8 +267,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-
-      - run: npm ci --no-audit
 
       - name: Resolve production release comparison context
         id: production-release-context
@@ -171,7 +303,40 @@ jobs:
           {
             echo "before=$before"
             echo "custom_domain_required=$custom_domain_required"
+            echo "release_context_json=$release_context"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Download verified production deployment plan gate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.verify-deployment-plan.outputs.artifact_name }}
+          path: ${{ runner.temp }}/production-deployment-plan-protected
+          merge-multiple: false
+          digest-mismatch: error
+
+      - name: Revalidate production deployment plan after approval
+        env:
+          EXPECTED_ARTIFACT_NAME: ${{ needs.verify-deployment-plan.outputs.artifact_name }}
+          EXPECTED_SHA256: ${{ needs.verify-deployment-plan.outputs.plan_sha256 }}
+          EXPECTED_RELEASE_CONTEXT_JSON: ${{ steps.production-release-context.outputs.release_context_json }}
+        run: |
+          verified="$(node scripts/production-deployment-plan.mjs verify \
+            --directory "$RUNNER_TEMP/production-deployment-plan-protected")"
+          EXPECTED_VERIFIED_ARTIFACT_NAME="$EXPECTED_ARTIFACT_NAME" \
+          EXPECTED_VERIFIED_PLAN_SHA256="$EXPECTED_SHA256" \
+          node --input-type=module -e '
+            const value = JSON.parse(process.argv[1]);
+            const keys = ["artifactName", "planSha256", "classificationSucceeded", "deployRequired", "decision", "reason", "base", "head", "changedPathEvidenceCount"];
+            if (
+              typeof value !== "object" || value === null || Array.isArray(value) ||
+              Object.keys(value).length !== keys.length || keys.some(key => !Object.hasOwn(value, key)) ||
+              value.artifactName !== process.env.EXPECTED_VERIFIED_ARTIFACT_NAME ||
+              value.planSha256 !== process.env.EXPECTED_VERIFIED_PLAN_SHA256 ||
+              value.classificationSucceeded !== true || value.deployRequired !== true || value.decision !== "deploy"
+            ) throw new Error("protected production deployment plan revalidation failed");
+          ' "$verified"
+
+      - run: npm ci --no-audit
 
       - name: Detect production custom-domain declaration change
         id: production-custom-domain-change

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -693,6 +693,29 @@ Production deployment is assigned to the GitHub `production` environment.
 Configure required reviewers there as a release gate. Both workflows pin the
 same Wrangler version used for local configuration validation.
 
+Before that environment can be queued, the unprivileged classifier writes one
+canonical `production-deployment-plan.json` plus its SHA-256 sidecar and uploads
+them as the run-attempt-specific
+`production-deployment-plan-<run-id>-attempt-<attempt>` gate artifact. The gate
+artifact is retained for one day and is API-visible independently of the
+protected job. A separate unprivileged job downloads that exact current-run
+artifact, checks its closed schema, digest, run identity, release context, Git
+identity, decision, and complete changed-path evidence, and independently
+reproduces the classifier result. A documentation-only push therefore completes
+verification and skips the protected job. A deploy-required push or main-only
+manual dispatch can queue the protected job only after verification succeeds;
+missing, malformed, stale, failed, or inconsistent evidence fails before the
+environment rather than falling through to deployment.
+
+After approval, the protected job downloads and revalidates the same gate
+artifact before `npm ci`, production secrets, Wrangler, Cloudflare, or D1 are
+used. If the one-day gate artifact expires while approval is pending, do not
+bypass this check: rerun the workflow to produce a new run-attempt-bound plan.
+The plan is one short-lived pre-deployment gate artifact, distinct from the
+seven 30-day post-deployment release-evidence artifacts. Successful protected
+releases continue to require all seven existing readiness, predecessor,
+cutover, edge-stabilization, final-routing, reconciliation, and audit artifacts.
+
 After environment approval and before deployment, each job runs a read-only D1
 readiness query that checks integrity, exact manifest row counts, and required
 indexes, column signatures, foreign keys, and schema/corpus identity markers. A

--- a/scripts/production-deployment-plan.mjs
+++ b/scripts/production-deployment-plan.mjs
@@ -1,0 +1,258 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { lstatSync, readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { collectGitClassification } from './classify-production-deployment.mjs';
+
+const SHA = /^[0-9a-f]{40}$/;
+const POSITIVE_DECIMAL = /^[1-9][0-9]*$/;
+const STATUS = /^(?:A|M|D|[RC][0-9]{1,3})$/;
+const ARTIFACT_NAME = /^production-deployment-plan-([1-9][0-9]*)-attempt-([1-9][0-9]*)$/;
+const PLAN_FILE = 'production-deployment-plan.json';
+const SHA_FILE = 'production-deployment-plan.sha256';
+const MAX_PLAN_BYTES = 1024 * 1024;
+const MAX_CHANGES = 4096;
+const MAX_PATH_BYTES = 4096;
+const REASONS = new Set([
+  'manual-main-dispatch', 'markdown-documentation-only', 'non-documentation-path',
+  'invalid-before-sha', 'zero-before-sha', 'invalid-after-sha', 'invalid-head-sha',
+  'head-does-not-match-after', 'before-object-missing', 'after-object-missing',
+  'before-is-not-ancestor', 'diff-failed', 'malformed-diff', 'empty-diff', 'classifier-error',
+]);
+
+function fail(code) { throw new Error(code); }
+
+function requireExactKeys(value, keys, code) {
+  if (
+    typeof value !== 'object' || value === null || Array.isArray(value) ||
+    Object.keys(value).length !== keys.length || keys.some(key => !Object.hasOwn(value, key))
+  ) fail(code);
+}
+
+function requireString(value, pattern, code) {
+  if (typeof value !== 'string' || !pattern.test(value)) fail(code);
+  return value;
+}
+
+function createChangedPathEvidence(value) {
+  if (!Array.isArray(value) || value.length > MAX_CHANGES) fail('invalid-changed-path-evidence');
+  return value.map(change => {
+    requireExactKeys(change, ['status', 'paths'], 'invalid-changed-path-record');
+    const status = requireString(change.status, STATUS, 'invalid-changed-path-status');
+    if ((status.startsWith('R') || status.startsWith('C')) && Number(status.slice(1)) > 100) fail('invalid-changed-path-status');
+    const expectedPaths = status.startsWith('R') || status.startsWith('C') ? 2 : 1;
+    if (!Array.isArray(change.paths) || change.paths.length !== expectedPaths) fail('invalid-changed-path-arity');
+    const paths = change.paths.map(path => {
+      if (
+        typeof path !== 'string' || path.length === 0 || path.includes('\0') ||
+        Buffer.byteLength(path, 'utf8') > MAX_PATH_BYTES
+      ) fail('invalid-changed-path');
+      return path;
+    });
+    return { status, paths };
+  });
+}
+
+function createReleaseContext(value) {
+  requireExactKeys(value, ['before', 'mode', 'forceDeploy', 'customDomainRequired', 'reason'], 'invalid-release-context');
+  const before = requireString(value.before, SHA, 'invalid-release-context-before');
+  if (!['push', 'manual'].includes(value.mode)) fail('invalid-release-context-mode');
+  if (typeof value.forceDeploy !== 'boolean' || typeof value.customDomainRequired !== 'boolean') fail('invalid-release-context-flags');
+  const reason = requireString(value.reason, /^(?:push-before|manual-main-dispatch)$/, 'invalid-release-context-reason');
+  if (value.mode === 'push' && (value.forceDeploy || value.customDomainRequired || reason !== 'push-before')) fail('inconsistent-push-release-context');
+  if (value.mode === 'manual' && (!value.forceDeploy || !value.customDomainRequired || reason !== 'manual-main-dispatch')) fail('inconsistent-manual-release-context');
+  return { before, mode: value.mode, forceDeploy: value.forceDeploy, customDomainRequired: value.customDomainRequired, reason };
+}
+
+function createClassification(value) {
+  requireExactKeys(value, ['succeeded', 'deployRequired', 'decision', 'reason', 'base', 'head', 'changedPathEvidence'], 'invalid-classification');
+  if (typeof value.succeeded !== 'boolean' || typeof value.deployRequired !== 'boolean') fail('invalid-classification-flags');
+  const decision = requireString(value.decision, /^(?:deploy|skip)$/, 'invalid-classification-decision');
+  if (decision !== (value.deployRequired ? 'deploy' : 'skip')) fail('inconsistent-classification-decision');
+  if (!value.succeeded && !value.deployRequired) fail('failed-classification-must-fail-safe');
+  const reason = requireString(value.reason, /^[a-z0-9-]{1,80}$/, 'invalid-classification-reason');
+  if (!REASONS.has(reason)) fail('unknown-classification-reason');
+  const base = requireString(value.base, SHA, 'invalid-classification-base');
+  const head = requireString(value.head, SHA, 'invalid-classification-head');
+  return {
+    succeeded: value.succeeded, deployRequired: value.deployRequired, decision, reason, base, head,
+    changedPathEvidence: createChangedPathEvidence(value.changedPathEvidence),
+  };
+}
+
+export function createProductionDeploymentPlan(value) {
+  requireExactKeys(value, ['schemaVersion', 'artifactName', 'run', 'releaseContext', 'classification'], 'invalid-plan');
+  if (value.schemaVersion !== 1) fail('invalid-schema-version');
+  const artifactName = requireString(value.artifactName, ARTIFACT_NAME, 'invalid-artifact-name');
+  const artifactMatch = artifactName.match(ARTIFACT_NAME);
+  requireExactKeys(value.run, ['id', 'attempt', 'eventName', 'ref', 'head'], 'invalid-run');
+  const id = requireString(value.run.id, POSITIVE_DECIMAL, 'invalid-run-id');
+  const attempt = requireString(value.run.attempt, POSITIVE_DECIMAL, 'invalid-run-attempt');
+  if (artifactMatch[1] !== id || artifactMatch[2] !== attempt) fail('artifact-name-run-mismatch');
+  const eventName = requireString(value.run.eventName, /^(?:push|workflow_dispatch)$/, 'invalid-event-name');
+  if (value.run.ref !== 'refs/heads/main') fail('invalid-run-ref');
+  const head = requireString(value.run.head, SHA, 'invalid-run-head');
+  const releaseContext = createReleaseContext(value.releaseContext);
+  const classification = createClassification(value.classification);
+  if (head !== classification.head) fail('run-head-mismatch');
+  if (releaseContext.before !== classification.base) fail('release-context-base-mismatch');
+  if (eventName === 'push' && releaseContext.mode !== 'push') fail('event-mode-mismatch');
+  if (eventName === 'workflow_dispatch' && releaseContext.mode !== 'manual') fail('event-mode-mismatch');
+  if (releaseContext.mode === 'manual' && (
+    !classification.succeeded || !classification.deployRequired || classification.decision !== 'deploy' ||
+    classification.reason !== 'manual-main-dispatch' || classification.changedPathEvidence.length !== 0
+  )) fail('invalid-manual-classification');
+  if (classification.decision === 'skip' && classification.reason !== 'markdown-documentation-only') fail('invalid-skip-reason');
+  return {
+    schemaVersion: 1,
+    artifactName,
+    run: { id, attempt, eventName, ref: 'refs/heads/main', head },
+    releaseContext,
+    classification,
+  };
+}
+
+export function serializeProductionDeploymentPlan(value) {
+  const bytes = `${JSON.stringify(createProductionDeploymentPlan(value))}\n`;
+  if (Buffer.byteLength(bytes, 'utf8') > MAX_PLAN_BYTES) fail('plan-too-large');
+  return bytes;
+}
+
+export function productionDeploymentPlanSha256(value) {
+  return createHash('sha256').update(serializeProductionDeploymentPlan(value)).digest('hex');
+}
+
+export function verifyProductionDeploymentPlan({ planBytes, sha256Bytes, expected, classification }) {
+  if (!Buffer.isBuffer(planBytes) && !(planBytes instanceof Uint8Array)) fail('invalid-plan-bytes');
+  if (!Buffer.isBuffer(sha256Bytes) && !(sha256Bytes instanceof Uint8Array)) fail('invalid-sha256-bytes');
+  if (planBytes.byteLength > MAX_PLAN_BYTES) fail('plan-too-large');
+  const rawPlan = Buffer.from(planBytes).toString('utf8');
+  let decoded;
+  try { decoded = JSON.parse(rawPlan); } catch { fail('invalid-plan-json'); }
+  const plan = createProductionDeploymentPlan(decoded);
+  if (rawPlan !== serializeProductionDeploymentPlan(plan)) fail('noncanonical-plan-bytes');
+  const planSha256 = createHash('sha256').update(planBytes).digest('hex');
+  if (Buffer.from(sha256Bytes).toString('utf8') !== `${planSha256}\n`) fail('plan-sha256-sidecar-mismatch');
+
+  requireExactKeys(expected, ['artifactName', 'sha256', 'run', 'releaseContext'], 'invalid-verification-expectation');
+  requireString(expected.sha256, /^[0-9a-f]{64}$/, 'invalid-expected-sha256');
+  const expectedIdentity = createProductionDeploymentPlan({
+    ...plan, artifactName: expected.artifactName, run: expected.run, releaseContext: expected.releaseContext,
+  });
+  if (planSha256 !== expected.sha256) fail('expected-plan-sha256-mismatch');
+  if (plan.artifactName !== expectedIdentity.artifactName) fail('artifact-name-mismatch');
+  if (JSON.stringify(plan.run) !== JSON.stringify(expectedIdentity.run)) fail('run-identity-mismatch');
+  if (JSON.stringify(plan.releaseContext) !== JSON.stringify(expectedIdentity.releaseContext)) fail('release-context-mismatch');
+  if (!plan.classification.succeeded) fail('classification-did-not-succeed');
+  if (JSON.stringify(plan.classification) !== JSON.stringify(createClassification(classification))) fail('classification-reproduction-mismatch');
+  return {
+    artifactName: plan.artifactName, planSha256,
+    classificationSucceeded: plan.classification.succeeded,
+    deployRequired: plan.classification.deployRequired,
+    decision: plan.classification.decision,
+    reason: plan.classification.reason,
+    base: plan.classification.base,
+    head: plan.classification.head,
+    changedPathEvidenceCount: plan.classification.changedPathEvidence.length,
+  };
+}
+
+function gitSucceeds(...args) {
+  try { execFileSync('git', args, { stdio: 'ignore' }); return true; } catch { return false; }
+}
+function gitDiff(before, after) {
+  try {
+    return { ok: true, output: execFileSync('git', ['diff', '--name-status', '-z', '--find-renames', '--find-copies', before, after], { encoding: 'utf8' }) };
+  } catch { return { ok: false, error: 'git-diff-failed' }; }
+}
+function readEnvironment(names) { return Object.fromEntries(names.map(name => [name, process.env[name] ?? ''])); }
+function parseJson(value, code) { try { return JSON.parse(value); } catch { fail(code); } }
+
+function createFromEnvironment() {
+  const env = readEnvironment([
+    'PRODUCTION_PLAN_ARTIFACT_NAME', 'PRODUCTION_PLAN_RUN_ID', 'PRODUCTION_PLAN_RUN_ATTEMPT',
+    'PRODUCTION_PLAN_EVENT_NAME', 'PRODUCTION_PLAN_REF', 'PRODUCTION_PLAN_HEAD',
+    'PRODUCTION_PLAN_RELEASE_CONTEXT_JSON', 'PRODUCTION_PLAN_CLASSIFICATION_SUCCEEDED',
+    'PRODUCTION_PLAN_DEPLOY_REQUIRED', 'PRODUCTION_PLAN_DECISION', 'PRODUCTION_PLAN_CLASSIFICATION_REASON',
+    'PRODUCTION_PLAN_BASE', 'PRODUCTION_PLAN_CLASSIFICATION_HEAD', 'PRODUCTION_PLAN_CHANGED_PATH_EVIDENCE_JSON',
+  ]);
+  if (!['true', 'false'].includes(env.PRODUCTION_PLAN_CLASSIFICATION_SUCCEEDED) || !['true', 'false'].includes(env.PRODUCTION_PLAN_DEPLOY_REQUIRED)) fail('invalid-boolean-environment');
+  return createProductionDeploymentPlan({
+    schemaVersion: 1,
+    artifactName: env.PRODUCTION_PLAN_ARTIFACT_NAME,
+    run: {
+      id: env.PRODUCTION_PLAN_RUN_ID, attempt: env.PRODUCTION_PLAN_RUN_ATTEMPT,
+      eventName: env.PRODUCTION_PLAN_EVENT_NAME, ref: env.PRODUCTION_PLAN_REF, head: env.PRODUCTION_PLAN_HEAD,
+    },
+    releaseContext: parseJson(env.PRODUCTION_PLAN_RELEASE_CONTEXT_JSON, 'invalid-release-context-json'),
+    classification: {
+      succeeded: env.PRODUCTION_PLAN_CLASSIFICATION_SUCCEEDED === 'true',
+      deployRequired: env.PRODUCTION_PLAN_DEPLOY_REQUIRED === 'true',
+      decision: env.PRODUCTION_PLAN_DECISION, reason: env.PRODUCTION_PLAN_CLASSIFICATION_REASON,
+      base: env.PRODUCTION_PLAN_BASE, head: env.PRODUCTION_PLAN_CLASSIFICATION_HEAD,
+      changedPathEvidence: parseJson(env.PRODUCTION_PLAN_CHANGED_PATH_EVIDENCE_JSON, 'invalid-changed-path-evidence-json'),
+    },
+  });
+}
+
+function classificationForVerification(releaseContext, head) {
+  if (releaseContext.mode === 'manual') {
+    return {
+      succeeded: true, deployRequired: true, decision: 'deploy', reason: 'manual-main-dispatch',
+      base: releaseContext.before, head, changedPathEvidence: [],
+    };
+  }
+  const result = collectGitClassification(releaseContext.before, head, head, { succeeds: gitSucceeds, diff: gitDiff });
+  return {
+    succeeded: result.classificationSucceeded, deployRequired: result.deployRequired,
+    decision: result.deployRequired ? 'deploy' : 'skip', reason: result.reason,
+    base: result.base, head: result.head, changedPathEvidence: result.changedPathEvidence,
+  };
+}
+
+function verifyDirectory(directory) {
+  const absolute = resolve(directory);
+  if (readdirSync(absolute).sort().join('\n') !== [PLAN_FILE, SHA_FILE].sort().join('\n')) fail('invalid-plan-file-roster');
+  for (const name of [PLAN_FILE, SHA_FILE]) {
+    const stat = lstatSync(resolve(absolute, name));
+    if (!stat.isFile() || stat.isSymbolicLink()) fail('invalid-plan-file');
+  }
+  const env = readEnvironment([
+    'EXPECTED_ARTIFACT_NAME', 'EXPECTED_SHA256', 'EXPECTED_RUN_ID', 'EXPECTED_RUN_ATTEMPT',
+    'EXPECTED_EVENT_NAME', 'EXPECTED_REF', 'EXPECTED_HEAD', 'EXPECTED_RELEASE_CONTEXT_JSON',
+  ]);
+  const releaseContext = parseJson(env.EXPECTED_RELEASE_CONTEXT_JSON, 'invalid-expected-release-context-json');
+  return verifyProductionDeploymentPlan({
+    planBytes: readFileSync(resolve(absolute, PLAN_FILE)),
+    sha256Bytes: readFileSync(resolve(absolute, SHA_FILE)),
+    expected: {
+      artifactName: env.EXPECTED_ARTIFACT_NAME, sha256: env.EXPECTED_SHA256,
+      run: {
+        id: env.EXPECTED_RUN_ID, attempt: env.EXPECTED_RUN_ATTEMPT,
+        eventName: env.EXPECTED_EVENT_NAME, ref: env.EXPECTED_REF, head: env.EXPECTED_HEAD,
+      },
+      releaseContext,
+    },
+    classification: classificationForVerification(releaseContext, env.EXPECTED_HEAD),
+  });
+}
+
+function cli() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === 'create' && args.length === 0) {
+    process.stdout.write(serializeProductionDeploymentPlan(createFromEnvironment()));
+    return;
+  }
+  if (command === 'verify' && args.length === 2 && args[0] === '--directory' && args[1]) {
+    process.stdout.write(`${JSON.stringify(verifyDirectory(args[1]))}\n`);
+    return;
+  }
+  fail('invalid-command');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try { cli(); } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -43,13 +43,16 @@ const REVOCATION_PREDICATE = normalized(`
 `);
 
 describe('workflow topology', () => {
-  it('keeps production classification isolated and deployment fail-open behind production', async () => {
+  it('publishes and verifies one fail-closed production plan before the sole environment job', async () => {
     const workflow = await readWorkflow('deploy.yml');
     const trigger = uniqueBlock(workflow, 'on:');
     const concurrency = uniqueBlock(workflow, 'concurrency:');
+    const jobs = uniqueBlock(workflow, 'jobs:');
     const classifier = uniqueBlock(workflow, '  classify-deployment:');
+    const verifier = uniqueBlock(workflow, '  verify-deployment-plan:');
     const deploy = uniqueBlock(workflow, '  deploy:');
-    const outputs = uniqueBlock(classifier, '    outputs:');
+    const classifierOutputs = uniqueBlock(classifier, '    outputs:');
+    const verifierOutputs = uniqueBlock(verifier, '    outputs:');
 
     expect(normalized(trigger)).toBe(normalized(`
       on:
@@ -64,21 +67,20 @@ describe('workflow topology', () => {
     `));
     expect(normalized(concurrency)).toBe('concurrency: group: deploy-production cancel-in-progress: false');
     expect(occurrences(workflow, '  classify-deployment:')).toBe(1);
+    expect(occurrences(workflow, '  verify-deployment-plan:')).toBe(1);
     expect(occurrences(workflow, '  deploy:')).toBe(1);
+    expect([...jobs.matchAll(/^  ([a-z][a-z0-9-]+):$/gm)].map(match => match[1])).toEqual([
+      'classify-deployment', 'verify-deployment-plan', 'deploy',
+    ]);
 
     expect(classifier).toContain('name: Classify Production Deployment');
     expect(classifier).toContain('permissions:\n      contents: read');
     expect(classifier).toContain('fetch-depth: 0');
-    expect(classifier).not.toMatch(/\n\s+environment:|secrets\.|wrangler|cloudflare/i);
-    expect(normalized(outputs)).toBe(normalized(`
+    expect(classifier).not.toMatch(/\n\s+environment:|secrets\.|wrangler|cloudflare|checks:\s*write/i);
+    expect(normalized(classifierOutputs)).toBe(normalized(`
       outputs:
-        classification_succeeded: \${{ steps.classify.outputs.classification_succeeded }}
-        deploy_required: \${{ steps.classify.outputs.deploy_required }}
-        decision: \${{ steps.classify.outputs.decision }}
-        reason: \${{ steps.classify.outputs.reason }}
-        base: \${{ steps.classify.outputs.base }}
-        head: \${{ steps.classify.outputs.head }}
-        changed_path_evidence_json: \${{ steps.classify.outputs.changed_path_evidence_json }}
+        artifact_name: \${{ steps.production-deployment-plan.outputs.artifact_name }}
+        plan_sha256: \${{ steps.production-deployment-plan.outputs.plan_sha256 }}
     `));
     expect(classifier).toContain('PRODUCTION_RELEASE_EVENT_NAME: ${{ github.event_name }}');
     expect(classifier).toContain('PRODUCTION_RELEASE_REF: ${{ github.ref }}');
@@ -94,14 +96,46 @@ describe('workflow topology', () => {
     expect(classifier).toContain('echo "reason=$selection_reason"');
     expect(classifier).toContain('--before "$before"');
     expect(classifier).toContain('--after "$PRODUCTION_RELEASE_HEAD"');
-    expect(classifier).not.toMatch(/run:\s*\|[\s\S]*?\$\{\{\s*github\./);
+    const classifierRunSources = [...classifier.matchAll(/        run: \|\n([\s\S]*?)(?=\n      - |$)/g)].map(match => match[1]);
+    expect(classifierRunSources.length).toBeGreaterThan(0);
+    for (const runSource of classifierRunSources) expect(runSource).not.toMatch(/\$\{\{\s*github\./);
     expect(classifier).not.toContain('${{ inputs.reason }}');
+    expect(classifier).toContain("GITHUB_STEP_SUMMARY='' node scripts/classify-production-deployment.mjs");
+    expect(classifier).toContain('node scripts/production-deployment-plan.mjs create');
+    expect(classifier).toContain('production-deployment-plan-${{ github.run_id }}-attempt-${{ github.run_attempt }}');
+    expect(occurrences(classifier, '        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1')).toBe(1);
+    expect(classifier).toContain('retention-days: 1');
+    expect(classifier).toContain('compression-level: 0');
+    expect(classifier).toContain('overwrite: false');
+    expect(classifier).toContain('include-hidden-files: false');
 
-    expect(deploy).toContain('needs: classify-deployment');
-    expect(deploy).toContain("if: ${{ always() && github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.classify-deployment.result != 'success' || needs.classify-deployment.outputs.classification_succeeded != 'true' || needs.classify-deployment.outputs.deploy_required != 'false') }}");
+    expect(verifier).toContain('name: Verify Production Deployment Plan');
+    expect(verifier).toContain('needs: classify-deployment');
+    expect(verifier).toContain('permissions:\n      contents: read');
+    expect(verifier).toContain('fetch-depth: 0');
+    expect(verifier).not.toMatch(/\n\s+environment:|secrets\.|upload-artifact|wrangler|cloudflare|checks:\s*write/i);
+    expect(normalized(verifierOutputs)).toBe(normalized(`
+      outputs:
+        artifact_name: \${{ steps.verify.outputs.artifact_name }}
+        plan_sha256: \${{ steps.verify.outputs.plan_sha256 }}
+        deploy_required: \${{ steps.verify.outputs.deploy_required }}
+        decision: \${{ steps.verify.outputs.decision }}
+    `));
+    expect(verifier).toContain('actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1');
+    expect(verifier).toContain('name: ${{ needs.classify-deployment.outputs.artifact_name }}');
+    expect(verifier).toContain('digest-mismatch: error');
+    expect(verifier).toContain('node scripts/production-deployment-plan.mjs verify');
+    expect(verifier).toContain('value.classificationSucceeded !== true');
+
+    expect(deploy).toContain('needs: verify-deployment-plan');
+    expect(deploy).toContain("if: ${{ github.ref == 'refs/heads/main' && needs.verify-deployment-plan.outputs.deploy_required == 'true' && needs.verify-deployment-plan.outputs.decision == 'deploy' }}");
+    expect(deploy.slice(0, deploy.indexOf('    runs-on:'))).not.toContain('always()');
+    expect(deploy).not.toContain('needs.classify-deployment');
     expect(deploy).toContain('environment:\n      name: production\n      url: https://mcp.theologai.xyz/mcp');
     expect(deploy).toContain('permissions:\n      contents: read');
     expect(occurrences(workflow, '      name: production')).toBe(1);
+    expect(occurrences(workflow, '        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1')).toBe(2);
+    expect(workflow).not.toMatch(/checks:\s*write|github-token:|artifact-ids:|merge-multiple:\s*true|repository:|run-id:|pattern:/);
   });
 
   it('keeps the five PR checks and preview authorization boundary exact', async () => {

--- a/test/unit/scripts/classifyProductionDeployment.test.ts
+++ b/test/unit/scripts/classifyProductionDeployment.test.ts
@@ -1,5 +1,17 @@
+import { createHash } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readdirSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { classifyProductionDeployment, collectGitClassification, parseNameStatusNul } from '../../../scripts/classify-production-deployment.mjs';
+import {
+  createProductionDeploymentPlan,
+  productionDeploymentPlanSha256,
+  serializeProductionDeploymentPlan,
+  verifyProductionDeploymentPlan,
+} from '../../../scripts/production-deployment-plan.mjs';
 
 const before = 'a'.repeat(40);
 const after = 'b'.repeat(40);
@@ -64,4 +76,242 @@ describe('production deployment classifier', () => {
     ]);
   });
 
+});
+
+describe('production deployment plan', () => {
+  const script = fileURLToPath(new URL('../../../scripts/production-deployment-plan.mjs', import.meta.url));
+  const plan = {
+    schemaVersion: 1,
+    artifactName: 'production-deployment-plan-123-attempt-2',
+    run: { id: '123', attempt: '2', eventName: 'push', ref: 'refs/heads/main', head: after },
+    releaseContext: { before, mode: 'push', forceDeploy: false, customDomainRequired: false, reason: 'push-before' },
+    classification: {
+      succeeded: true, deployRequired: false, decision: 'skip', reason: 'markdown-documentation-only',
+      base: before, head: after, changedPathEvidence: [{ status: 'M', paths: ['docs/PLAN.md'] }],
+    },
+  };
+  const golden = '{"schemaVersion":1,"artifactName":"production-deployment-plan-123-attempt-2","run":{"id":"123","attempt":"2","eventName":"push","ref":"refs/heads/main","head":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"releaseContext":{"before":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mode":"push","forceDeploy":false,"customDomainRequired":false,"reason":"push-before"},"classification":{"succeeded":true,"deployRequired":false,"decision":"skip","reason":"markdown-documentation-only","base":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","changedPathEvidence":[{"status":"M","paths":["docs/PLAN.md"]}]}}\n';
+
+  it('emits exact canonical one-LF bytes with a frozen digest and closed key order', () => {
+    expect(serializeProductionDeploymentPlan(plan)).toBe(golden);
+    expect(productionDeploymentPlanSha256(plan)).toBe('845b3e9f1834b09ebff8c0105bd96fc46d90061c8d9b5f58bdec387bedaa5dbe');
+    expect(createProductionDeploymentPlan({
+      classification: plan.classification,
+      releaseContext: plan.releaseContext,
+      run: plan.run,
+      artifactName: plan.artifactName,
+      schemaVersion: 1,
+    })).toEqual(plan);
+  });
+
+  it('preserves classifier-authoritative zero-padded rename/copy scores in golden create and verify bytes', () => {
+    const scoredPlan = {
+      ...plan,
+      artifactName: 'production-deployment-plan-321-attempt-4',
+      run: { ...plan.run, id: '321', attempt: '4' },
+      classification: {
+        ...plan.classification,
+        changedPathEvidence: [
+          { status: 'R097', paths: ['docs/old.md', 'docs/new.md'] },
+          { status: 'C095', paths: ['docs/source.md', 'docs/copy.md'] },
+        ],
+      },
+    };
+    const scoredGolden = '{"schemaVersion":1,"artifactName":"production-deployment-plan-321-attempt-4","run":{"id":"321","attempt":"4","eventName":"push","ref":"refs/heads/main","head":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"releaseContext":{"before":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","mode":"push","forceDeploy":false,"customDomainRequired":false,"reason":"push-before"},"classification":{"succeeded":true,"deployRequired":false,"decision":"skip","reason":"markdown-documentation-only","base":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","head":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","changedPathEvidence":[{"status":"R097","paths":["docs/old.md","docs/new.md"]},{"status":"C095","paths":["docs/source.md","docs/copy.md"]}]}}\n';
+    const scoredDigest = 'd376b825708ea33d5c91eedfa40d0cd46392268a052fdf71e2d8a8a3e6f0dd0c';
+    expect(serializeProductionDeploymentPlan(scoredPlan)).toBe(scoredGolden);
+    expect(productionDeploymentPlanSha256(scoredPlan)).toBe(scoredDigest);
+    expect(verifyProductionDeploymentPlan({
+      planBytes: Buffer.from(scoredGolden),
+      sha256Bytes: Buffer.from(`${scoredDigest}\n`),
+      expected: {
+        artifactName: scoredPlan.artifactName,
+        sha256: scoredDigest,
+        run: scoredPlan.run,
+        releaseContext: scoredPlan.releaseContext,
+      },
+      classification: scoredPlan.classification,
+    })).toMatchObject({
+      artifactName: scoredPlan.artifactName,
+      planSha256: scoredDigest,
+      classificationSucceeded: true,
+      deployRequired: false,
+      decision: 'skip',
+      changedPathEvidenceCount: 2,
+    });
+  });
+
+  it('fails closed for missing, extra, mistyped, inconsistent, and unbounded plan fields', () => {
+    const invalid = [
+      { ...plan, schemaVersion: 2 },
+      { ...plan, extra: true },
+      { ...plan, run: { ...plan.run, id: 123 } },
+      { ...plan, run: { ...plan.run, extra: true } },
+      { ...plan, artifactName: 'production-deployment-plan-124-attempt-2' },
+      { ...plan, releaseContext: { ...plan.releaseContext, forceDeploy: true } },
+      { ...plan, classification: { ...plan.classification, decision: 'deploy' } },
+      { ...plan, classification: { ...plan.classification, succeeded: false } },
+      { ...plan, classification: { ...plan.classification, changedPathEvidence: [{ status: 'R100', paths: ['only-one.md'] }] } },
+      { ...plan, classification: { ...plan.classification, changedPathEvidence: [{ status: 'R101', paths: ['docs/old.md', 'docs/new.md'] }] } },
+      { ...plan, classification: { ...plan.classification, changedPathEvidence: [{ status: 'X', paths: ['docs/x.md'] }] } },
+      { ...plan, classification: { ...plan.classification, changedPathEvidence: [{ status: 'M', paths: ['x'.repeat(4097)] }] } },
+    ];
+    for (const value of invalid) expect(() => serializeProductionDeploymentPlan(value)).toThrow();
+  });
+
+  it('rejects noncanonical bytes, missing LF, hash drift, identity drift, and failed classification', () => {
+    const bytes = Buffer.from(golden);
+    const sha256 = createHash('sha256').update(bytes).digest('hex');
+    const expected = { artifactName: plan.artifactName, sha256, run: plan.run, releaseContext: plan.releaseContext };
+    expect(verifyProductionDeploymentPlan({ planBytes: bytes, sha256Bytes: Buffer.from(`${sha256}\n`), expected, classification: plan.classification })).toEqual({
+      artifactName: plan.artifactName,
+      planSha256: sha256,
+      classificationSucceeded: true,
+      deployRequired: false,
+      decision: 'skip',
+      reason: 'markdown-documentation-only',
+      base: before,
+      head: after,
+      changedPathEvidenceCount: 1,
+    });
+    for (const [planBytes, sha256Bytes, overrides = expected, classification = plan.classification] of [
+      [Buffer.from(golden.slice(0, -1)), Buffer.from(`${sha256}\n`)],
+      [Buffer.from(` ${golden}`), Buffer.from(`${sha256}\n`)],
+      [bytes, Buffer.from(`${'0'.repeat(64)}\n`)],
+      [bytes, Buffer.from(`${sha256}\n`), { ...expected, artifactName: 'production-deployment-plan-999-attempt-2' }],
+      [bytes, Buffer.from(`${sha256}\n`), expected, { ...plan.classification, changedPathEvidence: [] }],
+    ] as const) expect(() => verifyProductionDeploymentPlan({ planBytes, sha256Bytes, expected: overrides, classification })).toThrow();
+    const failedBytes = Buffer.from(serializeProductionDeploymentPlan({
+      ...plan,
+      classification: { ...plan.classification, succeeded: false, deployRequired: true, decision: 'deploy', reason: 'classifier-error' },
+    }));
+    const failedDigest = createHash('sha256').update(failedBytes).digest('hex');
+    expect(() => verifyProductionDeploymentPlan({
+      planBytes: failedBytes,
+      sha256Bytes: Buffer.from(`${failedDigest}\n`),
+      expected: { ...expected, sha256: failedDigest },
+      classification: { ...plan.classification, succeeded: false, deployRequired: true, decision: 'deploy', reason: 'classifier-error' },
+    })).toThrow('classification-did-not-succeed');
+  });
+
+  it('creates through stdout only and accepts exact manual-main semantics', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'theologai-plan-create-'));
+    const manual = {
+      ...plan,
+      artifactName: 'production-deployment-plan-9-attempt-1',
+      run: { id: '9', attempt: '1', eventName: 'workflow_dispatch', ref: 'refs/heads/main', head: after },
+      releaseContext: { before, mode: 'manual', forceDeploy: true, customDomainRequired: true, reason: 'manual-main-dispatch' },
+      classification: { succeeded: true, deployRequired: true, decision: 'deploy', reason: 'manual-main-dispatch', base: before, head: after, changedPathEvidence: [] },
+    };
+    const result = spawnSync(process.execPath, [script, 'create'], {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        PATH: process.env.PATH,
+        PRODUCTION_PLAN_ARTIFACT_NAME: manual.artifactName,
+        PRODUCTION_PLAN_RUN_ID: manual.run.id,
+        PRODUCTION_PLAN_RUN_ATTEMPT: manual.run.attempt,
+        PRODUCTION_PLAN_EVENT_NAME: manual.run.eventName,
+        PRODUCTION_PLAN_REF: manual.run.ref,
+        PRODUCTION_PLAN_HEAD: manual.run.head,
+        PRODUCTION_PLAN_RELEASE_CONTEXT_JSON: JSON.stringify(manual.releaseContext),
+        PRODUCTION_PLAN_CLASSIFICATION_SUCCEEDED: 'true',
+        PRODUCTION_PLAN_DEPLOY_REQUIRED: 'true',
+        PRODUCTION_PLAN_DECISION: 'deploy',
+        PRODUCTION_PLAN_CLASSIFICATION_REASON: 'manual-main-dispatch',
+        PRODUCTION_PLAN_BASE: before,
+        PRODUCTION_PLAN_CLASSIFICATION_HEAD: after,
+        PRODUCTION_PLAN_CHANGED_PATH_EVIDENCE_JSON: '[]',
+      },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(serializeProductionDeploymentPlan(manual));
+    expect(result.stderr).toBe('');
+    expect(readdirSync(cwd)).toEqual([]);
+
+    const directory = join(cwd, 'artifact');
+    mkdirSync(directory);
+    const manualBytes = serializeProductionDeploymentPlan(manual);
+    const manualDigest = createHash('sha256').update(manualBytes).digest('hex');
+    writeFileSync(join(directory, 'production-deployment-plan.json'), manualBytes);
+    writeFileSync(join(directory, 'production-deployment-plan.sha256'), `${manualDigest}\n`);
+    const verification = spawnSync(process.execPath, [script, 'verify', '--directory', directory], {
+      cwd,
+      encoding: 'utf8',
+      env: {
+        PATH: process.env.PATH,
+        EXPECTED_ARTIFACT_NAME: manual.artifactName,
+        EXPECTED_SHA256: manualDigest,
+        EXPECTED_RUN_ID: manual.run.id,
+        EXPECTED_RUN_ATTEMPT: manual.run.attempt,
+        EXPECTED_EVENT_NAME: manual.run.eventName,
+        EXPECTED_REF: manual.run.ref,
+        EXPECTED_HEAD: manual.run.head,
+        EXPECTED_RELEASE_CONTEXT_JSON: JSON.stringify(manual.releaseContext),
+      },
+    });
+    expect(verification.status).toBe(0);
+    expect(JSON.parse(verification.stdout)).toMatchObject({
+      artifactName: manual.artifactName,
+      planSha256: manualDigest,
+      classificationSucceeded: true,
+      deployRequired: true,
+      decision: 'deploy',
+      reason: 'manual-main-dispatch',
+      changedPathEvidenceCount: 0,
+    });
+  });
+
+  it('verifies exactly two regular files and freshly reproduces the push classifier', () => {
+    const repository = mkdtempSync(join(tmpdir(), 'theologai-plan-verify-'));
+    execFileSync('git', ['init', '-q'], { cwd: repository });
+    execFileSync('git', ['config', 'user.email', 'test@example.invalid'], { cwd: repository });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: repository });
+    mkdirSync(join(repository, 'docs'));
+    writeFileSync(join(repository, 'docs/PLAN.md'), 'before\n');
+    execFileSync('git', ['add', '.'], { cwd: repository });
+    execFileSync('git', ['commit', '-qm', 'before'], { cwd: repository });
+    const base = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repository, encoding: 'utf8' }).trim();
+    writeFileSync(join(repository, 'docs/PLAN.md'), 'after\n');
+    execFileSync('git', ['add', '.'], { cwd: repository });
+    execFileSync('git', ['commit', '-qm', 'after'], { cwd: repository });
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repository, encoding: 'utf8' }).trim();
+    const artifactName = 'production-deployment-plan-7-attempt-3';
+    const releaseContext = { before: base, mode: 'push', forceDeploy: false, customDomainRequired: false, reason: 'push-before' };
+    const record = {
+      schemaVersion: 1, artifactName,
+      run: { id: '7', attempt: '3', eventName: 'push', ref: 'refs/heads/main', head },
+      releaseContext,
+      classification: { succeeded: true, deployRequired: false, decision: 'skip', reason: 'markdown-documentation-only', base, head, changedPathEvidence: [{ status: 'M', paths: ['docs/PLAN.md'] }] },
+    };
+    const directory = join(repository, 'artifact');
+    mkdirSync(directory);
+    const recordBytes = serializeProductionDeploymentPlan(record);
+    const digest = createHash('sha256').update(recordBytes).digest('hex');
+    writeFileSync(join(directory, 'production-deployment-plan.json'), recordBytes);
+    writeFileSync(join(directory, 'production-deployment-plan.sha256'), `${digest}\n`);
+    const env = {
+      PATH: process.env.PATH,
+      EXPECTED_ARTIFACT_NAME: artifactName,
+      EXPECTED_SHA256: digest,
+      EXPECTED_RUN_ID: '7',
+      EXPECTED_RUN_ATTEMPT: '3',
+      EXPECTED_EVENT_NAME: 'push',
+      EXPECTED_REF: 'refs/heads/main',
+      EXPECTED_HEAD: head,
+      EXPECTED_RELEASE_CONTEXT_JSON: JSON.stringify(releaseContext),
+    };
+    const verify = () => spawnSync(process.execPath, [script, 'verify', '--directory', directory], { cwd: repository, env, encoding: 'utf8' });
+    const success = verify();
+    expect(success.status).toBe(0);
+    expect(JSON.parse(success.stdout)).toEqual({ artifactName, planSha256: digest, classificationSucceeded: true, deployRequired: false, decision: 'skip', reason: 'markdown-documentation-only', base, head, changedPathEvidenceCount: 1 });
+    expect(success.stderr).toBe('');
+
+    writeFileSync(join(directory, 'extra.txt'), 'unexpected');
+    expect(verify().status).not.toBe(0);
+    unlinkSync(join(directory, 'extra.txt'));
+    unlinkSync(join(directory, 'production-deployment-plan.sha256'));
+    symlinkSync(join(directory, 'production-deployment-plan.json'), join(directory, 'production-deployment-plan.sha256'));
+    expect(verify().status).not.toBe(0);
+  });
 });

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -70,6 +70,44 @@ describe('production release guards', () => {
     expect(workflow).not.toContain('d1 delete');
   });
 
+  it('revalidates the exact gate artifact before dependencies, secrets, Cloudflare, or D1 and retains seven release artifacts', async () => {
+    const workflow = await readFile(new URL('.github/workflows/deploy.yml', root), 'utf8');
+    const deployStart = workflow.indexOf('  deploy:');
+    const resolveContext = workflow.indexOf('Resolve production release comparison context', deployStart);
+    const downloadPlan = workflow.indexOf('Download verified production deployment plan gate', deployStart);
+    const revalidatePlan = workflow.indexOf('Revalidate production deployment plan after approval', deployStart);
+    const npmInstall = workflow.indexOf('- run: npm ci --no-audit', deployStart);
+    const customDomain = workflow.indexOf('Detect production custom-domain declaration change', deployStart);
+    const firstCloudflareRead = workflow.indexOf('Capture checked-out candidate production D1 mapping (read-only)', deployStart);
+    const deployMutation = workflow.indexOf('Deploy to Cloudflare Workers', deployStart);
+    expect([deployStart, resolveContext, downloadPlan, revalidatePlan, npmInstall, customDomain, firstCloudflareRead, deployMutation].every(index => index >= 0)).toBe(true);
+    expect(resolveContext).toBeLessThan(downloadPlan);
+    expect(downloadPlan).toBeLessThan(revalidatePlan);
+    expect(revalidatePlan).toBeLessThan(npmInstall);
+    expect(npmInstall).toBeLessThan(customDomain);
+    expect(customDomain).toBeLessThan(firstCloudflareRead);
+    expect(firstCloudflareRead).toBeLessThan(deployMutation);
+
+    const preRevalidation = workflow.slice(deployStart, revalidatePlan);
+    expect(preRevalidation).not.toMatch(/npm ci|secrets\.|wrangler|cloudflare|d1\b/i);
+    const revalidationToInstall = workflow.slice(revalidatePlan, npmInstall);
+    expect(revalidationToInstall).toContain('production-deployment-plan.mjs verify');
+    expect(revalidationToInstall).toContain('value.classificationSucceeded !== true');
+    expect(revalidationToInstall).toContain('value.deployRequired !== true');
+    expect(revalidationToInstall).not.toMatch(/secrets\.|wrangler|cloudflare|d1\b/i);
+
+    const deployJob = workflow.slice(deployStart);
+    expect((deployJob.match(/uses: actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\.0\.1/g) ?? [])).toHaveLength(7);
+    expect((deployJob.match(/retention-days: 30/g) ?? [])).toHaveLength(7);
+    const releaseUploads = [...deployJob.matchAll(/      - name: Upload [^\n]+[\s\S]*?(?=\n      - name:|$)/g)].map(match => match[0]);
+    expect(releaseUploads).toHaveLength(7);
+    for (const upload of releaseUploads) {
+      expect(upload).not.toContain('production-deployment-plan.json');
+      expect(upload).not.toContain('production-deployment-plan.sha256');
+      expect(upload).not.toContain('retention-days: 1\n');
+    }
+  });
+
   it('retains a non-strict final routing observation after every attempted deploy, while requiring it for a successful release', async () => {
     const workflow = await readFile(new URL('.github/workflows/deploy.yml', root), 'utf8');
     const historicalAuditScript = await readFile(new URL('../../../scripts/audit-historical-core-preview.ts', import.meta.url), 'utf8');


### PR DESCRIPTION
## Change

- publish one canonical, SHA-256-bound `production-deployment-plan` artifact from the unprivileged classifier
- verify the exact same-run artifact in a separate unprivileged job before production can queue
- revalidate the reviewed plan after environment approval and before npm, secrets, Cloudflare, or D1
- fail closed on missing, malformed, inconsistent, failed, or unreproducible classification evidence
- retain the existing seven post-deployment evidence artifacts unchanged

## Security boundary

- no `checks: write` permission and no custom check run
- classifier and verifier use `contents: read` only, with no environment or production secrets
- deploy routing depends only on verified `succeeded=true` plan evidence
- documentation-only pushes still skip; deploy-required pushes and main-only manual dispatch retain their intended paths

## Validation

- focused topology/classifier/release-guard suite: 5 files, 48 tests passed
- full sequential coverage suite: 197 files; 2,530 passed, 5 skipped; thresholds passed
- root typecheck and current integration passed
- YAML parsing and `git diff --check` passed
- exact six-file scope independently reviewed

## Release boundary

This workflow change is deploy-required. Merge and the expected protected production release require the owner's single bundled gate after ready-state review; no merge or environment action is part of this draft publication.
