### PR TITLE
fix(ci): reconstruct historical rollback rehearsal seed

### DIFF
--- a/.github/workflows/production-rollback-rehearsal.yml
+++ b/.github/workflows/production-rollback-rehearsal.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -117,6 +118,7 @@ jobs:
           ref: 8da99fd0a161b90a4bd90ab29bde1abf796b3bf6
           path: pr108-source
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Verify exact historical source identity
         env:
@@ -160,6 +162,10 @@ jobs:
             jq -e '(.schemaVersion == "theologai-bounded-command.v1") and (.exitStatus == 0) and (.overflow == false)' "$result"
           }
           capture "$RUNNER_TEMP/pr108-npm-ci.out" "$RUNNER_TEMP/pr108-npm-ci.err" "$RUNNER_TEMP/pr108-npm-ci.result.json" npm ci --no-audit
+          capture "$RUNNER_TEMP/pr108-build-db.out" "$RUNNER_TEMP/pr108-build-db.err" "$RUNNER_TEMP/pr108-build-db.result.json" npm run build:db -- --output "$RUNNER_TEMP/pr108-theologai.db"
+          capture "$RUNNER_TEMP/pr108-verify-db.out" "$RUNNER_TEMP/pr108-verify-db.err" "$RUNNER_TEMP/pr108-verify-db.result.json" npm run data:verify-db -- --database "$RUNNER_TEMP/pr108-theologai.db"
+          capture "$RUNNER_TEMP/pr108-seed-export.out" "$RUNNER_TEMP/pr108-seed-export.err" "$RUNNER_TEMP/pr108-seed-export.result.json" npm run d1:seed:export -- --database "$RUNNER_TEMP/pr108-theologai.db" --clean
+          capture "$RUNNER_TEMP/pr108-seed-verify.out" "$RUNNER_TEMP/pr108-seed-verify.err" "$RUNNER_TEMP/pr108-seed-verify.result.json" npm run d1:seed:verify
           capture "$RUNNER_TEMP/pr108-workerd.out" "$RUNNER_TEMP/pr108-workerd.err" "$RUNNER_TEMP/pr108-workerd.result.json" npm run d1:seed:verify-workerd
           capture "$RUNNER_TEMP/pr108-runtime.out" "$RUNNER_TEMP/pr108-runtime.err" "$RUNNER_TEMP/pr108-runtime.result.json" npm run test:worker-production-runtime
 

--- a/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
+++ b/docs/PRODUCTION-ROLLBACK-REHEARSAL.md
@@ -53,7 +53,11 @@ after. It retrieves the fixed historical deployment through the exact
 read-only Cloudflare deployment-ID endpoint rather than relying on a truncated
 deployment list. It checks out the fixed source in a separate directory and runs its
 historical `npm ci`, local Workerd seed/readiness, production-like Worker
-runtime, and remote D1 readiness checks. Raw Wrangler output stays in runner
+runtime, and remote D1 readiness checks. Because the historical checkout omits
+ignored/generated artifacts, its SQLite database is rebuilt into runner
+temporary storage and its D1 seed is regenerated in the source checkout before
+the Workerd and runtime gates; those temporary/generated artifacts are
+discarded with the runner. Raw Wrangler output stays in runner
 temporary storage. The committed dependency-free `scripts/capture-bounded-command.mjs`
 runner is used before and after dependency installation, so output capture does
 not depend on `node_modules`. The runner uses a detached, dependency-free

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -299,7 +299,27 @@ describe('workflow topology', () => {
     const localGateStart = workflow.indexOf('      - name: Run historical PR108 local gates without credentials');
     const localGateEnd = workflow.indexOf('\n      - name:', localGateStart + 1);
     expect(localGateStart).toBeGreaterThan(0);
-    expect(workflow.slice(localGateStart, localGateEnd)).not.toMatch(/CLOUDFLARE|secrets\./);
+    const localGate = workflow.slice(localGateStart, localGateEnd);
+    expect(localGate).not.toMatch(/CLOUDFLARE|secrets\.|--remote\b|d1:remote/i);
+    const historicalCommands = [
+      'npm ci --no-audit',
+      'npm run build:db -- --output "$RUNNER_TEMP/pr108-theologai.db"',
+      'npm run data:verify-db -- --database "$RUNNER_TEMP/pr108-theologai.db"',
+      'npm run d1:seed:export -- --database "$RUNNER_TEMP/pr108-theologai.db" --clean',
+      'npm run d1:seed:verify',
+      'npm run d1:seed:verify-workerd',
+      'npm run test:worker-production-runtime',
+    ];
+    let previousCommandIndex = -1;
+    for (const command of historicalCommands) {
+      expect(localGate).toContain(command);
+      const commandIndex = localGate.indexOf(command);
+      expect(commandIndex).toBeGreaterThan(previousCommandIndex);
+      previousCommandIndex = commandIndex;
+    }
+    expect(localGate.match(/\$RUNNER_TEMP\/pr108-theologai\.db/g)).toHaveLength(3);
+    expect(localGate).toContain('--clean');
+    expect(workflow.match(/^          persist-credentials: false$/gm)).toHaveLength(2);
     expect(workflow).not.toMatch(/wrangler\s+rollback|versions\s+upload|wrangler\s+deploy(?!ments)/i);
     expect(workflow).not.toMatch(/d1\s+(execute|migrations|delete|create|update)|secret\s+(put|delete)|triggers\s+deploy/i);
     expect(workflow).not.toContain('github-token:');


### PR DESCRIPTION
## Summary

- rebuild and verify PR108 SQLite into runner-temporary storage before exporting/verifying its ignored D1 seed
- run the existing Workerd and production-like runtime gates only after that deterministic reconstruction chain
- disable persisted checkout credentials and enforce the local/credential-free ordering in topology tests
- clarify historical artifact regeneration and disposal in the rollback runbook

## Failure evidence

Protected rehearsal run 33273272526 failed safely before target proof, remote readiness, dry-run, or after-capture steps because the exact PR108 checkout intentionally omits `scripts/d1-seed/`. Its bounded Workerd gate reported the deterministic absent-seed failure. No Worker, traffic, preview, D1, binding, or secret mutation step ran.

## Verification

- `npx vitest run test/unit/config/workflowTopology.test.ts test/unit/scripts/productionRollbackRehearsal.test.ts` (24/24)
- `npm run typecheck:release-scripts`
- `git diff --check`
- Sol High pre-PR review: finding-free