### PR TITLE
docs: centralize release authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+<!-- theologai-release-authority v1 role=historical-changelog current=docs/CURRENT-RELEASE.md -->
+
+This changelog preserves dated change and release evidence; it is not the
+active assignment authority. See the
+[current release snapshot](docs/CURRENT-RELEASE.md) for present-tense identity.
+
 All notable changes to TheologAI will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -11,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Recorded the PR #96 production identity: source commit
+- Historically recorded the PR #96 production identity: source commit
   `ac4b5ed774302fbfc86bf846b6ee77a07beed456`, tree
   `adf08edbf6bfcb14b9613354b2b8fb9f62ec8c16`, canonical endpoint
   `https://mcp.theologai.xyz/mcp` (server `3.6.0`), deployment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,12 @@
 # TheologAI — Development Guide
 
+<!-- theologai-release-authority v1 role=developer-guide current=docs/CURRENT-RELEASE.md -->
+
+This developer guide is not release-identity authority. For the sole active
+production and preview-control snapshot, see
+[`docs/CURRENT-RELEASE.md`](docs/CURRENT-RELEASE.md); release identities below
+are dated historical evidence.
+
 Production MCP server for theological research. Eleven tools, six prompts, eight Bible translations, six commentaries, 35 historical documents and works, Greek/Hebrew language tools, and on-chain donation support. Tools, resources, and prompts are available on every transport; MCP Logging is stdio-only because HTTP is stateless.
 
 <!-- theologai-public-contract tools=11 structured=bible_cross_references,bible_lookup,bible_verse_morphology,classic_text_lookup,commentary_lookup,donation_config,original_language_lookup,original_language_study,parallel_passages,primary_source_search,verify_donation -->
@@ -172,9 +179,10 @@ npm run build:stepbible:lexicons # STEPBible lexicons → src/data/
 
 The SQLite database (`data/theologai.db`) is a derived artifact. Cross-references, Strong's, morphology, and historical documents are all queried via FTS5-indexed SQLite.
 
-## Release-state boundary
+## Historical release-state evidence
 
-PR #108 is the current production release record. It merged as source commit
+The PR #108 record below is dated historical release evidence, not current
+today. It merged as source commit
 `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6`. At the canonical endpoint
 `https://mcp.theologai.xyz/mcp`, protected workflow `30496350408` proved the
 same sole 100% Cloudflare production assignment before and after testing:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TheologAI
 
+<!-- theologai-release-authority v1 role=project-entrypoint current=docs/CURRENT-RELEASE.md -->
+
 TheologAI is an MCP server for Bible study and theological research. It runs
 locally over stdio or Streamable HTTP and on Cloudflare Workers with D1.
 
@@ -7,8 +9,8 @@ The checked-out local registry contains eleven tools, six guided prompts, eight
 English Bible translations, six commentary sources, 35 locally indexed
 historical works, Strong's dictionaries, and Greek/Hebrew morphology. The
 checked-out Transform 11 release adds ten reviewed editions to the former
-25-work production baseline. Preview and production now serve the 35-work
-catalog after the separately protected PR #108 D1 cutover.
+25-work baseline. The current release snapshot records the active 35-work
+assignment; the separately protected PR #108 D1 cutover is historical evidence.
 
 The integrated Transform 10 candidate is local-only and unpublished. Its
 Aquinas packet, schema, and standalone materializer are retained for future
@@ -213,8 +215,8 @@ For a preview-client rollback without changing server state, use the direct prev
 `workers.dev` address above; the production `workers.dev` address intentionally
 redirects rather than serving a separate legacy Worker.
 
-Production and preview now use their distinct audited PR #122 schema-`0009`
-Candidate-C D1 databases. Earlier local-only and preview-only activation
+In the historical PR #122 record, production and preview used their distinct
+audited schema-`0009` Candidate-C D1 databases. Earlier local-only and preview-only activation
 statements are historical. The historical PR #96 public
 `original_language_study` v2 audit does not independently establish the runtime
 path for every later historical transform. The pinned packet's `SOURCE.json`

--- a/docs/CURRENT-RELEASE.md
+++ b/docs/CURRENT-RELEASE.md
@@ -1,78 +1,88 @@
 # Current release snapshot
 
-This dated, sanitized record is the **designated current snapshot for these
-entry/reconciliation documents**: the README, production and preview release
-reconciliations, Worker operations, the Phase 3B plan, and primary-source
-catalog scope. It was observed through protected run `32165010129`, completed
-`2026-08-18T17:44:52Z`; it is not a timeless guarantee or the sole authority
-for every historical document in this repository.
+<!-- theologai-release-authority v1 role=current-snapshot current=self -->
+
+This dated, sanitized record is the repository's sole present-tense release
+identity authority. Other release documents provide operational guidance,
+plans, or historical evidence and point here for the active assignment. This
+snapshot was observed through protected run `32639881439`, completed
+`2026-08-23T13:02:45Z`; it remains a point-in-time record, not a guarantee
+against later authorized release activity.
 
 ## Active production assignment
 
