### PR TITLE
ops: add protected rollback rehearsal

### DIFF
--- a/.github/workflows/production-rollback-rehearsal.yml
+++ b/.github/workflows/production-rollback-rehearsal.yml
@@ -92,7 +92,10 @@ jobs:
           cache: npm
 
       - name: Install verifier dependencies
-        run: npm ci --no-audit
+        run: |
+          set -euo pipefail
+          npm ci --no-audit > "$RUNNER_TEMP/verifier-npm-ci.out" 2>&1
+          test "$(wc -c < "$RUNNER_TEMP/verifier-npm-ci.out")" -le 8388608
 
       - name: Verify pinned Wrangler version
         env:

--- a/.github/workflows/production-rollback-rehearsal.yml
+++ b/.github/workflows/production-rollback-rehearsal.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install verifier dependencies
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+          node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
             --stdout "$RUNNER_TEMP/verifier-npm-ci.out" --stderr "$RUNNER_TEMP/verifier-npm-ci.err" \
             --result "$RUNNER_TEMP/verifier-npm-ci.result.json" --max-bytes 8388608 -- npm ci --no-audit
           jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' \
@@ -103,7 +103,7 @@ jobs:
       - name: Verify pinned Wrangler version
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+          node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
             --stdout "$RUNNER_TEMP/wrangler-version.out" --stderr "$RUNNER_TEMP/wrangler-version.err" \
             --result "$RUNNER_TEMP/wrangler-version.result.json" --max-bytes 65536 -- \
             npx --no-install wrangler --version
@@ -139,7 +139,7 @@ jobs:
           MAX_CAPTURE_BYTES=8388608
           bounded_json() {
             stdout="$1"; stderr="$2"; shift 2
-            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
               --stdout "$stdout" --stderr "$stderr" --result "$stdout.result.json" --max-bytes "$MAX_CAPTURE_BYTES" -- "$@"
             jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$stdout.result.json"
           }
