### PR TITLE
Architecture integrity: enforce an inward-only kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,17 @@ and implement service-owned ports. The application-boundary guard resolves
 every static, type-only, dynamic, import-equals, and literal CommonJS import in
 `src/services/` and rejects any adapter dependency.
 
+The kernel dependency boundary is inward-only: local imports resolved from
+`src/kernel/` must remain within `src/kernel/`. Application services and
+adapters may depend on kernel contracts, but the kernel does not depend on
+application services, adapters, or composition roots.
+
+The original-language study v2 context is an application concern: the
+service-owned `OriginalLanguageStudyV2ContextPort` and its authoritative
+context live under `src/services/languages/`. The kernel retains only the
+target-independent v2 request, result, cursor, and proof primitives used by
+that port; it does not own the application context provider.
+
 Business services depend on shared repository ports. Node uses synchronous
 SQLite repositories through async-compatible service boundaries; Workers uses
 per-request D1 repositories. Both targets share one MCP registry.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -880,6 +880,18 @@ behavior, schemas, corpus, migrations, generated data, runtime configuration,
 or release identity, and it does not activate, repair, execute, or typecheck
 quarantined tests.
 
+### Architecture integrity program — Train 0 / PR 4 service-owned v2 context port complete
+
+Train 0 / PR 4 makes the original-language study v2 application context
+service-owned: `OriginalLanguageStudyV2ContextPort` and its authoritative
+context live under `src/services/languages/`, while the kernel retains the
+target-independent v2 request, result, cursor, and proof primitives. It also
+enforces an inward-only local kernel dependency boundary, preventing kernel
+imports from resolving into services, adapters, or composition roots. The
+implementation preserves existing shapes and runtime behavior; it does not
+change schemas, output bytes, formatting, errors, tool registration, corpus,
+migrations, generated data, runtime configuration, or release identity.
+
 - Production and preview D1 bindings are distinct and managed through protected
   workflows. Deployment never migrates or seeds remote D1.
 - Readiness requires schema and exact corpus/materialization identity. Do not

--- a/docs/bible-mcp-architecture.md
+++ b/docs/bible-mcp-architecture.md
@@ -32,6 +32,17 @@ compiler-API guard resolves every static, type-only, dynamic, import-equals,
 and literal CommonJS specifier in `src/services/` and rejects any dependency
 resolving under `src/adapters/`.
 
+The kernel boundary is inward-only: every local `src/` dependency resolved from
+`src/kernel/` must remain inside `src/kernel/`. Services, adapters, and
+composition roots may depend on kernel contracts; the kernel does not depend
+on those application layers.
+
+For original-language study v2, the authoritative application context and its
+`OriginalLanguageStudyV2ContextPort` are service-owned under
+`src/services/languages/`. The kernel retains the target-independent v2
+request, result, cursor, and proof primitives, while application composition
+provides the context through the service port.
+
 
 **Current Status: Production Ready - Beta Launch (v3.4.1)**
 

