### PR TITLE
docs: route CCEL identity authority

### DIFF
--- a/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
+++ b/docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md
@@ -1,5 +1,7 @@
 # CCEL live-preview canary transaction
 
+<!-- theologai-release-authority v1 role=canary-runbook current=docs/CURRENT-RELEASE.md -->
+
 This is the transaction procedure for the one deliberately temporary state in
 which preview may execute CCEL discovery. The canary transaction itself does
 not change a corpus, D1 schema, rate-limit policy, production deployment, or
@@ -22,9 +24,13 @@ The retained historical PR #107 preview Worker
 unpublished pin to `https://www.ccel.org/home3/search`. It remains valid
 point-in-time predecessor evidence, but it is no longer active. PR #122's
 schema-`0009` Worker `b2c62527-5759-4c1d-a9a3-8c1d43dddabe` is the retained
-same-D1 predecessor to PR #123. The audited current preview `100` baseline is
-PR #123 Worker `70bbbecf-3fe6-4a04-8c34-babc3df09ad0` (#144), deployment
-`4108d59a-4092-4389-824c-fa3820ab66f6`.
+same-D1 predecessor to PR #123. This runbook does not establish current preview
+identity. At the dated PR #123 observation, the audited preview `100` baseline
+was Worker `70bbbecf-3fe6-4a04-8c34-babc3df09ad0`
+(#144), deployment `4108d59a-4092-4389-824c-fa3820ab66f6`. Current release
+identity is owned by the [current release snapshot](CURRENT-RELEASE.md) and
+must be freshly resolved there and from live control-plane reads before any
+operation.
 
 Current `main` also includes PR #117's Transform-12 schema `0009` contract.
 PR #107 preview and PR #108 production are retained schema-`0008` predecessor
@@ -63,11 +69,14 @@ and the completed releases/isolation evidence do not authorize credential stagin
 or the canary.
 
 The schema-`0009` candidates have retained preparation and release evidence.
-The active preview target is
+In that dated release evidence, the preview target was
 `theologai-preview-20260811-schema0009-a`
-(`74f456e2-6951-4003-bb6f-91951342bf8f`), and the active production target is
+(`74f456e2-6951-4003-bb6f-91951342bf8f`), and the production target was
 `theologai-production-20260811-schema0009-a`
-(`9bc79346-338b-439e-a2a5-424f4418eb21`). This does not make the canary ready.
+(`9bc79346-338b-439e-a2a5-424f4418eb21`). These are historical evidence
+anchors, not current identity; before any operation, resolve current identity
+from the [current release snapshot](CURRENT-RELEASE.md) and fresh live reads.
+This does not make the canary ready.
 Until a separate reviewed release replaces the hard inert
 schema-`0009` canary gate, the canary workflow rejects both retained schema-`0008`
 D1 identities during its first local validation, before any Wrangler command or

--- a/docs/ccel-search-preflight.md
+++ b/docs/ccel-search-preflight.md
@@ -1,10 +1,16 @@
 # CCEL live-search preflight record
 
-> **Current status:** exposure-only preview record. Production remains deployed
-> v6/local-only. Preview is deployed and audited on the v7/discovery-only
+<!-- theologai-release-authority v1 role=architecture-record current=docs/CURRENT-RELEASE.md -->
+
+> **Dated PR #123 status:** exposure-only preview record. At that observation,
+> production remained deployed v6/local-only and preview was deployed and
+> audited on the v7/discovery-only
 > contract, with CCEL execution disabled before adapter, coordinator, or fetch.
-> PR #122's audited schema-`0009` preview Worker now contains the current-main
+> PR #122's audited schema-`0009` preview Worker contained the then-current-main
 > endpoint pin below; the retained PR #107 Worker is historical predecessor evidence.
+> Current release identity is owned by the [current release snapshot](CURRENT-RELEASE.md)
+> and must be freshly resolved there and from live control-plane reads before
+> any operation.
 > TheologAI does not retrieve or republish CCEL
 > document bodies. Live discovery still requires a fresh operational preflight
 > and separate explicit release review.

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -27,6 +27,8 @@ const releaseAuthorityDocuments = {
   'CLAUDE.md': ['developer-guide', 'docs/CURRENT-RELEASE.md'],
   'CHANGELOG.md': ['historical-changelog', 'docs/CURRENT-RELEASE.md'],
   'README.md': ['project-entrypoint', 'docs/CURRENT-RELEASE.md'],
+  'docs/CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md': ['canary-runbook', 'docs/CURRENT-RELEASE.md'],
+  'docs/ccel-search-preflight.md': ['architecture-record', 'docs/CURRENT-RELEASE.md'],
   'docs/CURRENT-RELEASE.md': ['current-snapshot', 'self'],
   'docs/CUSTOM-DOMAIN-MIGRATION.md': ['operations-runbook', 'docs/CURRENT-RELEASE.md'],
   'docs/D1-DATA-WORKFLOW.md': ['data-runbook', 'docs/CURRENT-RELEASE.md'],
@@ -101,6 +103,11 @@ describe('published project contract', () => {
       'Production v6/local-only is deployed from PR #108',
       'Preview now serves PR #123',
       'Production and preview now use their distinct audited PR #122',
+      'The audited current preview `100` baseline is',
+      'The active preview target is',
+      'the active production target is',
+      '**Current status:** exposure-only preview record',
+      "PR #122's audited schema-`0009` preview Worker now contains the current-main",
     ];
     for (const document of historical) {
       for (const staleClaim of competingAuthority) expect(document).not.toContain(staleClaim);
@@ -557,7 +564,7 @@ describe('published project contract', () => {
       readProjectFile('docs/CCEL-UPSTREAM-COORDINATOR.md'),
       readProjectFile('docs/ccel-search-preflight.md'),
     ]);
-    for (const document of documents) {
+    for (const document of documents.slice(0, 2)) {
       const normalized = document.replace(/^>\s?/gm, '').replace(/\s+/g, ' ');
 
       expect(normalized).toContain('Production remains deployed v6/local-only');
@@ -572,6 +579,15 @@ describe('published project contract', () => {
 
     const liveAudit = documents[0]!;
     const preflight = documents[2]!;
+    const normalizedPreflight = preflight.replace(/^>\s?/gm, '').replace(/\s+/g, ' ');
+    expect(normalizedPreflight).toContain('Dated PR #123 status');
+    expect(normalizedPreflight).toContain('production remained deployed v6/local-only');
+    expect(normalizedPreflight).toContain(
+      'preview was deployed and audited on the v7/discovery-only contract',
+    );
+    expect(normalizedPreflight).toContain(
+      'CCEL execution disabled before adapter, coordinator, or fetch',
+    );
     expect(liveAudit).toContain('exactly two concurrent `searchDepth: "expanded"` contenders');
     expect(liveAudit).toContain('`searchDepth: "standard"` call');
     expect(liveAudit).toContain('partial, non-error response');
@@ -603,6 +619,8 @@ describe('published project contract', () => {
       expect(normalized).toMatch(/code\/resource-equivalent (?:`100` )?preview predecessor|code\/resource-equivalent `100` predecessor/);
     }
     expect(canary).toContain('five separately authorized stages');
+    expect(canary).toContain('[current release snapshot](CURRENT-RELEASE.md)');
+    expect(canary).toContain('must be freshly resolved there and from live control-plane reads before any\noperation');
     expect(canary).toContain('Completion or authorization of any stage does not authorize the next stage.');
     expect(canary).toContain('fresh, separate preview and production D1 candidates');
     expect(canary).toContain('schema `0009`');
@@ -627,6 +645,8 @@ describe('published project contract', () => {
     expect(canary).toContain('temporary `111` two-request preview canary transaction');
     expect(reconciliation).toContain('PR #122 completed the\nrequired current-main schema-`0009` preview refresh and audit');
     expect(preflight).toContain('fixed current-main candidate endpoint');
+    expect(preflight).toContain('[current release snapshot](CURRENT-RELEASE.md)');
+    expect(preflight).toContain('must be freshly resolved there and from live control-plane reads before');
     expect(preflight).toContain('PR #115 introduced this pin in repository code only. PR #122 subsequently');
     expect(preflight).toContain('The v7\ncandidate contract does not supersede');
     expect(secret).toContain('Executing staging is a production Worker-version upload mutation');


### PR DESCRIPTION
## Summary

- add closed release-authority markers to the CCEL canary transaction and preflight records
- time-scope the dated PR #122/#123 Worker, deployment, and D1 identity evidence
- route current identity through docs/CURRENT-RELEASE.md plus fresh live control-plane verification before operation
- extend public-contract coverage for the authority graph and stale-claim rejection

## Validation

- npm run docs:check
- focused testTopology (6/6)
- npm run typecheck
- npm run test:unit (197 files; 2,532 passed, 5 skipped)
- npm run test:coverage (86.71% statements / 80.94% branches / 92.04% functions / 90.89% lines)
- git diff --check

## Release boundary

This three-path documentation/test authority correction is deploy-required under repository policy. It changes no runtime, workflow, package, data, CCEL execution policy, secrets, or environment configuration. The protected release gate remains separate and must preserve one gate artifact plus seven release artifacts, one same-value ESV_API_KEY re-put, one production Worker deployment, unchanged D1 and preview identities, and all existing audits.