@@ -154,7 +154,7 @@ jobs:
           set -euo pipefail
           capture() {
             stdout="$1"; stderr="$2"; result="$3"; shift 3
-            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
               --stdout "$stdout" --stderr "$stderr" --result "$result" --cwd "$GITHUB_WORKSPACE/pr108-source" \
               --max-bytes 8388608 -- "$@"
             jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$result"
@@ -175,7 +175,7 @@ jobs:
           MAX_CAPTURE_BYTES=8388608
           bounded_json() {
             stdout="$1"; stderr="$2"; shift 2
-            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
               --stdout "$stdout" --stderr "$stderr" --result "$stdout.result.json" --max-bytes "$MAX_CAPTURE_BYTES" -- "$@"
             jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$stdout.result.json"
           }
@@ -193,7 +193,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+          node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
             --stdout "$RUNNER_TEMP/pr108-remote-d1.out" --stderr "$RUNNER_TEMP/pr108-remote-d1.err" \
             --result "$RUNNER_TEMP/pr108-remote-d1.result.json" --cwd "$GITHUB_WORKSPACE/pr108-source" \
             --max-bytes 8388608 -- npm run d1:remote:check -- --database theologai-production-20260729-transform11-a
@@ -207,7 +207,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+          node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
             --stdout "$RUNNER_TEMP/dry-run.out" --stderr "$RUNNER_TEMP/dry-run.err" \
             --stdout-prefix 'DRY_RUN_SENTINEL: fixed-pr108-dry-run' \
             --result "$RUNNER_TEMP/dry-run.result.json" --max-bytes 8388608 -- \
@@ -227,7 +227,7 @@ jobs:
           MAX_CAPTURE_BYTES=8388608
           bounded_json() {
             stdout="$1"; stderr="$2"; shift 2
-            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
               --stdout "$stdout" --stderr "$stderr" --result "$stdout.result.json" --max-bytes "$MAX_CAPTURE_BYTES" -- "$@"
             jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$stdout.result.json"
           }
@@ -255,7 +255,7 @@ jobs:
           EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
         run: |
           set -euo pipefail
-          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+          node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs" \
             --stdout "$RUNNER_TEMP/receipt.stdout" --stderr "$RUNNER_TEMP/receipt.stderr" \
             --result "$RUNNER_TEMP/receipt.result.json" --max-bytes 65536 -- \
             npx --no-install tsx scripts/production-rollback-rehearsal.ts create \

--- a/.github/workflows/production-rollback-rehearsal.yml
+++ b/.github/workflows/production-rollback-rehearsal.yml
@@ -94,13 +94,22 @@ jobs:
       - name: Install verifier dependencies
         run: |
           set -euo pipefail
-          npm ci --no-audit > "$RUNNER_TEMP/verifier-npm-ci.out" 2>&1
-          test "$(wc -c < "$RUNNER_TEMP/verifier-npm-ci.out")" -le 8388608
+          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            --stdout "$RUNNER_TEMP/verifier-npm-ci.out" --stderr "$RUNNER_TEMP/verifier-npm-ci.err" \
+            --result "$RUNNER_TEMP/verifier-npm-ci.result.json" --max-bytes 8388608 -- npm ci --no-audit
+          jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' \
+            "$RUNNER_TEMP/verifier-npm-ci.result.json"
 
       - name: Verify pinned Wrangler version
-        env:
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-version-logs
-        run: test "$(npx --no-install wrangler --version)" = '4.114.0'
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            --stdout "$RUNNER_TEMP/wrangler-version.out" --stderr "$RUNNER_TEMP/wrangler-version.err" \
+            --result "$RUNNER_TEMP/wrangler-version.result.json" --max-bytes 65536 -- \
+            npx --no-install wrangler --version
+          jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' \
+            "$RUNNER_TEMP/wrangler-version.result.json"
+          test "$(sed -n '1p' "$RUNNER_TEMP/wrangler-version.out")" = '4.114.0'
 
       - name: Check out exact historical PR108 source separately
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -121,8 +130,8 @@ jobs:
       - name: Capture production and preview controls before rehearsal (read-only)
         env:
           CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
           EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
           EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
         run: |
@@ -130,9 +139,9 @@ jobs:
           MAX_CAPTURE_BYTES=8388608
           bounded_json() {
             stdout="$1"; stderr="$2"; shift 2
-            "$@" > "$stdout" 2> "$stderr"
-            test "$(wc -c < "$stdout")" -le "$MAX_CAPTURE_BYTES"
-            test "$(wc -c < "$stderr")" -le "$MAX_CAPTURE_BYTES"
+            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+              --stdout "$stdout" --stderr "$stderr" --result "$stdout.result.json" --max-bytes "$MAX_CAPTURE_BYTES" -- "$@"
+            jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$stdout.result.json"
           }
           bounded_json "$RUNNER_TEMP/d1-before.json" "$RUNNER_TEMP/d1-before.stderr" npx --no-install wrangler d1 list --json
           bounded_json "$RUNNER_TEMP/production-before.json" "$RUNNER_TEMP/production-before.stderr" npx --no-install wrangler deployments list --json
@@ -143,24 +152,22 @@ jobs:
       - name: Run historical PR108 local gates without credentials
         run: |
           set -euo pipefail
-          MAX_CAPTURE_BYTES=8388608
-          bounded() {
-            output="$1"; shift
-            "$@" > "$output" 2>&1
-            test "$(wc -c < "$output")" -le "$MAX_CAPTURE_BYTES"
+          capture() {
+            stdout="$1"; stderr="$2"; result="$3"; shift 3
+            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+              --stdout "$stdout" --stderr "$stderr" --result "$result" --cwd "$GITHUB_WORKSPACE/pr108-source" \
+              --max-bytes 8388608 -- "$@"
+            jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$result"
           }
-          (
-            cd pr108-source
-            bounded "$RUNNER_TEMP/pr108-npm-ci.out" npm ci --no-audit
-            bounded "$RUNNER_TEMP/pr108-workerd.out" npm run d1:seed:verify-workerd
-            bounded "$RUNNER_TEMP/pr108-runtime.out" npm run test:worker-production-runtime
-          )
+          capture "$RUNNER_TEMP/pr108-npm-ci.out" "$RUNNER_TEMP/pr108-npm-ci.err" "$RUNNER_TEMP/pr108-npm-ci.result.json" npm ci --no-audit
+          capture "$RUNNER_TEMP/pr108-workerd.out" "$RUNNER_TEMP/pr108-workerd.err" "$RUNNER_TEMP/pr108-workerd.result.json" npm run d1:seed:verify-workerd
+          capture "$RUNNER_TEMP/pr108-runtime.out" "$RUNNER_TEMP/pr108-runtime.err" "$RUNNER_TEMP/pr108-runtime.result.json" npm run test:worker-production-runtime
 
       - name: Capture fixed PR108 Worker/version and deployment proof (read-only)
         env:
           CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
           EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
           EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
         run: |
@@ -168,50 +175,51 @@ jobs:
           MAX_CAPTURE_BYTES=8388608
           bounded_json() {
             stdout="$1"; stderr="$2"; shift 2
-            "$@" > "$stdout" 2> "$stderr"
-            test "$(wc -c < "$stdout")" -le "$MAX_CAPTURE_BYTES"
-            test "$(wc -c < "$stderr")" -le "$MAX_CAPTURE_BYTES"
+            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+              --stdout "$stdout" --stderr "$stderr" --result "$stdout.result.json" --max-bytes "$MAX_CAPTURE_BYTES" -- "$@"
+            jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$stdout.result.json"
           }
           bounded_json "$RUNNER_TEMP/target-version.json" "$RUNNER_TEMP/target-version.stderr" \
             npx --no-install wrangler versions view 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6 --name theologai --json
-          curl --fail --silent --show-error --location --max-time 30 --proto '=https' --tlsv1.2 \
-            -H "Authorization: Bearer $CLOUDFLARE_READ_ONLY_API_TOKEN" -H 'Accept: application/json' \
-            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/theologai/deployments/3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8" \
-            > "$RUNNER_TEMP/target-deployment.json"
-          test "$(wc -c < "$RUNNER_TEMP/target-deployment.json")" -le "$MAX_CAPTURE_BYTES"
+          bounded_json "$RUNNER_TEMP/target-deployment.json" "$RUNNER_TEMP/target-deployment.stderr" \
+            curl --fail --silent --show-error --location --max-time 30 --proto '=https' --tlsv1.2 \
+              -H "Authorization: Bearer $CLOUDFLARE_READ_ONLY_API_TOKEN" -H 'Accept: application/json' \
+              "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/theologai/deployments/3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8"
 
       - name: Run fixed PR108 remote readiness (read-only token only)
         env:
           CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
         run: |
           set -euo pipefail
-          MAX_CAPTURE_BYTES=8388608
-          cd pr108-source
-          npm run d1:remote:check -- --database theologai-production-20260729-transform11-a \
-            > "$RUNNER_TEMP/pr108-remote-d1.out" 2>&1
-          test "$(wc -c < "$RUNNER_TEMP/pr108-remote-d1.out")" -le "$MAX_CAPTURE_BYTES"
+          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            --stdout "$RUNNER_TEMP/pr108-remote-d1.out" --stderr "$RUNNER_TEMP/pr108-remote-d1.err" \
+            --result "$RUNNER_TEMP/pr108-remote-d1.result.json" --cwd "$GITHUB_WORKSPACE/pr108-source" \
+            --max-bytes 8388608 -- npm run d1:remote:check -- --database theologai-production-20260729-transform11-a
+          jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' \
+            "$RUNNER_TEMP/pr108-remote-d1.result.json"
 
       - name: Run exact PR108 recovery command in dry-run mode only
         env:
           CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
         run: |
           set -euo pipefail
-          MAX_CAPTURE_BYTES=8388608
-          printf 'DRY_RUN_SENTINEL: fixed-pr108-dry-run\n' > "$RUNNER_TEMP/dry-run.out"
-          npx --no-install wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --config wrangler.release.toml --name theologai --dry-run --yes >> "$RUNNER_TEMP/dry-run.out" 2>&1
-          test "$(wc -c < "$RUNNER_TEMP/dry-run.out")" -le "$MAX_CAPTURE_BYTES"
+          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            --stdout "$RUNNER_TEMP/dry-run.out" --stderr "$RUNNER_TEMP/dry-run.err" \
+            --stdout-prefix 'DRY_RUN_SENTINEL: fixed-pr108-dry-run' \
+            --result "$RUNNER_TEMP/dry-run.result.json" --max-bytes 8388608 -- \
+            npx --no-install wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --config wrangler.release.toml --name theologai --dry-run --yes
+          jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' \
+            "$RUNNER_TEMP/dry-run.result.json"
 
       - name: Capture production and preview controls after rehearsal (read-only)
         env:
           CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
           EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
           EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
         run: |
@@ -219,9 +227,9 @@ jobs:
           MAX_CAPTURE_BYTES=8388608
           bounded_json() {
             stdout="$1"; stderr="$2"; shift 2
-            "$@" > "$stdout" 2> "$stderr"
-            test "$(wc -c < "$stdout")" -le "$MAX_CAPTURE_BYTES"
-            test "$(wc -c < "$stderr")" -le "$MAX_CAPTURE_BYTES"
+            "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+              --stdout "$stdout" --stderr "$stderr" --result "$stdout.result.json" --max-bytes "$MAX_CAPTURE_BYTES" -- "$@"
+            jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$stdout.result.json"
           }
           bounded_json "$RUNNER_TEMP/d1-after.json" "$RUNNER_TEMP/d1-after.stderr" npx --no-install wrangler d1 list --json
           bounded_json "$RUNNER_TEMP/production-after.json" "$RUNNER_TEMP/production-after.stderr" npx --no-install wrangler deployments list --json
@@ -247,7 +255,10 @@ jobs:
           EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
         run: |
           set -euo pipefail
-          npx --no-install tsx scripts/production-rollback-rehearsal.ts create \
+          "$GITHUB_WORKSPACE/node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command.ts" \
+            --stdout "$RUNNER_TEMP/receipt.stdout" --stderr "$RUNNER_TEMP/receipt.stderr" \
+            --result "$RUNNER_TEMP/receipt.result.json" --max-bytes 65536 -- \
+            npx --no-install tsx scripts/production-rollback-rehearsal.ts create \
             --confirmation "$CONFIRMATION" \
             --repository "$REPOSITORY" \
             --workflow "$WORKFLOW" \
@@ -275,12 +286,14 @@ jobs:
             --target-version "$RUNNER_TEMP/target-version.json" \
             --target-deployment "$RUNNER_TEMP/target-deployment.json" \
             --readiness-output "$RUNNER_TEMP/pr108-remote-d1.out" \
-            --runtime-output "$RUNNER_TEMP/pr108-runtime.out" \
-            --dry-run-output "$RUNNER_TEMP/dry-run.out" \
-            --npm-install-output "$RUNNER_TEMP/pr108-npm-ci.out" \
-            --workerd-output "$RUNNER_TEMP/pr108-workerd.out" \
-            --output "$RUNNER_TEMP/production-rollback-rehearsal.json" \
-            > "$RUNNER_TEMP/receipt.stdout"
+            --readiness-stderr "$RUNNER_TEMP/pr108-remote-d1.err" \
+            --runtime-output "$RUNNER_TEMP/pr108-runtime.out" --runtime-stderr "$RUNNER_TEMP/pr108-runtime.err" \
+            --dry-run-output "$RUNNER_TEMP/dry-run.out" --dry-run-stderr "$RUNNER_TEMP/dry-run.err" \
+            --npm-install-output "$RUNNER_TEMP/pr108-npm-ci.out" --npm-install-stderr "$RUNNER_TEMP/pr108-npm-ci.err" \
+            --workerd-output "$RUNNER_TEMP/pr108-workerd.out" --workerd-stderr "$RUNNER_TEMP/pr108-workerd.err" \
+            --output "$RUNNER_TEMP/production-rollback-rehearsal.json"
+          jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' \
+            "$RUNNER_TEMP/receipt.result.json"
           jq -e 'type == "object" and .schemaVersion == "theologai-production-rollback-rehearsal.v1" and .status == "passed" and .trafficMutation == false and .d1Mutation == false and .previewMutation == false and .targetInactiveBefore == true and .targetInactiveAfter == true and (.exitStatuses | to_entries | all(.value == 0))' "$RUNNER_TEMP/production-rollback-rehearsal.json"
 
       - name: Upload sanitized rehearsal receipt only

--- a/.github/workflows/production-rollback-rehearsal.yml
+++ b/.github/workflows/production-rollback-rehearsal.yml
@@ -1,0 +1,189 @@
+name: Production Rollback Rehearsal
+
+# This workflow is a protected, read-only rehearsal. It never changes Worker
+# traffic, uploads a version, changes a binding, mutates D1, or deletes data.
+# Fixed PR108 deployment target: 3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8.
+# Fixed PR108 Worker version: 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6; D1:
+# theologai-production-20260729-transform11-a / 53211f50-a893-4b4c-be1e-bc625a595dc7.
+on:
+  workflow_dispatch:
+    inputs:
+      expected_production_deployment_id:
+        description: Exact active production deployment UUID captured immediately before dispatch
+        required: true
+        type: string
+      expected_production_version_id:
+        description: Exact active production Worker version UUID captured immediately before dispatch
+        required: true
+        type: string
+      expected_preview_deployment_id:
+        description: Exact active preview deployment UUID captured immediately before dispatch
+        required: true
+        type: string
+      expected_preview_version_id:
+        description: Exact active preview Worker version UUID captured immediately before dispatch
+        required: true
+        type: string
+      confirmation:
+        description: 'Type REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC'
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  rehearse:
+    name: Rehearse PR108 rollback without traffic
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment:
+      name: production
+      url: https://mcp.theologai.xyz/mcp
+    permissions:
+      contents: read
+    steps:
+      - name: Confirm main-only dispatch and exact confirmation
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          test "$DISPATCH_REF" = 'refs/heads/main'
+          test "$CONFIRMATION" = 'REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC'
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      - name: Install verifier dependencies
+        run: npm ci --no-audit
+
+      - name: Check out exact historical PR108 source separately
+        env:
+          PR108_COMMIT: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
+          PR108_TREE: a59d9a062b2e6c7884de97fd97309878e1cbdc23
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
+          path: pr108-source
+          fetch-depth: 1
+
+      - name: Verify exact historical source identity
+        env:
+          PR108_COMMIT: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
+          PR108_TREE: a59d9a062b2e6c7884de97fd97309878e1cbdc23
+        run: |
+          set -euo pipefail
+          test "$(git -C pr108-source rev-parse HEAD)" = "$PR108_COMMIT"
+          test "$(git -C pr108-source rev-parse HEAD^{tree})" = "$PR108_TREE"
+
+      - name: Capture production and preview controls before rehearsal (read-only)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
+          EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
+        run: |
+          set -euo pipefail
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/d1-before.json"
+          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-before.json"
+          npx --no-install wrangler versions view "$EXPECTED_PRODUCTION_VERSION" --name theologai --json > "$RUNNER_TEMP/production-version-before.json"
+          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-before.json"
+          npx --no-install wrangler versions view "$EXPECTED_PREVIEW_VERSION" --name theologai-preview --env preview --json > "$RUNNER_TEMP/preview-version-before.json"
+
+      - name: Validate fixed PR108 target and historical local gates (read-only)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --no-install wrangler versions view 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6 --name theologai --json > "$RUNNER_TEMP/target-version.json"
+          (
+            cd pr108-source
+            npm ci --no-audit > "$RUNNER_TEMP/pr108-npm-ci.out" 2>&1
+            npm run d1:seed:verify-workerd > "$RUNNER_TEMP/pr108-workerd.out" 2>&1
+            npm run test:worker-production-runtime > "$RUNNER_TEMP/pr108-runtime.out" 2>&1
+            npm run d1:remote:check -- --database theologai-production-20260729-transform11-a > "$RUNNER_TEMP/pr108-remote-d1.out" 2>&1
+          )
+
+      - name: Run exact PR108 recovery command in dry-run mode only
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          npx --no-install wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --dry-run --yes > "$RUNNER_TEMP/dry-run.out" 2>&1
+
+      - name: Capture production and preview controls after rehearsal (read-only)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
+          EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
+        run: |
+          set -euo pipefail
+          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/d1-after.json"
+          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-after.json"
+          npx --no-install wrangler versions view "$EXPECTED_PRODUCTION_VERSION" --name theologai --json > "$RUNNER_TEMP/production-version-after.json"
+          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-after.json"
+          npx --no-install wrangler versions view "$EXPECTED_PREVIEW_VERSION" --name theologai-preview --env preview --json > "$RUNNER_TEMP/preview-version-after.json"
+
+      - name: Create bounded sanitized rehearsal receipt
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+          SOURCE_COMMIT: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
+          SOURCE_TREE: a59d9a062b2e6c7884de97fd97309878e1cbdc23
+          EXPECTED_PRODUCTION_DEPLOYMENT: ${{ inputs.expected_production_deployment_id }}
+          EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
+          EXPECTED_PREVIEW_DEPLOYMENT: ${{ inputs.expected_preview_deployment_id }}
+          EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
+        run: |
+          set -euo pipefail
+          npx --no-install tsx scripts/production-rollback-rehearsal.ts create \
+            --confirmation "$CONFIRMATION" \
+            --source-commit "$SOURCE_COMMIT" \
+            --source-tree "$SOURCE_TREE" \
+            --expected-production-deployment "$EXPECTED_PRODUCTION_DEPLOYMENT" \
+            --expected-production-version "$EXPECTED_PRODUCTION_VERSION" \
+            --expected-preview-deployment "$EXPECTED_PREVIEW_DEPLOYMENT" \
+            --expected-preview-version "$EXPECTED_PREVIEW_VERSION" \
+            --production-before "$RUNNER_TEMP/production-before.json" \
+            --production-after "$RUNNER_TEMP/production-after.json" \
+            --production-version-before "$RUNNER_TEMP/production-version-before.json" \
+            --production-version-after "$RUNNER_TEMP/production-version-after.json" \
+            --preview-before "$RUNNER_TEMP/preview-before.json" \
+            --preview-after "$RUNNER_TEMP/preview-after.json" \
+            --preview-version-before "$RUNNER_TEMP/preview-version-before.json" \
+            --preview-version-after "$RUNNER_TEMP/preview-version-after.json" \
+            --d1-before "$RUNNER_TEMP/d1-before.json" \
+            --d1-after "$RUNNER_TEMP/d1-after.json" \
+            --target-version "$RUNNER_TEMP/target-version.json" \
+            --readiness-output "$RUNNER_TEMP/pr108-remote-d1.out" \
+            --runtime-output "$RUNNER_TEMP/pr108-runtime.out" \
+            --dry-run-output "$RUNNER_TEMP/dry-run.out" \
+            --output "$RUNNER_TEMP/production-rollback-rehearsal.json" \
+            > "$RUNNER_TEMP/receipt.stdout"
+          jq -e 'type == "object" and .schemaVersion == "theologai-production-rollback-rehearsal.v1" and .status == "passed" and .trafficMutation == false and .d1Mutation == false and .previewMutation == false and .targetInactiveBefore == true and .targetInactiveAfter == true' "$RUNNER_TEMP/production-rollback-rehearsal.json"
+
+      - name: Upload sanitized rehearsal receipt only
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-rollback-rehearsal-${{ github.run_id }}-attempt-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/production-rollback-rehearsal.json
+          retention-days: 30
+          if-no-files-found: error
+          compression-level: 0
+          overwrite: false
+          include-hidden-files: false

--- a/.github/workflows/production-rollback-rehearsal.yml
+++ b/.github/workflows/production-rollback-rehearsal.yml
@@ -37,14 +37,38 @@ permissions:
   contents: read
 
 jobs:
+  preflight:
+    name: Validate dispatch inputs (unprotected)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: Reject non-main, wrong confirmation, or malformed UUID inputs
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          PRODUCTION_DEPLOYMENT: ${{ inputs.expected_production_deployment_id }}
+          PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
+          PREVIEW_DEPLOYMENT: ${{ inputs.expected_preview_deployment_id }}
+          PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
+        run: |
+          set -euo pipefail
+          test "$DISPATCH_REF" = 'refs/heads/main'
+          test "$CONFIRMATION" = 'REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC'
+          for value in "$PRODUCTION_DEPLOYMENT" "$PRODUCTION_VERSION" "$PREVIEW_DEPLOYMENT" "$PREVIEW_VERSION"; do
+            printf '%s' "$value" | grep -Eiq '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+          done
+
   rehearse:
     name: Rehearse PR108 rollback without traffic
-    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: preflight
+    if: ${{ needs.preflight.result == 'success' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment:
       name: production
-      url: https://mcp.theologai.xyz/mcp
+      deployment: false
     permissions:
       contents: read
     steps:
@@ -70,10 +94,12 @@ jobs:
       - name: Install verifier dependencies
         run: npm ci --no-audit
 
-      - name: Check out exact historical PR108 source separately
+      - name: Verify pinned Wrangler version
         env:
-          PR108_COMMIT: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
-          PR108_TREE: a59d9a062b2e6c7884de97fd97309878e1cbdc23
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-version-logs
+        run: test "$(npx --no-install wrangler --version)" = '4.114.0'
+
+      - name: Check out exact historical PR108 source separately
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
@@ -91,58 +117,125 @@ jobs:
 
       - name: Capture production and preview controls before rehearsal (read-only)
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
           EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
           EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
         run: |
           set -euo pipefail
-          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/d1-before.json"
-          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-before.json"
-          npx --no-install wrangler versions view "$EXPECTED_PRODUCTION_VERSION" --name theologai --json > "$RUNNER_TEMP/production-version-before.json"
-          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-before.json"
-          npx --no-install wrangler versions view "$EXPECTED_PREVIEW_VERSION" --name theologai-preview --env preview --json > "$RUNNER_TEMP/preview-version-before.json"
+          MAX_CAPTURE_BYTES=8388608
+          bounded_json() {
+            stdout="$1"; stderr="$2"; shift 2
+            "$@" > "$stdout" 2> "$stderr"
+            test "$(wc -c < "$stdout")" -le "$MAX_CAPTURE_BYTES"
+            test "$(wc -c < "$stderr")" -le "$MAX_CAPTURE_BYTES"
+          }
+          bounded_json "$RUNNER_TEMP/d1-before.json" "$RUNNER_TEMP/d1-before.stderr" npx --no-install wrangler d1 list --json
+          bounded_json "$RUNNER_TEMP/production-before.json" "$RUNNER_TEMP/production-before.stderr" npx --no-install wrangler deployments list --json
+          bounded_json "$RUNNER_TEMP/production-version-before.json" "$RUNNER_TEMP/production-version-before.stderr" npx --no-install wrangler versions view "$EXPECTED_PRODUCTION_VERSION" --name theologai --json
+          bounded_json "$RUNNER_TEMP/preview-before.json" "$RUNNER_TEMP/preview-before.stderr" npx --no-install wrangler deployments list --env preview --json
+          bounded_json "$RUNNER_TEMP/preview-version-before.json" "$RUNNER_TEMP/preview-version-before.stderr" npx --no-install wrangler versions view "$EXPECTED_PREVIEW_VERSION" --name theologai-preview --env preview --json
 
-      - name: Validate fixed PR108 target and historical local gates (read-only)
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Run historical PR108 local gates without credentials
         run: |
           set -euo pipefail
-          npx --no-install wrangler versions view 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6 --name theologai --json > "$RUNNER_TEMP/target-version.json"
+          MAX_CAPTURE_BYTES=8388608
+          bounded() {
+            output="$1"; shift
+            "$@" > "$output" 2>&1
+            test "$(wc -c < "$output")" -le "$MAX_CAPTURE_BYTES"
+          }
           (
             cd pr108-source
-            npm ci --no-audit > "$RUNNER_TEMP/pr108-npm-ci.out" 2>&1
-            npm run d1:seed:verify-workerd > "$RUNNER_TEMP/pr108-workerd.out" 2>&1
-            npm run test:worker-production-runtime > "$RUNNER_TEMP/pr108-runtime.out" 2>&1
-            npm run d1:remote:check -- --database theologai-production-20260729-transform11-a > "$RUNNER_TEMP/pr108-remote-d1.out" 2>&1
+            bounded "$RUNNER_TEMP/pr108-npm-ci.out" npm ci --no-audit
+            bounded "$RUNNER_TEMP/pr108-workerd.out" npm run d1:seed:verify-workerd
+            bounded "$RUNNER_TEMP/pr108-runtime.out" npm run test:worker-production-runtime
           )
+
+      - name: Capture fixed PR108 Worker/version and deployment proof (read-only)
+        env:
+          CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+          EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
+          EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
+        run: |
+          set -euo pipefail
+          MAX_CAPTURE_BYTES=8388608
+          bounded_json() {
+            stdout="$1"; stderr="$2"; shift 2
+            "$@" > "$stdout" 2> "$stderr"
+            test "$(wc -c < "$stdout")" -le "$MAX_CAPTURE_BYTES"
+            test "$(wc -c < "$stderr")" -le "$MAX_CAPTURE_BYTES"
+          }
+          bounded_json "$RUNNER_TEMP/target-version.json" "$RUNNER_TEMP/target-version.stderr" \
+            npx --no-install wrangler versions view 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6 --name theologai --json
+          curl --fail --silent --show-error --location --max-time 30 --proto '=https' --tlsv1.2 \
+            -H "Authorization: Bearer $CLOUDFLARE_READ_ONLY_API_TOKEN" -H 'Accept: application/json' \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/workers/scripts/theologai/deployments/3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8" \
+            > "$RUNNER_TEMP/target-deployment.json"
+          test "$(wc -c < "$RUNNER_TEMP/target-deployment.json")" -le "$MAX_CAPTURE_BYTES"
+
+      - name: Run fixed PR108 remote readiness (read-only token only)
+        env:
+          CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
+        run: |
+          set -euo pipefail
+          MAX_CAPTURE_BYTES=8388608
+          cd pr108-source
+          npm run d1:remote:check -- --database theologai-production-20260729-transform11-a \
+            > "$RUNNER_TEMP/pr108-remote-d1.out" 2>&1
+          test "$(wc -c < "$RUNNER_TEMP/pr108-remote-d1.out")" -le "$MAX_CAPTURE_BYTES"
 
       - name: Run exact PR108 recovery command in dry-run mode only
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
         run: |
           set -euo pipefail
-          npx --no-install wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --dry-run --yes > "$RUNNER_TEMP/dry-run.out" 2>&1
+          MAX_CAPTURE_BYTES=8388608
+          printf 'DRY_RUN_SENTINEL: fixed-pr108-dry-run\n' > "$RUNNER_TEMP/dry-run.out"
+          npx --no-install wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --config wrangler.release.toml --name theologai --dry-run --yes >> "$RUNNER_TEMP/dry-run.out" 2>&1
+          test "$(wc -c < "$RUNNER_TEMP/dry-run.out")" -le "$MAX_CAPTURE_BYTES"
 
       - name: Capture production and preview controls after rehearsal (read-only)
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_READ_ONLY_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          WRANGLER_LOG_PATH: ${{ runner.temp }}/wrangler-logs
           EXPECTED_PRODUCTION_VERSION: ${{ inputs.expected_production_version_id }}
           EXPECTED_PREVIEW_VERSION: ${{ inputs.expected_preview_version_id }}
         run: |
           set -euo pipefail
-          npx --no-install wrangler d1 list --json > "$RUNNER_TEMP/d1-after.json"
-          npx --no-install wrangler deployments list --json > "$RUNNER_TEMP/production-after.json"
-          npx --no-install wrangler versions view "$EXPECTED_PRODUCTION_VERSION" --name theologai --json > "$RUNNER_TEMP/production-version-after.json"
-          npx --no-install wrangler deployments list --env preview --json > "$RUNNER_TEMP/preview-after.json"
-          npx --no-install wrangler versions view "$EXPECTED_PREVIEW_VERSION" --name theologai-preview --env preview --json > "$RUNNER_TEMP/preview-version-after.json"
+          MAX_CAPTURE_BYTES=8388608
+          bounded_json() {
+            stdout="$1"; stderr="$2"; shift 2
+            "$@" > "$stdout" 2> "$stderr"
+            test "$(wc -c < "$stdout")" -le "$MAX_CAPTURE_BYTES"
+            test "$(wc -c < "$stderr")" -le "$MAX_CAPTURE_BYTES"
+          }
+          bounded_json "$RUNNER_TEMP/d1-after.json" "$RUNNER_TEMP/d1-after.stderr" npx --no-install wrangler d1 list --json
+          bounded_json "$RUNNER_TEMP/production-after.json" "$RUNNER_TEMP/production-after.stderr" npx --no-install wrangler deployments list --json
+          bounded_json "$RUNNER_TEMP/production-version-after.json" "$RUNNER_TEMP/production-version-after.stderr" npx --no-install wrangler versions view "$EXPECTED_PRODUCTION_VERSION" --name theologai --json
+          bounded_json "$RUNNER_TEMP/preview-after.json" "$RUNNER_TEMP/preview-after.stderr" npx --no-install wrangler deployments list --env preview --json
+          bounded_json "$RUNNER_TEMP/preview-version-after.json" "$RUNNER_TEMP/preview-version-after.stderr" npx --no-install wrangler versions view "$EXPECTED_PREVIEW_VERSION" --name theologai-preview --env preview --json
 
       - name: Create bounded sanitized rehearsal receipt
         env:
           CONFIRMATION: ${{ inputs.confirmation }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW: Production Rollback Rehearsal
+          HEAD_SHA: ${{ github.sha }}
+          REF: ${{ github.ref }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          WRANGLER_VERSION: 4.114.0
           SOURCE_COMMIT: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
           SOURCE_TREE: a59d9a062b2e6c7884de97fd97309878e1cbdc23
           EXPECTED_PRODUCTION_DEPLOYMENT: ${{ inputs.expected_production_deployment_id }}
@@ -153,6 +246,13 @@ jobs:
           set -euo pipefail
           npx --no-install tsx scripts/production-rollback-rehearsal.ts create \
             --confirmation "$CONFIRMATION" \
+            --repository "$REPOSITORY" \
+            --workflow "$WORKFLOW" \
+            --head-sha "$HEAD_SHA" \
+            --ref "$REF" \
+            --run-id "$RUN_ID" \
+            --run-attempt "$RUN_ATTEMPT" \
+            --wrangler-version "$WRANGLER_VERSION" \
             --source-commit "$SOURCE_COMMIT" \
             --source-tree "$SOURCE_TREE" \
             --expected-production-deployment "$EXPECTED_PRODUCTION_DEPLOYMENT" \
@@ -170,12 +270,15 @@ jobs:
             --d1-before "$RUNNER_TEMP/d1-before.json" \
             --d1-after "$RUNNER_TEMP/d1-after.json" \
             --target-version "$RUNNER_TEMP/target-version.json" \
+            --target-deployment "$RUNNER_TEMP/target-deployment.json" \
             --readiness-output "$RUNNER_TEMP/pr108-remote-d1.out" \
             --runtime-output "$RUNNER_TEMP/pr108-runtime.out" \
             --dry-run-output "$RUNNER_TEMP/dry-run.out" \
+            --npm-install-output "$RUNNER_TEMP/pr108-npm-ci.out" \
+            --workerd-output "$RUNNER_TEMP/pr108-workerd.out" \
             --output "$RUNNER_TEMP/production-rollback-rehearsal.json" \
             > "$RUNNER_TEMP/receipt.stdout"
-          jq -e 'type == "object" and .schemaVersion == "theologai-production-rollback-rehearsal.v1" and .status == "passed" and .trafficMutation == false and .d1Mutation == false and .previewMutation == false and .targetInactiveBefore == true and .targetInactiveAfter == true' "$RUNNER_TEMP/production-rollback-rehearsal.json"
+          jq -e 'type == "object" and .schemaVersion == "theologai-production-rollback-rehearsal.v1" and .status == "passed" and .trafficMutation == false and .d1Mutation == false and .previewMutation == false and .targetInactiveBefore == true and .targetInactiveAfter == true and (.exitStatuses | to_entries | all(.value == 0))' "$RUNNER_TEMP/production-rollback-rehearsal.json"
 
       - name: Upload sanitized rehearsal receipt only
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/D1-DATA-WORKFLOW.md
+++ b/docs/D1-DATA-WORKFLOW.md
@@ -133,6 +133,13 @@ deployment.
 
 ### Readiness compatibility and rollback
 
+The protected [production rollback rehearsal](PRODUCTION-ROLLBACK-REHEARSAL.md)
+is the required read-only proof for the retained PR #108 matched pair. It
+checks the fixed Worker version and D1 name/UUID independently, plus unchanged
+production and preview control identities before and after a dry-run recovery
+command. It does not mutate traffic or D1 and does not replace the normal
+production approval gate.
+
 The deploy readiness query requires the current schema and corpus identity
 markers, including `theologai_metadata`, in addition to integrity, foreign-key,
 index, column-signature, and exact manifest-count checks. A predecessor D1
@@ -156,6 +163,16 @@ retention, exact Worker revision, and readiness compatibility through a
 read-only inventory/check. If retention or compatibility has not been verified,
 document the target as candidate/unverified. Database deletion remains a later,
 separately authorized operation after the retention window and rollback review.
+
+Retention is conservative and review-only: keep the active D1, the immediate
+same-D1 Worker predecessor, and the two newest cross-schema matched
+generations. No automatic deletion is permitted. A database becomes only
+review-eligible after two newer matched generations, a fresh successful
+rehearsal, 30 days of current-release stability, no active bindings, proven
+reconstruction/compatibility, and exact owner authorization naming the database
+name and UUID. Review quarterly, initially with the `2026-11-15` H1
+reassessment; delete at most one explicitly authorized database per operation.
+H1 GitHub artifact expiry remains a separate policy.
 
 ### Schema-0009 preview-release preparation record
 

--- a/docs/PHASE-3B-PLAN.md
+++ b/docs/PHASE-3B-PLAN.md
@@ -174,6 +174,24 @@ review.
 
 ## Release order
 
+### 3B.0 closure implementation — C1
+
+The remaining closure implementation adds the protected, read-only production
+rollback rehearsal in [the rollback runbook](PRODUCTION-ROLLBACK-REHEARSAL.md).
+It is workflow-dispatch-only from `main`, uses the `production` environment
+and `deploy-production` concurrency group, pins the PR #108 source/tree and
+Worker/D1 target, and records only sanitized hashes. The rehearsal itself is
+pending and must be executed after the consolidated production release. A
+later Markdown-only reconciliation (C2) records the actual run; this section
+does not update `CURRENT-RELEASE`.
+
+The retention decision is conservative: active D1, immediate same-D1 Worker
+predecessor, and two newest cross-schema matched generations are retained; no
+automatic deletion. Review eligibility requires two newer matched generations,
+a fresh rehearsal, 30 days of stability, no active binding, reconstruction and
+compatibility proof, and exact owner authorization. Quarterly review begins
+with the `2026-11-15` H1 reassessment, independently of H1 artifact expiry.
+
 The default critical path is:
 
 ```text

--- a/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
+++ b/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
@@ -54,7 +54,9 @@ read-only Cloudflare deployment-ID endpoint rather than relying on a truncated
 deployment list. It checks out the fixed source in a separate directory and runs its
 historical `npm ci`, local Workerd seed/readiness, production-like Worker
 runtime, and remote D1 readiness checks. Raw Wrangler output stays in runner
-temporary storage. Only the bounded, hash-only receipt is uploaded.
+temporary storage. The committed dependency-free `scripts/capture-bounded-command.mjs`
+runner is used before and after dependency installation, so output capture does
+not depend on `node_modules`. Only the bounded, hash-only receipt is uploaded.
 
 The sole recovery command is:
 

--- a/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
+++ b/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
@@ -1,0 +1,104 @@
+# Production rollback rehearsal
+
+<!-- theologai-release-authority v1 role=rollback-rehearsal-runbook current=docs/CURRENT-RELEASE.md -->
+
+This runbook defines the protected, read-only rehearsal for the matched PR
+#108 Worker/D1 rollback pair. The rehearsal execution is **pending**; this
+document records the capability and its acceptance criteria, not a claim that
+the rehearsal has passed.
+
+## Fixed recovery target
+
+The target is code-owned and cannot be selected by a workflow input:
+
+| Identity | Exact value |
+| --- | --- |
+| Source commit | `8da99fd0a161b90a4bd90ab29bde1abf796b3bf6` |
+| Source tree | `a59d9a062b2e6c7884de97fd97309878e1cbdc23` |
+| Cloudflare deployment | `3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8` |
+| Worker version | `291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` |
+| D1 name | `theologai-production-20260729-transform11-a` |
+| D1 UUID | `53211f50-a893-4b4c-be1e-bc625a595dc7` |
+
+The historical source and target version are validated independently. A
+Worker version contains code, configuration, and bindings; it does not
+snapshot D1 contents. The rehearsal therefore validates the target D1 name
+and UUID in a fresh read-only inventory and validates the Worker’s
+`THEOLOGAI_DB` binding separately.
+
+## Protected workflow
+
+Run `Production Rollback Rehearsal` only from `main`, while the normal
+`deploy-production` concurrency lock is respected, and only after the
+`production` environment approves the job. The operator supplies the exact
+current production and preview deployment/version UUIDs observed immediately
+before dispatch, then types:
+
+```text
+REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC
+```
+
+The workflow captures production and preview deployments and authoritative
+version views before and after the rehearsal, plus a D1 inventory before and
+after. It checks out the fixed source in a separate directory and runs its
+historical `npm ci`, local Workerd seed/readiness, production-like Worker
+runtime, and remote D1 readiness checks. Raw Wrangler output stays in runner
+temporary storage. Only the bounded, hash-only receipt is uploaded.
+
+The sole recovery command is:
+
+```text
+wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --dry-run --yes
+```
+
+The workflow has no `rollback`, version upload, ordinary deploy, trigger,
+secret, D1 write, binding, route, DNS, or deletion command. `--dry-run` is
+required by both the workflow topology test and the receipt verifier. A
+successful rehearsal proves target availability, compatibility, binding
+integrity, and recovery-command validity; it does not test live failover.
+
+## Fail-closed acceptance criteria
+
+The receipt is accepted only when all of the following remain true:
+
+- the fixed source commit/tree and Worker/D1 target identities match exactly;
+- the target Worker version is inactive in both production and preview before
+  and after the run;
+- the target version has exactly one `THEOLOGAI_DB` D1 binding to the fixed
+  UUID, and the inventory maps the fixed name to that UUID;
+- production and preview deployment/version identities match the expected
+  inputs before and after;
+- active production and preview D1 bindings are unchanged before and after;
+- the D1 inventory mapping is unchanged before and after;
+- all historical local and remote readiness commands succeed; and
+- the receipt reports `trafficMutation=false`, `d1Mutation=false`, and
+  `previewMutation=false`.
+
+Any missing target, identity drift, malformed control-plane response, failed
+readiness check, or unavailable dry-run command fails the run. No automatic
+fallback to PR #101 is permitted.
+
+## Evidence and retention
+
+The uploaded receipt contains exact target/current identities, boolean safety
+claims, and SHA-256 hashes of private captures and command output. It does not
+contain source text, SQL, Wrangler JSON, request metadata, or credentials.
+The receipt artifact is retained for 30 days; the H1 deployment-plan artifact
+expiry policy remains separate.
+
+The remote retention policy is conservative and review-only:
+
+1. Retain the active production D1.
+2. Retain the immediate same-D1 Worker predecessor.
+3. Retain the two newest cross-schema matched generations. At this baseline,
+   those are schema-`0009`, PR #108 Transform-11, and the PR #101 hierarchy
+   generation as the older matched record.
+4. Never delete automatically. A D1 is only review-eligible after two newer
+   matched generations exist, the newest fallback has passed a fresh
+   rehearsal, the current release has been stable for at least 30 days, fresh
+   inventories show no active binding, reconstruction and compatibility are
+   proven, and the owner authorizes the exact name and UUID.
+5. Review quarterly, initially aligned to the `2026-11-15` H1 reassessment.
+   Delete at most one explicitly authorized database at a time; never use a
+   glob or batch cleanup.
+

--- a/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
+++ b/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
@@ -56,7 +56,12 @@ historical `npm ci`, local Workerd seed/readiness, production-like Worker
 runtime, and remote D1 readiness checks. Raw Wrangler output stays in runner
 temporary storage. The committed dependency-free `scripts/capture-bounded-command.mjs`
 runner is used before and after dependency installation, so output capture does
-not depend on `node_modules`. Only the bounded, hash-only receipt is uploaded.
+not depend on `node_modules`. The runner uses a detached, dependency-free
+supervisor with a parent acknowledgement handshake: it closes both capture
+streams and reports the child status before the supervisor exits, while an
+overflow or capture failure leaves the supervisor pinned in its process group
+for bounded TERM-to-KILL cleanup. Only the bounded, hash-only receipt is
+uploaded.
 
 The sole recovery command is:
 

--- a/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
+++ b/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
@@ -7,6 +7,13 @@ This runbook defines the protected, read-only rehearsal for the matched PR
 document records the capability and its acceptance criteria, not a claim that
 the rehearsal has passed.
 
+Before execution, the protected `production` environment must provision a
+dedicated `CLOUDFLARE_READ_ONLY_API_TOKEN` with only the read permissions
+needed for Worker versions/deployments and D1 inventory. The protected job is
+marked `deployment: false` because it must not create a deployment record. The
+workflow never uses the normal deployment token, and credential-free historical
+checkout and local gates receive no Cloudflare credential.
+
 ## Fixed recovery target
 
 The target is code-owned and cannot be selected by a workflow input:
@@ -40,7 +47,9 @@ REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC
 
 The workflow captures production and preview deployments and authoritative
 version views before and after the rehearsal, plus a D1 inventory before and
-after. It checks out the fixed source in a separate directory and runs its
+after. It retrieves the fixed historical deployment through the exact
+read-only Cloudflare deployment-ID endpoint rather than relying on a truncated
+deployment list. It checks out the fixed source in a separate directory and runs its
 historical `npm ci`, local Workerd seed/readiness, production-like Worker
 runtime, and remote D1 readiness checks. Raw Wrangler output stays in runner
 temporary storage. Only the bounded, hash-only receipt is uploaded.
@@ -48,7 +57,7 @@ temporary storage. Only the bounded, hash-only receipt is uploaded.
 The sole recovery command is:
 
 ```text
-wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --dry-run --yes
+wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --config wrangler.release.toml --name theologai --dry-run --yes
 ```
 
 The workflow has no `rollback`, version upload, ordinary deploy, trigger,
@@ -101,4 +110,3 @@ The remote retention policy is conservative and review-only:
 5. Review quarterly, initially aligned to the `2026-11-15` H1 reassessment.
    Delete at most one explicitly authorized database at a time; never use a
    glob or batch cleanup.
-

--- a/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
+++ b/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
@@ -8,11 +8,13 @@ document records the capability and its acceptance criteria, not a claim that
 the rehearsal has passed.
 
 Before execution, the protected `production` environment must provision a
-dedicated `CLOUDFLARE_READ_ONLY_API_TOKEN` with only the read permissions
-needed for Worker versions/deployments and D1 inventory. The protected job is
-marked `deployment: false` because it must not create a deployment record. The
-workflow never uses the normal deployment token, and credential-free historical
-checkout and local gates receive no Cloudflare credential.
+dedicated `CLOUDFLARE_READ_ONLY_API_TOKEN` with exactly these account-scoped
+permissions: `Workers Scripts Read` and `D1 Read`; no additional permissions
+or account grants are allowed. The protected job is marked `deployment: false`
+because it must not create a deployment record. Wrangler receives this secret only through its
+`CLOUDFLARE_API_TOKEN` environment variable in authenticated read-only steps.
+The workflow never uses the normal deployment token, and credential-free
+historical checkout and local gates receive no Cloudflare credential.
 
 ## Fixed recovery target
 
@@ -99,9 +101,9 @@ The remote retention policy is conservative and review-only:
 
 1. Retain the active production D1.
 2. Retain the immediate same-D1 Worker predecessor.
-3. Retain the two newest cross-schema matched generations. At this baseline,
-   those are schema-`0009`, PR #108 Transform-11, and the PR #101 hierarchy
-   generation as the older matched record.
+3. Retain the two newest older cross-schema matched generations. schema-`0009` is active;
+   the two retained older cross-schema matched generations are PR #108 Transform-11
+   and PR #101 hierarchy.
 4. Never delete automatically. A D1 is only review-eligible after two newer
    matched generations exist, the newest fallback has passed a fresh
    rehearsal, the current release has been stable for at least 30 days, fresh

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -838,6 +838,12 @@ Code readiness and operational readiness are deliberately separate:
   contract materially helps agents, retaining backward-compatible Markdown.
 - Rehearse matched Worker/D1 rollback and define retention policy before any
   predecessor database cleanup.
+- C1 implements the protected, read-only [production rollback rehearsal](PRODUCTION-ROLLBACK-REHEARSAL.md)
+  for the fixed PR #108 matched pair. Execution remains pending; only a
+  sanitized hash receipt may be retained. The active D1, immediate same-D1
+  Worker predecessor, and two newest cross-schema generations remain retained;
+  deletion is never automatic and requires the documented 30-day, fresh-
+  rehearsal, no-binding, reconstruction, compatibility, and exact-owner gates.
 - Revisit the parked public-edge traffic issue: a Frankfurt/AWS client has
   generated sustained anonymous production invocations. The custom domain and
   ordinary-request PR #72 legacy-host redirect are already deployed. Any

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -16,9 +16,13 @@ environment. Its fixed PR #108 target is Worker version
 (`53211f50-a893-4b4c-be1e-bc625a595dc7`). The rehearsal execution remains
 pending. It captures both environments before and after, runs the historical
 readiness/runtime gates, and permits only
-`versions deploy <fixed>@100 --dry-run --yes`; no rollback, D1, binding,
+`versions deploy <fixed>@100 --config wrangler.release.toml --name theologai --dry-run --yes`; no rollback, D1, binding,
 route, secret, or deletion command is present. Only a bounded hash-only receipt
 is uploaded. See [the full runbook](PRODUCTION-ROLLBACK-REHEARSAL.md).
+
+Provision the dedicated `CLOUDFLARE_READ_ONLY_API_TOKEN` in the protected
+environment before execution; historical checkout and local gates receive no
+Cloudflare credential.
 
 Retain the active D1, immediate same-D1 Worker predecessor, and two newest
 cross-schema matched generations. Deletion is never automatic and is only

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -21,7 +21,10 @@ route, secret, or deletion command is present. Only a bounded hash-only receipt
 is uploaded. See [the full runbook](PRODUCTION-ROLLBACK-REHEARSAL.md).
 
 Provision the dedicated `CLOUDFLARE_READ_ONLY_API_TOKEN` in the protected
-environment before execution; historical checkout and local gates receive no
+environment before execution with exactly the account-scoped `Workers Scripts
+Read` and `D1 Read` permissions; no additional permissions or account grants
+are allowed. The workflow aliases it to Wrangler's `CLOUDFLARE_API_TOKEN` variable only in
+authenticated read-only steps. Historical checkout and local gates receive no
 Cloudflare credential.
 
 Retain the active D1, immediate same-D1 Worker predecessor, and two newest
@@ -30,6 +33,9 @@ review-eligible after two newer matched generations, a fresh rehearsal, 30
 stable days, no active bindings, reconstruction/compatibility proof, and exact
 owner authorization. Review quarterly with the `2026-11-15` H1 reassessment;
 H1 artifact expiry is separate.
+
+Schema-`0009` is active; the two retained older cross-schema matched
+generations are PR #108 Transform-11 and PR #101 hierarchy.
 
 ## Historical PR #122 live baseline
 

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -6,6 +6,27 @@ The [current release snapshot](CURRENT-RELEASE.md) is the designated current
 snapshot for this operations document. The dated records below retain release
 evidence and are not current identity authority.
 
+## Production rollback rehearsal capability
+
+The protected `Production Rollback Rehearsal` workflow is manual, main-only,
+serialized with `deploy-production`, and bound to the protected `production`
+environment. Its fixed PR #108 target is Worker version
+`291f3292-3fa9-44fc-bf6f-b68fd2f4cef6` and D1
+`theologai-production-20260729-transform11-a`
+(`53211f50-a893-4b4c-be1e-bc625a595dc7`). The rehearsal execution remains
+pending. It captures both environments before and after, runs the historical
+readiness/runtime gates, and permits only
+`versions deploy <fixed>@100 --dry-run --yes`; no rollback, D1, binding,
+route, secret, or deletion command is present. Only a bounded hash-only receipt
+is uploaded. See [the full runbook](PRODUCTION-ROLLBACK-REHEARSAL.md).
+
+Retain the active D1, immediate same-D1 Worker predecessor, and two newest
+cross-schema matched generations. Deletion is never automatic and is only
+review-eligible after two newer matched generations, a fresh rehearsal, 30
+stable days, no active bindings, reconstruction/compatibility proof, and exact
+owner authorization. Review quarterly with the `2026-11-15` H1 reassessment;
+H1 artifact expiry is separate.
+
 ## Historical PR #122 live baseline
 
 The integrated checked-out normal build excludes the Transform-10 Aquinas

--- a/scripts/capture-bounded-command.d.mts
+++ b/scripts/capture-bounded-command.d.mts
@@ -1,0 +1,30 @@
+export interface BoundedCommandOptions {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdoutPath: string;
+  stderrPath: string;
+  maxBytes?: number;
+  stdoutPrefix?: string;
+  openCapture?: (path: string) => Promise<{ write: (value: Buffer) => Promise<unknown>; close: () => Promise<unknown> }>;
+}
+
+export interface BoundedCommandResult {
+  schemaVersion: 'theologai-bounded-command.v1';
+  exitStatus: number | null;
+  signal: NodeJS.Signals | null;
+  overflow: boolean;
+  stdoutBytes: number;
+  stderrBytes: number;
+  stdoutSha256: string;
+  stderrSha256: string;
+}
+
+export declare class BoundedCommandError extends Error {
+  readonly result: BoundedCommandResult;
+}
+
+export declare const DEFAULT_MAX_CAPTURE_BYTES: number;
+export declare function runBoundedCommand(options: BoundedCommandOptions): Promise<BoundedCommandResult>;
+export declare function isBoundedCommandResult(value: unknown): value is BoundedCommandResult;

--- a/scripts/capture-bounded-command.d.mts
+++ b/scripts/capture-bounded-command.d.mts
@@ -8,6 +8,7 @@ export interface BoundedCommandOptions {
   maxBytes?: number;
   stdoutPrefix?: string;
   openCapture?: (path: string) => Promise<{ write: (value: Buffer) => Promise<unknown>; close: () => Promise<unknown> }>;
+  /** Receives the positive process-group ID; the default sends to -processGroupId. */
   signalGroup?: (processGroupId: number, signal: NodeJS.Signals) => void;
   signalChild?: (child: unknown, signal: NodeJS.Signals) => boolean;
 }

--- a/scripts/capture-bounded-command.d.mts
+++ b/scripts/capture-bounded-command.d.mts
@@ -1,6 +1,6 @@
 export interface BoundedCommandOptions {
   command: string;
-  args: string[];
+  args?: string[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   stdoutPath: string;
@@ -8,6 +8,8 @@ export interface BoundedCommandOptions {
   maxBytes?: number;
   stdoutPrefix?: string;
   openCapture?: (path: string) => Promise<{ write: (value: Buffer) => Promise<unknown>; close: () => Promise<unknown> }>;
+  signalGroup?: (processGroupId: number, signal: NodeJS.Signals) => void;
+  signalChild?: (child: unknown, signal: NodeJS.Signals) => boolean;
 }
 
 export interface BoundedCommandResult {
@@ -22,9 +24,9 @@ export interface BoundedCommandResult {
 }
 
 export declare class BoundedCommandError extends Error {
+  constructor(result: BoundedCommandResult);
   readonly result: BoundedCommandResult;
 }
 
 export declare const DEFAULT_MAX_CAPTURE_BYTES: number;
 export declare function runBoundedCommand(options: BoundedCommandOptions): Promise<BoundedCommandResult>;
-export declare function isBoundedCommandResult(value: unknown): value is BoundedCommandResult;

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -268,14 +268,24 @@ async function consume(stream, handle, maxBytes, onOverflow, onCaptureFailure, i
       const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
       const remaining = maxBytes - state.bytes;
       if (chunk.byteLength > remaining) {
+        state.overflow = true;
+        // Start group termination before waiting on the final bounded write;
+        // a slow or wedged sink must not postpone killing an overflowing
+        // producer. The write is still given a bounded chance to preserve the
+        // deterministic prefix already within the byte budget.
+        const terminationPromise = onOverflow();
         if (remaining > 0) {
           const prefix = chunk.subarray(0, remaining);
-          await handle.write(prefix);
-          state.digest.update(prefix);
-          state.bytes += prefix.byteLength;
+          try {
+            await boundedAwait(handle.write(prefix), TERMINATION_TIMEOUT_MS, 'bounded command overflow prefix write timed out');
+            state.digest.update(prefix);
+            state.bytes += prefix.byteLength;
+          } catch {
+            // Overflow remains the primary result; termination and stream
+            // cleanup are handled by the outer runner.
+          }
         }
-        state.overflow = true;
-        await onOverflow();
+        await terminationPromise;
         break;
       }
       await handle.write(chunk);

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -194,6 +194,18 @@ function captureSnapshot(state) {
   return { bytes: state.bytes, hash: state.digest.copy().digest('hex'), overflow: state.overflow };
 }
 
+async function sendSupervisorMessage(message) {
+  if (typeof process.send !== 'function' || !process.connected) return false;
+  try {
+    await boundedAwait(new Promise((resolve, reject) => {
+      process.send(message, error => error ? reject(error) : resolve());
+    }), TERMINATION_TIMEOUT_MS, 'bounded command supervisor message timed out');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function relay(source, destination) {
   return new Promise(resolve => {
     let settled = false;
@@ -203,6 +215,7 @@ function relay(source, destination) {
       resolve();
     };
     source.once('end', finish);
+    source.once('close', finish);
     source.once('error', () => {
       source.destroy();
       finish();
@@ -216,6 +229,10 @@ function relay(source, destination) {
 }
 
 async function supervisor(argv) {
+  let commandProcess;
+  let stdoutRelay;
+  let stderrRelay;
+  try {
   const separator = argv.indexOf('--');
   assert(separator >= 0, 'supervisor command separator -- is required');
   const flags = argv.slice(0, separator);
@@ -251,11 +268,11 @@ async function supervisor(argv) {
   process.stdout.on('error', () => undefined);
   process.stderr.on('error', () => undefined);
 
-  const commandProcess = spawn(command, args, {
+  commandProcess = spawn(command, args, {
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  const stdoutRelay = relay(commandProcess.stdout, process.stdout);
-  const stderrRelay = relay(commandProcess.stderr, process.stderr);
+  stdoutRelay = relay(commandProcess.stdout, process.stdout);
+  stderrRelay = relay(commandProcess.stderr, process.stderr);
   const [exitStatus, signal] = await new Promise((resolve, reject) => {
     commandProcess.once('error', reject);
     commandProcess.once('close', (code, childSignal) => resolve([code, childSignal]));
@@ -299,6 +316,20 @@ async function supervisor(argv) {
   }
   process.disconnect();
   process.exit(exitStatus ?? 0);
+  } catch (error) {
+    destroy(commandProcess?.stdout);
+    destroy(commandProcess?.stderr);
+    await settleWithin([stdoutRelay, stderrRelay].filter(Boolean));
+    try { process.stdout.end(); } catch { /* failure cleanup is best effort */ }
+    try { process.stderr.end(); } catch { /* failure cleanup is best effort */ }
+    await sendSupervisorMessage({
+      type: 'failure',
+      message: error instanceof Error ? error.message : String(error),
+    });
+    process.removeAllListeners('message');
+    try { process.disconnect(); } catch { /* IPC cleanup is best effort */ }
+    process.exit(1);
+  }
 }
 
 async function waitForCompletionOrTermination(completionPromise, exitPromise, isTerminating) {
@@ -427,6 +458,12 @@ export async function runBoundedCommand(options) {
     exitPromise.then(outcome => { observedOutcome = outcome; }, () => undefined);
     const completionPromise = new Promise((resolve, reject) => {
       const onMessage = message => {
+        if (message?.type === 'failure' && typeof message.message === 'string' && message.message.length > 0) {
+          const failure = new Error(`bounded command supervisor failed: ${message.message}`);
+          failure.controlledSupervisorFailure = true;
+          reject(failure);
+          return;
+        }
         if (!message || message.type !== 'completion'
           || !isOutcome(message.exitStatus, message.signal)) {
           reject(new Error('bounded command supervisor completion is malformed'));
@@ -458,7 +495,7 @@ export async function runBoundedCommand(options) {
         captures = await capturesPromise;
       }
     } catch (error) {
-      await requestTermination(false);
+      if (!error?.controlledSupervisorFailure) await requestTermination(false);
       await settleWithin([exitPromise, completionPromise, capturesPromise]);
       throw error;
     }
@@ -488,7 +525,7 @@ export async function runBoundedCommand(options) {
     if (result.overflow || result.exitStatus !== 0) throw new BoundedCommandError(result);
     return result;
   } catch (error) {
-    await requestTermination(false);
+    if (!error?.controlledSupervisorFailure) await requestTermination(false);
     if (child) {
       await settleWithin([new Promise(resolve => {
         if (!alive(child)) {
@@ -497,6 +534,7 @@ export async function runBoundedCommand(options) {
         }
         child.once('exit', resolve);
       })]);
+      if (error?.controlledSupervisorFailure && alive(child)) detachChild(child);
     }
     throw error;
   } finally {

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -40,8 +40,14 @@ function signalProcessGroup(child, processGroupId, signal) {
     // an output overflow. A negative PID targets the complete process group.
     process.kill(-processGroupId, signal);
   } catch (error) {
-    if (error?.code !== 'ESRCH' && alive(child)) child.kill(signal);
+    if (error?.code !== 'ESRCH' && alive(child)) {
+      try { child.kill(signal); } catch { /* the process may have exited */ }
+    }
   }
+}
+
+function destroy(stream) {
+  try { stream?.destroy(); } catch { /* cleanup must remain best-effort */ }
 }
 
 async function terminate(child, processGroupId) {
@@ -52,8 +58,8 @@ async function terminate(child, processGroupId) {
   signalProcessGroup(child, processGroupId, 'SIGKILL');
   // A descendant that inherited a pipe must not hold the parent close event
   // open indefinitely after the process group has been signalled.
-  child.stdout?.destroy();
-  child.stderr?.destroy();
+  destroy(child.stdout);
+  destroy(child.stderr);
   await new Promise(resolve => setTimeout(resolve, 25));
 }
 
@@ -88,11 +94,19 @@ async function supervisor(argv) {
   assert(typeof command === 'string' && command.length > 0, 'supervisor command is required');
 
   let signalRequested = false;
+  let keeper;
+  const keepAliveAfterTermination = () => {
+    signalRequested = true;
+    // This referenced handle deliberately remains alive until the outer
+    // runner's SIGKILL. It pins the supervisor's process group after the
+    // requested command and its relays have closed.
+    keeper ??= setInterval(() => undefined, 1_000_000_000);
+  };
   // The supervisor is the stable process-group leader. It must not exit when
   // the group receives SIGTERM; the outer runner escalates to SIGKILL after
   // its grace interval if output overflow is still being handled.
-  process.on('SIGTERM', () => { signalRequested = true; });
-  process.on('SIGINT', () => { signalRequested = true; });
+  process.on('SIGTERM', keepAliveAfterTermination);
+  process.on('SIGINT', keepAliveAfterTermination);
   process.stdout.on('error', () => undefined);
   process.stderr.on('error', () => undefined);
 
@@ -110,12 +124,14 @@ async function supervisor(argv) {
   // process group until the outer runner can observe all output.
   await Promise.all([stdoutRelay, stderrRelay]);
   if (signal) {
+    if (signalRequested) await new Promise(() => undefined);
     process.removeAllListeners('SIGTERM');
     process.removeAllListeners('SIGINT');
     process.kill(process.pid, signal);
     return;
   }
-  process.exit(exitStatus ?? (signalRequested ? 1 : 0));
+  if (signalRequested) await new Promise(() => undefined);
+  process.exitCode = exitStatus ?? 0;
 }
 
 async function exitAfterTermination(exitPromise, termination) {
@@ -137,7 +153,7 @@ async function exitAfterTermination(exitPromise, termination) {
   return Promise.race([exitPromise, waitForTermination()]);
 }
 
-async function consume(stream, handle, maxBytes, onOverflow, isTerminating, initial = Buffer.alloc(0)) {
+async function consume(stream, handle, maxBytes, onOverflow, onCaptureFailure, isTerminating, initial = Buffer.alloc(0)) {
   const digest = createHash('sha256');
   digest.update(initial);
   let bytes = initial.byteLength;
@@ -164,7 +180,7 @@ async function consume(stream, handle, maxBytes, onOverflow, isTerminating, init
   } catch (error) {
     // The peer stream is destroyed when the other stream overflows. This is
     // expected cleanup, not a successful uncapped command.
-    if (!isTerminating()) throw error;
+    if (!isTerminating()) await onCaptureFailure(error);
   }
   return { bytes, hash: digest.digest('hex'), overflow };
 }
@@ -176,26 +192,33 @@ export async function runBoundedCommand(options) {
   const prefix = Buffer.from(options.stdoutPrefix ?? '', 'utf8');
   assert(prefix.byteLength <= maxBytes, 'stdout prefix exceeds maxBytes');
 
-  const stdout = await open(options.stdoutPath, 'wx');
+  const openCapture = options.openCapture ?? (path => open(path, 'wx'));
+  const stdout = await openCapture(options.stdoutPath);
   let stderr;
   try {
-    stderr = await open(options.stderrPath, 'wx');
+    stderr = await openCapture(options.stderrPath);
   } catch (error) {
     await stdout.close();
     throw error;
   }
-  if (prefix.byteLength > 0) await stdout.write(prefix);
   let child;
   let processGroupId;
   let overflow = false;
   let termination;
-  const stop = async () => {
-    overflow = true;
+  let captureFailure;
+  const requestTermination = (isOverflow) => {
+    if (isOverflow) overflow = true;
     if (!termination && child && processGroupId) termination = terminate(child, processGroupId);
-    await termination;
+    return termination ?? Promise.resolve();
+  };
+  const stop = () => requestTermination(true);
+  const onCaptureFailure = error => {
+    captureFailure ??= error;
+    return requestTermination(false);
   };
 
   try {
+    if (prefix.byteLength > 0) await stdout.write(prefix);
     child = spawn(process.execPath, [
       fileURLToPath(import.meta.url),
       '--supervise',
@@ -212,12 +235,25 @@ export async function runBoundedCommand(options) {
       childProcess.once('exit', (code, signal) => resolve([code, signal]));
       childProcess.once('error', reject);
     });
-    const stdoutPromise = consume(childProcess.stdout, stdout, maxBytes, stop, () => overflow, prefix);
-    const stderrPromise = consume(childProcess.stderr, stderr, maxBytes, stop, () => overflow);
-    const [exitStatus, signal] = await exitAfterTermination(exitPromise, () => termination);
+    const stdoutPromise = consume(childProcess.stdout, stdout, maxBytes, stop, onCaptureFailure, () => overflow, prefix);
+    const stderrPromise = consume(childProcess.stderr, stderr, maxBytes, stop, onCaptureFailure, () => overflow);
+    const capturesPromise = Promise.all([stdoutPromise, stderrPromise]);
+    let outcome;
+    let captures;
+    try {
+      [outcome, captures] = await Promise.all([
+        exitAfterTermination(exitPromise, () => termination),
+        capturesPromise,
+      ]);
+    } catch (error) {
+      await requestTermination(false);
+      await Promise.allSettled([exitPromise, capturesPromise]);
+      throw error;
+    }
     await termination;
-    const stdoutResult = await stdoutPromise;
-    const stderrResult = await stderrPromise;
+    const [exitStatus, signal] = outcome;
+    const [stdoutResult, stderrResult] = captures;
+    if (captureFailure) throw captureFailure;
     const result = {
       schemaVersion: 'theologai-bounded-command.v1',
       exitStatus,
@@ -230,6 +266,9 @@ export async function runBoundedCommand(options) {
     };
     if (result.overflow || result.exitStatus !== 0) throw new BoundedCommandError(result);
     return result;
+  } catch (error) {
+    await requestTermination(false);
+    throw error;
   } finally {
     await Promise.allSettled([stdout.close(), stderr.close()]);
   }

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -61,12 +61,16 @@ function alive(child) {
   return child.exitCode === null && child.signalCode === null;
 }
 
-function signalProcessGroup(child, processGroupId, signal, signalGroup = process.kill) {
+function defaultSignalGroup(processGroupId, signal) {
+  process.kill(-processGroupId, signal);
+}
+
+function signalProcessGroup(child, processGroupId, signal, signalGroup = defaultSignalGroup) {
   if (!processGroupId) return;
   try {
     // Detached children form their own group, so descendants cannot survive
     // an output overflow. A negative PID targets the complete process group.
-    signalGroup(-processGroupId, signal);
+    signalGroup(processGroupId, signal);
     return true;
   } catch (error) {
     return false;
@@ -86,7 +90,7 @@ function destroy(stream) {
   try { stream?.destroy(); } catch { /* cleanup must remain best-effort */ }
 }
 
-async function terminate(child, processGroupId, signalGroup = process.kill, signaler = (target, signal) => {
+async function terminate(child, processGroupId, signalGroup = defaultSignalGroup, signaler = (target, signal) => {
   if (!alive(target)) return false;
   try { return target.kill(signal); } catch { return false; }
 }) {
@@ -136,6 +140,34 @@ function sendAck(child) {
       reject(error);
     }
   });
+}
+
+function sendAbort(child) {
+  return new Promise((resolve, reject) => {
+    if (!child.connected || typeof child.send !== 'function') {
+      resolve(false);
+      return;
+    }
+    try {
+      child.send({ type: 'abort' }, error => error ? reject(error) : resolve(true));
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function abortSupervisor(child, exitPromise) {
+  try {
+    await boundedAwait(sendAbort(child), TERMINATION_TIMEOUT_MS, 'bounded command supervisor abort send timed out');
+  } catch {
+    return;
+  }
+  try {
+    await boundedAwait(exitPromise, TERMINATION_TIMEOUT_MS, 'bounded command supervisor abort exit timed out');
+  } catch {
+    // The outer runner remains bounded even if the supervisor cannot report
+    // its final OS-level exit after self-terminating the stable group.
+  }
 }
 
 function captureState(initial = Buffer.alloc(0)) {
@@ -192,6 +224,16 @@ async function supervisor(argv) {
   // its grace interval if output overflow is still being handled.
   process.on('SIGTERM', keepAliveAfterTermination);
   process.on('SIGINT', keepAliveAfterTermination);
+  process.on('message', message => {
+    if (message?.type !== 'abort') return;
+    // This signal originates inside the still-live supervisor, so its own
+    // process group identity is stable and cannot refer to a reused PGID.
+    try {
+      process.kill(-process.pid, 'SIGKILL');
+    } catch {
+      try { process.kill(process.pid, 'SIGKILL'); } catch { /* best effort */ }
+    }
+  });
   process.stdout.on('error', () => undefined);
   process.stderr.on('error', () => undefined);
 
@@ -234,12 +276,15 @@ async function supervisor(argv) {
   });
   if (signalRequested) await new Promise(() => undefined);
   if (signal) {
-    process.removeAllListeners('SIGTERM');
-    process.removeAllListeners('SIGINT');
-    process.kill(process.pid, signal);
+    // The child outcome is authoritative. The supervisor is only a control
+    // process; replaying the child's signal can be ignored or reserved by
+    // Node (for example SIGPIPE), so exit neutrally after the ACK.
+    process.disconnect();
+    process.exit(0);
     return;
   }
-  process.exitCode = exitStatus ?? 0;
+  process.disconnect();
+  process.exit(exitStatus ?? 0);
 }
 
 async function waitForCompletionOrTermination(completionPromise, exitPromise, isTerminating) {
@@ -317,6 +362,7 @@ export async function runBoundedCommand(options) {
     throw error;
   }
   let child;
+  let childExitPromise;
   let processGroupId;
   let overflow = false;
   let termination;
@@ -325,10 +371,16 @@ export async function runBoundedCommand(options) {
   const requestTermination = (isOverflow) => {
     if (isOverflow) overflow = true;
     if (!termination && child && processGroupId) {
-      termination = terminate(child, processGroupId, options.signalGroup, options.signalChild);
-      termination.then(result => { groupIdentityLost ||= result.groupIdentityLost; }, () => {
-        groupIdentityLost = true;
-      });
+      termination = terminate(child, processGroupId, options.signalGroup, options.signalChild)
+        .then(async result => {
+          groupIdentityLost ||= result.groupIdentityLost;
+          if (result.groupIdentityLost && childExitPromise) await abortSupervisor(child, childExitPromise);
+          return result;
+        }, async error => {
+          groupIdentityLost = true;
+          if (childExitPromise) await abortSupervisor(child, childExitPromise);
+          throw error;
+        });
     }
     return termination ?? Promise.resolve();
   };
@@ -356,6 +408,7 @@ export async function runBoundedCommand(options) {
       childProcess.once('exit', (code, signal) => resolve([code, signal]));
       childProcess.once('error', reject);
     });
+    childExitPromise = exitPromise;
     let observedOutcome = [null, 'SIGTERM'];
     exitPromise.then(outcome => { observedOutcome = outcome; }, () => undefined);
     const completionPromise = new Promise((resolve, reject) => {
@@ -403,10 +456,7 @@ export async function runBoundedCommand(options) {
     let signal;
     if (completion) {
       await boundedAwait(sendAck(childProcess), TERMINATION_TIMEOUT_MS, 'bounded command supervisor acknowledgement timed out');
-      const outcome = await boundedAwait(exitPromise, TERMINATION_TIMEOUT_MS, 'bounded command supervisor exit timed out');
-      if (outcome[0] !== completion.exitStatus || outcome[1] !== completion.signal) {
-        throw new Error('bounded command supervisor exit status did not match completion');
-      }
+      await boundedAwait(exitPromise, TERMINATION_TIMEOUT_MS, 'bounded command supervisor exit timed out');
       [exitStatus, signal] = [completion.exitStatus, completion.signal];
     } else {
       [exitStatus, signal] = observedOutcome;

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -1,47 +1,21 @@
 /**
  * Execute one command while streaming stdout and stderr into bounded files.
  *
- * The child is terminated as soon as either stream exceeds the byte budget.
- * Chunks are treated as bytes (never as JavaScript characters), so a UTF-8
- * chunk split across reads cannot bypass the limit. No unbounded command
- * output is accumulated in memory or queued in a writable stream.
+ * This entrypoint intentionally uses only Node.js built-ins. It runs before
+ * npm ci in the protected rehearsal workflow, so it cannot depend on the
+ * repository's node_modules directory.
  */
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { open, writeFile } from 'node:fs/promises';
-import { pathToFileURL } from 'node:url';
 
 export const DEFAULT_MAX_CAPTURE_BYTES = 8 * 1024 * 1024;
 const TERMINATION_GRACE_MS = 250;
 const TERMINATION_TIMEOUT_MS = 2_000;
 const SHA256 = /^[0-9a-f]{64}$/;
 
-export interface BoundedCommandOptions {
-  command: string;
-  args: string[];
-  cwd?: string;
-  env?: NodeJS.ProcessEnv;
-  stdoutPath: string;
-  stderrPath: string;
-  maxBytes?: number;
-  stdoutPrefix?: string;
-}
-
-export interface BoundedCommandResult {
-  schemaVersion: 'theologai-bounded-command.v1';
-  exitStatus: number | null;
-  signal: NodeJS.Signals | null;
-  overflow: boolean;
-  stdoutBytes: number;
-  stderrBytes: number;
-  stdoutSha256: string;
-  stderrSha256: string;
-}
-
 export class BoundedCommandError extends Error {
-  readonly result: BoundedCommandResult;
-
-  constructor(result: BoundedCommandResult) {
+  constructor(result) {
     super(result.overflow
       ? 'bounded command output exceeded its byte budget'
       : `bounded command exited with status ${result.exitStatus ?? `signal ${result.signal ?? 'unknown'}`}`);
@@ -50,30 +24,26 @@ export class BoundedCommandError extends Error {
   }
 }
 
-function assert(condition: unknown, message: string): asserts condition {
+function assert(condition, message) {
   if (!condition) throw new Error(`Bounded command refused: ${message}.`);
 }
 
-function sha256(bytes: Buffer): string {
-  return createHash('sha256').update(bytes).digest('hex');
-}
-
-function alive(child: ReturnType<typeof spawn>): boolean {
+function alive(child) {
   return child.exitCode === null && child.signalCode === null;
 }
 
-function signalProcessGroup(child: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
+function signalProcessGroup(child, signal) {
   if (!child.pid) return;
   try {
     // Detached children form their own group, so descendants cannot survive
     // an output overflow. A negative PID targets the complete process group.
     process.kill(-child.pid, signal);
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') child.kill(signal);
+    if (error?.code !== 'ESRCH') child.kill(signal);
   }
 }
 
-async function terminate(child: ReturnType<typeof spawn>): Promise<void> {
+async function terminate(child) {
   if (!alive(child)) return;
   signalProcessGroup(child, 'SIGTERM');
   await new Promise(resolve => setTimeout(resolve, TERMINATION_GRACE_MS));
@@ -85,42 +55,32 @@ async function terminate(child: ReturnType<typeof spawn>): Promise<void> {
   await new Promise(resolve => setTimeout(resolve, 25));
 }
 
-async function closeAfterTermination(
-  closePromise: Promise<[number | null, NodeJS.Signals | null]>,
-  termination: () => Promise<void> | undefined,
-): Promise<[number | null, NodeJS.Signals | null]> {
+async function exitAfterTermination(exitPromise, termination) {
   let closed = false;
-  closePromise.then(() => { closed = true; }, () => { closed = true; });
-  const waitForTermination = async (): Promise<[number | null, NodeJS.Signals | null]> => {
+  exitPromise.then(() => { closed = true; }, () => { closed = true; });
+  const waitForTermination = async () => {
     while (!closed && !termination()) await new Promise(resolve => setTimeout(resolve, 10));
     if (closed) throw new Error('bounded command close race was lost');
     const terminated = termination();
     if (!terminated) throw new Error('bounded command termination state was lost');
     await terminated;
     return Promise.race([
-      closePromise,
-      new Promise<[number | null, NodeJS.Signals | null]>((_, reject) => {
+      exitPromise,
+      new Promise((_, reject) => {
         setTimeout(() => reject(new Error('bounded command did not close after termination')), TERMINATION_TIMEOUT_MS);
       }),
     ]);
   };
-  return Promise.race([closePromise, waitForTermination()]);
+  return Promise.race([exitPromise, waitForTermination()]);
 }
 
-async function consume(
-  stream: NodeJS.ReadableStream,
-  handle: Awaited<ReturnType<typeof open>>,
-  maxBytes: number,
-  onOverflow: () => Promise<void>,
-  isTerminating: () => boolean,
-  initial: Buffer = Buffer.alloc(0),
-): Promise<{ bytes: number; hash: string; overflow: boolean }> {
+async function consume(stream, handle, maxBytes, onOverflow, isTerminating, initial = Buffer.alloc(0)) {
   const digest = createHash('sha256');
   digest.update(initial);
   let bytes = initial.byteLength;
   let overflow = false;
   try {
-    for await (const value of stream as AsyncIterable<Buffer | string>) {
+    for await (const value of stream) {
       const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
       const remaining = maxBytes - bytes;
       if (chunk.byteLength > remaining) {
@@ -146,15 +106,15 @@ async function consume(
   return { bytes, hash: digest.digest('hex'), overflow };
 }
 
-export async function runBoundedCommand(options: BoundedCommandOptions): Promise<BoundedCommandResult> {
+export async function runBoundedCommand(options) {
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_CAPTURE_BYTES;
   assert(Number.isSafeInteger(maxBytes) && maxBytes > 0, 'maxBytes must be a positive safe integer');
-  assert(options.command.length > 0, 'command is required');
+  assert(typeof options.command === 'string' && options.command.length > 0, 'command is required');
   const prefix = Buffer.from(options.stdoutPrefix ?? '', 'utf8');
   assert(prefix.byteLength <= maxBytes, 'stdout prefix exceeds maxBytes');
 
   const stdout = await open(options.stdoutPath, 'wx');
-  let stderr: Awaited<ReturnType<typeof open>>;
+  let stderr;
   try {
     stderr = await open(options.stderrPath, 'wx');
   } catch (error) {
@@ -162,9 +122,9 @@ export async function runBoundedCommand(options: BoundedCommandOptions): Promise
     throw error;
   }
   if (prefix.byteLength > 0) await stdout.write(prefix);
-  let child: ReturnType<typeof spawn> | undefined;
+  let child;
   let overflow = false;
-  let termination: Promise<void> | undefined;
+  let termination;
   const stop = async () => {
     overflow = true;
     if (!termination && child) termination = terminate(child);
@@ -172,25 +132,24 @@ export async function runBoundedCommand(options: BoundedCommandOptions): Promise
   };
 
   try {
-    child = spawn(options.command, options.args, {
+    child = spawn(options.command, options.args ?? [], {
       cwd: options.cwd,
       env: options.env ?? process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
     });
     const childProcess = child;
-    const closePromise = new Promise<[number | null, NodeJS.Signals | null]>((resolve, reject) => {
-      childProcess.once('close', (code, signal) => resolve([code, signal]));
+    const exitPromise = new Promise((resolve, reject) => {
+      childProcess.once('exit', (code, signal) => resolve([code, signal]));
       childProcess.once('error', reject);
     });
-    const stdoutPromise = consume(childProcess.stdout!, stdout, maxBytes, stop, () => overflow, prefix);
-    const stderrPromise = consume(childProcess.stderr!, stderr, maxBytes, stop, () => overflow);
-    const close = await closeAfterTermination(closePromise, () => termination);
+    const stdoutPromise = consume(childProcess.stdout, stdout, maxBytes, stop, () => overflow, prefix);
+    const stderrPromise = consume(childProcess.stderr, stderr, maxBytes, stop, () => overflow);
+    const [exitStatus, signal] = await exitAfterTermination(exitPromise, () => termination);
     await termination;
-    const [exitStatus, signal] = close;
     const stdoutResult = await stdoutPromise;
     const stderrResult = await stderrPromise;
-    const result: BoundedCommandResult = {
+    const result = {
       schemaVersion: 'theologai-bounded-command.v1',
       exitStatus,
       signal,
@@ -207,19 +166,20 @@ export async function runBoundedCommand(options: BoundedCommandOptions): Promise
   }
 }
 
-function parseCli(argv: string[]): { options: BoundedCommandOptions; resultPath?: string } {
+function parseCli(argv) {
   const separator = argv.indexOf('--');
   assert(separator > 0, 'command separator -- is required');
   const flags = argv.slice(0, separator);
   const command = argv[separator + 1];
   const args = argv.slice(separator + 2);
-  const values = new Map<string, string>();
+  const values = new Map();
   for (let index = 0; index < flags.length; index += 2) {
     const key = flags[index];
     const value = flags[index + 1];
     assert(typeof key === 'string' && key.startsWith('--') && typeof value === 'string' && value.length > 0 && !values.has(key), 'arguments are malformed');
     values.set(key, value);
   }
+  assert(typeof command === 'string' && command.length > 0, 'command is required');
   assert(values.has('--stdout') && values.has('--stderr'), 'stdout and stderr paths are required');
   const max = values.get('--max-bytes');
   const maxBytes = max === undefined ? undefined : Number(max);
@@ -227,15 +187,18 @@ function parseCli(argv: string[]): { options: BoundedCommandOptions; resultPath?
   return {
     resultPath: values.get('--result'),
     options: {
-      command: command!, args,
+      command,
+      args,
       cwd: values.get('--cwd'),
-      stdoutPath: values.get('--stdout')!, stderrPath: values.get('--stderr')!,
-      maxBytes, stdoutPrefix: values.get('--stdout-prefix'),
+      stdoutPath: values.get('--stdout'),
+      stderrPath: values.get('--stderr'),
+      maxBytes,
+      stdoutPrefix: values.get('--stdout-prefix'),
     },
   };
 }
 
-async function cli(argv: string[]): Promise<void> {
+async function cli(argv) {
   const { options, resultPath } = parseCli(argv);
   try {
     const result = await runBoundedCommand(options);
@@ -252,21 +215,22 @@ async function cli(argv: string[]): Promise<void> {
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === new URL(process.argv[1], 'file:').href) {
   cli(process.argv.slice(2)).catch(error => {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
   });
 }
 
-export function isBoundedCommandResult(value: unknown): value is BoundedCommandResult {
+export function isBoundedCommandResult(value) {
   if (!value || typeof value !== 'object') return false;
-  const result = value as Partial<BoundedCommandResult>;
+  const result = value;
   return result.schemaVersion === 'theologai-bounded-command.v1'
     && (result.exitStatus === null || Number.isSafeInteger(result.exitStatus))
     && (result.signal === null || typeof result.signal === 'string')
     && typeof result.overflow === 'boolean'
-    && Number.isSafeInteger(result.stdoutBytes) && Number.isSafeInteger(result.stderrBytes)
+    && Number.isSafeInteger(result.stdoutBytes) && result.stdoutBytes >= 0
+    && Number.isSafeInteger(result.stderrBytes) && result.stderrBytes >= 0
     && typeof result.stdoutSha256 === 'string' && SHA256.test(result.stdoutSha256)
     && typeof result.stderrSha256 === 'string' && SHA256.test(result.stderrSha256);
 }

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -8,12 +8,13 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { open, writeFile } from 'node:fs/promises';
+import { constants as osConstants } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 export const DEFAULT_MAX_CAPTURE_BYTES = 8 * 1024 * 1024;
 const TERMINATION_GRACE_MS = 250;
 const TERMINATION_TIMEOUT_MS = 2_000;
-const SHA256 = /^[0-9a-f]{64}$/;
+const SIGNAL_NAMES = new Set(Object.keys(osConstants.signals));
 
 export class BoundedCommandError extends Error {
   constructor(result) {
@@ -25,6 +26,33 @@ export class BoundedCommandError extends Error {
   }
 }
 
+function isSignal(value) {
+  return value === null || (typeof value === 'string' && SIGNAL_NAMES.has(value));
+}
+
+function isOutcome(exitStatus, signal) {
+  return (Number.isSafeInteger(exitStatus) && exitStatus >= 0 && signal === null)
+    || (exitStatus === null && typeof signal === 'string' && isSignal(signal));
+}
+
+function wait(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function boundedAwait(promise, timeoutMs, message) {
+  let timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
 function assert(condition, message) {
   if (!condition) throw new Error(`Bounded command refused: ${message}.`);
 }
@@ -33,16 +61,24 @@ function alive(child) {
   return child.exitCode === null && child.signalCode === null;
 }
 
-function signalProcessGroup(child, processGroupId, signal) {
+function signalProcessGroup(child, processGroupId, signal, signalGroup = process.kill) {
   if (!processGroupId) return;
   try {
     // Detached children form their own group, so descendants cannot survive
     // an output overflow. A negative PID targets the complete process group.
-    process.kill(-processGroupId, signal);
+    signalGroup(-processGroupId, signal);
+    return true;
   } catch (error) {
-    if (error?.code !== 'ESRCH' && alive(child)) {
-      try { child.kill(signal); } catch { /* the process may have exited */ }
-    }
+    return false;
+  }
+}
+
+function signalChild(child, signal, signaler) {
+  if (!alive(child)) return false;
+  try {
+    return signaler(child, signal) === true;
+  } catch {
+    return false;
   }
 }
 
@@ -50,17 +86,66 @@ function destroy(stream) {
   try { stream?.destroy(); } catch { /* cleanup must remain best-effort */ }
 }
 
-async function terminate(child, processGroupId) {
-  // The leader may have exited while a descendant still owns a pipe. Always
-  // signal the saved process group so that descendant cannot survive overflow.
-  signalProcessGroup(child, processGroupId, 'SIGTERM');
-  await new Promise(resolve => setTimeout(resolve, TERMINATION_GRACE_MS));
-  signalProcessGroup(child, processGroupId, 'SIGKILL');
-  // A descendant that inherited a pipe must not hold the parent close event
-  // open indefinitely after the process group has been signalled.
-  destroy(child.stdout);
-  destroy(child.stderr);
-  await new Promise(resolve => setTimeout(resolve, 25));
+async function terminate(child, processGroupId, signalGroup = process.kill, signaler = (target, signal) => {
+  if (!alive(target)) return false;
+  try { return target.kill(signal); } catch { return false; }
+}) {
+  try {
+    // The supervisor remains alive until the parent acknowledges completion,
+    // so this PGID cannot be reused during TERM -> KILL escalation.
+    const termGroup = signalProcessGroup(child, processGroupId, 'SIGTERM', signalGroup);
+    if (!termGroup) {
+      // The group identity is no longer trustworthy. Use only the direct
+      // supervisor handle and never send a delayed signal to that stale PGID.
+      signalChild(child, 'SIGTERM', signaler);
+      return { groupIdentityLost: true };
+    }
+    await wait(TERMINATION_GRACE_MS);
+    const killGroup = signalProcessGroup(child, processGroupId, 'SIGKILL', signalGroup);
+    if (!killGroup) {
+      // Do not retry the saved PGID after this point: it may be stale. A direct
+      // handle is safe to attempt once, and failure remains bounded.
+      signalChild(child, 'SIGKILL', signaler);
+    }
+    return { groupIdentityLost: !killGroup };
+  } finally {
+    // A descendant that inherited a pipe must not hold the parent close event
+    // open indefinitely after the process group has been signalled.
+    destroy(child.stdout);
+    destroy(child.stderr);
+  }
+}
+
+async function settleWithin(promises, timeoutMs = TERMINATION_TIMEOUT_MS) {
+  try {
+    await boundedAwait(Promise.allSettled(promises), timeoutMs, 'bounded command cleanup timed out');
+  } catch {
+    // Cleanup is deliberately best effort after the bounded deadline.
+  }
+}
+
+function sendAck(child) {
+  return new Promise((resolve, reject) => {
+    if (!child.connected || typeof child.send !== 'function') {
+      reject(new Error('bounded command supervisor IPC channel is unavailable'));
+      return;
+    }
+    try {
+      child.send({ type: 'ack' }, error => error ? reject(error) : resolve());
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function captureState(initial = Buffer.alloc(0)) {
+  const digest = createHash('sha256');
+  digest.update(initial);
+  return { digest, bytes: initial.byteLength, overflow: false };
+}
+
+function captureSnapshot(state) {
+  return { bytes: state.bytes, hash: state.digest.copy().digest('hex'), overflow: state.overflow };
 }
 
 function relay(source, destination) {
@@ -119,70 +204,90 @@ async function supervisor(argv) {
     commandProcess.once('error', reject);
     commandProcess.once('close', (code, childSignal) => resolve([code, childSignal]));
   });
+  assert(isOutcome(exitStatus, signal), 'supervisor exit outcome is malformed');
   // ChildProcess close is emitted only after its pipe-backed stdio closes, so
   // a descendant that inherited either pipe pins this supervisor in the same
   // process group until the outer runner can observe all output.
   await Promise.all([stdoutRelay, stderrRelay]);
+  process.stdout.end();
+  process.stderr.end();
+  assert(typeof process.send === 'function', 'supervisor IPC channel is unavailable');
+  await new Promise((resolve, reject) => {
+    try {
+      process.send({ type: 'completion', exitStatus, signal }, error => error ? reject(error) : resolve());
+    } catch (error) {
+      reject(error);
+    }
+  });
+  await new Promise((resolve, reject) => {
+    const onMessage = message => {
+      process.off('disconnect', onDisconnect);
+      if (message?.type === 'ack') resolve();
+      else reject(new Error('bounded command supervisor received malformed acknowledgement'));
+    };
+    const onDisconnect = () => {
+      process.off('message', onMessage);
+      reject(new Error('bounded command supervisor IPC channel disconnected'));
+    };
+    process.once('message', onMessage);
+    process.once('disconnect', onDisconnect);
+  });
+  if (signalRequested) await new Promise(() => undefined);
   if (signal) {
-    if (signalRequested) await new Promise(() => undefined);
     process.removeAllListeners('SIGTERM');
     process.removeAllListeners('SIGINT');
     process.kill(process.pid, signal);
     return;
   }
-  if (signalRequested) await new Promise(() => undefined);
   process.exitCode = exitStatus ?? 0;
 }
 
-async function exitAfterTermination(exitPromise, termination) {
-  let closed = false;
-  exitPromise.then(() => { closed = true; }, () => { closed = true; });
-  const waitForTermination = async () => {
-    while (!closed && !termination()) await new Promise(resolve => setTimeout(resolve, 10));
-    if (closed) throw new Error('bounded command close race was lost');
-    const terminated = termination();
-    if (!terminated) throw new Error('bounded command termination state was lost');
-    await terminated;
-    return Promise.race([
-      exitPromise,
-      new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('bounded command did not close after termination')), TERMINATION_TIMEOUT_MS);
-      }),
-    ]);
-  };
-  return Promise.race([exitPromise, waitForTermination()]);
+async function waitForCompletionOrTermination(completionPromise, exitPromise, isTerminating) {
+  let completion;
+  let completionFailure;
+  let complete = false;
+  let exited = false;
+  completionPromise.then(value => { completion = value; complete = true; }, error => {
+    completionFailure = error;
+    complete = true;
+  });
+  exitPromise.then(() => { exited = true; }, error => {
+    completionFailure = error;
+    exited = true;
+  });
+  while (!isTerminating() && !complete && !exited) await wait(10);
+  if (isTerminating()) return undefined;
+  if (completionFailure) throw completionFailure;
+  if (!complete) throw new Error('bounded command supervisor exited without completion');
+  return completion;
 }
 
-async function consume(stream, handle, maxBytes, onOverflow, onCaptureFailure, isTerminating, initial = Buffer.alloc(0)) {
-  const digest = createHash('sha256');
-  digest.update(initial);
-  let bytes = initial.byteLength;
-  let overflow = false;
+async function consume(stream, handle, maxBytes, onOverflow, onCaptureFailure, isTerminating, state) {
   try {
     for await (const value of stream) {
       const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
-      const remaining = maxBytes - bytes;
+      const remaining = maxBytes - state.bytes;
       if (chunk.byteLength > remaining) {
         if (remaining > 0) {
           const prefix = chunk.subarray(0, remaining);
           await handle.write(prefix);
-          digest.update(prefix);
-          bytes += prefix.byteLength;
+          state.digest.update(prefix);
+          state.bytes += prefix.byteLength;
         }
-        overflow = true;
+        state.overflow = true;
         await onOverflow();
         break;
       }
       await handle.write(chunk);
-      digest.update(chunk);
-      bytes += chunk.byteLength;
+      state.digest.update(chunk);
+      state.bytes += chunk.byteLength;
     }
   } catch (error) {
     // The peer stream is destroyed when the other stream overflows. This is
     // expected cleanup, not a successful uncapped command.
     if (!isTerminating()) await onCaptureFailure(error);
   }
-  return { bytes, hash: digest.digest('hex'), overflow };
+  return captureSnapshot(state);
 }
 
 export async function runBoundedCommand(options) {
@@ -198,7 +303,7 @@ export async function runBoundedCommand(options) {
   try {
     stderr = await openCapture(options.stderrPath);
   } catch (error) {
-    await stdout.close();
+    await boundedAwait(stdout.close(), TERMINATION_TIMEOUT_MS, 'bounded command stdout capture close timed out').catch(() => undefined);
     throw error;
   }
   let child;
@@ -206,9 +311,15 @@ export async function runBoundedCommand(options) {
   let overflow = false;
   let termination;
   let captureFailure;
+  let groupIdentityLost = false;
   const requestTermination = (isOverflow) => {
     if (isOverflow) overflow = true;
-    if (!termination && child && processGroupId) termination = terminate(child, processGroupId);
+    if (!termination && child && processGroupId) {
+      termination = terminate(child, processGroupId, options.signalGroup, options.signalChild);
+      termination.then(result => { groupIdentityLost ||= result.groupIdentityLost; }, () => {
+        groupIdentityLost = true;
+      });
+    }
     return termination ?? Promise.resolve();
   };
   const stop = () => requestTermination(true);
@@ -226,7 +337,7 @@ export async function runBoundedCommand(options) {
     ], {
       cwd: options.cwd,
       env: options.env ?? process.env,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
       detached: true,
     });
     const childProcess = child;
@@ -235,25 +346,61 @@ export async function runBoundedCommand(options) {
       childProcess.once('exit', (code, signal) => resolve([code, signal]));
       childProcess.once('error', reject);
     });
-    const stdoutPromise = consume(childProcess.stdout, stdout, maxBytes, stop, onCaptureFailure, () => overflow, prefix);
-    const stderrPromise = consume(childProcess.stderr, stderr, maxBytes, stop, onCaptureFailure, () => overflow);
+    let observedOutcome = [null, 'SIGTERM'];
+    exitPromise.then(outcome => { observedOutcome = outcome; }, () => undefined);
+    const completionPromise = new Promise((resolve, reject) => {
+      const onMessage = message => {
+        if (!message || message.type !== 'completion'
+          || !isOutcome(message.exitStatus, message.signal)) {
+          reject(new Error('bounded command supervisor completion is malformed'));
+          return;
+        }
+        resolve({ exitStatus: message.exitStatus, signal: message.signal });
+      };
+      const onDisconnect = () => reject(new Error('bounded command supervisor IPC channel disconnected'));
+      childProcess.once('message', onMessage);
+      childProcess.once('disconnect', onDisconnect);
+    });
+    const stdoutState = captureState(prefix);
+    const stderrState = captureState();
+    const stdoutPromise = consume(childProcess.stdout, stdout, maxBytes, stop, onCaptureFailure, () => overflow, stdoutState);
+    const stderrPromise = consume(childProcess.stderr, stderr, maxBytes, stop, onCaptureFailure, () => overflow, stderrState);
     const capturesPromise = Promise.all([stdoutPromise, stderrPromise]);
-    let outcome;
+    let completion;
     let captures;
     try {
-      [outcome, captures] = await Promise.all([
-        exitAfterTermination(exitPromise, () => termination),
-        capturesPromise,
-      ]);
+      completion = await waitForCompletionOrTermination(completionPromise, exitPromise, () => Boolean(termination));
+      if (termination) {
+        await boundedAwait(termination, TERMINATION_TIMEOUT_MS, 'bounded command termination timed out');
+        try {
+          captures = await boundedAwait(capturesPromise, TERMINATION_TIMEOUT_MS, 'bounded command capture settle timed out');
+        } catch {
+          captures = [captureSnapshot(stdoutState), captureSnapshot(stderrState)];
+        }
+      } else {
+        captures = await capturesPromise;
+      }
     } catch (error) {
       await requestTermination(false);
-      await Promise.allSettled([exitPromise, capturesPromise]);
+      await settleWithin([exitPromise, completionPromise, capturesPromise]);
       throw error;
     }
-    await termination;
-    const [exitStatus, signal] = outcome;
+    if (termination) await termination;
     const [stdoutResult, stderrResult] = captures;
     if (captureFailure) throw captureFailure;
+    if (groupIdentityLost && !overflow) throw new Error('bounded command process-group identity was lost during cleanup');
+    let exitStatus;
+    let signal;
+    if (completion) {
+      await boundedAwait(sendAck(childProcess), TERMINATION_TIMEOUT_MS, 'bounded command supervisor acknowledgement timed out');
+      const outcome = await boundedAwait(exitPromise, TERMINATION_TIMEOUT_MS, 'bounded command supervisor exit timed out');
+      if (outcome[0] !== completion.exitStatus || outcome[1] !== completion.signal) {
+        throw new Error('bounded command supervisor exit status did not match completion');
+      }
+      [exitStatus, signal] = [completion.exitStatus, completion.signal];
+    } else {
+      [exitStatus, signal] = observedOutcome;
+    }
     const result = {
       schemaVersion: 'theologai-bounded-command.v1',
       exitStatus,
@@ -268,9 +415,18 @@ export async function runBoundedCommand(options) {
     return result;
   } catch (error) {
     await requestTermination(false);
+    if (child) {
+      await settleWithin([new Promise(resolve => {
+        if (!alive(child)) {
+          resolve();
+          return;
+        }
+        child.once('exit', resolve);
+      })]);
+    }
     throw error;
   } finally {
-    await Promise.allSettled([stdout.close(), stderr.close()]);
+    await settleWithin([stdout.close(), stderr.close()]);
   }
 }
 
@@ -333,17 +489,4 @@ if (process.argv[2] === '--supervise') {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;
   });
-}
-
-export function isBoundedCommandResult(value) {
-  if (!value || typeof value !== 'object') return false;
-  const result = value;
-  return result.schemaVersion === 'theologai-bounded-command.v1'
-    && (result.exitStatus === null || Number.isSafeInteger(result.exitStatus))
-    && (result.signal === null || typeof result.signal === 'string')
-    && typeof result.overflow === 'boolean'
-    && Number.isSafeInteger(result.stdoutBytes) && result.stdoutBytes >= 0
-    && Number.isSafeInteger(result.stderrBytes) && result.stderrBytes >= 0
-    && typeof result.stdoutSha256 === 'string' && SHA256.test(result.stdoutSha256)
-    && typeof result.stderrSha256 === 'string' && SHA256.test(result.stderrSha256);
 }

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -32,22 +32,23 @@ function alive(child) {
   return child.exitCode === null && child.signalCode === null;
 }
 
-function signalProcessGroup(child, signal) {
-  if (!child.pid) return;
+function signalProcessGroup(child, processGroupId, signal) {
+  if (!processGroupId) return;
   try {
     // Detached children form their own group, so descendants cannot survive
     // an output overflow. A negative PID targets the complete process group.
-    process.kill(-child.pid, signal);
+    process.kill(-processGroupId, signal);
   } catch (error) {
-    if (error?.code !== 'ESRCH') child.kill(signal);
+    if (error?.code !== 'ESRCH' && alive(child)) child.kill(signal);
   }
 }
 
-async function terminate(child) {
-  if (!alive(child)) return;
-  signalProcessGroup(child, 'SIGTERM');
+async function terminate(child, processGroupId) {
+  // The leader may have exited while a descendant still owns a pipe. Always
+  // signal the saved process group so that descendant cannot survive overflow.
+  signalProcessGroup(child, processGroupId, 'SIGTERM');
   await new Promise(resolve => setTimeout(resolve, TERMINATION_GRACE_MS));
-  if (alive(child)) signalProcessGroup(child, 'SIGKILL');
+  signalProcessGroup(child, processGroupId, 'SIGKILL');
   // A descendant that inherited a pipe must not hold the parent close event
   // open indefinitely after the process group has been signalled.
   child.stdout?.destroy();
@@ -123,11 +124,12 @@ export async function runBoundedCommand(options) {
   }
   if (prefix.byteLength > 0) await stdout.write(prefix);
   let child;
+  let processGroupId;
   let overflow = false;
   let termination;
   const stop = async () => {
     overflow = true;
-    if (!termination && child) termination = terminate(child);
+    if (!termination && child && processGroupId) termination = terminate(child, processGroupId);
     await termination;
   };
 
@@ -139,6 +141,7 @@ export async function runBoundedCommand(options) {
       detached: true,
     });
     const childProcess = child;
+    processGroupId = childProcess.pid;
     const exitPromise = new Promise((resolve, reject) => {
       childProcess.once('exit', (code, signal) => resolve([code, signal]));
       childProcess.once('error', reject);

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -157,9 +157,14 @@ function sendAbort(child) {
 }
 
 async function abortSupervisor(child, exitPromise) {
+  let sent = false;
   try {
-    await boundedAwait(sendAbort(child), TERMINATION_TIMEOUT_MS, 'bounded command supervisor abort send timed out');
+    sent = await boundedAwait(sendAbort(child), TERMINATION_TIMEOUT_MS, 'bounded command supervisor abort send timed out');
   } catch {
+    sent = false;
+  }
+  if (!sent) {
+    detachChild(child);
     return;
   }
   try {
@@ -167,7 +172,16 @@ async function abortSupervisor(child, exitPromise) {
   } catch {
     // The outer runner remains bounded even if the supervisor cannot report
     // its final OS-level exit after self-terminating the stable group.
+    detachChild(child);
   }
+}
+
+function detachChild(child) {
+  destroy(child.stdout);
+  destroy(child.stderr);
+  try { child.disconnect?.(); } catch { /* IPC cleanup is best effort */ }
+  try { child.removeAllListeners(); } catch { /* listener cleanup is best effort */ }
+  try { child.unref?.(); } catch { /* handle detachment is best effort */ }
 }
 
 function captureState(initial = Buffer.alloc(0)) {

--- a/scripts/capture-bounded-command.mjs
+++ b/scripts/capture-bounded-command.mjs
@@ -8,6 +8,7 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { open, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 export const DEFAULT_MAX_CAPTURE_BYTES = 8 * 1024 * 1024;
 const TERMINATION_GRACE_MS = 250;
@@ -54,6 +55,67 @@ async function terminate(child, processGroupId) {
   child.stdout?.destroy();
   child.stderr?.destroy();
   await new Promise(resolve => setTimeout(resolve, 25));
+}
+
+function relay(source, destination) {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    source.once('end', finish);
+    source.once('error', () => {
+      source.destroy();
+      finish();
+    });
+    destination.once('error', () => {
+      source.destroy();
+      finish();
+    });
+    source.pipe(destination, { end: false });
+  });
+}
+
+async function supervisor(argv) {
+  const separator = argv.indexOf('--');
+  assert(separator >= 0, 'supervisor command separator -- is required');
+  const flags = argv.slice(0, separator);
+  assert(flags.length === 0, 'supervisor arguments are malformed');
+  const command = argv[separator + 1];
+  const args = argv.slice(separator + 2);
+  assert(typeof command === 'string' && command.length > 0, 'supervisor command is required');
+
+  let signalRequested = false;
+  // The supervisor is the stable process-group leader. It must not exit when
+  // the group receives SIGTERM; the outer runner escalates to SIGKILL after
+  // its grace interval if output overflow is still being handled.
+  process.on('SIGTERM', () => { signalRequested = true; });
+  process.on('SIGINT', () => { signalRequested = true; });
+  process.stdout.on('error', () => undefined);
+  process.stderr.on('error', () => undefined);
+
+  const commandProcess = spawn(command, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdoutRelay = relay(commandProcess.stdout, process.stdout);
+  const stderrRelay = relay(commandProcess.stderr, process.stderr);
+  const [exitStatus, signal] = await new Promise((resolve, reject) => {
+    commandProcess.once('error', reject);
+    commandProcess.once('close', (code, childSignal) => resolve([code, childSignal]));
+  });
+  // ChildProcess close is emitted only after its pipe-backed stdio closes, so
+  // a descendant that inherited either pipe pins this supervisor in the same
+  // process group until the outer runner can observe all output.
+  await Promise.all([stdoutRelay, stderrRelay]);
+  if (signal) {
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(exitStatus ?? (signalRequested ? 1 : 0));
 }
 
 async function exitAfterTermination(exitPromise, termination) {
@@ -134,7 +196,11 @@ export async function runBoundedCommand(options) {
   };
 
   try {
-    child = spawn(options.command, options.args ?? [], {
+    child = spawn(process.execPath, [
+      fileURLToPath(import.meta.url),
+      '--supervise',
+      '--', options.command, ...(options.args ?? []),
+    ], {
       cwd: options.cwd,
       env: options.env ?? process.env,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -218,7 +284,12 @@ async function cli(argv) {
   }
 }
 
-if (process.argv[1] && import.meta.url === new URL(process.argv[1], 'file:').href) {
+if (process.argv[2] === '--supervise') {
+  supervisor(process.argv.slice(3)).catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+} else if (process.argv[1] && import.meta.url === new URL(process.argv[1], 'file:').href) {
   cli(process.argv.slice(2)).catch(error => {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exitCode = 1;

--- a/scripts/capture-bounded-command.ts
+++ b/scripts/capture-bounded-command.ts
@@ -1,0 +1,272 @@
+/**
+ * Execute one command while streaming stdout and stderr into bounded files.
+ *
+ * The child is terminated as soon as either stream exceeds the byte budget.
+ * Chunks are treated as bytes (never as JavaScript characters), so a UTF-8
+ * chunk split across reads cannot bypass the limit. No unbounded command
+ * output is accumulated in memory or queued in a writable stream.
+ */
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { open, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+export const DEFAULT_MAX_CAPTURE_BYTES = 8 * 1024 * 1024;
+const TERMINATION_GRACE_MS = 250;
+const TERMINATION_TIMEOUT_MS = 2_000;
+const SHA256 = /^[0-9a-f]{64}$/;
+
+export interface BoundedCommandOptions {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdoutPath: string;
+  stderrPath: string;
+  maxBytes?: number;
+  stdoutPrefix?: string;
+}
+
+export interface BoundedCommandResult {
+  schemaVersion: 'theologai-bounded-command.v1';
+  exitStatus: number | null;
+  signal: NodeJS.Signals | null;
+  overflow: boolean;
+  stdoutBytes: number;
+  stderrBytes: number;
+  stdoutSha256: string;
+  stderrSha256: string;
+}
+
+export class BoundedCommandError extends Error {
+  readonly result: BoundedCommandResult;
+
+  constructor(result: BoundedCommandResult) {
+    super(result.overflow
+      ? 'bounded command output exceeded its byte budget'
+      : `bounded command exited with status ${result.exitStatus ?? `signal ${result.signal ?? 'unknown'}`}`);
+    this.name = 'BoundedCommandError';
+    this.result = result;
+  }
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Bounded command refused: ${message}.`);
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function alive(child: ReturnType<typeof spawn>): boolean {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+function signalProcessGroup(child: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
+  if (!child.pid) return;
+  try {
+    // Detached children form their own group, so descendants cannot survive
+    // an output overflow. A negative PID targets the complete process group.
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') child.kill(signal);
+  }
+}
+
+async function terminate(child: ReturnType<typeof spawn>): Promise<void> {
+  if (!alive(child)) return;
+  signalProcessGroup(child, 'SIGTERM');
+  await new Promise(resolve => setTimeout(resolve, TERMINATION_GRACE_MS));
+  if (alive(child)) signalProcessGroup(child, 'SIGKILL');
+  // A descendant that inherited a pipe must not hold the parent close event
+  // open indefinitely after the process group has been signalled.
+  child.stdout?.destroy();
+  child.stderr?.destroy();
+  await new Promise(resolve => setTimeout(resolve, 25));
+}
+
+async function closeAfterTermination(
+  closePromise: Promise<[number | null, NodeJS.Signals | null]>,
+  termination: () => Promise<void> | undefined,
+): Promise<[number | null, NodeJS.Signals | null]> {
+  let closed = false;
+  closePromise.then(() => { closed = true; }, () => { closed = true; });
+  const waitForTermination = async (): Promise<[number | null, NodeJS.Signals | null]> => {
+    while (!closed && !termination()) await new Promise(resolve => setTimeout(resolve, 10));
+    if (closed) throw new Error('bounded command close race was lost');
+    const terminated = termination();
+    if (!terminated) throw new Error('bounded command termination state was lost');
+    await terminated;
+    return Promise.race([
+      closePromise,
+      new Promise<[number | null, NodeJS.Signals | null]>((_, reject) => {
+        setTimeout(() => reject(new Error('bounded command did not close after termination')), TERMINATION_TIMEOUT_MS);
+      }),
+    ]);
+  };
+  return Promise.race([closePromise, waitForTermination()]);
+}
+
+async function consume(
+  stream: NodeJS.ReadableStream,
+  handle: Awaited<ReturnType<typeof open>>,
+  maxBytes: number,
+  onOverflow: () => Promise<void>,
+  isTerminating: () => boolean,
+  initial: Buffer = Buffer.alloc(0),
+): Promise<{ bytes: number; hash: string; overflow: boolean }> {
+  const digest = createHash('sha256');
+  digest.update(initial);
+  let bytes = initial.byteLength;
+  let overflow = false;
+  try {
+    for await (const value of stream as AsyncIterable<Buffer | string>) {
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      const remaining = maxBytes - bytes;
+      if (chunk.byteLength > remaining) {
+        if (remaining > 0) {
+          const prefix = chunk.subarray(0, remaining);
+          await handle.write(prefix);
+          digest.update(prefix);
+          bytes += prefix.byteLength;
+        }
+        overflow = true;
+        await onOverflow();
+        break;
+      }
+      await handle.write(chunk);
+      digest.update(chunk);
+      bytes += chunk.byteLength;
+    }
+  } catch (error) {
+    // The peer stream is destroyed when the other stream overflows. This is
+    // expected cleanup, not a successful uncapped command.
+    if (!isTerminating()) throw error;
+  }
+  return { bytes, hash: digest.digest('hex'), overflow };
+}
+
+export async function runBoundedCommand(options: BoundedCommandOptions): Promise<BoundedCommandResult> {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_CAPTURE_BYTES;
+  assert(Number.isSafeInteger(maxBytes) && maxBytes > 0, 'maxBytes must be a positive safe integer');
+  assert(options.command.length > 0, 'command is required');
+  const prefix = Buffer.from(options.stdoutPrefix ?? '', 'utf8');
+  assert(prefix.byteLength <= maxBytes, 'stdout prefix exceeds maxBytes');
+
+  const stdout = await open(options.stdoutPath, 'wx');
+  let stderr: Awaited<ReturnType<typeof open>>;
+  try {
+    stderr = await open(options.stderrPath, 'wx');
+  } catch (error) {
+    await stdout.close();
+    throw error;
+  }
+  if (prefix.byteLength > 0) await stdout.write(prefix);
+  let child: ReturnType<typeof spawn> | undefined;
+  let overflow = false;
+  let termination: Promise<void> | undefined;
+  const stop = async () => {
+    overflow = true;
+    if (!termination && child) termination = terminate(child);
+    await termination;
+  };
+
+  try {
+    child = spawn(options.command, options.args, {
+      cwd: options.cwd,
+      env: options.env ?? process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+    });
+    const childProcess = child;
+    const closePromise = new Promise<[number | null, NodeJS.Signals | null]>((resolve, reject) => {
+      childProcess.once('close', (code, signal) => resolve([code, signal]));
+      childProcess.once('error', reject);
+    });
+    const stdoutPromise = consume(childProcess.stdout!, stdout, maxBytes, stop, () => overflow, prefix);
+    const stderrPromise = consume(childProcess.stderr!, stderr, maxBytes, stop, () => overflow);
+    const close = await closeAfterTermination(closePromise, () => termination);
+    await termination;
+    const [exitStatus, signal] = close;
+    const stdoutResult = await stdoutPromise;
+    const stderrResult = await stderrPromise;
+    const result: BoundedCommandResult = {
+      schemaVersion: 'theologai-bounded-command.v1',
+      exitStatus,
+      signal,
+      overflow: overflow || stdoutResult.overflow || stderrResult.overflow,
+      stdoutBytes: stdoutResult.bytes,
+      stderrBytes: stderrResult.bytes,
+      stdoutSha256: stdoutResult.hash,
+      stderrSha256: stderrResult.hash,
+    };
+    if (result.overflow || result.exitStatus !== 0) throw new BoundedCommandError(result);
+    return result;
+  } finally {
+    await Promise.allSettled([stdout.close(), stderr.close()]);
+  }
+}
+
+function parseCli(argv: string[]): { options: BoundedCommandOptions; resultPath?: string } {
+  const separator = argv.indexOf('--');
+  assert(separator > 0, 'command separator -- is required');
+  const flags = argv.slice(0, separator);
+  const command = argv[separator + 1];
+  const args = argv.slice(separator + 2);
+  const values = new Map<string, string>();
+  for (let index = 0; index < flags.length; index += 2) {
+    const key = flags[index];
+    const value = flags[index + 1];
+    assert(typeof key === 'string' && key.startsWith('--') && typeof value === 'string' && value.length > 0 && !values.has(key), 'arguments are malformed');
+    values.set(key, value);
+  }
+  assert(values.has('--stdout') && values.has('--stderr'), 'stdout and stderr paths are required');
+  const max = values.get('--max-bytes');
+  const maxBytes = max === undefined ? undefined : Number(max);
+  if (max !== undefined) assert(Number.isSafeInteger(maxBytes), 'max-bytes is malformed');
+  return {
+    resultPath: values.get('--result'),
+    options: {
+      command: command!, args,
+      cwd: values.get('--cwd'),
+      stdoutPath: values.get('--stdout')!, stderrPath: values.get('--stderr')!,
+      maxBytes, stdoutPrefix: values.get('--stdout-prefix'),
+    },
+  };
+}
+
+async function cli(argv: string[]): Promise<void> {
+  const { options, resultPath } = parseCli(argv);
+  try {
+    const result = await runBoundedCommand(options);
+    const output = `${JSON.stringify(result)}\n`;
+    if (resultPath) await writeFile(resultPath, output, { encoding: 'utf8', flag: 'wx' });
+    process.stdout.write(output);
+  } catch (error) {
+    if (error instanceof BoundedCommandError) {
+      const output = `${JSON.stringify(error.result)}\n`;
+      if (resultPath) await writeFile(resultPath, output, { encoding: 'utf8', flag: 'wx' }).catch(() => undefined);
+      process.stderr.write(output);
+    }
+    throw error;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  cli(process.argv.slice(2)).catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export function isBoundedCommandResult(value: unknown): value is BoundedCommandResult {
+  if (!value || typeof value !== 'object') return false;
+  const result = value as Partial<BoundedCommandResult>;
+  return result.schemaVersion === 'theologai-bounded-command.v1'
+    && (result.exitStatus === null || Number.isSafeInteger(result.exitStatus))
+    && (result.signal === null || typeof result.signal === 'string')
+    && typeof result.overflow === 'boolean'
+    && Number.isSafeInteger(result.stdoutBytes) && Number.isSafeInteger(result.stderrBytes)
+    && typeof result.stdoutSha256 === 'string' && SHA256.test(result.stdoutSha256)
+    && typeof result.stderrSha256 === 'string' && SHA256.test(result.stderrSha256);
+}

--- a/scripts/production-rollback-rehearsal.ts
+++ b/scripts/production-rollback-rehearsal.ts
@@ -8,7 +8,7 @@
  * rehearsal.
  */
 import { createHash } from 'node:crypto';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, stat, writeFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -18,7 +18,10 @@ const MAX_INPUT_BYTES = 8 * 1024 * 1024;
 const MAX_RECEIPT_BYTES = 32 * 1024;
 
 export const ROLLBACK_REHEARSAL_CONFIRMATION = 'REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC';
-export const ROLLBACK_REHEARSAL_COMMAND = 'wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --dry-run --yes';
+export const ROLLBACK_REHEARSAL_COMMAND = 'wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --config wrangler.release.toml --name theologai --dry-run --yes';
+export const ROLLBACK_REHEARSAL_WORKFLOW = 'Production Rollback Rehearsal';
+export const ROLLBACK_REHEARSAL_REPOSITORY = 'TJ-Frederick/TheologAI';
+export const ROLLBACK_REHEARSAL_WRANGLER_VERSION = '4.114.0';
 
 export const ROLLBACK_REHEARSAL_TARGET = Object.freeze({
   sourceCommit: '8da99fd0a161b90a4bd90ab29bde1abf796b3bf6',
@@ -34,6 +37,15 @@ type JsonRecord = Record<string, unknown>;
 export interface RollbackRehearsalReceipt {
   schemaVersion: 'theologai-production-rollback-rehearsal.v1';
   status: 'passed';
+  provenance: {
+    repository: string;
+    workflow: string;
+    headSha: string;
+    ref: 'refs/heads/main';
+    runId: string;
+    runAttempt: string;
+    wranglerVersion: '4.114.0';
+  };
   source: { commit: string; tree: string };
   target: {
     deploymentId: string;
@@ -42,8 +54,8 @@ export interface RollbackRehearsalReceipt {
     d1Id: string;
   };
   controls: {
-    production: { deploymentId: string; workerVersionId: string };
-    preview: { deploymentId: string; workerVersionId: string };
+    production: { deploymentId: string; workerVersionId: string; d1Name: string; d1Id: string };
+    preview: { deploymentId: string; workerVersionId: string; d1Name: string; d1Id: string };
   };
   evidence: {
     productionBeforeSha256: string;
@@ -57,10 +69,14 @@ export interface RollbackRehearsalReceipt {
     d1InventoryBeforeSha256: string;
     d1InventoryAfterSha256: string;
     targetVersionSha256: string;
+    targetDeploymentSha256: string;
+    npmInstallSha256: string;
+    workerdSha256: string;
     readinessOutputSha256: string;
     runtimeOutputSha256: string;
     dryRunOutputSha256: string;
   };
+  exitStatuses: { npmInstall: 0; workerd: 0; readiness: 0; runtime: 0; dryRun: 0 };
   trafficMutation: false;
   d1Mutation: false;
   previewMutation: false;
@@ -98,6 +114,15 @@ function sha256(text: string): string {
   return createHash('sha256').update(text).digest('hex');
 }
 
+async function readCapped(path: string, label: string): Promise<string> {
+  const metadata = await stat(path);
+  assert(metadata.isFile(), `${label} is not a regular file`);
+  assert(metadata.size <= MAX_INPUT_BYTES, `${label} exceeds the bounded input size`);
+  const text = await readFile(path, 'utf8');
+  assert(Buffer.byteLength(text, 'utf8') <= MAX_INPUT_BYTES, `${label} exceeds the bounded input size`);
+  return text;
+}
+
 function uuid(value: unknown, label: string): string {
   assert(typeof value === 'string' && UUID.test(value), `${label} is not a UUID`);
   return value.toLowerCase();
@@ -105,7 +130,14 @@ function uuid(value: unknown, label: string): string {
 
 export function parseRollbackRehearsalReceipt(value: unknown): RollbackRehearsalReceipt {
   const receipt = record(value, 'rehearsal receipt');
-  exactKeys(receipt, ['schemaVersion', 'status', 'source', 'target', 'controls', 'evidence', 'trafficMutation', 'd1Mutation', 'previewMutation', 'targetInactiveBefore', 'targetInactiveAfter'], 'rehearsal receipt');
+  exactKeys(receipt, ['schemaVersion', 'status', 'provenance', 'source', 'target', 'controls', 'evidence', 'exitStatuses', 'trafficMutation', 'd1Mutation', 'previewMutation', 'targetInactiveBefore', 'targetInactiveAfter'], 'rehearsal receipt');
+  const provenance = record(receipt.provenance, 'rehearsal provenance');
+  exactKeys(provenance, ['repository', 'workflow', 'headSha', 'ref', 'runId', 'runAttempt', 'wranglerVersion'], 'rehearsal provenance');
+  assert(provenance.repository === ROLLBACK_REHEARSAL_REPOSITORY && provenance.workflow === ROLLBACK_REHEARSAL_WORKFLOW
+    && provenance.ref === 'refs/heads/main' && provenance.wranglerVersion === ROLLBACK_REHEARSAL_WRANGLER_VERSION
+    && typeof provenance.runId === 'string' && /^[1-9][0-9]*$/.test(provenance.runId)
+    && typeof provenance.runAttempt === 'string' && /^[1-9][0-9]*$/.test(provenance.runAttempt)
+    && typeof provenance.headSha === 'string' && SHA1.test(provenance.headSha), 'rehearsal provenance is not canonical');
   const source = record(receipt.source, 'rehearsal source');
   exactKeys(source, ['commit', 'tree'], 'rehearsal source');
   const target = record(receipt.target, 'rehearsal target');
@@ -114,16 +146,20 @@ export function parseRollbackRehearsalReceipt(value: unknown): RollbackRehearsal
   exactKeys(controls, ['production', 'preview'], 'rehearsal controls');
   for (const name of ['production', 'preview'] as const) {
     const control = record(controls[name], `${name} control`);
-    exactKeys(control, ['deploymentId', 'workerVersionId'], `${name} control`);
-    uuid(control.deploymentId, `${name} control deployment`); uuid(control.workerVersionId, `${name} control version`);
+    exactKeys(control, ['deploymentId', 'workerVersionId', 'd1Name', 'd1Id'], `${name} control`);
+    uuid(control.deploymentId, `${name} control deployment`); uuid(control.workerVersionId, `${name} control version`); uuid(control.d1Id, `${name} control D1`);
+    assert(typeof control.d1Name === 'string' && control.d1Name.length > 0, `${name} control D1 name is invalid`);
   }
   const evidence = record(receipt.evidence, 'rehearsal evidence');
   exactKeys(evidence, [
     'productionBeforeSha256', 'productionAfterSha256', 'productionVersionBeforeSha256', 'productionVersionAfterSha256',
     'previewBeforeSha256', 'previewAfterSha256', 'previewVersionBeforeSha256', 'previewVersionAfterSha256',
-    'd1InventoryBeforeSha256', 'd1InventoryAfterSha256', 'targetVersionSha256', 'readinessOutputSha256', 'runtimeOutputSha256', 'dryRunOutputSha256',
+    'd1InventoryBeforeSha256', 'd1InventoryAfterSha256', 'targetVersionSha256', 'targetDeploymentSha256', 'npmInstallSha256', 'workerdSha256', 'readinessOutputSha256', 'runtimeOutputSha256', 'dryRunOutputSha256',
   ], 'rehearsal evidence');
   for (const [key, value] of Object.entries(evidence)) assert(typeof value === 'string' && SHA256.test(value), `rehearsal evidence ${key} is not SHA-256`);
+  const exitStatuses = record(receipt.exitStatuses, 'rehearsal exit statuses');
+  exactKeys(exitStatuses, ['npmInstall', 'workerd', 'readiness', 'runtime', 'dryRun'], 'rehearsal exit statuses');
+  for (const [key, value] of Object.entries(exitStatuses)) assert(value === 0, `rehearsal ${key} exit status is not zero`);
   assert(receipt.schemaVersion === 'theologai-production-rollback-rehearsal.v1' && receipt.status === 'passed'
     && receipt.trafficMutation === false && receipt.d1Mutation === false && receipt.previewMutation === false
     && receipt.targetInactiveBefore === true && receipt.targetInactiveAfter === true, 'rehearsal receipt safety flags are not passed');
@@ -135,7 +171,6 @@ export function parseRollbackRehearsalReceipt(value: unknown): RollbackRehearsal
 
 interface DeploymentSnapshot {
   latest: { deploymentId: string; versionId: string };
-  targetDeploymentPresent: boolean;
 }
 
 function parseActiveVersionView(text: string, expectedVersionId: string, label: string): string {
@@ -177,17 +212,28 @@ function parseDeployments(text: string, label: string): DeploymentSnapshot {
   const latest = deployments.reduce((current, deployment) => deployment.createdOn > current.createdOn ? deployment : current);
   assert(latest.versions.length === 1 && latest.versions[0]!.percentage === 100,
     `${label} latest deployment is not a sole 100% assignment`);
-  const targetDeploymentPresent = deployments.some(deployment => (
-    deployment.deploymentId === ROLLBACK_REHEARSAL_TARGET.deploymentId
-    && deployment.versions.some(version => version.versionId === ROLLBACK_REHEARSAL_TARGET.workerVersionId)
-  ));
-  return { latest: { deploymentId: latest.deploymentId, versionId: latest.versions[0]!.versionId }, targetDeploymentPresent };
+  return { latest: { deploymentId: latest.deploymentId, versionId: latest.versions[0]!.versionId } };
 }
 
-function parseD1Inventory(text: string, label: string): Set<string> {
+function validateTargetDeployment(text: string): void {
+  const envelope = record(parseJson(text, 'fixed PR108 deployment response'), 'fixed PR108 deployment response');
+  exactKeys(envelope, ['errors', 'messages', 'result', 'success'], 'fixed PR108 deployment response');
+  assert(envelope.success === true && Array.isArray(envelope.errors) && Array.isArray(envelope.messages), 'fixed PR108 deployment response is not successful');
+  const result = record(envelope.result, 'fixed PR108 deployment');
+  assert(uuid(result.id, 'fixed PR108 deployment id') === ROLLBACK_REHEARSAL_TARGET.deploymentId, 'fixed PR108 deployment ID does not match');
+  assert(Array.isArray(result.versions) && result.versions.length > 0, 'fixed PR108 deployment versions are missing');
+  const versions = result.versions.map((entry, index) => {
+    const version = record(entry, `fixed PR108 deployment version ${index}`);
+    return { id: uuid(version.version_id, `fixed PR108 deployment version ${index}`), percentage: version.percentage };
+  });
+  assert(versions.length === 1 && versions[0]!.id === ROLLBACK_REHEARSAL_TARGET.workerVersionId && versions[0]!.percentage === 100,
+    'fixed PR108 deployment does not contain the exact 100% Worker version');
+}
+
+function parseD1Inventory(text: string, label: string): Map<string, string> {
   const value = parseJson(text, label);
   assert(Array.isArray(value) && value.length > 0, `${label} must be a nonempty array`);
-  const pairs = new Set<string>();
+  const pairs = new Map<string, string>();
   const ids = new Set<string>();
   const names = new Set<string>();
   for (const [index, entry] of value.entries()) {
@@ -195,15 +241,21 @@ function parseD1Inventory(text: string, label: string): Set<string> {
     const id = uuid(item.uuid, `${label} entry ${index} uuid`);
     assert(typeof item.name === 'string' && /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(item.name), `${label} entry ${index} name is invalid`);
     assert(!ids.has(id) && !names.has(item.name), `${label} contains duplicate D1 identities`);
-    ids.add(id); names.add(item.name); pairs.add(`${item.name}\u0000${id}`);
+    ids.add(id); names.add(item.name); pairs.set(item.name, id);
   }
   return pairs;
 }
 
 function assertTargetInventory(text: string, label: string): void {
   const pairs = parseD1Inventory(text, label);
-  assert(pairs.has(`${ROLLBACK_REHEARSAL_TARGET.d1Name}\u0000${ROLLBACK_REHEARSAL_TARGET.d1Id}`),
+  assert(pairs.get(ROLLBACK_REHEARSAL_TARGET.d1Name) === ROLLBACK_REHEARSAL_TARGET.d1Id,
     `${label} does not contain the fixed PR108 D1 name/UUID mapping`);
+}
+
+function d1NameForId(inventory: Map<string, string>, d1Id: string, label: string): string {
+  const names = [...inventory.entries()].filter(([, id]) => id === d1Id).map(([name]) => name);
+  assert(names.length === 1, `${label} active D1 UUID is not present exactly once in inventory`);
+  return names[0]!;
 }
 
 function assertTargetVersionView(text: string): void {
@@ -241,6 +293,13 @@ function assertSource(value: string, pattern: RegExp, expected: string, label: s
 
 export interface CreateRollbackRehearsalInput {
   confirmation: string;
+  repository: string;
+  workflow: string;
+  headSha: string;
+  ref: string;
+  runId: string;
+  runAttempt: string;
+  wranglerVersion: string;
   sourceCommit: string;
   sourceTree: string;
   expectedProductionDeploymentId: string;
@@ -261,10 +320,18 @@ export interface CreateRollbackRehearsalInput {
   readinessOutputText: string;
   runtimeOutputText: string;
   dryRunOutputText: string;
+  npmInstallOutputText: string;
+  workerdOutputText: string;
+  targetDeploymentText: string;
 }
 
 export function createRollbackRehearsalReceipt(input: CreateRollbackRehearsalInput): RollbackRehearsalReceipt {
   assert(input.confirmation === ROLLBACK_REHEARSAL_CONFIRMATION, 'confirmation phrase is incorrect');
+  assert(input.repository === ROLLBACK_REHEARSAL_REPOSITORY && input.workflow === ROLLBACK_REHEARSAL_WORKFLOW
+    && input.ref === 'refs/heads/main' && input.wranglerVersion === ROLLBACK_REHEARSAL_WRANGLER_VERSION,
+  'workflow provenance is not fixed');
+  assertSource(input.headSha, SHA1, input.headSha, 'workflow head SHA');
+  assert(/^[1-9][0-9]*$/.test(input.runId) && /^[1-9][0-9]*$/.test(input.runAttempt), 'workflow run identity is malformed');
   assertSource(input.sourceCommit, SHA1, ROLLBACK_REHEARSAL_TARGET.sourceCommit, 'source commit');
   assertSource(input.sourceTree, SHA1, ROLLBACK_REHEARSAL_TARGET.sourceTree, 'source tree');
   assertTargetVersionView(input.targetVersionText);
@@ -286,18 +353,32 @@ export function createRollbackRehearsalReceipt(input: CreateRollbackRehearsalInp
     && previewBefore.latest.versionId !== ROLLBACK_REHEARSAL_TARGET.workerVersionId, 'fixed PR108 target was active before rehearsal');
   assert(productionAfter.latest.versionId !== ROLLBACK_REHEARSAL_TARGET.workerVersionId
     && previewAfter.latest.versionId !== ROLLBACK_REHEARSAL_TARGET.workerVersionId, 'fixed PR108 target was active after rehearsal');
-  assert(productionBefore.targetDeploymentPresent && productionAfter.targetDeploymentPresent,
-    'fixed PR108 deployment/version pair is missing from production history');
+  validateTargetDeployment(input.targetDeploymentText);
+  assert(input.dryRunOutputText.includes('DRY_RUN_SENTINEL: fixed-pr108-dry-run'), 'dry-run output does not contain the exact recovery-command sentinel');
+  const d1Before = parseD1Inventory(input.d1InventoryBeforeText, 'D1 inventory before');
+  const d1After = parseD1Inventory(input.d1InventoryAfterText, 'D1 inventory after');
   assertTargetInventory(input.d1InventoryBeforeText, 'D1 inventory before');
   assertTargetInventory(input.d1InventoryAfterText, 'D1 inventory after');
-  assert(JSON.stringify([...parseD1Inventory(input.d1InventoryBeforeText, 'D1 inventory before')].sort())
-    === JSON.stringify([...parseD1Inventory(input.d1InventoryAfterText, 'D1 inventory after')].sort()), 'D1 inventory changed during rehearsal');
-  assert(input.readinessOutputText.length <= MAX_INPUT_BYTES, 'readiness output exceeds the bounded input size');
-  assert(input.runtimeOutputText.length <= MAX_INPUT_BYTES, 'runtime output exceeds the bounded input size');
-  assert(input.dryRunOutputText.length <= MAX_INPUT_BYTES, 'dry-run output exceeds the bounded input size');
+  assert(JSON.stringify([...d1Before.entries()].sort()) === JSON.stringify([...d1After.entries()].sort()), 'D1 inventory changed during rehearsal');
+  const productionD1NameBefore = d1NameForId(d1Before, productionD1Before, 'production before');
+  const productionD1NameAfter = d1NameForId(d1After, productionD1After, 'production after');
+  const previewD1NameBefore = d1NameForId(d1Before, previewD1Before, 'preview before');
+  const previewD1NameAfter = d1NameForId(d1After, previewD1After, 'preview after');
+  assert(productionD1NameBefore === productionD1NameAfter && previewD1NameBefore === previewD1NameAfter,
+    'active D1 names changed during rehearsal');
+  assert(productionD1Before !== previewD1Before && productionD1NameBefore !== previewD1NameBefore,
+    'production and preview D1 identities must be distinct');
+  for (const [text, label] of [[input.npmInstallOutputText, 'npm install'], [input.workerdOutputText, 'Workerd'], [input.readinessOutputText, 'readiness'], [input.runtimeOutputText, 'runtime'], [input.dryRunOutputText, 'dry-run']] as const) {
+    assert(Buffer.byteLength(text, 'utf8') <= MAX_INPUT_BYTES, `${label} output exceeds the bounded input size`);
+  }
   return {
     schemaVersion: 'theologai-production-rollback-rehearsal.v1',
     status: 'passed',
+    provenance: {
+      repository: ROLLBACK_REHEARSAL_REPOSITORY, workflow: ROLLBACK_REHEARSAL_WORKFLOW,
+      headSha: input.headSha, ref: 'refs/heads/main', runId: input.runId, runAttempt: input.runAttempt,
+      wranglerVersion: ROLLBACK_REHEARSAL_WRANGLER_VERSION,
+    },
     source: { commit: ROLLBACK_REHEARSAL_TARGET.sourceCommit, tree: ROLLBACK_REHEARSAL_TARGET.sourceTree },
     target: {
       deploymentId: ROLLBACK_REHEARSAL_TARGET.deploymentId,
@@ -306,8 +387,8 @@ export function createRollbackRehearsalReceipt(input: CreateRollbackRehearsalInp
       d1Id: ROLLBACK_REHEARSAL_TARGET.d1Id,
     },
     controls: {
-      production: { deploymentId: productionAfter.latest.deploymentId, workerVersionId: productionAfter.latest.versionId },
-      preview: { deploymentId: previewAfter.latest.deploymentId, workerVersionId: previewAfter.latest.versionId },
+      production: { deploymentId: productionAfter.latest.deploymentId, workerVersionId: productionAfter.latest.versionId, d1Name: productionD1NameAfter, d1Id: productionD1After },
+      preview: { deploymentId: previewAfter.latest.deploymentId, workerVersionId: previewAfter.latest.versionId, d1Name: previewD1NameAfter, d1Id: previewD1After },
     },
     evidence: {
       productionBeforeSha256: sha256(input.productionBeforeText), productionAfterSha256: sha256(input.productionAfterText),
@@ -315,9 +396,11 @@ export function createRollbackRehearsalReceipt(input: CreateRollbackRehearsalInp
       previewBeforeSha256: sha256(input.previewBeforeText), previewAfterSha256: sha256(input.previewAfterText),
       previewVersionBeforeSha256: sha256(input.previewVersionBeforeText), previewVersionAfterSha256: sha256(input.previewVersionAfterText),
       d1InventoryBeforeSha256: sha256(input.d1InventoryBeforeText), d1InventoryAfterSha256: sha256(input.d1InventoryAfterText),
-      targetVersionSha256: sha256(input.targetVersionText), readinessOutputSha256: sha256(input.readinessOutputText),
+      targetVersionSha256: sha256(input.targetVersionText), targetDeploymentSha256: sha256(input.targetDeploymentText),
+      npmInstallSha256: sha256(input.npmInstallOutputText), workerdSha256: sha256(input.workerdOutputText), readinessOutputSha256: sha256(input.readinessOutputText),
       runtimeOutputSha256: sha256(input.runtimeOutputText), dryRunOutputSha256: sha256(input.dryRunOutputText),
     },
+    exitStatuses: { npmInstall: 0, workerd: 0, readiness: 0, runtime: 0, dryRun: 0 },
     trafficMutation: false, d1Mutation: false, previewMutation: false,
     targetInactiveBefore: true, targetInactiveAfter: true,
   };
@@ -331,11 +414,11 @@ export function serializeRollbackRehearsalReceipt(input: CreateRollbackRehearsal
 
 function exactArgs(argv: string[]): Map<string, string> {
   const expected = [
-    '--confirmation', '--source-commit', '--source-tree', '--expected-production-deployment', '--expected-production-version',
+    '--confirmation', '--repository', '--workflow', '--head-sha', '--ref', '--run-id', '--run-attempt', '--wrangler-version', '--source-commit', '--source-tree', '--expected-production-deployment', '--expected-production-version',
     '--expected-preview-deployment', '--expected-preview-version', '--production-before', '--production-after',
     '--production-version-before', '--production-version-after', '--preview-before', '--preview-after',
     '--preview-version-before', '--preview-version-after', '--d1-before', '--d1-after', '--target-version',
-    '--readiness-output', '--runtime-output', '--dry-run-output', '--output',
+    '--readiness-output', '--runtime-output', '--dry-run-output', '--npm-install-output', '--workerd-output', '--target-deployment', '--output',
   ];
   assert(argv.length === expected.length * 2, 'create expects exactly the reviewed option pairs');
   const values = new Map<string, string>();
@@ -351,9 +434,11 @@ function exactArgs(argv: string[]): Map<string, string> {
 async function cli(argv: string[]): Promise<void> {
   assert(argv[0] === 'create', 'only the create command is supported');
   const values = exactArgs(argv.slice(1));
-  const read = async (option: string) => readFile(values.get(option)!, 'utf8');
+  const read = async (option: string) => readCapped(values.get(option)!, option);
   const receipt = serializeRollbackRehearsalReceipt({
-    confirmation: values.get('--confirmation')!, sourceCommit: values.get('--source-commit')!, sourceTree: values.get('--source-tree')!,
+    confirmation: values.get('--confirmation')!, repository: values.get('--repository')!, workflow: values.get('--workflow')!,
+    headSha: values.get('--head-sha')!, ref: values.get('--ref')!, runId: values.get('--run-id')!, runAttempt: values.get('--run-attempt')!,
+    wranglerVersion: values.get('--wrangler-version')!, sourceCommit: values.get('--source-commit')!, sourceTree: values.get('--source-tree')!,
     expectedProductionDeploymentId: values.get('--expected-production-deployment')!, expectedProductionVersionId: values.get('--expected-production-version')!,
     expectedPreviewDeploymentId: values.get('--expected-preview-deployment')!, expectedPreviewVersionId: values.get('--expected-preview-version')!,
     productionBeforeText: await read('--production-before'), productionAfterText: await read('--production-after'),
@@ -363,6 +448,8 @@ async function cli(argv: string[]): Promise<void> {
     d1InventoryBeforeText: await read('--d1-before'), d1InventoryAfterText: await read('--d1-after'),
     targetVersionText: await read('--target-version'), readinessOutputText: await read('--readiness-output'),
     runtimeOutputText: await read('--runtime-output'), dryRunOutputText: await read('--dry-run-output'),
+    npmInstallOutputText: await read('--npm-install-output'), workerdOutputText: await read('--workerd-output'),
+    targetDeploymentText: await read('--target-deployment'),
   });
   await writeFile(values.get('--output')!, receipt, { encoding: 'utf8', flag: 'wx' });
   process.stdout.write(receipt);

--- a/scripts/production-rollback-rehearsal.ts
+++ b/scripts/production-rollback-rehearsal.ts
@@ -71,10 +71,15 @@ export interface RollbackRehearsalReceipt {
     targetVersionSha256: string;
     targetDeploymentSha256: string;
     npmInstallSha256: string;
+    npmInstallStderrSha256: string;
     workerdSha256: string;
+    workerdStderrSha256: string;
     readinessOutputSha256: string;
+    readinessStderrSha256: string;
     runtimeOutputSha256: string;
+    runtimeStderrSha256: string;
     dryRunOutputSha256: string;
+    dryRunStderrSha256: string;
   };
   exitStatuses: { npmInstall: 0; workerd: 0; readiness: 0; runtime: 0; dryRun: 0 };
   trafficMutation: false;
@@ -154,7 +159,10 @@ export function parseRollbackRehearsalReceipt(value: unknown): RollbackRehearsal
   exactKeys(evidence, [
     'productionBeforeSha256', 'productionAfterSha256', 'productionVersionBeforeSha256', 'productionVersionAfterSha256',
     'previewBeforeSha256', 'previewAfterSha256', 'previewVersionBeforeSha256', 'previewVersionAfterSha256',
-    'd1InventoryBeforeSha256', 'd1InventoryAfterSha256', 'targetVersionSha256', 'targetDeploymentSha256', 'npmInstallSha256', 'workerdSha256', 'readinessOutputSha256', 'runtimeOutputSha256', 'dryRunOutputSha256',
+    'd1InventoryBeforeSha256', 'd1InventoryAfterSha256', 'targetVersionSha256', 'targetDeploymentSha256',
+    'npmInstallSha256', 'npmInstallStderrSha256', 'workerdSha256', 'workerdStderrSha256',
+    'readinessOutputSha256', 'readinessStderrSha256', 'runtimeOutputSha256', 'runtimeStderrSha256',
+    'dryRunOutputSha256', 'dryRunStderrSha256',
   ], 'rehearsal evidence');
   for (const [key, value] of Object.entries(evidence)) assert(typeof value === 'string' && SHA256.test(value), `rehearsal evidence ${key} is not SHA-256`);
   const exitStatuses = record(receipt.exitStatuses, 'rehearsal exit statuses');
@@ -318,10 +326,15 @@ export interface CreateRollbackRehearsalInput {
   d1InventoryAfterText: string;
   targetVersionText: string;
   readinessOutputText: string;
+  readinessStderrText: string;
   runtimeOutputText: string;
+  runtimeStderrText: string;
   dryRunOutputText: string;
+  dryRunStderrText: string;
   npmInstallOutputText: string;
+  npmInstallStderrText: string;
   workerdOutputText: string;
+  workerdStderrText: string;
   targetDeploymentText: string;
 }
 
@@ -368,7 +381,13 @@ export function createRollbackRehearsalReceipt(input: CreateRollbackRehearsalInp
     'active D1 names changed during rehearsal');
   assert(productionD1Before !== previewD1Before && productionD1NameBefore !== previewD1NameBefore,
     'production and preview D1 identities must be distinct');
-  for (const [text, label] of [[input.npmInstallOutputText, 'npm install'], [input.workerdOutputText, 'Workerd'], [input.readinessOutputText, 'readiness'], [input.runtimeOutputText, 'runtime'], [input.dryRunOutputText, 'dry-run']] as const) {
+  for (const [text, label] of [
+    [input.npmInstallOutputText, 'npm install stdout'], [input.npmInstallStderrText, 'npm install stderr'],
+    [input.workerdOutputText, 'Workerd stdout'], [input.workerdStderrText, 'Workerd stderr'],
+    [input.readinessOutputText, 'readiness stdout'], [input.readinessStderrText, 'readiness stderr'],
+    [input.runtimeOutputText, 'runtime stdout'], [input.runtimeStderrText, 'runtime stderr'],
+    [input.dryRunOutputText, 'dry-run stdout'], [input.dryRunStderrText, 'dry-run stderr'],
+  ] as const) {
     assert(Buffer.byteLength(text, 'utf8') <= MAX_INPUT_BYTES, `${label} output exceeds the bounded input size`);
   }
   return {
@@ -397,8 +416,11 @@ export function createRollbackRehearsalReceipt(input: CreateRollbackRehearsalInp
       previewVersionBeforeSha256: sha256(input.previewVersionBeforeText), previewVersionAfterSha256: sha256(input.previewVersionAfterText),
       d1InventoryBeforeSha256: sha256(input.d1InventoryBeforeText), d1InventoryAfterSha256: sha256(input.d1InventoryAfterText),
       targetVersionSha256: sha256(input.targetVersionText), targetDeploymentSha256: sha256(input.targetDeploymentText),
-      npmInstallSha256: sha256(input.npmInstallOutputText), workerdSha256: sha256(input.workerdOutputText), readinessOutputSha256: sha256(input.readinessOutputText),
-      runtimeOutputSha256: sha256(input.runtimeOutputText), dryRunOutputSha256: sha256(input.dryRunOutputText),
+      npmInstallSha256: sha256(input.npmInstallOutputText), npmInstallStderrSha256: sha256(input.npmInstallStderrText),
+      workerdSha256: sha256(input.workerdOutputText), workerdStderrSha256: sha256(input.workerdStderrText),
+      readinessOutputSha256: sha256(input.readinessOutputText), readinessStderrSha256: sha256(input.readinessStderrText),
+      runtimeOutputSha256: sha256(input.runtimeOutputText), runtimeStderrSha256: sha256(input.runtimeStderrText),
+      dryRunOutputSha256: sha256(input.dryRunOutputText), dryRunStderrSha256: sha256(input.dryRunStderrText),
     },
     exitStatuses: { npmInstall: 0, workerd: 0, readiness: 0, runtime: 0, dryRun: 0 },
     trafficMutation: false, d1Mutation: false, previewMutation: false,
@@ -418,7 +440,8 @@ function exactArgs(argv: string[]): Map<string, string> {
     '--expected-preview-deployment', '--expected-preview-version', '--production-before', '--production-after',
     '--production-version-before', '--production-version-after', '--preview-before', '--preview-after',
     '--preview-version-before', '--preview-version-after', '--d1-before', '--d1-after', '--target-version',
-    '--readiness-output', '--runtime-output', '--dry-run-output', '--npm-install-output', '--workerd-output', '--target-deployment', '--output',
+    '--readiness-output', '--readiness-stderr', '--runtime-output', '--runtime-stderr', '--dry-run-output', '--dry-run-stderr',
+    '--npm-install-output', '--npm-install-stderr', '--workerd-output', '--workerd-stderr', '--target-deployment', '--output',
   ];
   assert(argv.length === expected.length * 2, 'create expects exactly the reviewed option pairs');
   const values = new Map<string, string>();
@@ -446,9 +469,10 @@ async function cli(argv: string[]): Promise<void> {
     previewBeforeText: await read('--preview-before'), previewAfterText: await read('--preview-after'),
     previewVersionBeforeText: await read('--preview-version-before'), previewVersionAfterText: await read('--preview-version-after'),
     d1InventoryBeforeText: await read('--d1-before'), d1InventoryAfterText: await read('--d1-after'),
-    targetVersionText: await read('--target-version'), readinessOutputText: await read('--readiness-output'),
-    runtimeOutputText: await read('--runtime-output'), dryRunOutputText: await read('--dry-run-output'),
-    npmInstallOutputText: await read('--npm-install-output'), workerdOutputText: await read('--workerd-output'),
+    targetVersionText: await read('--target-version'), readinessOutputText: await read('--readiness-output'), readinessStderrText: await read('--readiness-stderr'),
+    runtimeOutputText: await read('--runtime-output'), runtimeStderrText: await read('--runtime-stderr'), dryRunOutputText: await read('--dry-run-output'), dryRunStderrText: await read('--dry-run-stderr'),
+    npmInstallOutputText: await read('--npm-install-output'), npmInstallStderrText: await read('--npm-install-stderr'),
+    workerdOutputText: await read('--workerd-output'), workerdStderrText: await read('--workerd-stderr'),
     targetDeploymentText: await read('--target-deployment'),
   });
   await writeFile(values.get('--output')!, receipt, { encoding: 'utf8', flag: 'wx' });

--- a/scripts/production-rollback-rehearsal.ts
+++ b/scripts/production-rollback-rehearsal.ts
@@ -1,0 +1,376 @@
+/**
+ * Read-only production rollback rehearsal verifier.
+ *
+ * This module deliberately has no Wrangler or Cloudflare mutation command. It
+ * consumes private control-plane captures and emits a bounded, hash-only
+ * receipt. The fixed PR #108 target is code-owned; callers can provide only
+ * the expected current identities that they observed immediately before the
+ * rehearsal.
+ */
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256 = /^[0-9a-f]{64}$/i;
+const SHA1 = /^[0-9a-f]{40}$/i;
+const MAX_INPUT_BYTES = 8 * 1024 * 1024;
+const MAX_RECEIPT_BYTES = 32 * 1024;
+
+export const ROLLBACK_REHEARSAL_CONFIRMATION = 'REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC';
+export const ROLLBACK_REHEARSAL_COMMAND = 'wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --dry-run --yes';
+
+export const ROLLBACK_REHEARSAL_TARGET = Object.freeze({
+  sourceCommit: '8da99fd0a161b90a4bd90ab29bde1abf796b3bf6',
+  sourceTree: 'a59d9a062b2e6c7884de97fd97309878e1cbdc23',
+  deploymentId: '3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8',
+  workerVersionId: '291f3292-3fa9-44fc-bf6f-b68fd2f4cef6',
+  d1Name: 'theologai-production-20260729-transform11-a',
+  d1Id: '53211f50-a893-4b4c-be1e-bc625a595dc7',
+});
+
+type JsonRecord = Record<string, unknown>;
+
+export interface RollbackRehearsalReceipt {
+  schemaVersion: 'theologai-production-rollback-rehearsal.v1';
+  status: 'passed';
+  source: { commit: string; tree: string };
+  target: {
+    deploymentId: string;
+    workerVersionId: string;
+    d1Name: string;
+    d1Id: string;
+  };
+  controls: {
+    production: { deploymentId: string; workerVersionId: string };
+    preview: { deploymentId: string; workerVersionId: string };
+  };
+  evidence: {
+    productionBeforeSha256: string;
+    productionAfterSha256: string;
+    productionVersionBeforeSha256: string;
+    productionVersionAfterSha256: string;
+    previewBeforeSha256: string;
+    previewAfterSha256: string;
+    previewVersionBeforeSha256: string;
+    previewVersionAfterSha256: string;
+    d1InventoryBeforeSha256: string;
+    d1InventoryAfterSha256: string;
+    targetVersionSha256: string;
+    readinessOutputSha256: string;
+    runtimeOutputSha256: string;
+    dryRunOutputSha256: string;
+  };
+  trafficMutation: false;
+  d1Mutation: false;
+  previewMutation: false;
+  targetInactiveBefore: true;
+  targetInactiveAfter: true;
+}
+
+function fail(message: string): never {
+  throw new Error(`Production rollback rehearsal refused: ${message}.`);
+}
+
+function assert(value: unknown, message: string): asserts value {
+  if (!value) fail(message);
+}
+
+function record(value: unknown, label: string): JsonRecord {
+  assert(value !== null && typeof value === 'object' && !Array.isArray(value), `${label} must be an object`);
+  return value as JsonRecord;
+}
+
+function exactKeys(value: JsonRecord, keys: readonly string[], label: string): void {
+  assert(JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort()), `${label} keys are malformed`);
+}
+
+function parseJson(text: string, label: string): unknown {
+  assert(Buffer.byteLength(text, 'utf8') <= MAX_INPUT_BYTES, `${label} exceeds the bounded input size`);
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    fail(`${label} is not valid JSON`);
+  }
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function uuid(value: unknown, label: string): string {
+  assert(typeof value === 'string' && UUID.test(value), `${label} is not a UUID`);
+  return value.toLowerCase();
+}
+
+export function parseRollbackRehearsalReceipt(value: unknown): RollbackRehearsalReceipt {
+  const receipt = record(value, 'rehearsal receipt');
+  exactKeys(receipt, ['schemaVersion', 'status', 'source', 'target', 'controls', 'evidence', 'trafficMutation', 'd1Mutation', 'previewMutation', 'targetInactiveBefore', 'targetInactiveAfter'], 'rehearsal receipt');
+  const source = record(receipt.source, 'rehearsal source');
+  exactKeys(source, ['commit', 'tree'], 'rehearsal source');
+  const target = record(receipt.target, 'rehearsal target');
+  exactKeys(target, ['deploymentId', 'workerVersionId', 'd1Name', 'd1Id'], 'rehearsal target');
+  const controls = record(receipt.controls, 'rehearsal controls');
+  exactKeys(controls, ['production', 'preview'], 'rehearsal controls');
+  for (const name of ['production', 'preview'] as const) {
+    const control = record(controls[name], `${name} control`);
+    exactKeys(control, ['deploymentId', 'workerVersionId'], `${name} control`);
+    uuid(control.deploymentId, `${name} control deployment`); uuid(control.workerVersionId, `${name} control version`);
+  }
+  const evidence = record(receipt.evidence, 'rehearsal evidence');
+  exactKeys(evidence, [
+    'productionBeforeSha256', 'productionAfterSha256', 'productionVersionBeforeSha256', 'productionVersionAfterSha256',
+    'previewBeforeSha256', 'previewAfterSha256', 'previewVersionBeforeSha256', 'previewVersionAfterSha256',
+    'd1InventoryBeforeSha256', 'd1InventoryAfterSha256', 'targetVersionSha256', 'readinessOutputSha256', 'runtimeOutputSha256', 'dryRunOutputSha256',
+  ], 'rehearsal evidence');
+  for (const [key, value] of Object.entries(evidence)) assert(typeof value === 'string' && SHA256.test(value), `rehearsal evidence ${key} is not SHA-256`);
+  assert(receipt.schemaVersion === 'theologai-production-rollback-rehearsal.v1' && receipt.status === 'passed'
+    && receipt.trafficMutation === false && receipt.d1Mutation === false && receipt.previewMutation === false
+    && receipt.targetInactiveBefore === true && receipt.targetInactiveAfter === true, 'rehearsal receipt safety flags are not passed');
+  assert(source.commit === ROLLBACK_REHEARSAL_TARGET.sourceCommit && source.tree === ROLLBACK_REHEARSAL_TARGET.sourceTree, 'rehearsal source identity is not fixed');
+  assert(target.deploymentId === ROLLBACK_REHEARSAL_TARGET.deploymentId && target.workerVersionId === ROLLBACK_REHEARSAL_TARGET.workerVersionId
+    && target.d1Name === ROLLBACK_REHEARSAL_TARGET.d1Name && target.d1Id === ROLLBACK_REHEARSAL_TARGET.d1Id, 'rehearsal target identity is not fixed');
+  return receipt as unknown as RollbackRehearsalReceipt;
+}
+
+interface DeploymentSnapshot {
+  latest: { deploymentId: string; versionId: string };
+  targetDeploymentPresent: boolean;
+}
+
+function parseActiveVersionView(text: string, expectedVersionId: string, label: string): string {
+  const view = record(parseJson(text, `${label} version view`), `${label} version view`);
+  assert(uuid(view.id, `${label} version id`) === uuid(expectedVersionId, `${label} expected version`), `${label} version view does not match deployment`);
+  const resources = record(view.resources, `${label} version resources`);
+  assert(Array.isArray(resources.bindings), `${label} version bindings are not an array`);
+  const d1 = resources.bindings
+    .map((entry, index) => record(entry, `${label} binding ${index}`))
+    .filter(binding => binding.name === 'THEOLOGAI_DB');
+  assert(d1.length === 1, `${label} version must expose exactly one THEOLOGAI_DB binding`);
+  const binding = d1[0]!;
+  const id = uuid(binding.id, `${label} D1 binding id`);
+  assert(binding.type === 'd1', `${label} THEOLOGAI_DB binding is not D1`);
+  if (binding.database_id !== undefined) assert(uuid(binding.database_id, `${label} D1 database_id`) === id, `${label} D1 IDs disagree`);
+  return id;
+}
+
+function parseDeployments(text: string, label: string): DeploymentSnapshot {
+  const value = parseJson(text, label);
+  assert(Array.isArray(value) && value.length > 0, `${label} must be a nonempty array`);
+  const seen = new Set<string>();
+  const deployments = value.map((entry, index) => {
+    const item = record(entry, `${label} entry ${index}`);
+    assert(typeof item.created_on === 'string' && Number.isFinite(Date.parse(item.created_on)), `${label} entry ${index} created_on is invalid`);
+    const deploymentId = uuid(item.id, `${label} entry ${index} id`);
+    assert(!seen.has(deploymentId), `${label} contains duplicate deployment IDs`);
+    seen.add(deploymentId);
+    assert(Array.isArray(item.versions) && item.versions.length > 0, `${label} entry ${index} versions are invalid`);
+    const versions = item.versions.map((version, versionIndex) => {
+      const v = record(version, `${label} entry ${index} version ${versionIndex}`);
+      const versionId = uuid(v.version_id, `${label} entry ${index} version ${versionIndex} id`);
+      assert(typeof v.percentage === 'number' && Number.isFinite(v.percentage) && v.percentage >= 0 && v.percentage <= 100,
+        `${label} entry ${index} version ${versionIndex} percentage is invalid`);
+      return { versionId, percentage: v.percentage as number };
+    });
+    return { deploymentId, createdOn: item.created_on, versions };
+  });
+  const latest = deployments.reduce((current, deployment) => deployment.createdOn > current.createdOn ? deployment : current);
+  assert(latest.versions.length === 1 && latest.versions[0]!.percentage === 100,
+    `${label} latest deployment is not a sole 100% assignment`);
+  const targetDeploymentPresent = deployments.some(deployment => (
+    deployment.deploymentId === ROLLBACK_REHEARSAL_TARGET.deploymentId
+    && deployment.versions.some(version => version.versionId === ROLLBACK_REHEARSAL_TARGET.workerVersionId)
+  ));
+  return { latest: { deploymentId: latest.deploymentId, versionId: latest.versions[0]!.versionId }, targetDeploymentPresent };
+}
+
+function parseD1Inventory(text: string, label: string): Set<string> {
+  const value = parseJson(text, label);
+  assert(Array.isArray(value) && value.length > 0, `${label} must be a nonempty array`);
+  const pairs = new Set<string>();
+  const ids = new Set<string>();
+  const names = new Set<string>();
+  for (const [index, entry] of value.entries()) {
+    const item = record(entry, `${label} entry ${index}`);
+    const id = uuid(item.uuid, `${label} entry ${index} uuid`);
+    assert(typeof item.name === 'string' && /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(item.name), `${label} entry ${index} name is invalid`);
+    assert(!ids.has(id) && !names.has(item.name), `${label} contains duplicate D1 identities`);
+    ids.add(id); names.add(item.name); pairs.add(`${item.name}\u0000${id}`);
+  }
+  return pairs;
+}
+
+function assertTargetInventory(text: string, label: string): void {
+  const pairs = parseD1Inventory(text, label);
+  assert(pairs.has(`${ROLLBACK_REHEARSAL_TARGET.d1Name}\u0000${ROLLBACK_REHEARSAL_TARGET.d1Id}`),
+    `${label} does not contain the fixed PR108 D1 name/UUID mapping`);
+}
+
+function assertTargetVersionView(text: string): void {
+  const view = record(parseJson(text, 'target Worker version view'), 'target Worker version view');
+  assert(uuid(view.id, 'target Worker version id') === ROLLBACK_REHEARSAL_TARGET.workerVersionId,
+    'target Worker version is not the fixed PR108 version');
+  const resources = record(view.resources, 'target Worker version resources');
+  assert(Array.isArray(resources.bindings), 'target Worker version bindings are not an array');
+  const d1Bindings = resources.bindings
+    .map((entry, index) => record(entry, `target Worker binding ${index}`))
+    .filter(binding => binding.name === 'THEOLOGAI_DB');
+  assert(d1Bindings.length === 1, 'target Worker version must expose exactly one THEOLOGAI_DB binding');
+  const binding = d1Bindings[0]!;
+  assert(binding.type === 'd1' && uuid(binding.id, 'target Worker D1 binding id') === ROLLBACK_REHEARSAL_TARGET.d1Id,
+    'target Worker version THEOLOGAI_DB binding does not match the fixed PR108 D1');
+  if (binding.database_id !== undefined) {
+    assert(uuid(binding.database_id, 'target Worker D1 database_id') === ROLLBACK_REHEARSAL_TARGET.d1Id,
+      'target Worker D1 id/database_id disagree');
+  }
+}
+
+function assertExpectedControl(
+  snapshot: DeploymentSnapshot,
+  expectedDeploymentId: string,
+  expectedVersionId: string,
+  label: string,
+): void {
+  assert(snapshot.latest.deploymentId === uuid(expectedDeploymentId, `${label} expected deployment`), `${label} deployment changed`);
+  assert(snapshot.latest.versionId === uuid(expectedVersionId, `${label} expected Worker version`), `${label} Worker version changed`);
+}
+
+function assertSource(value: string, pattern: RegExp, expected: string, label: string): void {
+  assert(pattern.test(value) && value === expected, `${label} does not match the fixed PR108 source identity`);
+}
+
+export interface CreateRollbackRehearsalInput {
+  confirmation: string;
+  sourceCommit: string;
+  sourceTree: string;
+  expectedProductionDeploymentId: string;
+  expectedProductionVersionId: string;
+  expectedPreviewDeploymentId: string;
+  expectedPreviewVersionId: string;
+  productionBeforeText: string;
+  productionAfterText: string;
+  productionVersionBeforeText: string;
+  productionVersionAfterText: string;
+  previewBeforeText: string;
+  previewAfterText: string;
+  previewVersionBeforeText: string;
+  previewVersionAfterText: string;
+  d1InventoryBeforeText: string;
+  d1InventoryAfterText: string;
+  targetVersionText: string;
+  readinessOutputText: string;
+  runtimeOutputText: string;
+  dryRunOutputText: string;
+}
+
+export function createRollbackRehearsalReceipt(input: CreateRollbackRehearsalInput): RollbackRehearsalReceipt {
+  assert(input.confirmation === ROLLBACK_REHEARSAL_CONFIRMATION, 'confirmation phrase is incorrect');
+  assertSource(input.sourceCommit, SHA1, ROLLBACK_REHEARSAL_TARGET.sourceCommit, 'source commit');
+  assertSource(input.sourceTree, SHA1, ROLLBACK_REHEARSAL_TARGET.sourceTree, 'source tree');
+  assertTargetVersionView(input.targetVersionText);
+  const productionBefore = parseDeployments(input.productionBeforeText, 'production deployments before');
+  const productionAfter = parseDeployments(input.productionAfterText, 'production deployments after');
+  const previewBefore = parseDeployments(input.previewBeforeText, 'preview deployments before');
+  const previewAfter = parseDeployments(input.previewAfterText, 'preview deployments after');
+  assertExpectedControl(productionBefore, input.expectedProductionDeploymentId, input.expectedProductionVersionId, 'production before');
+  assertExpectedControl(productionAfter, input.expectedProductionDeploymentId, input.expectedProductionVersionId, 'production after');
+  assertExpectedControl(previewBefore, input.expectedPreviewDeploymentId, input.expectedPreviewVersionId, 'preview before');
+  assertExpectedControl(previewAfter, input.expectedPreviewDeploymentId, input.expectedPreviewVersionId, 'preview after');
+  const productionD1Before = parseActiveVersionView(input.productionVersionBeforeText, productionBefore.latest.versionId, 'production before');
+  const productionD1After = parseActiveVersionView(input.productionVersionAfterText, productionAfter.latest.versionId, 'production after');
+  const previewD1Before = parseActiveVersionView(input.previewVersionBeforeText, previewBefore.latest.versionId, 'preview before');
+  const previewD1After = parseActiveVersionView(input.previewVersionAfterText, previewAfter.latest.versionId, 'preview after');
+  assert(productionD1Before === productionD1After, 'production D1 binding changed during rehearsal');
+  assert(previewD1Before === previewD1After, 'preview D1 binding changed during rehearsal');
+  assert(productionBefore.latest.versionId !== ROLLBACK_REHEARSAL_TARGET.workerVersionId
+    && previewBefore.latest.versionId !== ROLLBACK_REHEARSAL_TARGET.workerVersionId, 'fixed PR108 target was active before rehearsal');
+  assert(productionAfter.latest.versionId !== ROLLBACK_REHEARSAL_TARGET.workerVersionId
+    && previewAfter.latest.versionId !== ROLLBACK_REHEARSAL_TARGET.workerVersionId, 'fixed PR108 target was active after rehearsal');
+  assert(productionBefore.targetDeploymentPresent && productionAfter.targetDeploymentPresent,
+    'fixed PR108 deployment/version pair is missing from production history');
+  assertTargetInventory(input.d1InventoryBeforeText, 'D1 inventory before');
+  assertTargetInventory(input.d1InventoryAfterText, 'D1 inventory after');
+  assert(JSON.stringify([...parseD1Inventory(input.d1InventoryBeforeText, 'D1 inventory before')].sort())
+    === JSON.stringify([...parseD1Inventory(input.d1InventoryAfterText, 'D1 inventory after')].sort()), 'D1 inventory changed during rehearsal');
+  assert(input.readinessOutputText.length <= MAX_INPUT_BYTES, 'readiness output exceeds the bounded input size');
+  assert(input.runtimeOutputText.length <= MAX_INPUT_BYTES, 'runtime output exceeds the bounded input size');
+  assert(input.dryRunOutputText.length <= MAX_INPUT_BYTES, 'dry-run output exceeds the bounded input size');
+  return {
+    schemaVersion: 'theologai-production-rollback-rehearsal.v1',
+    status: 'passed',
+    source: { commit: ROLLBACK_REHEARSAL_TARGET.sourceCommit, tree: ROLLBACK_REHEARSAL_TARGET.sourceTree },
+    target: {
+      deploymentId: ROLLBACK_REHEARSAL_TARGET.deploymentId,
+      workerVersionId: ROLLBACK_REHEARSAL_TARGET.workerVersionId,
+      d1Name: ROLLBACK_REHEARSAL_TARGET.d1Name,
+      d1Id: ROLLBACK_REHEARSAL_TARGET.d1Id,
+    },
+    controls: {
+      production: { deploymentId: productionAfter.latest.deploymentId, workerVersionId: productionAfter.latest.versionId },
+      preview: { deploymentId: previewAfter.latest.deploymentId, workerVersionId: previewAfter.latest.versionId },
+    },
+    evidence: {
+      productionBeforeSha256: sha256(input.productionBeforeText), productionAfterSha256: sha256(input.productionAfterText),
+      productionVersionBeforeSha256: sha256(input.productionVersionBeforeText), productionVersionAfterSha256: sha256(input.productionVersionAfterText),
+      previewBeforeSha256: sha256(input.previewBeforeText), previewAfterSha256: sha256(input.previewAfterText),
+      previewVersionBeforeSha256: sha256(input.previewVersionBeforeText), previewVersionAfterSha256: sha256(input.previewVersionAfterText),
+      d1InventoryBeforeSha256: sha256(input.d1InventoryBeforeText), d1InventoryAfterSha256: sha256(input.d1InventoryAfterText),
+      targetVersionSha256: sha256(input.targetVersionText), readinessOutputSha256: sha256(input.readinessOutputText),
+      runtimeOutputSha256: sha256(input.runtimeOutputText), dryRunOutputSha256: sha256(input.dryRunOutputText),
+    },
+    trafficMutation: false, d1Mutation: false, previewMutation: false,
+    targetInactiveBefore: true, targetInactiveAfter: true,
+  };
+}
+
+export function serializeRollbackRehearsalReceipt(input: CreateRollbackRehearsalInput): string {
+  const bytes = `${JSON.stringify(parseRollbackRehearsalReceipt(createRollbackRehearsalReceipt(input)))}\n`;
+  assert(Buffer.byteLength(bytes, 'utf8') <= MAX_RECEIPT_BYTES, 'receipt exceeds the bounded output size');
+  return bytes;
+}
+
+function exactArgs(argv: string[]): Map<string, string> {
+  const expected = [
+    '--confirmation', '--source-commit', '--source-tree', '--expected-production-deployment', '--expected-production-version',
+    '--expected-preview-deployment', '--expected-preview-version', '--production-before', '--production-after',
+    '--production-version-before', '--production-version-after', '--preview-before', '--preview-after',
+    '--preview-version-before', '--preview-version-after', '--d1-before', '--d1-after', '--target-version',
+    '--readiness-output', '--runtime-output', '--dry-run-output', '--output',
+  ];
+  assert(argv.length === expected.length * 2, 'create expects exactly the reviewed option pairs');
+  const values = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const option = argv[index]; const value = argv[index + 1];
+    assert(typeof option === 'string' && expected.includes(option) && typeof value === 'string' && value.length > 0 && !values.has(option), 'arguments are malformed');
+    values.set(option, value);
+  }
+  assert(values.size === expected.length, 'arguments are incomplete');
+  return values;
+}
+
+async function cli(argv: string[]): Promise<void> {
+  assert(argv[0] === 'create', 'only the create command is supported');
+  const values = exactArgs(argv.slice(1));
+  const read = async (option: string) => readFile(values.get(option)!, 'utf8');
+  const receipt = serializeRollbackRehearsalReceipt({
+    confirmation: values.get('--confirmation')!, sourceCommit: values.get('--source-commit')!, sourceTree: values.get('--source-tree')!,
+    expectedProductionDeploymentId: values.get('--expected-production-deployment')!, expectedProductionVersionId: values.get('--expected-production-version')!,
+    expectedPreviewDeploymentId: values.get('--expected-preview-deployment')!, expectedPreviewVersionId: values.get('--expected-preview-version')!,
+    productionBeforeText: await read('--production-before'), productionAfterText: await read('--production-after'),
+    productionVersionBeforeText: await read('--production-version-before'), productionVersionAfterText: await read('--production-version-after'),
+    previewBeforeText: await read('--preview-before'), previewAfterText: await read('--preview-after'),
+    previewVersionBeforeText: await read('--preview-version-before'), previewVersionAfterText: await read('--preview-version-after'),
+    d1InventoryBeforeText: await read('--d1-before'), d1InventoryAfterText: await read('--d1-after'),
+    targetVersionText: await read('--target-version'), readinessOutputText: await read('--readiness-output'),
+    runtimeOutputText: await read('--runtime-output'), dryRunOutputText: await read('--dry-run-output'),
+  });
+  await writeFile(values.get('--output')!, receipt, { encoding: 'utf8', flag: 'wx' });
+  process.stdout.write(receipt);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  cli(process.argv.slice(2)).catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -10,8 +10,8 @@
     "conformance": 1
   },
   "current": {
-    "totalTestTypeScript": 281,
-    "activeVitest": 202,
+    "totalTestTypeScript": 282,
+    "activeVitest": 203,
     "support": 24,
     "manual": 4,
     "legacyOrphan": 50,
@@ -177,6 +177,7 @@
       "test/unit/scripts/previewReleaseReconciliation.test.ts",
       "test/unit/scripts/primarySourceEdgeStabilization.test.ts",
       "test/unit/scripts/productionReleaseGuards.test.ts",
+      "test/unit/scripts/productionRollbackRehearsal.test.ts",
       "test/unit/scripts/publicDomainHistoricalSources.test.ts",
       "test/unit/scripts/releaseCorpusCapacity.test.ts",
       "test/unit/scripts/resolveProductionReleaseContext.test.ts",

--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -10,8 +10,8 @@
     "conformance": 1
   },
   "current": {
-    "totalTestTypeScript": 282,
-    "activeVitest": 203,
+    "totalTestTypeScript": 283,
+    "activeVitest": 204,
     "support": 24,
     "manual": 4,
     "legacyOrphan": 50,
@@ -127,6 +127,7 @@
       "test/unit/scripts/augustinePuseyStrictPackage.test.ts",
       "test/unit/scripts/biblicalLanguageSources.test.ts",
       "test/unit/scripts/buildUbsParallelPassages.test.ts",
+      "test/unit/scripts/captureBoundedCommand.test.ts",
       "test/unit/scripts/ccelCoordinatorOperator.test.ts",
       "test/unit/scripts/ccelLivePreviewCanary.test.ts",
       "test/unit/scripts/ccelOperatorSecretRelease.test.ts",

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -278,6 +278,16 @@ describe('workflow topology', () => {
     expect([...workflow.matchAll(/wrangler versions deploy/g)]).toHaveLength(1);
     expect(workflow).toContain('CLOUDFLARE_READ_ONLY_API_TOKEN');
     expect(workflow).not.toContain('secrets.CLOUDFLARE_API_TOKEN');
+    expect(workflow.match(/^\s+CLOUDFLARE_READ_ONLY_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_READ_ONLY_API_TOKEN \}\}$/gm)).toHaveLength(5);
+    expect(workflow.match(/^\s+CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_READ_ONLY_API_TOKEN \}\}$/gm)).toHaveLength(5);
+    expect(workflow).toContain('capture-bounded-command.ts');
+    expect(workflow).not.toContain('WRANGLER_LOG_PATH');
+    expect(workflow).not.toMatch(/^\s*[^#\n]*>\s*["']?\$RUNNER_TEMP/m);
+    for (const step of workflow.split('\n      - ')) {
+      if (!/\bwrangler(?:\s|$)/.test(step)) continue;
+      if (step.includes('name: Verify pinned Wrangler version')) continue;
+      expect(step).toContain('CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_ONLY_API_TOKEN }}');
+    }
     expect(workflow).toContain('target-deployment.json');
     expect(workflow).toContain('/workers/scripts/theologai/deployments/3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8');
     expect(workflow).toContain('all(.value == 0)');
@@ -290,5 +300,15 @@ describe('workflow topology', () => {
     expect(workflow).not.toMatch(/wrangler\s+rollback|versions\s+upload|wrangler\s+deploy(?!ments)/i);
     expect(workflow).not.toMatch(/d1\s+(execute|migrations|delete|create|update)|secret\s+(put|delete)|triggers\s+deploy/i);
     expect(workflow).not.toContain('github-token:');
+  });
+
+  it('documents the exact least-privilege token permissions and matched retention baseline', async () => {
+    const runbook = await readFile(new URL('../../../docs/PRODUCTION-ROLLBACK-REHEARSAL.md', import.meta.url), 'utf8');
+    expect(runbook).toContain('Workers Scripts Read');
+    expect(runbook).toContain('D1 Read');
+    expect(runbook).toContain('no additional permissions');
+    expect(runbook).toContain('schema-`0009` is active');
+    expect(runbook).toContain('PR #108 Transform-11');
+    expect(runbook).toContain('PR #101 hierarchy');
   });
 });

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -242,4 +242,35 @@ describe('workflow topology', () => {
     expect(occurrences(job, '      - name: Confirm active preview cancellation')).toBe(1);
     expect(job).toContain('run: echo "Preview authorization was revoked; matching in-flight PR Checks runs were canceled."');
   });
+
+  it('keeps the production rollback rehearsal manual, protected, fixed-target, and read-only', async () => {
+    const workflow = await readWorkflow('production-rollback-rehearsal.yml');
+    const trigger = uniqueBlock(workflow, 'on:');
+    const concurrency = uniqueBlock(workflow, 'concurrency:');
+    const job = uniqueBlock(workflow, '  rehearse:');
+    expect(normalized(trigger)).toContain('on: workflow_dispatch: inputs:');
+    expect(trigger).not.toMatch(/\n\s+(push|pull_request):/);
+    expect(normalized(concurrency)).toBe('concurrency: group: deploy-production cancel-in-progress: false');
+    expect(workflow).toContain('permissions:\n  contents: read');
+    expect(job).toContain("if: ${{ github.ref == 'refs/heads/main' }}");
+    expect(job).toContain('environment:\n      name: production');
+    expect(job).toContain('contents: read');
+    for (const value of [
+      '8da99fd0a161b90a4bd90ab29bde1abf796b3bf6',
+      'a59d9a062b2e6c7884de97fd97309878e1cbdc23',
+      '3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8',
+      '291f3292-3fa9-44fc-bf6f-b68fd2f4cef6',
+      'theologai-production-20260729-transform11-a',
+      '53211f50-a893-4b4c-be1e-bc625a595dc7',
+      'REHEARSE THE EXACT PR108 ROLLBACK WITHOUT TRAFFIC',
+    ]) expect(workflow).toContain(value);
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('Capture production and preview controls before rehearsal (read-only)');
+    expect(workflow).toContain('Capture production and preview controls after rehearsal (read-only)');
+    expect(workflow).toContain('Upload sanitized rehearsal receipt only');
+    expect(workflow).toContain('--dry-run --yes');
+    expect(workflow).not.toMatch(/wrangler\s+rollback|versions\s+upload|wrangler\s+deploy(?!ments)/i);
+    expect(workflow).not.toMatch(/d1\s+(execute|migrations|delete|create|update)|secret\s+(put|delete)|triggers\s+deploy/i);
+    expect(workflow).not.toContain('github-token:');
+  });
 });

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -280,7 +280,10 @@ describe('workflow topology', () => {
     expect(workflow).not.toContain('secrets.CLOUDFLARE_API_TOKEN');
     expect(workflow.match(/^\s+CLOUDFLARE_READ_ONLY_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_READ_ONLY_API_TOKEN \}\}$/gm)).toHaveLength(5);
     expect(workflow.match(/^\s+CLOUDFLARE_API_TOKEN: \$\{\{ secrets\.CLOUDFLARE_READ_ONLY_API_TOKEN \}\}$/gm)).toHaveLength(5);
-    expect(workflow).toContain('capture-bounded-command.ts');
+    expect(workflow).toContain('capture-bounded-command.mjs');
+    expect(workflow).not.toContain('node_modules/.bin/tsx" "$GITHUB_WORKSPACE/scripts/capture-bounded-command');
+    const installVerifier = uniqueBlock(job, '      - name: Install verifier dependencies');
+    expect(installVerifier).toContain('node "$GITHUB_WORKSPACE/scripts/capture-bounded-command.mjs"');
     expect(workflow).not.toContain('WRANGLER_LOG_PATH');
     expect(workflow).not.toMatch(/^\s*[^#\n]*>\s*["']?\$RUNNER_TEMP/m);
     for (const step of workflow.split('\n      - ')) {

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -252,8 +252,14 @@ describe('workflow topology', () => {
     expect(trigger).not.toMatch(/\n\s+(push|pull_request):/);
     expect(normalized(concurrency)).toBe('concurrency: group: deploy-production cancel-in-progress: false');
     expect(workflow).toContain('permissions:\n  contents: read');
-    expect(job).toContain("if: ${{ github.ref == 'refs/heads/main' }}");
-    expect(job).toContain('environment:\n      name: production');
+    const preflight = uniqueBlock(workflow, '  preflight:');
+    expect(preflight).toContain('name: Validate dispatch inputs (unprotected)');
+    expect(preflight).toContain("test \"$DISPATCH_REF\" = 'refs/heads/main'");
+    expect(preflight).toContain('grep -Eiq');
+    expect(job).toContain('needs: preflight');
+    expect(job).toContain("if: ${{ needs.preflight.result == 'success' && github.ref == 'refs/heads/main' }}");
+    expect(job).toContain('environment:\n      name: production\n      deployment: false');
+    expect(job).not.toContain('url:');
     expect(job).toContain('contents: read');
     for (const value of [
       '8da99fd0a161b90a4bd90ab29bde1abf796b3bf6',
@@ -268,7 +274,19 @@ describe('workflow topology', () => {
     expect(workflow).toContain('Capture production and preview controls before rehearsal (read-only)');
     expect(workflow).toContain('Capture production and preview controls after rehearsal (read-only)');
     expect(workflow).toContain('Upload sanitized rehearsal receipt only');
-    expect(workflow).toContain('--dry-run --yes');
+    expect(workflow).toContain('--config wrangler.release.toml --name theologai --dry-run --yes');
+    expect([...workflow.matchAll(/wrangler versions deploy/g)]).toHaveLength(1);
+    expect(workflow).toContain('CLOUDFLARE_READ_ONLY_API_TOKEN');
+    expect(workflow).not.toContain('secrets.CLOUDFLARE_API_TOKEN');
+    expect(workflow).toContain('target-deployment.json');
+    expect(workflow).toContain('/workers/scripts/theologai/deployments/3d7489d9-7b48-4ad0-bdc6-95ffbda53bd8');
+    expect(workflow).toContain('all(.value == 0)');
+    expect(workflow).toContain('deployment: false');
+    expect(workflow).toContain('wrangler-version');
+    const localGateStart = workflow.indexOf('      - name: Run historical PR108 local gates without credentials');
+    const localGateEnd = workflow.indexOf('\n      - name:', localGateStart + 1);
+    expect(localGateStart).toBeGreaterThan(0);
+    expect(workflow.slice(localGateStart, localGateEnd)).not.toMatch(/CLOUDFLARE|secrets\./);
     expect(workflow).not.toMatch(/wrangler\s+rollback|versions\s+upload|wrangler\s+deploy(?!ments)/i);
     expect(workflow).not.toMatch(/d1\s+(execute|migrations|delete|create|update)|secret\s+(put|delete)|triggers\s+deploy/i);
     expect(workflow).not.toContain('github-token:');

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -36,6 +36,7 @@ const releaseAuthorityDocuments = {
   'docs/PREVIEW-RELEASE-RECONCILIATION.md': ['historical-reconciliation', 'docs/CURRENT-RELEASE.md'],
   'docs/PRIMARY-SOURCE-CATALOG-SCOPE.md': ['catalog-history', 'docs/CURRENT-RELEASE.md'],
   'docs/PRODUCTION-RELEASE-RECONCILIATION.md': ['historical-reconciliation', 'docs/CURRENT-RELEASE.md'],
+  'docs/PRODUCTION-ROLLBACK-REHEARSAL.md': ['rollback-rehearsal-runbook', 'docs/CURRENT-RELEASE.md'],
   'docs/ROADMAP.md': ['delivery-roadmap', 'docs/CURRENT-RELEASE.md'],
   'docs/TRANSFORM11-HISTORICAL-SPINE-ACTIVATION.md': ['historical-activation', 'docs/CURRENT-RELEASE.md'],
   'docs/UBS-HEBREW-V0.9.2-DERIVED-NOTICE.md': ['historical-rights-notice', 'docs/CURRENT-RELEASE.md'],

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -73,7 +73,7 @@ describe('bounded command capture', () => {
   it.each([
     ['stdout', "setInterval(() => process.stdout.write('é'.repeat(1024)), 0);"],
     ['stderr', "setInterval(() => process.stderr.write('ß'.repeat(1024)), 0);"],
-  ])('terminates immediately when %s exceeds the byte budget', async (_stream, source) => {
+  ])('terminates promptly when %s exceeds the byte budget', async (_stream, source) => {
     await withCapture(async directory => {
       const stdoutPath = join(directory, 'stdout');
       const stderrPath = join(directory, 'stderr');
@@ -81,7 +81,9 @@ describe('bounded command capture', () => {
       const run = await runCapture({ ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024 });
       expect(run.exitCode).not.toBe(0);
       expect(run.result).toMatchObject({ overflow: true });
-      expect(Date.now() - started).toBeLessThan(2_000);
+      // Include runner and child-process startup time so this remains stable on
+      // shared CI hosts while still bounding the complete overflow path.
+      expect(Date.now() - started).toBeLessThan(5_000);
       expect((await readFile(stdoutPath)).byteLength).toBeLessThanOrEqual(1_024);
       expect((await readFile(stderrPath)).byteLength).toBeLessThanOrEqual(1_024);
     });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  BoundedCommandError,
+  runBoundedCommand,
+} from '../../../scripts/capture-bounded-command.js';
+
+async function withCapture<T>(fn: (directory: string) => Promise<T>): Promise<T> {
+  const directory = await mkdtemp(join(tmpdir(), 'theologai-bounded-command-'));
+  try {
+    return await fn(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function nodeScript(source: string): { command: string; args: string[] } {
+  return { command: process.execPath, args: ['-e', source] };
+}
+
+describe('bounded command capture', () => {
+  it('streams both outputs, hashes exact UTF-8 bytes, and preserves exit status', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const result = await runBoundedCommand({
+        ...nodeScript("process.stdout.write('é'.repeat(200)); process.stderr.write('ß'.repeat(100));"),
+        stdoutPath, stderrPath, stdoutPrefix: 'prefix:', maxBytes: 1_000,
+      });
+      expect(result).toMatchObject({ exitStatus: 0, signal: null, overflow: false, stdoutBytes: 407, stderrBytes: 200 });
+      expect(await readFile(stdoutPath, 'utf8')).toBe(`prefix:${'é'.repeat(200)}`);
+      expect(await readFile(stderrPath, 'utf8')).toBe('ß'.repeat(100));
+    });
+  });
+
+  it.each([
+    ['stdout', "setInterval(() => process.stdout.write('é'.repeat(1024)), 0);"],
+    ['stderr', "setInterval(() => process.stderr.write('ß'.repeat(1024)), 0);"],
+  ])('terminates immediately when %s exceeds the byte budget', async (_stream, source) => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const started = Date.now();
+      await expect(runBoundedCommand({
+        ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024,
+      })).rejects.toSatisfy(error => {
+        expect(error).toBeInstanceOf(BoundedCommandError);
+        expect((error as BoundedCommandError).result.overflow).toBe(true);
+        expect((error as BoundedCommandError).result.exitStatus).not.toBe(0);
+        return true;
+      });
+      expect(Date.now() - started).toBeLessThan(2_000);
+      expect((await readFile(stdoutPath)).byteLength).toBeLessThanOrEqual(1_024);
+      expect((await readFile(stderrPath)).byteLength).toBeLessThanOrEqual(1_024);
+    });
+  });
+
+  it('uses SIGKILL cleanup when a child ignores SIGTERM and never hangs', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const source = "process.on('SIGTERM', () => {}); setInterval(() => process.stdout.write('x'.repeat(2048)), 0);";
+      await expect(runBoundedCommand({
+        ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024,
+      })).rejects.toBeInstanceOf(BoundedCommandError);
+      expect((await readFile(stdoutPath)).byteLength).toBeLessThanOrEqual(1_024);
+    });
+  });
+
+  it('cleans up descendants in the child process group after overflow', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const marker = join(directory, 'descendant-survived');
+      const source = [
+        "const {spawn}=require('node:child_process');",
+        `spawn(process.execPath, ['-e', ${JSON.stringify(`setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 500)`) }], {stdio: 'ignore'});`,
+        "setInterval(() => process.stdout.write('x'.repeat(2048)), 0);",
+      ].join('');
+      await expect(runBoundedCommand({
+        ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024,
+      })).rejects.toBeInstanceOf(BoundedCommandError);
+      await new Promise(resolve => setTimeout(resolve, 700));
+      await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+});

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -230,7 +230,7 @@ describe('bounded command capture', () => {
       };
       const quietSink = { write: async () => undefined, close: async () => undefined };
       await expect(captureModule.runBoundedCommand({
-        ...nodeScript(source), stdoutPath: join(directory, 'stdout'), stderrPath: join(directory, 'stderr'), maxBytes: 1_024,
+        ...nodeScript(source), stdoutPath: join(directory, 'stdout'), stderrPath: join(directory, 'stderr'), maxBytes: 1_000_000,
         openCapture: async (path: string) => path.endsWith('/stdout') ? failingSink : quietSink,
       })).rejects.toThrow('injected capture failure');
       await new Promise(resolve => setTimeout(resolve, 700));

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -237,4 +237,69 @@ describe('bounded command capture', () => {
       await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });
   });
+
+  it('pins the supervisor while a finite oversized write is blocked by a slow sink', async () => {
+    await withCapture(async directory => {
+      const supervisorPidPath = join(directory, 'slow-sink-supervisor.pid');
+      const marker = join(directory, 'slow-sink-marker');
+      const source = [
+        `require('node:fs').writeFileSync(${JSON.stringify(supervisorPidPath)}, String(process.ppid));`,
+        `setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 700);`,
+        "process.stdout.write('x'.repeat(1024));",
+      ].join('');
+      let sinkStartedResolve!: () => void;
+      const sinkStarted = new Promise<void>(resolve => { sinkStartedResolve = resolve; });
+      let started = false;
+      const slowSink = {
+        write: async (_value: Buffer) => {
+          if (!started) {
+            started = true;
+            sinkStartedResolve();
+          }
+          await new Promise(resolve => setTimeout(resolve, 200));
+        },
+        close: async () => undefined,
+      };
+      const quietSink = { write: async () => undefined, close: async () => undefined };
+      const run = captureModule.runBoundedCommand({
+        ...nodeScript(source),
+        stdoutPath: join(directory, 'stdout'),
+        stderrPath: join(directory, 'stderr'),
+        maxBytes: 1,
+        openCapture: async (path: string) => path.endsWith('/stdout') ? slowSink : quietSink,
+      });
+      await sinkStarted;
+      const supervisorPid = Number(await readFile(supervisorPidPath, 'utf8'));
+      expect(() => process.kill(supervisorPid, 0)).not.toThrow();
+      await expect(run).rejects.toBeInstanceOf(captureModule.BoundedCommandError);
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(() => process.kill(supervisorPid, 0)).toThrow();
+      await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+
+  it('returns boundedly when group and direct termination callbacks fail without stale PGID retries', async () => {
+    await withCapture(async directory => {
+      const calls: string[] = [];
+      const run = captureModule.runBoundedCommand({
+        ...nodeScript("process.stdout.write('x'.repeat(2048)); setInterval(() => {}, 1000);"),
+        stdoutPath: join(directory, 'stdout'),
+        stderrPath: join(directory, 'stderr'),
+        maxBytes: 1,
+        signalGroup: (_pid: number, signal: NodeJS.Signals) => {
+          calls.push(`group:${signal}`);
+          throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+        },
+        signalChild: (child: unknown, signal: NodeJS.Signals) => {
+          calls.push(`direct:${signal}`);
+          (child as { kill: (value: NodeJS.Signals) => boolean }).kill('SIGKILL');
+          throw new Error('EPERM');
+        },
+      });
+      const started = Date.now();
+      await expect(run).rejects.toBeInstanceOf(captureModule.BoundedCommandError);
+      expect(Date.now() - started).toBeLessThan(2_000);
+      expect(calls).toEqual(['group:SIGTERM', 'direct:SIGTERM']);
+    });
+  });
 });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -324,4 +324,71 @@ describe('bounded command capture', () => {
       await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });
   });
+
+  it('lets a containing CLI exit when abort IPC is unavailable after signaling failures', async () => {
+    await withCapture(async directory => {
+      const supervisorPidPath = join(directory, 'unavailable-abort-supervisor.pid');
+      const marker = join(directory, 'unavailable-abort-descendant-survived');
+      const signalLogPath = join(directory, 'unavailable-abort-signals.log');
+      const outcomePath = join(directory, 'unavailable-abort-outcome');
+      const descendant = `setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 10_000);`;
+      const actualSource = [
+        `require('node:fs').writeFileSync(${JSON.stringify(supervisorPidPath)}, String(process.ppid));`,
+        `require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], {stdio: 'ignore'});`,
+        "process.stdout.write('x'.repeat(2048)); setInterval(() => {}, 1000);",
+      ].join('');
+      const harnessSource = `
+        import { runBoundedCommand } from ${JSON.stringify(runner)};
+        import { writeFileSync } from 'node:fs';
+        try {
+          await runBoundedCommand({
+            command: process.execPath,
+            args: ['-e', ${JSON.stringify(actualSource)}],
+            stdoutPath: ${JSON.stringify(join(directory, 'stdout'))},
+            stderrPath: ${JSON.stringify(join(directory, 'stderr'))},
+            maxBytes: 1,
+            signalGroup: (pid, signal) => {
+              writeFileSync(${JSON.stringify(signalLogPath)}, JSON.stringify({ kind: 'group', pid, signal }) + '\\n', { flag: 'a' });
+              throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            },
+            signalChild: (child, signal) => {
+              writeFileSync(${JSON.stringify(signalLogPath)}, JSON.stringify({ kind: 'direct', signal }) + '\\n', { flag: 'a' });
+              child.disconnect();
+              throw new Error('EPERM');
+            },
+          });
+        } catch (error) {
+          writeFileSync(${JSON.stringify(outcomePath)}, error?.constructor?.name ?? String(error));
+        }
+      `;
+      const containing = spawn(process.execPath, ['--input-type=module', '-e', harnessSource], { stdio: 'ignore' });
+      const started = Date.now();
+      let supervisorPid: number | undefined;
+      try {
+        const exitCode = await new Promise<number | null>((resolve, reject) => {
+          containing.once('close', code => resolve(code));
+          containing.once('error', reject);
+        });
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expect(exitCode).toBe(0);
+        expect(await readFile(outcomePath, 'utf8')).toBe('BoundedCommandError');
+        const exactSupervisorPid = Number(await readFile(supervisorPidPath, 'utf8'));
+        supervisorPid = exactSupervisorPid;
+        expect(() => process.kill(exactSupervisorPid, 0)).not.toThrow();
+        const calls = (await readFile(signalLogPath, 'utf8')).trim().split('\n').map(line => JSON.parse(line) as { kind: string; pid?: number; signal: string });
+        expect(calls).toEqual([
+          { kind: 'group', pid: exactSupervisorPid, signal: 'SIGTERM' },
+          { kind: 'direct', signal: 'SIGTERM' },
+        ]);
+        await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+      } finally {
+        // The injected hooks intentionally make cleanup impossible from the
+        // caller. Remove the deliberately orphaned fixture group only after
+        // proving the containing process exited without doing so.
+        if (supervisorPid) {
+          try { process.kill(-supervisorPid, 'SIGKILL'); } catch { /* already gone */ }
+        }
+      }
+    });
+  });
 });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -135,7 +135,9 @@ describe('bounded command capture', () => {
       const run = await runCapture({ ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024 });
       expect(run.exitCode).not.toBe(0);
       expect(run.result).toMatchObject({ overflow: true });
-      expect(Date.now() - started).toBeLessThan(2_000);
+      // This exercises the complete supervisor startup, TERM grace, KILL, and
+      // teardown path; retain CI margin while keeping the path time-bounded.
+      expect(Date.now() - started).toBeLessThan(5_000);
       await new Promise(resolve => setTimeout(resolve, 700));
       await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -1,9 +1,11 @@
 import { spawn } from 'node:child_process';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+
+const captureModule = await import('../../../scripts/capture-bounded-command.mjs');
 
 const runner = fileURLToPath(new URL('../../../scripts/capture-bounded-command.mjs', import.meta.url));
 
@@ -67,6 +69,26 @@ describe('bounded command capture', () => {
       expect(run).toMatchObject({ exitCode: 0, result: { exitStatus: 0, signal: null, overflow: false, stdoutBytes: 407, stderrBytes: 200 } });
       expect(await readFile(stdoutPath, 'utf8')).toBe(`prefix:${'é'.repeat(200)}`);
       expect(await readFile(stderrPath, 'utf8')).toBe('ß'.repeat(100));
+    });
+  });
+
+  it('preserves a normal nonzero child exit status in the bounded result', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const run = await runCapture({ ...nodeScript("process.stdout.write('failed'); process.exit(7);"), stdoutPath, stderrPath });
+      expect(run.exitCode).toBe(1);
+      expect(run.result).toMatchObject({ exitStatus: 7, signal: null, overflow: false });
+    });
+  });
+
+  it('preserves a normal child signal in the bounded result', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const run = await runCapture({ ...nodeScript("process.kill(process.pid, 'SIGTERM');"), stdoutPath, stderrPath });
+      expect(run.exitCode).toBe(1);
+      expect(run.result).toMatchObject({ exitStatus: null, signal: 'SIGTERM', overflow: false });
     });
   });
 
@@ -138,6 +160,79 @@ describe('bounded command capture', () => {
       // This exercises the complete supervisor startup, TERM grace, KILL, and
       // teardown path; retain CI margin while keeping the path time-bounded.
       expect(Date.now() - started).toBeLessThan(5_000);
+      await new Promise(resolve => setTimeout(resolve, 700));
+      await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+
+  it('keeps the supervisor alive through TERM grace after capture overflow', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const resultPath = `${stdoutPath}.result.json`;
+      const supervisorPidPath = join(directory, 'supervisor.pid');
+      const marker = join(directory, 'keeper-survived');
+      const descendant = `setTimeout(() => { process.stdout.write('z'.repeat(2048)); setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 500); }, 100);`;
+      const source = [
+        "const {spawn}=require('node:child_process');",
+        `require('node:fs').writeFileSync(${JSON.stringify(supervisorPidPath)}, String(process.ppid));`,
+        `spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], {stdio: ['ignore', 'inherit', 'inherit']});`,
+      ].join('');
+      const args = [
+        runner, '--stdout', stdoutPath, '--stderr', stderrPath, '--result', resultPath,
+        '--max-bytes', '1024', '--', process.execPath, '-e', source,
+      ];
+      const outer = spawn(process.execPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+      outer.stdout.resume();
+      outer.stderr.resume();
+      const done = new Promise<number | null>((resolve, reject) => {
+        outer.once('close', (code, signal) => resolve(code ?? (signal ? 1 : null)));
+        outer.once('error', reject);
+      });
+      let supervisorPid: number | undefined;
+      for (let attempt = 0; attempt < 30 && supervisorPid === undefined; attempt += 1) {
+        try {
+          supervisorPid = Number(await readFile(supervisorPidPath, 'utf8'));
+        } catch {
+          await new Promise(resolve => setTimeout(resolve, 10));
+        }
+      }
+      expect(supervisorPid).toSatisfy(value => Number.isSafeInteger(value) && value > 0);
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        try {
+          if ((await stat(stdoutPath)).size >= 1_024) break;
+        } catch { /* wait for the first bounded write */ }
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+      expect((await stat(stdoutPath)).size).toBe(1_024);
+      // The runner has started TERM cleanup; the keeper must still be alive
+      // inside the configured grace interval before outer SIGKILL.
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(() => process.kill(supervisorPid!, 0)).not.toThrow();
+      expect(await done).not.toBe(0);
+      await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(() => process.kill(supervisorPid!, 0)).toThrow();
+    });
+  });
+
+  it('terminates the process group when an output sink fails unexpectedly', async () => {
+    await withCapture(async directory => {
+      const marker = join(directory, 'capture-failure-descendant-survived');
+      const descendant = `setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 500);`;
+      const source = [
+        "const {spawn}=require('node:child_process');",
+        `spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], {stdio: 'ignore'});`,
+        "setInterval(() => process.stdout.write('x'.repeat(2048)), 0);",
+      ].join('');
+      const failingSink = {
+        write: async () => { throw new Error('injected capture failure'); },
+        close: async () => undefined,
+      };
+      const quietSink = { write: async () => undefined, close: async () => undefined };
+      await expect(captureModule.runBoundedCommand({
+        ...nodeScript(source), stdoutPath: join(directory, 'stdout'), stderrPath: join(directory, 'stderr'), maxBytes: 1_024,
+        openCapture: async (path: string) => path.endsWith('/stdout') ? failingSink : quietSink,
+      })).rejects.toThrow('injected capture failure');
       await new Promise(resolve => setTimeout(resolve, 700));
       await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -92,6 +92,18 @@ describe('bounded command capture', () => {
     });
   });
 
+  it('preserves a SIGPIPE child outcome without replaying it on the supervisor', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const run = await runCapture({
+        command: '/bin/sh', args: ['-c', 'kill -PIPE $$'], stdoutPath, stderrPath,
+      });
+      expect(run.exitCode).toBe(1);
+      expect(run.result).toMatchObject({ exitStatus: null, signal: 'SIGPIPE', overflow: false });
+    });
+  });
+
   it.each([
     ['stdout', "setInterval(() => process.stdout.write('é'.repeat(1024)), 0);"],
     ['stderr', "setInterval(() => process.stderr.write('ß'.repeat(1024)), 0);"],
@@ -280,26 +292,36 @@ describe('bounded command capture', () => {
 
   it('returns boundedly when group and direct termination callbacks fail without stale PGID retries', async () => {
     await withCapture(async directory => {
+      const supervisorPidPath = join(directory, 'failed-signal-supervisor.pid');
+      const marker = join(directory, 'failed-signal-descendant-survived');
       const calls: string[] = [];
       const run = captureModule.runBoundedCommand({
-        ...nodeScript("process.stdout.write('x'.repeat(2048)); setInterval(() => {}, 1000);"),
+        ...nodeScript([
+          `require('node:fs').writeFileSync(${JSON.stringify(supervisorPidPath)}, String(process.ppid));`,
+          `require('node:child_process').spawn(process.execPath, ['-e', ${JSON.stringify(`setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 700)`) }], {stdio: 'ignore'});`,
+          "process.stdout.write('x'.repeat(2048)); setInterval(() => {}, 1000);",
+        ].join('')),
         stdoutPath: join(directory, 'stdout'),
         stderrPath: join(directory, 'stderr'),
         maxBytes: 1,
-        signalGroup: (_pid: number, signal: NodeJS.Signals) => {
+        signalGroup: (pid: number, signal: NodeJS.Signals) => {
+          expect(pid).toBeGreaterThan(0);
           calls.push(`group:${signal}`);
           throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
         },
         signalChild: (child: unknown, signal: NodeJS.Signals) => {
           calls.push(`direct:${signal}`);
-          (child as { kill: (value: NodeJS.Signals) => boolean }).kill('SIGKILL');
+          expect(child).toBeTruthy();
           throw new Error('EPERM');
         },
       });
       const started = Date.now();
       await expect(run).rejects.toBeInstanceOf(captureModule.BoundedCommandError);
-      expect(Date.now() - started).toBeLessThan(2_000);
+      expect(Date.now() - started).toBeLessThan(5_000);
       expect(calls).toEqual(['group:SIGTERM', 'direct:SIGTERM']);
+      const supervisorPid = Number(await readFile(supervisorPidPath, 'utf8'));
+      expect(() => process.kill(supervisorPid, 0)).toThrow();
+      await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });
   });
 });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -120,4 +120,24 @@ describe('bounded command capture', () => {
       await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });
   });
+
+  it('kills a pipe-inheriting descendant when the leader exits before overflow', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const marker = join(directory, 'leader-exited-descendant-survived');
+      const descendant = `setTimeout(() => { process.stdout.write('z'.repeat(2048)); setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 500); }, 50);`;
+      const source = [
+        "const {spawn}=require('node:child_process');",
+        `spawn(process.execPath, ['-e', ${JSON.stringify(descendant)}], {stdio: ['ignore', 'inherit', 'inherit']});`,
+      ].join('');
+      const started = Date.now();
+      const run = await runCapture({ ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024 });
+      expect(run.exitCode).not.toBe(0);
+      expect(run.result).toMatchObject({ overflow: true });
+      expect(Date.now() - started).toBeLessThan(2_000);
+      await new Promise(resolve => setTimeout(resolve, 700));
+      await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
 });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -1,11 +1,11 @@
+import { spawn } from 'node:child_process';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import {
-  BoundedCommandError,
-  runBoundedCommand,
-} from '../../../scripts/capture-bounded-command.js';
+
+const runner = fileURLToPath(new URL('../../../scripts/capture-bounded-command.mjs', import.meta.url));
 
 async function withCapture<T>(fn: (directory: string) => Promise<T>): Promise<T> {
   const directory = await mkdtemp(join(tmpdir(), 'theologai-bounded-command-'));
@@ -20,16 +20,51 @@ function nodeScript(source: string): { command: string; args: string[] } {
   return { command: process.execPath, args: ['-e', source] };
 }
 
+async function runCapture(options: {
+  command: string;
+  args: string[];
+  stdoutPath: string;
+  stderrPath: string;
+  maxBytes?: number;
+  stdoutPrefix?: string;
+}): Promise<{ exitCode: number | null; result: Record<string, unknown> }> {
+  const args = [
+    runner,
+    '--stdout', options.stdoutPath,
+    '--stderr', options.stderrPath,
+    '--result', `${options.stdoutPath}.result.json`,
+    ...(options.maxBytes === undefined ? [] : ['--max-bytes', String(options.maxBytes)]),
+    ...(options.stdoutPrefix === undefined ? [] : ['--stdout-prefix', options.stdoutPrefix]),
+    '--', options.command, ...options.args,
+  ];
+  const child = spawn(process.execPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', chunk => { stdout += chunk; });
+  child.stderr.on('data', chunk => { stderr += chunk; });
+  const [exitCode] = await new Promise<[number | null, NodeJS.Signals | null]>((resolve, reject) => {
+    child.once('close', (code, signal) => resolve([code, signal]));
+    child.once('error', reject);
+  });
+  expect(`${stdout}${stderr}`).toContain('theologai-bounded-command.v1');
+  return {
+    exitCode,
+    result: JSON.parse(await readFile(`${options.stdoutPath}.result.json`, 'utf8')) as Record<string, unknown>,
+  };
+}
+
 describe('bounded command capture', () => {
   it('streams both outputs, hashes exact UTF-8 bytes, and preserves exit status', async () => {
     await withCapture(async directory => {
       const stdoutPath = join(directory, 'stdout');
       const stderrPath = join(directory, 'stderr');
-      const result = await runBoundedCommand({
+      const run = await runCapture({
         ...nodeScript("process.stdout.write('é'.repeat(200)); process.stderr.write('ß'.repeat(100));"),
         stdoutPath, stderrPath, stdoutPrefix: 'prefix:', maxBytes: 1_000,
       });
-      expect(result).toMatchObject({ exitStatus: 0, signal: null, overflow: false, stdoutBytes: 407, stderrBytes: 200 });
+      expect(run).toMatchObject({ exitCode: 0, result: { exitStatus: 0, signal: null, overflow: false, stdoutBytes: 407, stderrBytes: 200 } });
       expect(await readFile(stdoutPath, 'utf8')).toBe(`prefix:${'é'.repeat(200)}`);
       expect(await readFile(stderrPath, 'utf8')).toBe('ß'.repeat(100));
     });
@@ -43,14 +78,9 @@ describe('bounded command capture', () => {
       const stdoutPath = join(directory, 'stdout');
       const stderrPath = join(directory, 'stderr');
       const started = Date.now();
-      await expect(runBoundedCommand({
-        ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024,
-      })).rejects.toSatisfy(error => {
-        expect(error).toBeInstanceOf(BoundedCommandError);
-        expect((error as BoundedCommandError).result.overflow).toBe(true);
-        expect((error as BoundedCommandError).result.exitStatus).not.toBe(0);
-        return true;
-      });
+      const run = await runCapture({ ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024 });
+      expect(run.exitCode).not.toBe(0);
+      expect(run.result).toMatchObject({ overflow: true });
       expect(Date.now() - started).toBeLessThan(2_000);
       expect((await readFile(stdoutPath)).byteLength).toBeLessThanOrEqual(1_024);
       expect((await readFile(stderrPath)).byteLength).toBeLessThanOrEqual(1_024);
@@ -61,10 +91,12 @@ describe('bounded command capture', () => {
     await withCapture(async directory => {
       const stdoutPath = join(directory, 'stdout');
       const stderrPath = join(directory, 'stderr');
-      const source = "process.on('SIGTERM', () => {}); setInterval(() => process.stdout.write('x'.repeat(2048)), 0);";
-      await expect(runBoundedCommand({
-        ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024,
-      })).rejects.toBeInstanceOf(BoundedCommandError);
+      const run = await runCapture({
+        ...nodeScript("process.on('SIGTERM', () => {}); setInterval(() => process.stdout.write('x'.repeat(2048)), 0);"),
+        stdoutPath, stderrPath, maxBytes: 1_024,
+      });
+      expect(run.exitCode).not.toBe(0);
+      expect(run.result).toMatchObject({ overflow: true });
       expect((await readFile(stdoutPath)).byteLength).toBeLessThanOrEqual(1_024);
     });
   });
@@ -79,9 +111,9 @@ describe('bounded command capture', () => {
         `spawn(process.execPath, ['-e', ${JSON.stringify(`setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'alive'), 500)`) }], {stdio: 'ignore'});`,
         "setInterval(() => process.stdout.write('x'.repeat(2048)), 0);",
       ].join('');
-      await expect(runBoundedCommand({
-        ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024,
-      })).rejects.toBeInstanceOf(BoundedCommandError);
+      const run = await runCapture({ ...nodeScript(source), stdoutPath, stderrPath, maxBytes: 1_024 });
+      expect(run.exitCode).not.toBe(0);
+      expect(run.result).toMatchObject({ overflow: true });
       await new Promise(resolve => setTimeout(resolve, 700));
       await expect(readFile(marker, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
     });

--- a/test/unit/scripts/captureBoundedCommand.test.ts
+++ b/test/unit/scripts/captureBoundedCommand.test.ts
@@ -104,6 +104,42 @@ describe('bounded command capture', () => {
     });
   });
 
+  it('fails promptly when the requested executable cannot be spawned', async () => {
+    await withCapture(async directory => {
+      const stdoutPath = join(directory, 'stdout');
+      const stderrPath = join(directory, 'stderr');
+      const resultPath = join(directory, 'result.json');
+      const child = spawn(process.execPath, [
+        runner, '--stdout', stdoutPath, '--stderr', stderrPath, '--result', resultPath,
+        '--', '/definitely/not-a-real-theologai-command',
+      ], { stdio: ['ignore', 'pipe', 'pipe'] });
+      let stderr = '';
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', chunk => { stderr += chunk; });
+      const started = Date.now();
+      let timedOut = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const exitCode = await Promise.race([
+          new Promise<number | null>((resolve, reject) => {
+            child.once('close', code => resolve(code));
+            child.once('error', reject);
+          }),
+          new Promise<null>(resolve => { timeout = setTimeout(() => { timedOut = true; resolve(null); }, 5_000); }),
+        ]);
+        if (timeout) clearTimeout(timeout);
+        expect(timedOut).toBe(false);
+        expect(exitCode).not.toBe(0);
+        expect(Date.now() - started).toBeLessThan(5_000);
+        expect(stderr).toContain('bounded command supervisor failed');
+        expect(stderr).toContain('not-a-real-theologai-command');
+        await expect(readFile(resultPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+      } finally {
+        if (timedOut) child.kill('SIGKILL');
+      }
+    });
+  });
+
   it.each([
     ['stdout', "setInterval(() => process.stdout.write('é'.repeat(1024)), 0);"],
     ['stderr', "setInterval(() => process.stderr.write('ß'.repeat(1024)), 0);"],

--- a/test/unit/scripts/productionRollbackRehearsal.test.ts
+++ b/test/unit/scripts/productionRollbackRehearsal.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   ROLLBACK_REHEARSAL_CONFIRMATION,
+  ROLLBACK_REHEARSAL_COMMAND,
   ROLLBACK_REHEARSAL_TARGET,
   createRollbackRehearsalReceipt,
   parseRollbackRehearsalReceipt,
@@ -13,6 +14,7 @@ const productionVersion = '623e4567-e89b-42d3-a456-426614174000';
 const previewVersion = '723e4567-e89b-42d3-a456-426614174000';
 const productionD1 = '823e4567-e89b-42d3-a456-426614174000';
 const previewD1 = '923e4567-e89b-42d3-a456-426614174000';
+const headSha = 'a'.repeat(40);
 
 function deployments(deploymentId: string, versionId: string): string {
   return JSON.stringify([
@@ -44,9 +46,19 @@ const inventory = JSON.stringify([
   { name: 'theologai-preview-20260811-schema0009-a', uuid: previewD1 },
 ]);
 
+const targetDeployment = JSON.stringify({
+  errors: [], messages: [], success: true,
+  result: {
+    id: ROLLBACK_REHEARSAL_TARGET.deploymentId,
+    versions: [{ version_id: ROLLBACK_REHEARSAL_TARGET.workerVersionId, percentage: 100 }],
+  },
+});
+
 function input(overrides: Partial<Parameters<typeof createRollbackRehearsalReceipt>[0]> = {}) {
   return {
     confirmation: ROLLBACK_REHEARSAL_CONFIRMATION,
+    repository: 'TJ-Frederick/TheologAI', workflow: 'Production Rollback Rehearsal', headSha,
+    ref: 'refs/heads/main', runId: '123', runAttempt: '1', wranglerVersion: '4.114.0',
     sourceCommit: ROLLBACK_REHEARSAL_TARGET.sourceCommit,
     sourceTree: ROLLBACK_REHEARSAL_TARGET.sourceTree,
     expectedProductionDeploymentId: productionDeployment,
@@ -66,15 +78,22 @@ function input(overrides: Partial<Parameters<typeof createRollbackRehearsalRecei
     targetVersionText: versionView(ROLLBACK_REHEARSAL_TARGET.workerVersionId, ROLLBACK_REHEARSAL_TARGET.d1Id),
     readinessOutputText: '{"status":"passed"}\n',
     runtimeOutputText: 'worker runtime passed\n',
-    dryRunOutputText: 'dry run completed\n',
+    dryRunOutputText: 'DRY_RUN_SENTINEL: fixed-pr108-dry-run\ndry run completed\n',
+    npmInstallOutputText: 'npm ci passed\n', workerdOutputText: 'workerd passed\n', targetDeploymentText: targetDeployment,
     ...overrides,
   };
 }
 
 describe('production rollback rehearsal verifier', () => {
+  it('owns the only permitted recovery command and requires its dry-run flags', () => {
+    expect(ROLLBACK_REHEARSAL_COMMAND).toBe('wrangler versions deploy 291f3292-3fa9-44fc-bf6f-b68fd2f4cef6@100 --config wrangler.release.toml --name theologai --dry-run --yes');
+    expect(ROLLBACK_REHEARSAL_COMMAND).toContain('--dry-run --yes');
+  });
+
   it('emits a bounded sanitized receipt for an unchanged control plane', () => {
     const receipt = createRollbackRehearsalReceipt(input());
     expect(receipt.status).toBe('passed');
+    expect(receipt.provenance.headSha).toBe(headSha);
     expect(receipt.target).toEqual({
       deploymentId: ROLLBACK_REHEARSAL_TARGET.deploymentId,
       workerVersionId: ROLLBACK_REHEARSAL_TARGET.workerVersionId,
@@ -91,11 +110,19 @@ describe('production rollback rehearsal verifier', () => {
     ['wrong confirmation', { confirmation: 'REHEARSE' }],
     ['wrong source commit', { sourceCommit: 'a'.repeat(40) }],
     ['wrong source tree', { sourceTree: 'b'.repeat(40) }],
+    ['wrong repository', { repository: 'attacker/repo' }],
+    ['wrong workflow', { workflow: 'Other Workflow' }],
+    ['wrong ref', { ref: 'refs/heads/feature' }],
+    ['wrong Wrangler', { wranglerVersion: '4.113.0' }],
+    ['wrong run ID', { runId: '0' }],
     ['wrong target version', { targetVersionText: versionView(productionVersion, ROLLBACK_REHEARSAL_TARGET.d1Id) }],
     ['wrong target D1', { targetVersionText: versionView(ROLLBACK_REHEARSAL_TARGET.workerVersionId, productionD1) }],
+    ['wrong target deployment', { targetDeploymentText: targetDeployment.replace(ROLLBACK_REHEARSAL_TARGET.deploymentId, productionDeployment) }],
     ['wrong D1 inventory', { d1InventoryBeforeText: JSON.stringify([{ name: 'other', uuid: productionD1 }]) }],
+    ['non-distinct active D1 identities', { previewVersionBeforeText: versionView(previewVersion, productionD1), previewVersionAfterText: versionView(previewVersion, productionD1) }],
     ['production traffic drift', { productionAfterText: deployments(productionDeployment, 'a23e4567-e89b-42d3-a456-426614174000') }],
     ['preview D1 drift', { previewVersionAfterText: versionView(previewVersion, productionD1) }],
+    ['oversized output', { runtimeOutputText: 'é'.repeat(5 * 1024 * 1024) }],
   ])('fails closed for %s', (_label, override) => {
     expect(() => createRollbackRehearsalReceipt(input(override))).toThrow(/refused/);
   });

--- a/test/unit/scripts/productionRollbackRehearsal.test.ts
+++ b/test/unit/scripts/productionRollbackRehearsal.test.ts
@@ -76,10 +76,11 @@ function input(overrides: Partial<Parameters<typeof createRollbackRehearsalRecei
     d1InventoryBeforeText: inventory,
     d1InventoryAfterText: inventory,
     targetVersionText: versionView(ROLLBACK_REHEARSAL_TARGET.workerVersionId, ROLLBACK_REHEARSAL_TARGET.d1Id),
-    readinessOutputText: '{"status":"passed"}\n',
-    runtimeOutputText: 'worker runtime passed\n',
-    dryRunOutputText: 'DRY_RUN_SENTINEL: fixed-pr108-dry-run\ndry run completed\n',
-    npmInstallOutputText: 'npm ci passed\n', workerdOutputText: 'workerd passed\n', targetDeploymentText: targetDeployment,
+    readinessOutputText: '{"status":"passed"}\n', readinessStderrText: '',
+    runtimeOutputText: 'worker runtime passed\n', runtimeStderrText: '',
+    dryRunOutputText: 'DRY_RUN_SENTINEL: fixed-pr108-dry-run\ndry run completed\n', dryRunStderrText: '',
+    npmInstallOutputText: 'npm ci passed\n', npmInstallStderrText: '',
+    workerdOutputText: 'workerd passed\n', workerdStderrText: '', targetDeploymentText: targetDeployment,
     ...overrides,
   };
 }

--- a/test/unit/scripts/productionRollbackRehearsal.test.ts
+++ b/test/unit/scripts/productionRollbackRehearsal.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ROLLBACK_REHEARSAL_CONFIRMATION,
+  ROLLBACK_REHEARSAL_TARGET,
+  createRollbackRehearsalReceipt,
+  parseRollbackRehearsalReceipt,
+  serializeRollbackRehearsalReceipt,
+} from '../../../scripts/production-rollback-rehearsal.js';
+
+const productionDeployment = '423e4567-e89b-42d3-a456-426614174000';
+const previewDeployment = '523e4567-e89b-42d3-a456-426614174000';
+const productionVersion = '623e4567-e89b-42d3-a456-426614174000';
+const previewVersion = '723e4567-e89b-42d3-a456-426614174000';
+const productionD1 = '823e4567-e89b-42d3-a456-426614174000';
+const previewD1 = '923e4567-e89b-42d3-a456-426614174000';
+
+function deployments(deploymentId: string, versionId: string): string {
+  return JSON.stringify([
+    {
+      id: deploymentId,
+      created_on: '2026-08-27T10:00:00.000Z',
+      versions: [{ version_id: versionId, percentage: 100 }],
+    },
+    {
+      id: ROLLBACK_REHEARSAL_TARGET.deploymentId,
+      created_on: '2026-07-29T00:00:00.000Z',
+      versions: [{ version_id: ROLLBACK_REHEARSAL_TARGET.workerVersionId, percentage: 100 }],
+    },
+  ]);
+}
+
+function versionView(versionId: string, d1Id: string): string {
+  return JSON.stringify({
+    id: versionId,
+    resources: {
+      bindings: [{ name: 'THEOLOGAI_DB', type: 'd1', id: d1Id, database_id: d1Id }],
+    },
+  });
+}
+
+const inventory = JSON.stringify([
+  { name: ROLLBACK_REHEARSAL_TARGET.d1Name, uuid: ROLLBACK_REHEARSAL_TARGET.d1Id },
+  { name: 'theologai-production-20260811-schema0009-a', uuid: productionD1 },
+  { name: 'theologai-preview-20260811-schema0009-a', uuid: previewD1 },
+]);
+
+function input(overrides: Partial<Parameters<typeof createRollbackRehearsalReceipt>[0]> = {}) {
+  return {
+    confirmation: ROLLBACK_REHEARSAL_CONFIRMATION,
+    sourceCommit: ROLLBACK_REHEARSAL_TARGET.sourceCommit,
+    sourceTree: ROLLBACK_REHEARSAL_TARGET.sourceTree,
+    expectedProductionDeploymentId: productionDeployment,
+    expectedProductionVersionId: productionVersion,
+    expectedPreviewDeploymentId: previewDeployment,
+    expectedPreviewVersionId: previewVersion,
+    productionBeforeText: deployments(productionDeployment, productionVersion),
+    productionAfterText: deployments(productionDeployment, productionVersion),
+    productionVersionBeforeText: versionView(productionVersion, productionD1),
+    productionVersionAfterText: versionView(productionVersion, productionD1),
+    previewBeforeText: deployments(previewDeployment, previewVersion),
+    previewAfterText: deployments(previewDeployment, previewVersion),
+    previewVersionBeforeText: versionView(previewVersion, previewD1),
+    previewVersionAfterText: versionView(previewVersion, previewD1),
+    d1InventoryBeforeText: inventory,
+    d1InventoryAfterText: inventory,
+    targetVersionText: versionView(ROLLBACK_REHEARSAL_TARGET.workerVersionId, ROLLBACK_REHEARSAL_TARGET.d1Id),
+    readinessOutputText: '{"status":"passed"}\n',
+    runtimeOutputText: 'worker runtime passed\n',
+    dryRunOutputText: 'dry run completed\n',
+    ...overrides,
+  };
+}
+
+describe('production rollback rehearsal verifier', () => {
+  it('emits a bounded sanitized receipt for an unchanged control plane', () => {
+    const receipt = createRollbackRehearsalReceipt(input());
+    expect(receipt.status).toBe('passed');
+    expect(receipt.target).toEqual({
+      deploymentId: ROLLBACK_REHEARSAL_TARGET.deploymentId,
+      workerVersionId: ROLLBACK_REHEARSAL_TARGET.workerVersionId,
+      d1Name: ROLLBACK_REHEARSAL_TARGET.d1Name,
+      d1Id: ROLLBACK_REHEARSAL_TARGET.d1Id,
+    });
+    expect(receipt.trafficMutation).toBe(false);
+    expect(receipt.evidence.dryRunOutputSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(serializeRollbackRehearsalReceipt(input()).length).toBeLessThan(32 * 1024);
+    expect(() => parseRollbackRehearsalReceipt({ ...receipt, unexpected: true })).toThrow(/keys are malformed/);
+  });
+
+  it.each([
+    ['wrong confirmation', { confirmation: 'REHEARSE' }],
+    ['wrong source commit', { sourceCommit: 'a'.repeat(40) }],
+    ['wrong source tree', { sourceTree: 'b'.repeat(40) }],
+    ['wrong target version', { targetVersionText: versionView(productionVersion, ROLLBACK_REHEARSAL_TARGET.d1Id) }],
+    ['wrong target D1', { targetVersionText: versionView(ROLLBACK_REHEARSAL_TARGET.workerVersionId, productionD1) }],
+    ['wrong D1 inventory', { d1InventoryBeforeText: JSON.stringify([{ name: 'other', uuid: productionD1 }]) }],
+    ['production traffic drift', { productionAfterText: deployments(productionDeployment, 'a23e4567-e89b-42d3-a456-426614174000') }],
+    ['preview D1 drift', { previewVersionAfterText: versionView(previewVersion, productionD1) }],
+  ])('fails closed for %s', (_label, override) => {
+    expect(() => createRollbackRehearsalReceipt(input(override))).toThrow(/refused/);
+  });
+
+  it('rejects a target that appears in either active deployment list', () => {
+    expect(() => createRollbackRehearsalReceipt(input({
+      productionAfterText: deployments(productionDeployment, ROLLBACK_REHEARSAL_TARGET.workerVersionId),
+    }))).toThrow(/refused/);
+  });
+});

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -22,6 +22,7 @@
     "scripts/macula-gate1.ts",
     "scripts/verify-database.ts",
     "scripts/ccel-live-preview-canary.ts",
+    "scripts/capture-bounded-command.ts",
     "scripts/production-rollback-rehearsal.ts"
   ]
 }

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -22,7 +22,6 @@
     "scripts/macula-gate1.ts",
     "scripts/verify-database.ts",
     "scripts/ccel-live-preview-canary.ts",
-    "scripts/capture-bounded-command.ts",
     "scripts/production-rollback-rehearsal.ts"
   ]
 }

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -21,6 +21,7 @@
     "scripts/macula-source-contract.ts",
     "scripts/macula-gate1.ts",
     "scripts/verify-database.ts",
-    "scripts/ccel-live-preview-canary.ts"
+    "scripts/ccel-live-preview-canary.ts",
+    "scripts/production-rollback-rehearsal.ts"
   ]
 }


### PR DESCRIPTION
## Summary

- add a protected, zero-traffic production rollback rehearsal for the exact PR #108 Worker/D1 matched pair
- enforce least-privilege Cloudflare reads, immutable run provenance, bounded subprocess evidence, and no GitHub Deployment record
- document conservative matched-generation retention and Phase 3B closure sequencing

## Safety properties

- manual dispatch from `main` with fail-fast immutable identity inputs
- `production` environment protection with `deployment: false`
- dedicated account-scoped token: Workers Scripts Read + D1 Read only
- exactly one pinned `wrangler versions deploy ... --dry-run --yes`; no traffic mutation
- stable supervisor/IPC acknowledgement protocol caps stdout/stderr during execution and bounds all cleanup paths
- pre/post Worker deployment, version, D1 inventory, and remote readiness evidence hashed into the receipt

## Verification

- Sol High pre-PR review: finding-free on `73afb4f`
- `npm run typecheck`
- unit: 201 files, 2,582 passed, 5 skipped
- integration: 3 passed
- `npm run build`
- focused rollback/workflow/capture suites
- `node --check scripts/capture-bounded-command.mjs`
- `git diff --check origin/main...HEAD`

No Cloudflare mutation or production deployment was performed by this PR.