--- a/src/kernel/originalLanguageStudyV2Contract.ts
+++ b/src/kernel/originalLanguageStudyV2Contract.ts
@@ -1,4 +1,3 @@
-import type { OriginalLanguageStudyDomainResult } from '../services/languages/OriginalLanguageStudyService.js';
 import { sha256Hex } from './sha256.js';
 import type {
   FutureExactHebrewTokenAlignmentProof,
@@ -39,21 +38,6 @@ export interface OriginalLanguageStudyV2Request {
 
 /** A proof may only be copied from a future server-owned verifier. */
 export interface ServerVerifiedHebrewSemanticAlignment extends FutureExactHebrewTokenAlignmentProof {}
-
-/**
- * Server-owned context.  The coordinator snapshots it before composition so
- * callers cannot inject source IDs, artifact identities, or alignment proofs.
- */
-export interface OriginalLanguageStudyV2AuthoritativeContext {
-  v1Result: OriginalLanguageStudyDomainResult;
-  semanticArtifactIdentity?: string;
-  serverVerifiedAlignment?: ServerVerifiedHebrewSemanticAlignment;
-}
-
-export interface IOriginalLanguageStudyV2ContextProvider {
-  resolve(request: Readonly<OriginalLanguageStudyV2ResolvedRequest>):
-    Promise<OriginalLanguageStudyV2AuthoritativeContext>;
-}
 
 export interface OriginalLanguageStudyV2ResolvedRequest {
   reference: string;

--- a/src/services/languages/OriginalLanguageStudyV2ContextPort.ts
+++ b/src/services/languages/OriginalLanguageStudyV2ContextPort.ts
@@ -1,0 +1,20 @@
+import type { OriginalLanguageStudyDomainResult } from './OriginalLanguageStudyService.js';
+import type {
+  OriginalLanguageStudyV2ResolvedRequest,
+  ServerVerifiedHebrewSemanticAlignment,
+} from '../../kernel/originalLanguageStudyV2Contract.js';
+
+/**
+ * Server-owned context. The coordinator snapshots it before composition so
+ * callers cannot inject source IDs, artifact identities, or alignment proofs.
+ */
+export interface OriginalLanguageStudyV2AuthoritativeContext {
+  v1Result: OriginalLanguageStudyDomainResult;
+  semanticArtifactIdentity?: string;
+  serverVerifiedAlignment?: ServerVerifiedHebrewSemanticAlignment;
+}
+
+export interface OriginalLanguageStudyV2ContextPort {
+  resolve(request: Readonly<OriginalLanguageStudyV2ResolvedRequest>):
+    Promise<OriginalLanguageStudyV2AuthoritativeContext>;
+}

--- a/src/services/languages/OriginalLanguageStudyV2ContextProvider.ts
+++ b/src/services/languages/OriginalLanguageStudyV2ContextProvider.ts
@@ -1,8 +1,10 @@
 import type {
-  IOriginalLanguageStudyV2ContextProvider,
-  OriginalLanguageStudyV2AuthoritativeContext,
   OriginalLanguageStudyV2ResolvedRequest,
 } from '../../kernel/originalLanguageStudyV2Contract.js';
+import type {
+  OriginalLanguageStudyV2AuthoritativeContext,
+  OriginalLanguageStudyV2ContextPort,
+} from './OriginalLanguageStudyV2ContextPort.js';
 import type { OriginalLanguageStudyService } from './OriginalLanguageStudyService.js';
 
 /**
@@ -18,7 +20,7 @@ export const ORIGINAL_LANGUAGE_STUDY_V2_SEMANTIC_ARTIFACT_IDENTITY =
  * coordinator.  It intentionally supplies no alignment proof: the current
  * runtime has no exact morphology-token-to-sense verifier.
  */
-export class OriginalLanguageStudyV2ContextProvider implements IOriginalLanguageStudyV2ContextProvider {
+export class OriginalLanguageStudyV2ContextProvider implements OriginalLanguageStudyV2ContextPort {
   constructor(private readonly v1StudyService: Pick<OriginalLanguageStudyService, 'study'>) {}
 
   async resolve(

--- a/src/services/languages/OriginalLanguageStudyV2Coordinator.ts
+++ b/src/services/languages/OriginalLanguageStudyV2Coordinator.ts
@@ -19,8 +19,6 @@ import {
   createOriginalLanguageStudyV2Cursor,
   deriveOriginalLanguageStudyV2MorphologyTokenIdentity,
   parseOriginalLanguageStudyV2Cursor,
-  type IOriginalLanguageStudyV2ContextProvider,
-  type OriginalLanguageStudyV2AuthoritativeContext,
   type OriginalLanguageStudyV2Candidate,
   type OriginalLanguageStudyV2CursorBinding,
   type OriginalLanguageStudyV2Detail,
@@ -31,6 +29,10 @@ import {
   type OriginalLanguageStudyV2SemanticEvidence,
   type ServerVerifiedHebrewSemanticAlignment,
 } from '../../kernel/originalLanguageStudyV2Contract.js';
+import type {
+  OriginalLanguageStudyV2AuthoritativeContext,
+  OriginalLanguageStudyV2ContextPort,
+} from './OriginalLanguageStudyV2ContextPort.js';
 import { presentOriginalLanguageStudy } from '../../presenters/originalLanguageStudyStructured.js';
 import {
   finalizeOriginalLanguageStudyV2Output,
@@ -38,12 +40,6 @@ import {
 } from '../../presenters/originalLanguageStudyV2Structured.js';
 import { formatOriginalLanguageStudyV2 } from '../../formatters/originalLanguageStudyV2Formatter.js';
 import type { OriginalLanguageStudyDomainResult } from './OriginalLanguageStudyService.js';
-
-export type {
-  IOriginalLanguageStudyV2ContextProvider,
-  OriginalLanguageStudyV2AuthoritativeContext,
-  OriginalLanguageStudyV2ResolvedRequest,
-} from '../../kernel/originalLanguageStudyV2Contract.js';
 
 /**
  * The coordinator returns both the closed structured v2 packet and a
@@ -71,7 +67,7 @@ const WITHHELD_EVIDENCE = Object.freeze([
  */
 export class OriginalLanguageStudyV2Coordinator {
   constructor(
-    private readonly contextProvider: IOriginalLanguageStudyV2ContextProvider,
+    private readonly contextProvider: OriginalLanguageStudyV2ContextPort,
     private readonly evidenceRepository: IUbsSemanticEvidenceBundleRepository,
   ) {}
 

--- a/test/README.md
+++ b/test/README.md
@@ -74,6 +74,11 @@ dynamic, import-equals, and literal CommonJS module specifiers under
 `src/services/`; no adapter allowlist exists. The synthetic cases prove the
 detector remains non-vacuous while quarantined tests remain untouched.
 
+The same guard enforces the kernel half of the boundary: every resolved local
+`src/` import from `src/kernel/` must remain within that directory, with no
+allowlist. Synthetic `.ts`, `.tsx`, `.mts`, and `.cts` cases cover the same
+static, type-only, dynamic, import-equals, and literal-`require` forms.
+
 ## Retired legacy commands
 
 The following former package commands have been removed. They are not runnable

--- a/test/helpers/originalLanguageStudyV2ProductionFixtures.ts
+++ b/test/helpers/originalLanguageStudyV2ProductionFixtures.ts
@@ -13,8 +13,6 @@ import {
   type UbsSemanticEvidenceBundleRepositoryQuery,
 } from '../../src/kernel/ubsSemanticEvidenceBundle.js';
 import {
-  type IOriginalLanguageStudyV2ContextProvider,
-  type OriginalLanguageStudyV2AuthoritativeContext,
   type OriginalLanguageStudyV2CursorBinding,
   deriveOriginalLanguageStudyV2MorphologyTokenIdentity,
 } from '../../src/kernel/originalLanguageStudyV2Contract.js';
@@ -24,6 +22,10 @@ import {
   type UbsSemanticSource,
 } from '../../src/kernel/ubsSemanticDomain.js';
 import { OriginalLanguageStudyV2Coordinator } from '../../src/services/languages/OriginalLanguageStudyV2Coordinator.js';
+import type {
+  OriginalLanguageStudyV2AuthoritativeContext,
+  OriginalLanguageStudyV2ContextPort,
+} from '../../src/services/languages/OriginalLanguageStudyV2ContextPort.js';
 import type { OriginalLanguageStudyDomainResult } from '../../src/services/languages/OriginalLanguageStudyService.js';
 
 export const SYNTHETIC_ARTIFACT = 'a'.repeat(64);
@@ -228,7 +230,7 @@ export class ProductionAggregateRepository implements IUbsSemanticEvidenceBundle
   }
 }
 
-export class ProductionContextProvider implements IOriginalLanguageStudyV2ContextProvider {
+export class ProductionContextProvider implements OriginalLanguageStudyV2ContextPort {
   calls = 0;
 
   constructor(private readonly context: OriginalLanguageStudyV2AuthoritativeContext) {}

--- a/test/unit/config/applicationBoundaries.test.ts
+++ b/test/unit/config/applicationBoundaries.test.ts
@@ -4,6 +4,8 @@ import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const repoRoot = resolve(import.meta.dirname, '../../..');
+const srcRoot = resolve(repoRoot, 'src');
+const kernelRoot = resolve(repoRoot, 'src/kernel');
 const servicesRoot = resolve(repoRoot, 'src/services');
 const adaptersRoot = resolve(repoRoot, 'src/adapters');
 const typeScriptFile = /\.(?:ts|tsx|mts|cts)$/;
@@ -32,19 +34,21 @@ function literalText(node: ts.Node): string | undefined {
   return undefined;
 }
 
-function resolvesUnderAdapters(fileName: string, specifier: string): boolean {
-  const resolved = ts.resolveModuleName(
+function resolveSpecifier(fileName: string, specifier: string): string | undefined {
+  return ts.resolveModuleName(
     specifier,
     fileName,
     compilerOptions,
     resolutionHost,
   ).resolvedModule?.resolvedFileName;
-  if (!resolved) return false;
-  const pathFromAdapters = relative(adaptersRoot, resolve(resolved));
-  return pathFromAdapters !== '' && !pathFromAdapters.startsWith('..') && !pathFromAdapters.startsWith('/');
 }
 
-function adapterReferencesInSource(fileName: string, sourceText: string): string[] {
+function pathWithin(fileName: string, root: string): boolean {
+  const pathFromRoot = relative(root, resolve(fileName));
+  return pathFromRoot !== '' && !pathFromRoot.startsWith('..') && !pathFromRoot.startsWith('/');
+}
+
+function moduleSpecifiersInSource(fileName: string, sourceText: string): string[] {
   const sourceFile = ts.createSourceFile(
     fileName,
     sourceText,
@@ -72,15 +76,26 @@ function adapterReferencesInSource(fileName: string, sourceText: string): string
     ) {
       specifier = literalText(node.arguments[0]!);
     }
-    if (specifier !== undefined && resolvesUnderAdapters(fileName, specifier)) references.push(specifier);
+    if (specifier !== undefined) references.push(specifier);
     ts.forEachChild(node, visit);
   };
   visit(sourceFile);
   return references;
 }
 
-function adapterReferences(fileName: string): string[] {
-  return adapterReferencesInSource(fileName, readFileSync(fileName, 'utf8'));
+function resolvedReferencesInSource(
+  fileName: string,
+  sourceText: string,
+  forbiddenRoot: string,
+): string[] {
+  return moduleSpecifiersInSource(fileName, sourceText).filter((specifier) => {
+    const resolved = resolveSpecifier(fileName, specifier);
+    return resolved !== undefined && pathWithin(resolved, forbiddenRoot);
+  });
+}
+
+function resolvedReferences(fileName: string, forbiddenRoot: string): string[] {
+  return resolvedReferencesInSource(fileName, readFileSync(fileName, 'utf8'), forbiddenRoot);
 }
 
 describe('application-owned service boundaries', () => {
@@ -95,7 +110,7 @@ describe('application-owned service boundaries', () => {
   });
 
   it('forbids every service import that resolves under src/adapters', () => {
-    const references = walk(servicesRoot).flatMap((fileName) => adapterReferences(fileName).map((specifier) => ({
+    const references = walk(servicesRoot).flatMap((fileName) => resolvedReferences(fileName, adaptersRoot).map((specifier) => ({
       file: relative(repoRoot, fileName).replaceAll('\\', '/'),
       specifier,
     })));
@@ -114,7 +129,36 @@ describe('application-owned service boundaries', () => {
     ];
     for (const { name, source } of cases) {
       const fileName = join(syntheticDirectory, `application-boundary-regression-${name}`);
-      expect(adapterReferencesInSource(fileName, source), name).toEqual([specifier]);
+      expect(resolvedReferencesInSource(fileName, source, adaptersRoot), name).toEqual([specifier]);
+    }
+  });
+
+  it('keeps every resolved kernel-local src dependency inside src/kernel', () => {
+    const references = walk(kernelRoot).flatMap((fileName) => moduleSpecifiersInSource(
+      fileName,
+      readFileSync(fileName, 'utf8'),
+    ).flatMap((specifier) => {
+      const resolved = resolveSpecifier(fileName, specifier);
+      return resolved !== undefined && pathWithin(resolved, srcRoot) && !pathWithin(resolved, kernelRoot)
+        ? [{ file: relative(repoRoot, fileName).replaceAll('\\', '/'), specifier }]
+        : [];
+    }));
+    expect(references).toEqual([]);
+  });
+
+  it('detects all import forms that would make a kernel file depend on a service', () => {
+    const syntheticDirectory = join(repoRoot, 'src/kernel');
+    const specifier = '../services/bible/BibleProviderPort.js';
+    const cases = [
+      { name: 'static.ts', source: `import type { BibleProviderPort } from '${specifier}';` },
+      { name: 'import-type.mts', source: `type Port = import('${specifier}').BibleProviderPort;` },
+      { name: 'dynamic.tsx', source: `void import('${specifier}'); const view = <div />;` },
+      { name: 'import-equals.cts', source: `import legacy = require('${specifier}');` },
+      { name: 'require.cts', source: `const legacy = require('${specifier}');` },
+    ];
+    for (const { name, source } of cases) {
+      const fileName = join(syntheticDirectory, `kernel-boundary-regression-${name}`);
+      expect(resolvedReferencesInSource(fileName, source, servicesRoot), name).toEqual([specifier]);
     }
   });
 });


### PR DESCRIPTION
## Summary

- move the original-language-study v2 application context port from kernel into the service layer
- leave target-independent request, result, cursor, and proof primitives in kernel
- enforce a zero-allowlist inward-only kernel dependency boundary
- update README, roadmap, architecture, and test documentation

## Architectural scope

This is a type-only ownership and dependency-direction change. It preserves provider behavior, schemas, output bytes, formatting, errors, tool registration, frozen fixture packets, corpus/data, migrations, runtime/deployment configuration, and release identity. The later service-to-presentation boundary cleanup is intentionally out of scope.

## Commit sequence

1. `refactor(services): own the original-language context port`
2. `test(architecture): enforce an inward-only kernel boundary`
3. `docs(architecture): record the kernel dependency boundary`

## Verification

- focused architecture/context/inertness suite: 6 files, 33 tests passed
- full maintained TypeScript project matrix: passed
- frozen v2 design compiler: passed
- complete unit suite: 199 files, 2,544 passed, 5 skipped
- integration suite: 3 passed
- Worker runtime suite: 25 passed
- CCEL coordinator runtime suite: 17 passed
- documentation contract checks: 14 passed
- production build: passed
- frozen original-language-study-v2 fixture directory: byte-identical to base
- staged and final diff integrity checks: clean

## Review gates

Sol High reviewed the exact committed head `1310ee5` and returned `APPROVE — finding-free and publication-ready`. The review verified commit atomicity/order, Tyler author and committer identity, exact port-shape preservation, zero stale consumers or compatibility aliases, kernel boundary-guard soundness, frozen-packet identity, documentation accuracy, and absence of public-contract/release-state drift.