-PR #124 merged as source `7f567ef0d050c91ac24e02e9798ac68cf448f8ff` with tree
-`a61e76014037a59d53db6ab92cf9d27707bf2059`. Protected run `32165010129`
-recorded GitHub production deployment `5967750549` and the active Cloudflare
-assignment: deployment `dec913dc-1c1e-4bb0-b616-8cdb4bb14822`, Worker
-`815b6e78-3dfc-435f-bcb4-5715802fd9aa` (version #108), and
+PR #136 merged as source `48a4ecd12c7b0c89e4b1075d75d2d2ff1b65e86f`
+with parents `5ada86d229da5e8a8b2135cc1cccc60af2b3ab4b` and
+`f4f55d465f6a3205e0262d7e62dafac372c6c08e`, and tree
+`5b659bc5ff70b82e3b5ccee388c19affb0fd983b`. Protected run
+`32639881439` recorded GitHub production deployment `6048025282` and the sole
+active Cloudflare production assignment: deployment
+`e0ac6d88-6592-444a-b065-8740713239d9`, Worker
+`9188f834-a8ae-4076-9c18-236806721316` (version #128), and
 `THEOLOGAI_DB` `theologai-production-20260811-schema0009-a`
-(`9bc79346-338b-439e-a2a5-424f4418eb21`). The numbered Worker version is not
-PR #108.
+(`9bc79346-338b-439e-a2a5-424f4418eb21`).
 
 The immediate same-D1 predecessor is retained only as predecessor evidence:
-deployment `b2541421-17eb-4cf2-9f35-e16d4e243038`, Worker
-`43ec9518-446e-4a26-bd34-ac4b647f0f51` (version #106), on the same production
-D1. It is not the active assignment.
+deployment `29cefacb-09d4-4ff2-a0b6-3adbb08a2121`, Worker
+`0b35d6de-fb59-40c5-aaf3-d0a41801863c`, on that same production D1. It is not
+the active assignment.
 
 ## Preview control
 
-The preview control observed with that release remains deployment
+The preview control observed before deployment, after deployment, and after
+the production audits remained deployment
 `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
 `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (version #144), and D1
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`). It is a control identity, not a
-claim that later release activity cannot change it.
+(`74f456e2-6951-4003-bb6f-91951342bf8f`). It is a read-only control identity,
+not production rollback authority.
 
-## Rollback boundary and evidence
+## Deployment gate and release evidence
 
-The separately retained PR #108 matched rollback record is historical
-evidence: deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
-`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` (version #98), and D1
-`theologai-production-20260729-transform11-a`
-(`53211f50-a893-4b4c-be1e-bc625a595dc7`). Do not mix a Worker from that pair
-with a different D1. Any rollback requires owner authorization plus fresh
-compatibility and readiness evidence for the complete matched pair.
+The unprivileged classifier in run `32639881439`, attempt `1`, emitted one
+canonical schema-v1 deployment plan for exact head
+`48a4ecd12c7b0c89e4b1075d75d2d2ff1b65e86f`. The plan recorded
+`classification_succeeded=true`, `deploy_required=true`, `decision=deploy`,
+`reason=non-documentation-path`, and six exact changed paths. Artifact
+`9493309553`, named
+`production-deployment-plan-32639881439-attempt-1`, contained only the plan and
+its SHA-256 sidecar. The canonical plan bytes hash to
+`575f40c63b1b2f8a27c556623f9e546dab08186ebe2f94b579e8a77d97341a82`;
+the artifact ZIP hashes to
+`290ae0b3cd1528a76d942416716c9cd9dffb977bff41f0cd15b99638b152604e`.
+The unprivileged verifier authenticated that exact gate before the production
+environment was queued, and the protected job revalidated it before mutation.
 
-Run `32165010129` uploaded seven sanitized evidence artifacts: audit
-`9335870200` (`e401a9e6139ef3503780261806890d3cebaf3de04682f08d6b32453e1f8e1651`),
-reconciliation `9335869860`
-(`86d586ff75cd32893c48501ae6bc5cce2a0f6dc9098701bd0040c3102143c647`),
-final routing `9335867356`
-(`c5eaec43f82d2571bef3e449c52ff0181f3742de536cee015f7e03dac5b1a283`),
-edge `9335841157`
-(`be8cc4c98ec86daa193c4113dc2a4166148e2dd733b3bb0b6766253c27597d7b`),
-candidate cutover `9335834854`
-(`5dc6672e60d0ef3ef4d5c9a5f07a2574b557076b1e94ec0c2ec623825ff4e43a`),
-predecessor `9335818590`
-(`a0d78b84fbd35ffdf3c87c4513d3558d5d1c9e70b683dbd624c6add3029a2d81`),
-and D1 readiness `9335816004`
-(`b177d9e0970ff23711059ba74acab2ef9024361cb458a58b47ba95aced297955`).
-They retain bounded identities, counts, and hashes rather than request bodies,
-tool output, source text, or credentials.
+The same run uploaded seven distinct post-deployment release-evidence
+artifacts. Their GitHub artifact IDs and ZIP SHA-256 values are:
 
-## Scope and deferred authority work
+| Evidence | Artifact ID | ZIP SHA-256 |
+|---|---:|---|
+| D1 readiness | `9493601405` | `dd2449e64c805036c667149329663c12ba5292fba46e19aeaaff62fea39bfca4` |
+| release predecessor | `9493602607` | `f059d328fd081932f5912282494ad4d4f54688893253c385ef25e613dbf42625` |
+| candidate cutover | `9493609334` | `1555ead9787ebb0b1efc90bd82ca6dc196c6ce57260c542a3bf0fd66f3f75ae7` |
+| edge stabilization | `9493612031` | `e5c78c5ace5df85db662970e6dc8bcaa360525800e9d757a6ff4a165c96b5937` |
+| final routing | `9493623849` | `598ad0592a30307554e3ad17a9ea848c06625a2a6e56a8f0741ae8de004f28df` |
+| release reconciliation | `9493625120` | `631c084cf18dbae9bc18b165f7a0365073adeffb1a9a837dce287404bb4149b5` |
+| release audit | `9493625427` | `b458359adf3a602489e9a6ecafc76bab1d8a441a485ad018a3a169a3d89b402e` |
 
-This snapshot intentionally does not reconcile every release claim in the
-repository. Confirmed deferred authority debt is in `CLAUDE.md`,
-`test/unit/docs/publicContract.test.ts`, `CHANGELOG.md`,
-`docs/CUSTOM-DOMAIN-MIGRATION.md`, `docs/D1-DATA-WORKFLOW.md`,
-`docs/ROADMAP.md`, `docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md`,
-`docs/UBS-HEBREW-V0.9.2-DERIVED-NOTICE.md`, and
-`docs/UBS-SEMANTICS-FOUNDATION.md`. The touched entry/reconciliation documents
-also retain contextually scoped legacy fixture literals as temporary debt. CCEL,
-architecture, development, and `NOTICE` documents are further-audit candidates,
-not confirmed stale claims.
+All seven ZIP digests matched GitHub's artifact metadata. Sanitized evidence
+proved D1 readiness and authority, exact predecessor/candidate/final routing,
+stable edge registration, the original-language 11/11, historical-core 8/8,
+historical-spine 10/10 audits, and production/preview environment isolation.
+The run used exactly one protected-environment approval, one same-value masked
+`ESV_API_KEY` re-put, and one production Worker deployment. It made no preview
+mutation or D1/schema/data write. The gate artifact is not one of the seven
+release artifacts.
 
-This document makes no no-deployment-canary result claim; only the post-merge
-main workflow establishes that result. On a successful documentation-only skip,
-Git main advances while the deployed source/tree remains the recorded assignment
-until a later protected production release changes it.
+## Rollback and custody boundary
+
+No historical Worker or D1 is authorized for rollback merely because it is
+documented. Never mix a Worker with a D1 from a different captured assignment.
+Rollback requires a separate owner decision plus fresh compatibility,
+readiness, and complete matched-pair evidence.
+
+Release artifacts are time-limited GitHub evidence. The private H1 ledgers
+record custody status and deadlines but grant no retention, deletion, cleanup,
+credential, or rollback authority. Natural expiry or durable private archival
+remains an owner decision.

--- a/docs/CUSTOM-DOMAIN-MIGRATION.md
+++ b/docs/CUSTOM-DOMAIN-MIGRATION.md
@@ -1,5 +1,10 @@
 # Custom-domain migration and rollback
 
+<!-- theologai-release-authority v1 role=operations-runbook current=docs/CURRENT-RELEASE.md -->
+
+This runbook defines routing operations; it is not release-identity authority.
+For the active assignment, see the [current release snapshot](CURRENT-RELEASE.md).
+
 This runbook governs the infrastructure-only migration to `theologai.xyz` and
 the separately reviewed, post-migration legacy-host redirect window. The
 initial domain migration must not be combined with application behavior,
@@ -32,9 +37,10 @@ custom-domain attachment, and the optional `www` redirect may require manual
 Cloudflare dashboard action even though Worker routes are declared in
 `wrangler.toml`.
 
-## Current operational release state (PR #96; 2026-07-24)
+## Historical operational release state (PR #96; 2026-07-24)
 
-The current production endpoint is `https://mcp.theologai.xyz/mcp`. PR #96
+The canonical production endpoint is `https://mcp.theologai.xyz/mcp`. In the
+dated PR #96 migration record, PR #96
 audit evidence fixed source commit
 `ac4b5ed774302fbfc86bf846b6ee77a07beed456` and tree
 `adf08edbf6bfcb14b9613354b2b8fb9f62ec8c16`; the endpoint reported server
@@ -50,7 +56,7 @@ per-response, and 1 MiB aggregate limits. Its fixture SHA-256 is
 `dabe124580904c411f11484d2c25fbd30452201f6c6f8927c94c0f3f294204a7`; retained
 evidence is sanitized metadata and hashes, not tool output or source text.
 Protected production workflow run `30064214043` and GitHub deployment
-`5583281706` link the recorded source/tree to the active Worker, and the
+`5583281706` historically linked the recorded source/tree to that Worker, and the
 read-only D1 compatibility check passed. Audit-evidence SHA-256:
 `321053d510217c20a79bc4d42505d67623378c2360f30c2f078a150f5a8f39bf`;
 identity-evidence SHA-256:
@@ -114,8 +120,8 @@ deployment comment:
 Do not substitute an historical deployment identifier for this record. If the
 planned predecessor is not yet released or has not passed its audit, capture
 the actual approved predecessor immediately before release and stop if it is
-not a suitable rollback target. For the documented PR #96 release, the current
-D1 is `theologai-production-20260723-a`
+not a suitable rollback target. For the documented PR #96 release, the recorded
+D1 was `theologai-production-20260723-a`
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`) and PR #72's
 `theologai-production-20260715-a`
 (`c6535a4a-1953-4279-b277-7368445fc61a`) is the retained rollback D1. This

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -1,5 +1,11 @@
 # D1 schema and corpus workflow
 
+<!-- theologai-release-authority v1 role=data-runbook current=docs/CURRENT-RELEASE.md -->
+
+This runbook owns schema and corpus procedure, not the active deployment
+identity. See the [current release snapshot](CURRENT-RELEASE.md); release
+assignments below are dated evidence.
+
 TheologAI treats database structure and corpus data as separate artifacts:
 
 - `migrations/*.sql` is the tracked, reviewable D1/SQLite schema history.
@@ -359,7 +365,7 @@ predecessor was deployment `070b292b-0bae-400a-b983-3d72157b5a96`, Worker
 `bd722b69-2e2c-4d8d-b42b-617e8caba13d` (#130), and D1
 `theologai-preview-20260728-hierarchy-a`
 (`51890e12-1c3f-421f-b661-9a5ea9637e43`). That former Transform-11 preview
-binding is historical. The current preview baseline is PR #123 deployment
+binding is historical. The dated PR #123 preview baseline was deployment
 `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
 `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
 `theologai-preview-20260811-schema0009-a`
@@ -383,7 +389,7 @@ Transform-11 source-pack authority audit (`1/1/1/1/1/1/133/17` pages) passed.
 An authorized read-only audit rerun followed one transient Cloudflare
 authentication failure; migration and seed application were not retried,
 resumed, or repaired. Protected preview deployment
-`5e812152-355b-4a5f-a123-2485e89f1550` now serves Worker
+`5e812152-355b-4a5f-a123-2485e89f1550` historically served Worker
 `06b9a603-8339-42b6-a246-ef9238563043` (#140) with that exact D1; this preview
 assignment remained unchanged during the later PR #108 production release.
 

--- a/docs/PHASE-3B-PLAN.md
+++ b/docs/PHASE-3B-PLAN.md
@@ -1,5 +1,7 @@
 # Phase 3B plan
 
+<!-- theologai-release-authority v1 role=delivery-plan current=docs/CURRENT-RELEASE.md -->
+
 This document defines the next TheologAI delivery program after the protected
 schema-`0009` preview and production releases completed by PR #122. Earlier
 roadmap sections use "Phase 3" for already-shipped work; **Phase 3B** is the
@@ -11,12 +13,12 @@ are historical planning baselines, not current identity authority.
 
 ## Historical known-good starting point
 
-GitHub `main` is PR #122 merge
+At this plan's historical starting point, GitHub `main` was PR #122 merge
 `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2`, exact tree
 `8150aa29e7e4a22141edbfc9ab568df933f9c9b3`. Its five required CI checks
 passed. Protected production workflow `31631924636` completed successfully.
 
-| Surface | Active release | D1 | Product profile |
+| Surface | Historical starting release | D1 | Product profile |
 | --- | --- | --- | --- |
 | Production | deployment `e62698f3-f6b0-4145-97bf-28abdeae0e3a`; Worker `02174f95-abe2-480b-84bf-3e8c1a3a0320` (#100) | `theologai-production-20260811-schema0009-a` (`9bc79346-338b-439e-a2a5-424f4418eb21`) | v6 local-only; CCEL execution disabled |
 | Preview | deployment `4108d59a-4092-4389-824c-fa3820ab66f6`; Worker `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144) | `theologai-preview-20260811-schema0009-a` (`74f456e2-6951-4003-bb6f-91951342bf8f`) | v7 discovery-aware; CCEL execution disabled |
@@ -34,7 +36,8 @@ deployment `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). Retain both databases. Any rollback
 or deletion remains separately authorized.
 
-The production Worker is the exact PR #122 `main` merge. PR #123 subsequently
+At this plan's starting point, the production Worker was the exact PR #122
+`main` merge. PR #123 subsequently
 deployed its exact reviewed head `7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0`
 (tree `28e555808ad3840d145a7ddd7e57934dc30e45c2`) to preview without changing
 the D1 binding. Its readiness, edge, original-language, historical-core, and

--- a/docs/PREVIEW-RELEASE-RECONCILIATION.md
+++ b/docs/PREVIEW-RELEASE-RECONCILIATION.md
@@ -1,5 +1,7 @@
 # Preview Release Reconciliation
 
+<!-- theologai-release-authority v1 role=historical-reconciliation current=docs/CURRENT-RELEASE.md -->
+
 For the active assignment in these entry/reconciliation documents, see the
 [designated current snapshot](CURRENT-RELEASE.md). The records below retain
 dated release evidence and are not current identity authority.

--- a/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
+++ b/docs/PRIMARY-SOURCE-CATALOG-SCOPE.md
@@ -1,5 +1,7 @@
 # Primary-source catalog scope
 
+<!-- theologai-release-authority v1 role=catalog-history current=docs/CURRENT-RELEASE.md -->
+
 For the active assignment in these entry/reconciliation documents, see the
 [designated current snapshot](CURRENT-RELEASE.md). The release bindings below
 are historical catalog and audit evidence, not current identity authority.
@@ -18,8 +20,9 @@ edition-scoped authority hierarchy packet and standalone materializer. Normal
 release builds deliberately exclude its hierarchy rows and shared lineage. It
 is unpublished and has no document or catalog projection, runtime composition
 dependency, or MCP surface. It leaves the active historical catalog boundary
-unchanged through preparation: preview and production serve the Transform-11
-35-work corpus, now on their distinct schema-`0009` PR #122 D1 releases.
+unchanged through preparation: in the dated PR #122 record, preview and
+production served the Transform-11 35-work corpus on their distinct
+schema-`0009` D1 releases.
 
 Transform 11 retains migration `0006_historical_source_packs` and schema
 `0008`, but expands the manifest allowlist to three checked-in packs, 18 works,

--- a/docs/PRODUCTION-RELEASE-RECONCILIATION.md
+++ b/docs/PRODUCTION-RELEASE-RECONCILIATION.md
@@ -1,5 +1,7 @@
 # Production Release Reconciliation
 
+<!-- theologai-release-authority v1 role=historical-reconciliation current=docs/CURRENT-RELEASE.md -->
+
 For the active assignment, see the [designated current snapshot](CURRENT-RELEASE.md).
 This document records the completed PR #122 schema-`0009` production cutover,
 its immediate PR #108 rollback pair, older PR #101 history, and the safeguards

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,11 @@
 # TheologAI roadmap
 
+<!-- theologai-release-authority v1 role=delivery-roadmap current=docs/CURRENT-RELEASE.md -->
+
+This roadmap owns delivery status and sequencing, not active deployment
+identity. See the [current release snapshot](CURRENT-RELEASE.md); deployment
+identities below are time-scoped milestone evidence.
+
 This is the tracked source of truth for delivery status and sequencing. The
 ignored [dated architecture and roadmap assessment](../test-output/ARCHITECTURE_AND_ROADMAP_ASSESSMENT.md)
 is local source context only and does not define the current product contract.
@@ -290,8 +296,8 @@ names for already-shipped work.
   historical acquisition-gate snapshot, not a release-state record.
 
 Entries through PR #83 describe merged repository state. PR #83 remains a
-foundation record, not by itself deployment evidence. The current deployment
-record is PR #96: audit source commit
+foundation record, not by itself deployment evidence. The dated PR #96
+deployment record used audit source commit
 `ac4b5ed774302fbfc86bf846b6ee77a07beed456`, exact tree
 `adf08edbf6bfcb14b9613354b2b8fb9f62ec8c16`, canonical endpoint
 `https://mcp.theologai.xyz/mcp`, and server version `3.6.0`. Cloudflare
@@ -302,7 +308,7 @@ assignment—deployment `2d10d693-958e-47a6-ae24-81647679c2f6`, Worker
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`).
 
 Protected production workflow run `30064214043` and GitHub deployment
-`5583281706` link the recorded source/tree to the active Worker; the read-only
+`5583281706` historically linked the recorded source/tree to that Worker; the read-only
 D1 compatibility check passed. Audit-evidence SHA-256:
 `321053d510217c20a79bc4d42505d67623378c2360f30c2f078a150f5a8f39bf`;
 identity-evidence SHA-256:
@@ -691,7 +697,7 @@ Code readiness and operational readiness are deliberately separate:
   controls when a cursor is present, and retains `includeText: false` as the
   existing default. Any future workflow or prompt change remains a separate
   slice rather than another cursor implementation.
-- Production v6/local-only is deployed from PR #108 merge
+- Historical PR #108 production v6/local-only was deployed from merge
   `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` by protected workflow
   `30496350408` as deployment
   `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8`, Worker
@@ -714,7 +720,7 @@ Code readiness and operational readiness are deliberately separate:
   `06b9a603-8339-42b6-a246-ef9238563043` (#140), and D1
   `theologai-preview-20260728-transform11-a`
   (`62b871a6-5b4d-4d9b-8f52-301f6c878f48`) are an earlier retained
-  predecessor. Preview now serves PR #123 deployment
+  predecessor. In the dated PR #123 record, preview served deployment
   `4108d59a-4092-4389-824c-fa3820ab66f6`, Worker
   `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), and schema-`0009` D1
   `theologai-preview-20260811-schema0009-a`

--- a/docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md
+++ b/docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md
@@ -1,5 +1,10 @@
 # Transform 11 historical-spine activation
 
+<!-- theologai-release-authority v1 role=historical-activation current=docs/CURRENT-RELEASE.md -->
+
+This document records the dated Transform 11 activation and is not current
+release-identity authority. See the [current release snapshot](CURRENT-RELEASE.md).
+
 Transform 11 activates the two reviewed historical-spine source packs prepared
 in PR #105. The normal local build now has an exact allowlist of three packs,
 18 reviewed editions, 43 pinned source artifacts, and 1,057 sectioned sections.
@@ -99,7 +104,8 @@ Protected PR #108 workflow `30496350408` then deployed merge
 Historical core passed 8/8, Transform-11 spine passed 10/10,
 original-language passed 11/11, primary-source edge stabilization matched on
 attempt 4 and remained stable, and independent post-release review returned
-`SHIP`. Preserve the former PR #101 assignment for rollback: Worker
+`SHIP`. The former PR #101 assignment is retained as historical matched-pair
+evidence only; this record does not authorize rollback: Worker
 `bae58cd3-cad7-4663-879d-408accf061b0` (#96), deployment
 `71b76d24-bf5f-490e-adc4-31cf63fb046e`, and D1
 `theologai-production-20260728-hierarchy-a`

--- a/docs/UBS-HEBREW-V0.9.2-DERIVED-NOTICE.md
+++ b/docs/UBS-HEBREW-V0.9.2-DERIVED-NOTICE.md
@@ -1,5 +1,11 @@
 # UBS Hebrew v0.9.2 derived-material notice
 
+<!-- theologai-release-authority v1 role=historical-rights-notice current=docs/CURRENT-RELEASE.md -->
+
+This notice owns rights and provenance for the described historical derived
+material, not active deployment identity. See the
+[current release snapshot](CURRENT-RELEASE.md).
+
 This notice applies only to the historical U3-T7 coordinate bridge and the
 transform-7 derived semantic layer reproducible from the exact pinned inputs.
 It does not apply CC BY-SA to TheologAI code or unrelated datasets. The
@@ -65,7 +71,7 @@ native-to-normalized mapping. It proves coordinate conversion only. It does
 not prove a UBS anchor identifies a particular morphology token, nor does it
 adjudicate a contextual word sense.
 
-## Current release state (PR #96; 2026-07-24)
+## Historical release state (PR #96; 2026-07-24)
 
 The historical local-only status above is superseded for deployment state by
 PR #96. Its production audit fixed source commit

--- a/docs/UBS-SEMANTICS-FOUNDATION.md
+++ b/docs/UBS-SEMANTICS-FOUNDATION.md
@@ -1,6 +1,12 @@
 # UBS Hebrew semantic foundation
 
-## Current production release record (PR #96; 2026-07-24)
+<!-- theologai-release-authority v1 role=historical-foundation current=docs/CURRENT-RELEASE.md -->
+
+This foundation records historical design, acquisition, and release evidence;
+it is not active deployment authority. See the
+[current release snapshot](CURRENT-RELEASE.md).
+
+## Historical production release record (PR #96; 2026-07-24)
 
 This foundation preserves the pre-release M4A design and acquisition record;
 those historical local-only statements are not current production-state claims.
@@ -248,7 +254,7 @@ model.
 
 The public semantic service and aggregate seam were unregistered in the
 historical M4A composition. The local adapters name the completed storage layout
-so it can be verified. PR #96's bounded v2 audit establishes the current public
+so it can be verified. PR #96's bounded v2 audit established the public
 result only; it must not be read as a claim that this historical seam is the
 current runtime path.
 

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -1,5 +1,7 @@
 # Worker operations
 
+<!-- theologai-release-authority v1 role=operations-runbook current=docs/CURRENT-RELEASE.md -->
+
 The [current release snapshot](CURRENT-RELEASE.md) is the designated current
 snapshot for this operations document. The dated records below retain release
 evidence and are not current identity authority.
@@ -8,7 +10,7 @@ evidence and are not current identity authority.
 
 The integrated checked-out normal build excludes the Transform-10 Aquinas
 hierarchy from all normal D1 corpora: it has no catalog, runtime, or MCP
-projection. In this dated record, Production is PR #122 merge
+projection. In this dated record, production was PR #122 merge
 `86475ecf8288cb0ebcb6467c77c0fd0998a8f1c2` (tree
 `8150aa29e7e4a22141edbfc9ab568df933f9c9b3`). Protected workflow
 `31631924636` deployed `e62698f3-f6b0-4145-97bf-28abdeae0e3a`, serving Worker
@@ -44,7 +46,7 @@ production binding observation is dated historical evidence, not current today;
 it proved the active binding, re-proved preview control after deployment and
 audits, and emitted the final environment-isolation receipt.
 
-In the dated release record, PR #123 completed the current protected preview release from
+In the dated release record, PR #123 completed that protected preview release from
 `7fb3ec5113a16ed86bfc4a403a3ec3678d4d4dd0` (tree
 `28e555808ad3840d145a7ddd7e57934dc30e45c2`); it is not current today. Cloudflare deployment
 `4108d59a-4092-4389-824c-fa3820ab66f6` assigns Worker
@@ -110,7 +112,7 @@ version, bound to D1 `theologai-production-20260723-a`
 (`3f7faa0e-689f-47aa-a601-dc662db9a6cf`).
 
 Protected production workflow run `30064214043` and GitHub deployment
-`5583281706` link that exact source/tree to the active Worker. The read-only D1
+`5583281706` historically linked that exact source/tree to the observed Worker. The read-only D1
 compatibility check passed against the bound production database.
 
 The production `original_language_study` v2 audit passed 11/11 cases. It made
@@ -721,12 +723,12 @@ readiness query that checks integrity, exact manifest row counts, and required
 indexes, column signatures, foreign keys, and schema/corpus identity markers. A
 missing, stale, partial, or incompatible corpus stops deployment.
 
-The current preview Transform-11 / 35-work release ran the same gate's complete
+The dated preview Transform-11 / 35-work release ran the same gate's complete
 source-pack authority audit, including direct normalized-section pages and
 identity/document/edition-FTS/runtime-FTS parity pages. The audit is read-only
 and catches an orphan or extra normalized section that a delivery-profile join
-alone would miss. Production now serves the same Transform-11 35-work corpus
-after its protected PR #108 cutover and audits. The normal corpus continues to
+alone would miss. In the historical PR #108 record, production served the same
+Transform-11 35-work corpus after its protected cutover and audits. The normal corpus continues to
 exclude inactive Aquinas hierarchy and publication rows; this does not
 authorize Aquinas activation.
 

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -21,6 +21,35 @@ interface DataManifest {
 
 const openConnections: Array<{ client: Client; server: Server }> = [];
 const PUBLIC_CONTRACT_MARKER = /<!-- theologai-public-contract tools=(\d+) structured=([a-z_,]+) -->/;
+const RELEASE_AUTHORITY_MARKER = /<!-- theologai-release-authority v1 role=([a-z-]+) current=([A-Za-z0-9./-]+) -->/;
+
+const releaseAuthorityDocuments = {
+  'CLAUDE.md': ['developer-guide', 'docs/CURRENT-RELEASE.md'],
+  'CHANGELOG.md': ['historical-changelog', 'docs/CURRENT-RELEASE.md'],
+  'README.md': ['project-entrypoint', 'docs/CURRENT-RELEASE.md'],
+  'docs/CURRENT-RELEASE.md': ['current-snapshot', 'self'],
+  'docs/CUSTOM-DOMAIN-MIGRATION.md': ['operations-runbook', 'docs/CURRENT-RELEASE.md'],
+  'docs/D1-DATA-WORKFLOW.md': ['data-runbook', 'docs/CURRENT-RELEASE.md'],
+  'docs/PHASE-3B-PLAN.md': ['delivery-plan', 'docs/CURRENT-RELEASE.md'],
+  'docs/PREVIEW-RELEASE-RECONCILIATION.md': ['historical-reconciliation', 'docs/CURRENT-RELEASE.md'],
+  'docs/PRIMARY-SOURCE-CATALOG-SCOPE.md': ['catalog-history', 'docs/CURRENT-RELEASE.md'],
+  'docs/PRODUCTION-RELEASE-RECONCILIATION.md': ['historical-reconciliation', 'docs/CURRENT-RELEASE.md'],
+  'docs/ROADMAP.md': ['delivery-roadmap', 'docs/CURRENT-RELEASE.md'],
+  'docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md': ['historical-activation', 'docs/CURRENT-RELEASE.md'],
+  'docs/UBS-HEBREW-V0.9.2-DERIVED-NOTICE.md': ['historical-rights-notice', 'docs/CURRENT-RELEASE.md'],
+  'docs/UBS-SEMANTICS-FOUNDATION.md': ['historical-foundation', 'docs/CURRENT-RELEASE.md'],
+  'docs/worker-operations.md': ['operations-runbook', 'docs/CURRENT-RELEASE.md'],
+} as const;
+
+function parseReleaseAuthorityMarker(document: string, path: string) {
+  expect(
+    document.match(/<!-- theologai-release-authority/g),
+    `${path} must contain one authority marker`,
+  ).toHaveLength(1);
+  const matches = [...document.matchAll(new RegExp(RELEASE_AUTHORITY_MARKER, 'g'))];
+  expect(matches, `${path} must contain exactly one closed release-authority marker`).toHaveLength(1);
+  return [matches[0][1], matches[0][2]];
+}
 
 function parsePublicContractMarker(document: string, path: string) {
   const matches = [...document.matchAll(new RegExp(PUBLIC_CONTRACT_MARKER, 'g'))];
@@ -42,6 +71,42 @@ afterAll(async () => {
 });
 
 describe('published project contract', () => {
+  it('routes one closed release-authority graph to the current snapshot', async () => {
+    const entries = Object.entries(releaseAuthorityDocuments);
+    const documents = await Promise.all(entries.map(([path]) => readProjectFile(path)));
+
+    for (const [index, [path, expectedMarker]] of entries.entries()) {
+      expect(parseReleaseAuthorityMarker(documents[index], path)).toEqual(expectedMarker);
+    }
+
+    const current = documents[entries.findIndex(([path]) => path === 'docs/CURRENT-RELEASE.md')];
+    expect(current).toContain("repository's sole present-tense release\nidentity authority");
+    expect(current).toContain('## Active production assignment');
+    expect(current).toContain('## Preview control');
+    expect(current).toContain('## Deployment gate and release evidence');
+    expect(current).toContain('## Rollback and custody boundary');
+    expect(current.match(/\| (?:D1 readiness|release predecessor|candidate cutover|edge stabilization|final routing|release reconciliation|release audit) \|/g)).toHaveLength(7);
+    expect(current.replace(/\s+/g, ' ')).toContain(
+      'The gate artifact is not one of the seven release artifacts.',
+    );
+    expect(current).toContain('Rollback requires a separate owner decision');
+
+    const historical = documents.filter((_, index) => entries[index][0] !== 'docs/CURRENT-RELEASE.md');
+    const competingAuthority = [
+      'PR #108 is the current production release record',
+      'Production is PR #122 merge',
+      'current protected preview release',
+      'The current preview baseline is PR #123',
+      'The current deployment record is PR #96',
+      'Production v6/local-only is deployed from PR #108',
+      'Preview now serves PR #123',
+      'Production and preview now use their distinct audited PR #122',
+    ];
+    for (const document of historical) {
+      for (const staleClaim of competingAuthority) expect(document).not.toContain(staleClaim);
+    }
+  });
+
   it('links the current roadmap and quarantines known historical artifacts', async () => {
     const historicalArtifacts = [
       'TEST_REPORT.md',
@@ -175,7 +240,7 @@ describe('published project contract', () => {
     expect(`${developerGuide}\n${confessionSkill}`).not.toMatch(/18 historical documents/i);
   });
 
-  it('records the current Transform 11 preview and production release states', async () => {
+  it('routes current corpus and transport behavior through the release snapshot', async () => {
     const [readme, operations, developerGuide] = await Promise.all([
       readProjectFile('README.md'),
       readProjectFile('docs/worker-operations.md'),
@@ -183,10 +248,12 @@ describe('published project contract', () => {
     ]);
 
     expect(readme).toContain('Production v6/local-only and preview v7/discovery-only currently search and\nretrieve the 35-work Transform-11 collection');
-    expect(operations).toContain('current preview Transform-11 / 35-work release');
-    expect(operations).toContain('Production is PR #122 merge');
+    expect(operations).toContain('[current release snapshot](CURRENT-RELEASE.md)');
+    expect(operations).toContain('dated preview Transform-11 / 35-work release');
+    expect(operations).toContain('In the historical PR #108 record, production served');
     expect(developerGuide).toContain('both deployed 35-work catalogs');
-    expect(developerGuide).toContain('PR #108 is the current production release record');
+    expect(developerGuide).toContain('[`docs/CURRENT-RELEASE.md`](docs/CURRENT-RELEASE.md)');
+    expect(developerGuide).toContain('PR #108 record below is dated historical release evidence');
   });
 
   it('does not reintroduce retired scope claims', async () => {
@@ -206,7 +273,7 @@ describe('published project contract', () => {
     expect(readme).toMatch(/Both deployed environments do \*\*not\*\* currently fetch CCEL search\s+results or document bodies/);
     expect(readme).toContain('Production v6/local-only is deployed');
     expect(readme).toContain('preview runs the audited v7/discovery-only contract with CCEL execution disabled');
-    expect(readme).toMatch(/Preview and production now serve the 35-work\s+catalog/);
+    expect(readme).toContain('current release snapshot records the active 35-work\nassignment');
     expect(readme).toContain('35 locally indexed');
     expect(readme).toContain('18 reviewed source-pack editions');
     expect(readme).toContain('The integrated Transform 10 candidate is local-only and unpublished');
@@ -651,7 +718,7 @@ describe('published project contract', () => {
     expect(reconciliation).toContain('31645546905');
     expect(reconciliation).toContain('This post-release documentation update is not\nitself deployed');
     expect(readme).toContain('This post-release evidence commit postdates the deployed source');
-    expect(operations).toContain('PR #123 completed the current protected preview release');
+    expect(operations).toContain('PR #123 completed that protected preview release');
     expect(operations).toContain('immediate retained\nsame-D1 predecessor is PR #122');
     expect(canary.replace(/\s+/g, ' ')).toContain('The gate remains `unrecorded` and inert');
   });


### PR DESCRIPTION
## Summary

- establish `docs/CURRENT-RELEASE.md` as the sole present-tense release-identity snapshot
- time-scope historical release evidence across the 15 authority-bearing documents
- enforce one closed authority-role graph and reject known competing claims in `publicContract.test.ts`
- record the verified PR #136 deployment-plan gate separately from its seven release-evidence artifacts

## Scope

Exactly 16 reviewed paths: 15 documentation files plus `test/unit/docs/publicContract.test.ts`. No workflow, runtime, package, data, schema, secret, or product behavior changes. Test topology remains 277 total / 200 active / 22 support.

## Validation

- `npm run docs:check`
- focused topology test
- `npm run typecheck`
- `npm run test:unit` (197 files; 2,532 passed, 5 skipped)
- `npm run test:coverage` (86.71% statements / 80.94% branches / 92.04% functions / 90.89% lines)
- `git diff --check`

## Release boundary

This change is deploy-required because it modifies an active unit test. Merge and the bundled protected production release require the separate owner gate. The cleanup release will supersede the PR #136 assignment; the later terminal two-file reconciliation will record that exact released identity.