### PR TITLE
Modernize MCP server for dual protocol eras

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -241,9 +241,113 @@ jobs:
             echo "- Changed-path evidence records: \`$evidence_count\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  verify-dual-era-preview:
+    name: Verify Protected Dual-Era Preview
+    needs: verify-deployment-plan
+    if: ${{ github.ref == 'refs/heads/main' && needs.verify-deployment-plan.outputs.deploy_required == 'true' && needs.verify-deployment-plan.outputs.decision == 'deploy' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    outputs:
+      artifact_name: ${{ steps.evidence.outputs.artifact_name }}
+      run_id: ${{ steps.evidence.outputs.run_id }}
+      source_commit: ${{ steps.evidence.outputs.source_commit }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci --no-audit
+
+      - name: Resolve fresh protected dual-era preview evidence
+        id: evidence
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            const merged = pulls.filter(pr =>
+              pr.merged_at && pr.base.ref === 'main' && pr.merge_commit_sha === context.sha
+            );
+            if (merged.length !== 1) {
+              core.setFailed(`Expected one merged main PR for ${context.sha}; found ${merged.length}.`);
+              return;
+            }
+            const pull = merged[0];
+            const artifactName = `preview-release-audit-${pull.number}-${pull.head.sha}`;
+            const { data } = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: artifactName,
+              per_page: 100,
+            });
+            const cutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+            const candidates = data.artifacts.filter(artifact =>
+              artifact.name === artifactName && !artifact.expired &&
+              Date.parse(artifact.created_at) >= cutoff &&
+              artifact.workflow_run?.head_sha === pull.head.sha
+            );
+            candidates.sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at));
+            let selected;
+            for (const artifact of candidates.slice(0, 10)) {
+              if (!artifact.workflow_run) continue;
+              const { data: run } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: artifact.workflow_run.id,
+              });
+              if (run.event === 'pull_request' && run.status === 'completed' && run.conclusion === 'success'
+                && run.head_sha === pull.head.sha) {
+                selected = { artifact, run };
+                break;
+              }
+            }
+            if (!selected) {
+              core.setFailed(`No fresh successful protected preview artifact named ${artifactName} matched the merged source.`);
+              return;
+            }
+            const { artifact, run } = selected;
+            core.setOutput('artifact_name', artifactName);
+            core.setOutput('run_id', String(run.id));
+            core.setOutput('source_commit', pull.head.sha);
+
+      - name: Download exact protected preview evidence with digest validation
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ steps.evidence.outputs.artifact_name }}
+          run-id: ${{ steps.evidence.outputs.run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/protected-dual-era-preview
+          merge-multiple: false
+          digest-mismatch: error
+
+      - name: Verify source-bound dual-era preview release receipt
+        env:
+          SOURCE_COMMIT: ${{ steps.evidence.outputs.source_commit }}
+        run: |
+          source_tree="$(git rev-parse 'HEAD^{tree}')"
+          server_version="$(node --input-type=module -e "import packageJson from './package.json' with { type: 'json' }; process.stdout.write(packageJson.version)")"
+          npx --no-install tsx scripts/dual-era-preview-release-receipt.ts verify \
+            --receipt "$RUNNER_TEMP/protected-dual-era-preview/dual-era-preview-release-receipt.json" \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-source-commit "$SOURCE_COMMIT" \
+            --expected-source-tree "$source_tree" \
+            --expected-server-version "$server_version"
+
   deploy:
     name: Test, Build & Deploy
-    needs: verify-deployment-plan
+    needs: [verify-deployment-plan, verify-dual-era-preview]
     if: ${{ github.ref == 'refs/heads/main' && needs.verify-deployment-plan.outputs.deploy_required == 'true' && needs.verify-deployment-plan.outputs.decision == 'deploy' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -251,6 +355,7 @@ jobs:
       name: production
       url: https://mcp.theologai.xyz/mcp
     permissions:
+      actions: read
       contents: read
     env:
       EXPECTED_RUN_ID: ${{ github.run_id }}
@@ -337,6 +442,29 @@ jobs:
           ' "$verified"
 
       - run: npm ci --no-audit
+
+      - name: Download exact protected preview evidence with digest validation
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.verify-dual-era-preview.outputs.artifact_name }}
+          run-id: ${{ needs.verify-dual-era-preview.outputs.run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/protected-dual-era-preview
+          merge-multiple: false
+          digest-mismatch: error
+
+      - name: Verify source-bound dual-era preview release receipt
+        env:
+          SOURCE_COMMIT: ${{ needs.verify-dual-era-preview.outputs.source_commit }}
+        run: |
+          source_tree="$(git rev-parse 'HEAD^{tree}')"
+          server_version="$(node --input-type=module -e "import packageJson from './package.json' with { type: 'json' }; process.stdout.write(packageJson.version)")"
+          npx --no-install tsx scripts/dual-era-preview-release-receipt.ts verify \
+            --receipt "$RUNNER_TEMP/protected-dual-era-preview/dual-era-preview-release-receipt.json" \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-source-commit "$SOURCE_COMMIT" \
+            --expected-source-tree "$source_tree" \
+            --expected-server-version "$server_version"
 
       - name: Detect production custom-domain declaration change
         id: production-custom-domain-change
@@ -448,7 +576,9 @@ jobs:
           npm run test:ccel-coordinator-runtime
 
       - name: Exercise production-like Worker bundle without test-only globals
-        run: npm run test:worker-production-runtime
+        run: |
+          npm run test:worker-bundle-ubs
+          npm run test:worker-production-runtime
 
       - name: Build Node.js target
         run: npm run build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,7 +186,9 @@ jobs:
           npm run test:ccel-coordinator-runtime
 
       - name: Exercise production-like Worker bundle without test-only globals
-        run: npm run test:worker-production-runtime
+        run: |
+          npm run test:worker-bundle-ubs
+          npm run test:worker-production-runtime
 
   node-http-e2e:
     name: Node HTTP E2E
@@ -578,6 +580,13 @@ jobs:
             --output "$RUNNER_TEMP/historical-spine-preview-audit.json"
           test -s "$RUNNER_TEMP/historical-spine-preview-audit.json"
 
+      - name: Prove legacy and modern MCP eras on the protected preview
+        id: preview-dual-era-audit
+        if: ${{ steps.preview-historical-spine-audit.outcome == 'success' }}
+        run: |
+          npm run audit:dual-era-preview -- --output "$RUNNER_TEMP/dual-era-mcp-preview-audit.json"
+          test -s "$RUNNER_TEMP/dual-era-mcp-preview-audit.json"
+
       # Runs after any post-deploy result (including audit failure or a later
       # authorization revocation) and is deliberately read-only. It does not
       # attempt an automatic rollback or destructive cleanup.
@@ -611,7 +620,7 @@ jobs:
 
       - name: Verify preview Worker remained active through audit (read-only)
         id: preview-worker-audit-identity
-        if: ${{ steps.preview-primary-source-edge-stabilization-gate.outcome == 'success' && steps.preview-original-language-v2-audit.outcome == 'success' && steps.preview-historical-core-audit.outcome == 'success' && steps.preview-historical-spine-audit.outcome == 'success' }}
+        if: ${{ steps.preview-primary-source-edge-stabilization-gate.outcome == 'success' && steps.preview-original-language-v2-audit.outcome == 'success' && steps.preview-historical-core-audit.outcome == 'success' && steps.preview-historical-spine-audit.outcome == 'success' && steps.preview-dual-era-audit.outcome == 'success' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -629,7 +638,7 @@ jobs:
       # a production change that happened during the black-box audit window.
       - name: Verify production control remained unchanged after preview audits (read-only)
         id: production-control-post-audit
-        if: ${{ steps.preview-primary-source-edge-stabilization-gate.outcome == 'success' && steps.preview-original-language-v2-audit.outcome == 'success' && steps.preview-historical-core-audit.outcome == 'success' && steps.preview-historical-spine-audit.outcome == 'success' && steps.preview-worker-audit-identity.outcome == 'success' }}
+        if: ${{ steps.preview-primary-source-edge-stabilization-gate.outcome == 'success' && steps.preview-original-language-v2-audit.outcome == 'success' && steps.preview-historical-core-audit.outcome == 'success' && steps.preview-historical-spine-audit.outcome == 'success' && steps.preview-dual-era-audit.outcome == 'success' && steps.preview-worker-audit-identity.outcome == 'success' }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -648,6 +657,24 @@ jobs:
             --wrangler-config wrangler.toml \
             --d1-inventory "$RUNNER_TEMP/production-control-d1-inventory-post-audit.json" \
             --output "$RUNNER_TEMP/production-control-post-audit.json"
+
+      - name: Create source-bound dual-era preview release receipt
+        if: ${{ steps.production-control-post-audit.outcome == 'success' }}
+        env:
+          SOURCE_COMMIT: ${{ github.event.pull_request.head.sha }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          source_tree="$(git rev-parse "$SOURCE_COMMIT^{tree}")"
+          npx --no-install tsx scripts/dual-era-preview-release-receipt.ts create \
+            --repository "$GITHUB_REPOSITORY" \
+            --pull-request "$PULL_REQUEST_NUMBER" \
+            --source-commit "$SOURCE_COMMIT" \
+            --source-tree "$source_tree" \
+            --audit "$RUNNER_TEMP/dual-era-mcp-preview-audit.json" \
+            --worker-identity "$RUNNER_TEMP/preview-worker-deployment-identity.json" \
+            --cutover "$RUNNER_TEMP/preview-worker-candidate-cutover.json" \
+            --d1-readiness "$RUNNER_TEMP/preview-d1-readiness-receipt.json" \
+            --output "$RUNNER_TEMP/dual-era-preview-release-receipt.json"
 
       - name: Hash sanitized preview audit evidence
         id: preview-audit-evidence
@@ -675,6 +702,8 @@ jobs:
             ${{ runner.temp }}/original-language-v2-preview-audit.json
             ${{ runner.temp }}/historical-core-preview-audit.json
             ${{ runner.temp }}/historical-spine-preview-audit.json
+            ${{ runner.temp }}/dual-era-mcp-preview-audit.json
+            ${{ runner.temp }}/dual-era-preview-release-receipt.json
             ${{ runner.temp }}/preview-worker-deployment-identity.json
             ${{ runner.temp }}/preview-worker-candidate-cutover-observation.json
             ${{ runner.temp }}/preview-worker-candidate-cutover.json

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ rollback unit in that dated release record; it is not current today: deployment
 history, not the immediate rollback claim.
 
 The successor delivery program is tracked in
-[Phase 3B](docs/PHASE-3B-PLAN.md). It begins with release hygiene and dual-era
-MCP modernization before the separate historical-research project.
+[Phase 3B](docs/PHASE-3B-PLAN.md). The 3B.1 dual-era implementation is locally
+release-ready and awaits its separately authorized protected preview proof;
+it makes no claim about the currently deployed runtime.
 
 The historical PR #96 `original_language_study` schema-v2 audit passed 11/11
 cases.
@@ -257,13 +258,16 @@ seed evidence, and release boundary are recorded in
 
 | Transport | Tools | Resources | Prompts | MCP Logging |
 |---|---:|---:|---:|---:|
-| stdio | Yes | Yes | Yes | Yes |
+| stdio | Yes | Yes | Yes | Legacy era only |
 | Node Streamable HTTP | Yes | Yes | Yes | No |
 | Cloudflare Streamable HTTP | Yes | Yes | Yes | No |
 
-HTTP is intentionally anonymous and stateless. MCP Logging is limited to stdio
-because `logging/setLevel` state cannot persist when each HTTP POST receives a
-fresh server and transport.
+The same endpoints serve legacy `2025-11-25` and modern `2026-07-28` clients.
+Modern requests use stateless discovery, explicit request metadata and modern
+HTTP headers; list and resource results carry private, zero-TTL cache hints.
+HTTP is intentionally anonymous and stateless. MCP Logging is retained only
+for legacy stdio compatibility; modern clients and both HTTP transports use
+stderr or privacy-safe telemetry instead.
 
 ### Tools
 
@@ -713,7 +717,9 @@ the language-service edge and does not claim that every service is presentation
 free. `LocalPrimarySourceSearchProvider` retains its historical formatter call
 to preserve exact local-resource sizing and identity behavior.
 
-Business services depend on shared repository ports. Node uses synchronous
+Business services depend on shared repository ports. The shared MCP registry
+uses the official v2 server and Node transport packages directly; the former
+Agents transport wrapper and local AI module shim are retired. Node uses synchronous
 SQLite repositories through async-compatible service boundaries; Workers uses
 per-request D1 repositories. Both targets share one MCP registry.
 

--- a/docs/PHASE-3B-PLAN.md
+++ b/docs/PHASE-3B-PLAN.md
@@ -65,9 +65,9 @@ The following boundaries remain deliberate:
 
 ## Phase 3B sequencing
 
-Status: **3B.0 complete (C1 + C2)**. The next work item is 3B.1; this plan
-does not authorize its deployment, binding changes, cleanup, or any other
-operational mutation.
+Status: **3B.0 complete (C1 + C2); 3B.1 implementation release-ready locally,
+protected preview proof pending**. This plan does not authorize deployment,
+binding changes, cleanup, or any other operational mutation.
 
 ### 3B.0 — Rebaseline and simplify
 
@@ -86,9 +86,10 @@ operational mutation.
 
 ### 3B.1 — Dual-era MCP modernization
 
-The current server uses `@modelcontextprotocol/sdk` v1 and negotiates the
-legacy `2025-11-25` protocol. The current MCP specification is `2026-07-28`,
-and the official TypeScript v2 packages support both legacy and modern eras.
+The deployed historical baseline uses `@modelcontextprotocol/sdk` v1 and
+negotiates the legacy `2025-11-25` protocol. The checked-out 3B.1 candidate
+uses the exact official TypeScript v2 server, client, and Node packages and
+supports both legacy and modern eras; that candidate is not a deployed claim.
 
 Implement this as a behavior-neutral infrastructure release:
 
@@ -106,6 +107,19 @@ Implement this as a behavior-neutral infrastructure release:
    retain only the compatibility behavior required by legacy clients.
 6. Add separate legacy and modern protocol fixtures, conformance coverage, and
    black-box audits. Preview must prove both eras before production.
+
+Implementation findings: the official v2 packages can own stdio, Node HTTP,
+and Worker HTTP directly, so the prior Agents transport dependency and local
+AI shim are unnecessary. The candidate preserves the eleven-tool/six-prompt
+contract and deterministic resource ordering, limits Logging to legacy stdio,
+adds modern discovery/header/metadata and private zero-TTL cache behavior, and
+sanitizes unexpected protocol failures. The reviewed Worker bundle is about
+2.40 MB raw and 470 KB gzip, with local Workerd startup around 58 ms under a
+1,000 ms fail-closed gate. Legacy and modern conformance, process-boundary,
+and real Workerd coverage are separate. A protected preview run must create a
+seven-day source/tree/Worker/D1-bound dual-era receipt; production must retrieve
+that exact successful artifact with digest validation and fail closed before
+any deployment if it is absent, stale, or mismatched.
 
 Do not add Tasks, MCP Apps, or Skills-over-MCP merely because they exist. Add
 an extension only when it solves a defined product workflow. Tasks are not

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -846,8 +846,10 @@ Code readiness and operational readiness are deliberately separate:
   cross-schema generations remain retained; deletion is never automatic and
   requires the documented 30-day, fresh-rehearsal, no-binding,
   reconstruction, compatibility, and exact-owner gates. No cleanup is
-  authorized. The next item is 3B.1 dual-era MCP modernization, which this
-  roadmap does not authorize to deploy.
+  authorized. The 3B.1 dual-era MCP modernization implementation is locally
+  release-ready; its source-bound protected preview proof and a separate
+  production approval remain required. This roadmap does not authorize either
+  deployment.
 - Revisit the parked public-edge traffic issue: a Frankfurt/AWS client has
   generated sustained anonymous production invocations. The custom domain and
   ordinary-request PR #72 legacy-host redirect are already deployed. Any

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "@cfworker/json-schema": "4.1.1",
-        "@modelcontextprotocol/sdk": "1.29.0",
-        "agents": "0.17.3",
+        "@modelcontextprotocol/node": "2.0.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "ajv": "8.20.0",
         "better-sqlite3": "^12.6.2",
         "dotenv": "^17.2.3",
+        "hono": "4.12.34",
         "parse5": "8.0.1",
         "typescript": "^5.9.2",
         "zod": "4.3.6"
@@ -22,7 +23,9 @@
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.18.8",
         "@cloudflare/workers-types": "5.20260722.1",
+        "@modelcontextprotocol/client": "2.0.0",
         "@modelcontextprotocol/conformance": "0.1.16",
+        "@modelcontextprotocol/conformance-modern": "npm:@modelcontextprotocol/conformance@0.2.0-alpha.11",
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^24.5.2",
         "@types/xml2js": "^0.4.14",
@@ -40,443 +43,6 @@
       },
       "engines": {
         "node": ">=22.18.0 <23"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
-      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^8.0.0",
-        "js-tokens": "^10.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
-      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
-      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^8.0.0",
-        "@babel/generator": "^8.0.0",
-        "@babel/helper-compilation-targets": "^8.0.0",
-        "@babel/helpers": "^8.0.0",
-        "@babel/parser": "^8.0.0",
-        "@babel/template": "^8.0.0",
-        "@babel/traverse": "^8.0.0",
-        "@babel/types": "^8.0.0",
-        "@types/gensync": "^1.0.5",
-        "convert-source-map": "^2.0.0",
-        "empathic": "^2.0.1",
-        "gensync": "^1.0.0-beta.2",
-        "import-meta-resolve": "^4.2.0",
-        "json5": "^2.2.3",
-        "obug": "^2.1.1",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/parser": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
-      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^8.0.4"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
-      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^8.0.0",
-        "@babel/types": "^8.0.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "@types/jsesc": "^2.5.0",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@babel/parser": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
-      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.4"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
-      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
-      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/compat-data": "^8.0.0",
-        "@babel/helper-validator-option": "^8.0.0",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^11.0.0",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "11.5.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
-      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
-      "integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^8.0.0",
-        "@babel/helper-member-expression-to-functions": "^8.0.0",
-        "@babel/helper-optimise-call-expression": "^8.0.0",
-        "@babel/helper-replace-supers": "^8.0.1",
-        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
-        "@babel/traverse": "^8.0.0",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
-      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
-      "integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
-      "integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
-      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-replace-supers": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
-      "integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^8.0.0",
-        "@babel/helper-optimise-call-expression": "^8.0.0",
-        "@babel/traverse": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^8.0.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
-      "integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -499,64 +65,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
-      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
-      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/template": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
@@ -571,183 +79,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-8.0.2.tgz",
-      "integrity": "sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^8.0.1",
-        "@babel/helper-plugin-utils": "^8.0.1",
-        "@babel/plugin-syntax-decorators": "^8.0.1"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^8.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-8.0.1.tgz",
-      "integrity": "sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^8.0.1"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^8.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
-      "integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.48.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
-      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^8.0.0",
-        "@babel/parser": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/template/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/template/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/template/node_modules/@babel/parser": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
-      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.4"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
-      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^8.0.0",
-        "@babel/generator": "^8.0.0",
-        "@babel/helper-globals": "^8.0.0",
-        "@babel/parser": "^8.0.4",
-        "@babel/template": "^8.0.0",
-        "@babel/types": "^8.0.4",
-        "obug": "^2.1.1"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
-      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
-      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/parser": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
-      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^8.0.4"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/types": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
-      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0",
-        "@babel/helper-validator-identifier": "^8.0.4"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/types": {
@@ -779,36 +110,6 @@
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
       "license": "MIT"
-    },
-    "node_modules/@cloudflare/codemode": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/codemode/-/codemode-0.4.2.tgz",
-      "integrity": "sha512-6sLMZDRY2USbXirrI4tjmGSMYAYM+E/PJIaDQLLbMdvQjk1z1TmJNSLomrZwErO1zFPXvGX2kaqkkxvixkfV2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15",
-        "acorn": "^8.17.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.0",
-        "@tanstack/ai": ">=0.8.0 <1.0.0",
-        "ai": "^6.0.0",
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        },
-        "@tanstack/ai": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",
@@ -985,6 +286,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -996,6 +298,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1006,6 +309,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1019,6 +323,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,6 +340,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1051,6 +357,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1067,6 +374,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1083,6 +391,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1099,6 +408,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1115,6 +425,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,6 +442,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1147,6 +459,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1163,6 +476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1179,6 +493,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,6 +510,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,6 +527,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,6 +544,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1243,6 +561,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1259,6 +578,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1275,6 +595,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1291,6 +612,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1307,6 +629,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1323,6 +646,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1339,6 +663,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1355,6 +680,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1371,6 +697,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1387,6 +714,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1403,6 +731,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1419,6 +748,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1426,18 +756,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@hono/node-server": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
-      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "hono": "^4"
       }
     },
     "node_modules/@img/colour": {
@@ -1967,20 +1285,11 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1990,16 +1299,37 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@modelcontextprotocol/conformance": {
@@ -2023,10 +1353,80 @@
         "conformance": "dist/index.js"
       }
     },
+    "node_modules/@modelcontextprotocol/conformance-modern": {
+      "name": "@modelcontextprotocol/conformance",
+      "version": "0.2.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/conformance/-/conformance-0.2.0-alpha.11.tgz",
+      "integrity": "sha512-imPK9tx5gQsL6ZKQq4MrsyDYfSaIwpRmX6+ogjbeAXs9LGvxkBxWcY7KcS7TvwaBk/ZiVWl6b/naF4q83UwDRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@octokit/rest": "^22.0.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "commander": "^14.0.2",
+        "eventsource-parser": "^3.0.8",
+        "express": "^5.1.0",
+        "jose": "^6.1.2",
+        "undici": "^7.25.0",
+        "yaml": "^2.8.2",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "conformance": "dist/index.js"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/node/node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -2063,10 +1463,37 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2266,6 +1693,7 @@
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -2327,6 +1755,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2343,6 +1772,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2359,6 +1789,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,6 +1806,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2391,6 +1823,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2407,6 +1840,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,6 +1857,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2439,6 +1874,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2455,6 +1891,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2471,6 +1908,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2487,6 +1925,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2503,6 +1942,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2519,6 +1959,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2537,6 +1978,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2553,6 +1995,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,6 +2009,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -2599,6 +2043,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2638,25 +2083,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/gensync": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
-      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2866,6 +2292,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -2873,159 +2300,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/agents": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/agents/-/agents-0.17.3.tgz",
-      "integrity": "sha512-h0rc+dXwe/B6WblHH+Q3625nN/aryZntj6NIJX7tf+VSjmnI1EZyWtVBYMdX4FJZLShpl/vcx/A1AkxytWCPNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-proposal-decorators": "^8.0.2",
-        "@cfworker/json-schema": "^4.1.1",
-        "@cloudflare/codemode": "^0.4.2",
-        "@modelcontextprotocol/sdk": "1.29.0",
-        "@rolldown/plugin-babel": "^0.2.3",
-        "cron-schedule": "^6.0.0",
-        "esbuild": "^0.28.1",
-        "mimetext": "^3.0.28",
-        "nanoid": "^5.1.16",
-        "partyserver": "^0.5.8",
-        "partysocket": "1.3.0",
-        "yaml": "^2.9.0",
-        "yargs": "^18.0.0"
-      },
-      "bin": {
-        "agents": "dist/cli/index.js"
-      },
-      "peerDependencies": {
-        "@ai-sdk/react": "^3.0.204",
-        "@tanstack/ai": ">=0.10.2 <1.0.0",
-        "@x402/core": "^2.0.0",
-        "@x402/evm": "^2.0.0",
-        "ai": "^6.0.0",
-        "chat": "^4.29.0",
-        "just-bash": "^3.0.0",
-        "react": "^19.0.0",
-        "vite": ">=6.0.0 <9.0.0",
-        "zod": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@ai-sdk/react": {
-          "optional": true
-        },
-        "@tanstack/ai": {
-          "optional": true
-        },
-        "@x402/core": {
-          "optional": true
-        },
-        "@x402/evm": {
-          "optional": true
-        },
-        "ai": {
-          "optional": true
-        },
-        "chat": {
-          "optional": true
-        },
-        "just-bash": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agents/node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
-      "license": "MIT OR Apache-2.0",
-      "peer": true
-    },
-    "node_modules/agents/node_modules/@rolldown/plugin-babel": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
-      "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=22.12.0 || ^24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
-        "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1",
-        "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1",
-        "rolldown": "^1.0.0-rc.5",
-        "vite": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/plugin-transform-runtime": {
-          "optional": true
-        },
-        "@babel/runtime": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agents/node_modules/nanoid": {
-      "version": "5.1.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
-      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
-    "node_modules/agents/node_modules/partyserver": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.5.8.tgz",
-      "integrity": "sha512-htgSwiBcBu9zIYLrsxBAOvdkjukHvncbTk0nDrJgfruvZ08rxtEN1Ab4T7j9osykP80Bq3zA2oWFd3ngc4Z9uw==",
-      "license": "ISC",
-      "dependencies": {
-        "nanoid": "^5.1.9"
-      },
-      "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260424.1"
-      }
-    },
-    "node_modules/agents/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/ajv": {
@@ -3048,6 +2322,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3059,30 +2334,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -3151,19 +2402,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.10.42",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -3229,6 +2467,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -3253,6 +2492,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3286,40 +2526,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/browserslist": {
-      "version": "4.28.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001800",
-        "electron-to-chromium": "^1.5.387",
-        "node-releases": "^2.0.50",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/buffer": {
@@ -3363,6 +2569,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3372,6 +2579,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3385,6 +2593,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3396,27 +2605,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001803",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0",
-      "peer": true
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -3466,60 +2654,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3534,6 +2668,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
       "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3547,6 +2682,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3556,12 +2692,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3571,26 +2709,17 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
-      "integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -3600,19 +2729,11 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/cron-schedule": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-6.0.0.tgz",
-      "integrity": "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3627,6 +2748,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3668,6 +2790,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3698,6 +2821,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3712,29 +2836,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/electron-to-chromium": {
-      "version": "1.5.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/empathic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
-      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3776,6 +2885,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3785,6 +2895,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3801,6 +2912,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3813,6 +2925,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3850,19 +2963,11 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/estree-walker": {
@@ -3879,21 +2984,17 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-polyfill": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
-      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
-      "license": "MIT"
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -3903,9 +3004,10 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -3934,6 +3036,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -3977,6 +3080,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -4043,6 +3147,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -4071,6 +3176,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4080,6 +3186,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4110,46 +3217,17 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4174,6 +3252,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4219,6 +3298,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4260,6 +3340,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4272,6 +3353,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4300,6 +3382,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -4320,6 +3403,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4359,17 +3443,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -4386,6 +3459,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
       "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4395,6 +3469,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -4450,12 +3525,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -4524,34 +3601,18 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -4563,6 +3624,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-with-bigint": {
@@ -4571,19 +3633,6 @@
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -4599,7 +3648,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4898,6 +3947,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4907,6 +3957,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4916,6 +3967,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4928,6 +3980,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4937,6 +3990,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -4947,43 +4001,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/mimetext": {
-      "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
-      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@babel/runtime-corejs3": "^7.26.0",
-        "js-base64": "^3.7.7",
-        "mime-types": "^2.1.35"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://patreon.com/muratgozel"
-      }
-    },
-    "node_modules/mimetext/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimetext/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-response": {
@@ -5064,13 +4081,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
       "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5095,6 +4113,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5110,16 +4129,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
-      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/nodemon": {
@@ -5165,6 +4174,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5174,6 +4184,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5186,6 +4197,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
       "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -5199,6 +4211,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -5244,32 +4257,17 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/partysocket": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.3.0.tgz",
-      "integrity": "sha512-1zToNyolZFK/7nuAw/K2bZrNzFqaZyRoCEkS+9vG6WSC5ikrN6qWRe96q6ImU51uptz2r+dAwSkwhJVdQi4LiA==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-polyfill": "^0.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=17"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5279,6 +4277,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -5296,6 +4295,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -5315,6 +4315,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
       "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -5324,7 +4325,7 @@
       "version": "8.5.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5379,6 +4380,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -5409,6 +4411,7 @@
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
       "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -5425,6 +4428,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5434,6 +4438,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -5458,16 +4463,6 @@
       },
       "bin": {
         "rc": "cli.js"
-      }
-    },
-    "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -5520,6 +4515,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
@@ -5553,6 +4549,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -5589,6 +4586,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -5614,6 +4612,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -5640,6 +4639,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -5659,6 +4659,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sharp": {
@@ -5710,6 +4711,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5722,6 +4724,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5731,6 +4734,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
       "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5750,6 +4754,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
       "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5766,6 +4771,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5784,6 +4790,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5896,7 +4903,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5913,6 +4920,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5932,21 +4940,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-json-comments": {
@@ -6020,7 +5013,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6037,7 +5030,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6055,7 +5048,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6091,6 +5084,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -6120,6 +5114,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -6643,6 +5638,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -6661,6 +5657,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6728,40 +5725,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -6774,6 +5741,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6783,7 +5751,7 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -6861,7 +5829,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6987,6 +5955,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7131,19 +6100,11 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -7153,55 +6114,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/youch": {
@@ -7256,6 +6168,7 @@
       "version": "3.25.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
       "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "audit:original-language-v2-preview": "tsx scripts/audit-original-language-v2-preview.ts",
     "audit:historical-core-preview": "tsx scripts/audit-historical-core-preview.ts",
     "audit:historical-spine-preview": "tsx scripts/audit-historical-spine-preview.ts",
+    "audit:dual-era-preview": "tsx scripts/audit-dual-era-mcp-preview.ts",
     "audit:primary-source-edge-stabilization-production": "tsx scripts/audit-primary-source-edge-stabilization-production.ts",
     "audit:original-language-v2-production": "tsx scripts/audit-original-language-v2-production.ts",
     "audit:historical-core-production": "tsx scripts/audit-historical-core-production.ts",
@@ -111,9 +112,6 @@
     "node": ">=22.18.0 <23"
   },
   "overrides": {
-    "@modelcontextprotocol/sdk": {
-      "@hono/node-server": "2.0.11"
-    },
     "brace-expansion": "5.0.9",
     "fast-uri": "3.1.5",
     "hono": "4.12.34",
@@ -125,11 +123,12 @@
   },
   "dependencies": {
     "@cfworker/json-schema": "4.1.1",
-    "@modelcontextprotocol/sdk": "1.29.0",
-    "agents": "0.17.3",
+    "@modelcontextprotocol/node": "2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "ajv": "8.20.0",
     "better-sqlite3": "^12.6.2",
     "dotenv": "^17.2.3",
+    "hono": "4.12.34",
     "parse5": "8.0.1",
     "typescript": "^5.9.2",
     "zod": "4.3.6"
@@ -137,7 +136,9 @@
   "devDependencies": {
     "@cloudflare/workers-types": "5.20260722.1",
     "@cloudflare/vitest-pool-workers": "^0.18.8",
+    "@modelcontextprotocol/client": "2.0.0",
     "@modelcontextprotocol/conformance": "0.1.16",
+    "@modelcontextprotocol/conformance-modern": "npm:@modelcontextprotocol/conformance@0.2.0-alpha.11",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^24.5.2",
     "@types/xml2js": "^0.4.14",

--- a/scripts/audit-ccel-preview.ts
+++ b/scripts/audit-ccel-preview.ts
@@ -1,5 +1,4 @@
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { normalizeCcelSectionLocator } from '../src/adapters/commentary/CcelSearchAdapter.js';
 import { CCEL_UPSTREAM_TERMINAL_ATTEMPT_LIMIT, type CcelCoordinatorSnapshot } from '../src/services/historical/CcelUpstreamCoordinator.js';
 import { CCEL_COMPOSITION_DATE_NOTICE } from '../src/services/historical/primarySourceTypes.js';

--- a/scripts/audit-dual-era-mcp-preview.ts
+++ b/scripts/audit-dual-era-mcp-preview.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import {
+  assertMcpTransportContract,
+  captureMcpTransportSnapshot,
+  fingerprintMcpTransportSnapshot,
+} from '../test/helpers/mcpTransportContract.js';
+
+const PROTOCOLS = ['2025-11-25', '2026-07-28'] as const;
+const DEFAULT_URL = 'https://preview-mcp.theologai.xyz/mcp';
+type ProtocolVersion = typeof PROTOCOLS[number];
+
+export interface DualEraMcpAudit {
+  schemaVersion: 'theologai-dual-era-mcp-preview-audit.v1';
+  capturedAt: string;
+  endpoint: string;
+  productProfile: '7';
+  eras: Array<{
+    protocolVersion: ProtocolVersion;
+    serverName: 'theologai-bible-server';
+    serverVersion: string;
+    counts: { tools: 11; prompts: 6; resourceTemplates: 2; staticResources: 3 };
+    fingerprints: {
+      capabilities: string;
+      tools: string;
+      prompts: string;
+      resourceTemplates: string;
+      staticResources: string;
+    };
+  }>;
+  crossEraContractSha256: string;
+}
+
+function fail(message: string): never {
+  throw new Error(`Dual-era preview MCP audit refused: ${message}`);
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record).sort().map(key => `${JSON.stringify(key)}:${canonicalJson(record[key])}`).join(',')}}`;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256').update(canonicalJson(value)).digest('hex');
+}
+
+export async function auditDualEraMcpPreview(
+  endpoint: string,
+  expectedServerVersion: string,
+  now: Date = new Date(),
+): Promise<DualEraMcpAudit> {
+  const url = new URL(endpoint);
+  if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash) {
+    fail('endpoint must be a credential-free HTTPS URL without query or fragment');
+  }
+  const eras: DualEraMcpAudit['eras'] = [];
+  for (const protocolVersion of PROTOCOLS) {
+    const client = new Client(
+      { name: `theologai-protected-preview-${protocolVersion}`, version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: protocolVersion } } },
+    );
+    try {
+      await client.connect(new StreamableHTTPClientTransport(url));
+      if (client.getNegotiatedProtocolVersion() !== protocolVersion) {
+        fail(`${protocolVersion} negotiation drifted`);
+      }
+      const snapshot = await captureMcpTransportSnapshot(client);
+      await assertMcpTransportContract(snapshot, { contractVersion: '7', logging: false });
+      if (snapshot.server.version !== expectedServerVersion) {
+        fail(`${protocolVersion} server version is ${snapshot.server.version}, expected ${expectedServerVersion}`);
+      }
+      eras.push({
+        protocolVersion,
+        serverName: 'theologai-bible-server',
+        serverVersion: snapshot.server.version,
+        counts: {
+          tools: snapshot.tools.length as 11,
+          prompts: snapshot.prompts.length as 6,
+          resourceTemplates: snapshot.resourceTemplates.length as 2,
+          staticResources: snapshot.staticResources.length as 3,
+        },
+        fingerprints: await fingerprintMcpTransportSnapshot(snapshot),
+      });
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  }
+  if (canonicalJson(eras[0]!.fingerprints) !== canonicalJson(eras[1]!.fingerprints)) {
+    fail('legacy and modern public contracts differ');
+  }
+  return {
+    schemaVersion: 'theologai-dual-era-mcp-preview-audit.v1',
+    capturedAt: now.toISOString(),
+    endpoint: url.href,
+    productProfile: '7',
+    eras,
+    crossEraContractSha256: sha256(eras.map(era => era.fingerprints)),
+  };
+}
+
+function option(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+async function main(): Promise<void> {
+  const packageJson = JSON.parse(await readFile(resolve('package.json'), 'utf8')) as { version?: unknown };
+  if (typeof packageJson.version !== 'string') fail('package version is invalid');
+  const output = option('--output');
+  if (!output) fail('--output is required');
+  const audit = await auditDualEraMcpPreview(option('--url') ?? DEFAULT_URL, packageJson.version);
+  await mkdir(dirname(resolve(output)), { recursive: true });
+  await writeFile(resolve(output), `${JSON.stringify(audit, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  console.error(`[dual-era-preview] ${audit.eras.length} eras, 11 tools, 6 prompts; ${audit.crossEraContractSha256}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  await main();
+}

--- a/scripts/audit-parallel-passages-preview.ts
+++ b/scripts/audit-parallel-passages-preview.ts
@@ -1,8 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { validateParallelPassagesOutputSemantics } from '../src/mcp/parallelPassagesOutputValidation.js';
 
 export interface AuditCase {

--- a/scripts/check-worker-bundle-excludes-ubs.ts
+++ b/scripts/check-worker-bundle-excludes-ubs.ts
@@ -31,7 +31,39 @@ try {
   // the multi-megabyte compiled UBS JSON artifact checked above. The 3.125 MiB
   // ceiling keeps a narrow review margin above the reviewed v2 bundle.
   if (rawBytes > 3.125 * 1024 * 1024) throw new Error(`Worker bundle exceeded reviewed 3.125 MiB raw ceiling: ${rawBytes}`);
-  console.error(`[worker-ubs-bundle] ${inputs.length} inputs; ${rawBytes} raw bytes; ${gzipBytes} gzip bytes; UBS JSON absent.`);
+
+  // Wrangler's startup profiler consumes the multipart bundle produced by
+  // --outfile, rather than the plain JavaScript emitted by --outdir. Keep the
+  // profile ephemeral and fail before deployment if local Workerd startup
+  // reaches Cloudflare's one-second Worker startup ceiling.
+  const startupBundle = join(output, 'worker.bundle');
+  const startupProfile = join(output, 'worker-startup.cpuprofile');
+  execFileSync(process.execPath, [
+    wrangler, 'deploy', '--dry-run', '--env', 'preview', '--outfile', startupBundle,
+  ], {
+    cwd: root,
+    stdio: ['ignore', 'ignore', 'inherit'],
+    env: { ...process.env, WRANGLER_LOG_PATH: join(output, 'wrangler-startup-build.log') },
+  });
+  execFileSync(process.execPath, [
+    wrangler, 'check', 'startup', '--workerBundle', startupBundle, '--outfile', startupProfile,
+  ], {
+    cwd: root,
+    // Wrangler currently prints an upstream AJV code-generation diagnostic
+    // even when profiling succeeds and emits a valid CPU profile. Preserve it
+    // on thrown command errors without flooding successful CI logs.
+    stdio: ['ignore', 'ignore', 'pipe'],
+    env: { ...process.env, WRANGLER_LOG_PATH: join(output, 'wrangler-startup-check.log') },
+  });
+  const profile = JSON.parse(readFileSync(startupProfile, 'utf8')) as { startTime?: unknown; endTime?: unknown };
+  if (typeof profile.startTime !== 'number' || typeof profile.endTime !== 'number'
+    || !Number.isFinite(profile.startTime) || !Number.isFinite(profile.endTime)
+    || profile.endTime < profile.startTime) {
+    throw new Error('Wrangler startup check produced an invalid CPU profile');
+  }
+  const startupMs = (profile.endTime - profile.startTime) / 1_000;
+  if (startupMs >= 1_000) throw new Error(`Worker startup exceeded the 1,000 ms gate: ${startupMs.toFixed(1)} ms`);
+  console.error(`[worker-ubs-bundle] ${inputs.length} inputs; ${rawBytes} raw bytes; ${gzipBytes} gzip bytes; ${startupMs.toFixed(1)} ms local startup; UBS JSON absent.`);
 } finally {
   rmSync(output, { recursive: true, force: true });
 }

--- a/scripts/dual-era-preview-release-receipt.ts
+++ b/scripts/dual-era-preview-release-receipt.ts
@@ -1,0 +1,223 @@
+import { createHash } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { DualEraMcpAudit } from './audit-dual-era-mcp-preview.js';
+
+type JsonRecord = Record<string, unknown>;
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1_000;
+const FUTURE_SKEW_MS = 5 * 60 * 1_000;
+const PROTOCOLS = ['2025-11-25', '2026-07-28'] as const;
+
+export interface DualEraPreviewReleaseReceipt {
+  schemaVersion: 'theologai-dual-era-preview-release-receipt.v1';
+  createdAt: string;
+  repository: string;
+  pullRequest: number;
+  sourceCommit: string;
+  sourceTree: string;
+  endpoint: string;
+  productProfile: '7';
+  protocols: ['2025-11-25', '2026-07-28'];
+  server: { name: 'theologai-bible-server'; version: string };
+  counts: { tools: 11; prompts: 6; resourceTemplates: 2; staticResources: 3 };
+  contractFingerprints: DualEraMcpAudit['eras'][number]['fingerprints'];
+  auditSha256: string;
+  worker: { deploymentId: string; versionId: string; versionNumber: number };
+  d1: { databaseName: string; databaseId: string };
+  d1ReadinessSha256: string;
+}
+
+function fail(message: string): never {
+  throw new Error(`Dual-era preview release receipt refused: ${message}`);
+}
+
+function object(value: unknown, label: string): JsonRecord {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+  return value as JsonRecord;
+}
+
+function exactKeys(value: JsonRecord, keys: readonly string[], label: string): void {
+  if (Object.keys(value).sort().join(',') !== [...keys].sort().join(',')) fail(`${label} keys are malformed`);
+}
+
+function isSha256(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{64}$/.test(value);
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+function parseJson(text: string, label: string): unknown {
+  try { return JSON.parse(text) as unknown; } catch { fail(`${label} is not valid JSON`); }
+}
+
+function parseAudit(text: string): DualEraMcpAudit {
+  const audit = object(parseJson(text, 'dual-era audit'), 'dual-era audit');
+  exactKeys(audit, ['schemaVersion', 'capturedAt', 'endpoint', 'productProfile', 'eras', 'crossEraContractSha256'], 'dual-era audit');
+  if (audit.schemaVersion !== 'theologai-dual-era-mcp-preview-audit.v1'
+    || audit.productProfile !== '7' || typeof audit.endpoint !== 'string'
+    || typeof audit.capturedAt !== 'string' || !Number.isFinite(Date.parse(audit.capturedAt))
+    || !Array.isArray(audit.eras) || audit.eras.length !== 2 || !isSha256(audit.crossEraContractSha256)) {
+    fail('dual-era audit header is malformed');
+  }
+  for (const [index, protocol] of PROTOCOLS.entries()) {
+    const era = object(audit.eras[index], `dual-era audit ${protocol}`);
+    exactKeys(era, ['protocolVersion', 'serverName', 'serverVersion', 'counts', 'fingerprints'], `dual-era audit ${protocol}`);
+    const counts = object(era.counts, `dual-era audit ${protocol} counts`);
+    const fingerprints = object(era.fingerprints, `dual-era audit ${protocol} fingerprints`);
+    exactKeys(counts, ['tools', 'prompts', 'resourceTemplates', 'staticResources'], `dual-era audit ${protocol} counts`);
+    exactKeys(fingerprints, ['capabilities', 'tools', 'prompts', 'resourceTemplates', 'staticResources'], `dual-era audit ${protocol} fingerprints`);
+    if (era.protocolVersion !== protocol || era.serverName !== 'theologai-bible-server'
+      || typeof era.serverVersion !== 'string' || era.serverVersion.length === 0
+      || counts.tools !== 11 || counts.prompts !== 6 || counts.resourceTemplates !== 2 || counts.staticResources !== 3
+      || !Object.values(fingerprints).every(value => typeof value === 'string' && /^[0-9a-f]{64}$/.test(value))) {
+      fail(`dual-era audit ${protocol} contract is malformed`);
+    }
+  }
+  const [legacy, modern] = audit.eras as DualEraMcpAudit['eras'];
+  if (JSON.stringify(legacy.fingerprints) !== JSON.stringify(modern.fingerprints)
+    || legacy.serverVersion !== modern.serverVersion) fail('dual-era audit contracts differ');
+  return audit as unknown as DualEraMcpAudit;
+}
+
+export function createDualEraPreviewReleaseReceipt(input: {
+  repository: string;
+  pullRequest: number;
+  sourceCommit: string;
+  sourceTree: string;
+  auditText: string;
+  workerIdentityText: string;
+  cutoverText: string;
+  d1ReadinessText: string;
+}): DualEraPreviewReleaseReceipt {
+  const audit = parseAudit(input.auditText);
+  const identity = object(parseJson(input.workerIdentityText, 'Worker identity'), 'Worker identity');
+  const cutover = object(parseJson(input.cutoverText, 'cutover record'), 'cutover record');
+  const candidateD1 = object(cutover.candidateD1, 'cutover candidate D1');
+  const observedD1 = object(cutover.observedActiveD1, 'cutover observed D1');
+  const readiness = object(parseJson(input.d1ReadinessText, 'D1 readiness receipt'), 'D1 readiness receipt');
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(input.repository)
+    || !Number.isSafeInteger(input.pullRequest) || input.pullRequest <= 0
+    || !/^[0-9a-f]{40}$/.test(input.sourceCommit) || !/^[0-9a-f]{40}$/.test(input.sourceTree)) fail('source identity is malformed');
+  if (identity.schemaVersion !== 2 || identity.worker !== 'theologai-preview'
+    || !isUuid(identity.deploymentId) || !isUuid(identity.deployedVersionId)
+    || !Number.isSafeInteger(identity.deployedVersionNumber) || (identity.deployedVersionNumber as number) <= 0) fail('Worker identity is malformed');
+  if (cutover.worker !== 'theologai-preview' || cutover.candidateBindingMatches !== true
+    || cutover.observedActiveDeploymentId !== identity.deploymentId
+    || cutover.observedActiveVersionId !== identity.deployedVersionId
+    || candidateD1.binding !== 'THEOLOGAI_DB' || observedD1.binding !== 'THEOLOGAI_DB'
+    || typeof candidateD1.databaseName !== 'string' || !isUuid(candidateD1.databaseId)
+    || observedD1.databaseId !== candidateD1.databaseId) fail('cutover identity does not match the audited Worker and D1');
+  if (readiness.schemaVersion !== 'theologai-remote-d1-readiness-receipt.v1'
+    || readiness.environment !== 'preview' || readiness.database !== candidateD1.databaseName) fail('D1 readiness does not match the audited candidate');
+  const first = audit.eras[0]!;
+  return {
+    schemaVersion: 'theologai-dual-era-preview-release-receipt.v1',
+    createdAt: audit.capturedAt,
+    repository: input.repository,
+    pullRequest: input.pullRequest,
+    sourceCommit: input.sourceCommit,
+    sourceTree: input.sourceTree,
+    endpoint: audit.endpoint,
+    productProfile: '7',
+    protocols: [...PROTOCOLS],
+    server: { name: 'theologai-bible-server', version: first.serverVersion },
+    counts: first.counts,
+    contractFingerprints: first.fingerprints,
+    auditSha256: sha256(input.auditText),
+    worker: {
+      deploymentId: identity.deploymentId,
+      versionId: identity.deployedVersionId,
+      versionNumber: identity.deployedVersionNumber as number,
+    },
+    d1: { databaseName: candidateD1.databaseName, databaseId: candidateD1.databaseId },
+    d1ReadinessSha256: sha256(input.d1ReadinessText),
+  };
+}
+
+export function verifyDualEraPreviewReleaseReceipt(receipt: unknown, expected: {
+  repository: string; sourceCommit: string; sourceTree: string; serverVersion: string; now?: Date;
+}): DualEraPreviewReleaseReceipt {
+  const value = object(receipt, 'receipt');
+  exactKeys(value, [
+    'schemaVersion', 'createdAt', 'repository', 'pullRequest', 'sourceCommit', 'sourceTree', 'endpoint',
+    'productProfile', 'protocols', 'server', 'counts', 'contractFingerprints', 'auditSha256', 'worker', 'd1',
+    'd1ReadinessSha256',
+  ], 'receipt');
+  const created = typeof value.createdAt === 'string' ? Date.parse(value.createdAt) : Number.NaN;
+  const now = (expected.now ?? new Date()).getTime();
+  if (value.schemaVersion !== 'theologai-dual-era-preview-release-receipt.v1'
+    || value.repository !== expected.repository || value.sourceCommit !== expected.sourceCommit
+    || value.sourceTree !== expected.sourceTree || value.productProfile !== '7'
+    || JSON.stringify(value.protocols) !== JSON.stringify(PROTOCOLS)
+    || !Number.isFinite(created) || created > now + FUTURE_SKEW_MS || now - created > MAX_AGE_MS) fail('receipt identity or seven-day freshness gate failed');
+  const server = object(value.server, 'receipt server');
+  const counts = object(value.counts, 'receipt counts');
+  const fingerprints = object(value.contractFingerprints, 'receipt fingerprints');
+  const worker = object(value.worker, 'receipt Worker');
+  const d1 = object(value.d1, 'receipt D1');
+  exactKeys(server, ['name', 'version'], 'receipt server');
+  exactKeys(counts, ['tools', 'prompts', 'resourceTemplates', 'staticResources'], 'receipt counts');
+  exactKeys(fingerprints, ['capabilities', 'tools', 'prompts', 'resourceTemplates', 'staticResources'], 'receipt fingerprints');
+  exactKeys(worker, ['deploymentId', 'versionId', 'versionNumber'], 'receipt Worker');
+  exactKeys(d1, ['databaseName', 'databaseId'], 'receipt D1');
+  if (server.name !== 'theologai-bible-server' || server.version !== expected.serverVersion
+    || value.endpoint !== 'https://preview-mcp.theologai.xyz/mcp'
+    || counts.tools !== 11 || counts.prompts !== 6 || counts.resourceTemplates !== 2 || counts.staticResources !== 3
+    || !Object.values(fingerprints).every(item => typeof item === 'string' && /^[0-9a-f]{64}$/.test(item))
+    || !isSha256(value.auditSha256) || !isSha256(value.d1ReadinessSha256)
+    || !isUuid(worker.deploymentId) || !isUuid(worker.versionId)
+    || !Number.isSafeInteger(worker.versionNumber) || (worker.versionNumber as number) <= 0
+    || typeof d1.databaseName !== 'string' || !isUuid(d1.databaseId)
+    || typeof value.pullRequest !== 'number' || !Number.isSafeInteger(value.pullRequest) || value.pullRequest <= 0) fail('receipt contract evidence is malformed');
+  return value as unknown as DualEraPreviewReleaseReceipt;
+}
+
+function args(argv: string[]): Map<string, string> {
+  if (argv.length % 2 !== 0) fail('arguments must be --option value pairs');
+  const output = new Map<string, string>();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]; const value = argv[index + 1];
+    if (!key?.startsWith('--') || !value || output.has(key)) fail('arguments are malformed');
+    output.set(key, value);
+  }
+  return output;
+}
+
+async function requiredFile(options: Map<string, string>, name: string): Promise<string> {
+  const path = options.get(name); if (!path) fail(`${name} is required`); return await readFile(resolve(path), 'utf8');
+}
+
+async function main(): Promise<void> {
+  const command = process.argv[2]; const options = args(process.argv.slice(3));
+  if (command === 'create') {
+    const output = options.get('--output'); if (!output) fail('--output is required');
+    const receipt = createDualEraPreviewReleaseReceipt({
+      repository: options.get('--repository') ?? '', pullRequest: Number(options.get('--pull-request')),
+      sourceCommit: options.get('--source-commit') ?? '', sourceTree: options.get('--source-tree') ?? '',
+      auditText: await requiredFile(options, '--audit'), workerIdentityText: await requiredFile(options, '--worker-identity'),
+      cutoverText: await requiredFile(options, '--cutover'), d1ReadinessText: await requiredFile(options, '--d1-readiness'),
+    });
+    await writeFile(resolve(output), `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+    return;
+  }
+  if (command === 'verify') {
+    const receipt = parseJson(await requiredFile(options, '--receipt'), 'receipt');
+    const verified = verifyDualEraPreviewReleaseReceipt(receipt, {
+      repository: options.get('--expected-repository') ?? '', sourceCommit: options.get('--expected-source-commit') ?? '',
+      sourceTree: options.get('--expected-source-tree') ?? '', serverVersion: options.get('--expected-server-version') ?? '',
+    });
+    process.stdout.write(`${JSON.stringify({ pullRequest: verified.pullRequest, worker: verified.worker, d1: verified.d1 })}\n`);
+    return;
+  }
+  fail('command must be create or verify');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) await main();

--- a/scripts/test-node-http-e2e.ts
+++ b/scripts/test-node-http-e2e.ts
@@ -9,8 +9,7 @@ import type { Readable } from 'node:stream';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import {
   assertMcpTransportContract,
   captureMcpTransportSnapshot,
@@ -288,7 +287,35 @@ async function main(): Promise<void> {
       'provider-neutral local search must retain one local provider group',
     );
 
-    console.error('[node-http-e2e] Compiled Node HTTP MCP server passed process-boundary checks.');
+    await withTimeout(client.close(), SHUTDOWN_TIMEOUT_MS, 'legacy MCP client close');
+    client = undefined;
+
+    client = new Client(
+      { name: 'theologai-node-e2e-modern', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    );
+    const modernTransport = new StreamableHTTPClientTransport(endpoint, {
+      requestInit: { headers: { Origin: TEST_ORIGIN } },
+    });
+    await withTimeout(client.connect(modernTransport), MCP_TIMEOUT_MS, 'modern MCP discovery');
+    assert.equal(client.getProtocolEra(), 'modern');
+    assert.equal(client.getNegotiatedProtocolVersion(), '2026-07-28');
+    assert.deepEqual(client.getDiscoverResult(), expectModernDiscovery());
+    const modernContract = await withTimeout(
+      captureMcpTransportSnapshot(client),
+      MCP_TIMEOUT_MS,
+      'modern MCP transport contract',
+    );
+    await assertMcpTransportContract(modernContract, { contractVersion: '6', logging: false });
+    const modernDonation = await withTimeout(
+      client.callTool({ name: 'donation_config', arguments: {} }),
+      MCP_TIMEOUT_MS,
+      'modern tools/call',
+    );
+    assert.equal(modernDonation.isError, undefined);
+    assert.equal((modernDonation.structuredContent as { kind?: string } | undefined)?.kind, 'donation_config');
+
+    console.error('[node-http-e2e] Compiled Node HTTP MCP server passed legacy and modern process-boundary checks.');
   } catch (error) {
     if (server) console.error(server.logs());
     throw error;
@@ -299,6 +326,22 @@ async function main(): Promise<void> {
     await stopServer(server);
     await rm(workspace, { recursive: true, force: true });
   }
+}
+
+function expectModernDiscovery(): Record<string, unknown> {
+  return {
+    supportedVersions: ['2026-07-28'],
+    capabilities: { tools: {}, resources: {}, prompts: {} },
+    resultType: 'complete',
+    ttlMs: 0,
+    cacheScope: 'private',
+    _meta: {
+      'io.modelcontextprotocol/serverInfo': {
+        name: 'theologai-bible-server',
+        version: '3.6.0',
+      },
+    },
+  };
 }
 
 main().catch(error => {

--- a/scripts/test-node-stdio-e2e.ts
+++ b/scripts/test-node-stdio-e2e.ts
@@ -8,12 +8,12 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { Client } from '@modelcontextprotocol/client';
 import {
   DEFAULT_INHERITED_ENV_VARS,
   StdioClientTransport,
   getDefaultEnvironment,
-} from '@modelcontextprotocol/sdk/client/stdio.js';
+} from '@modelcontextprotocol/client/stdio';
 import {
   assertMcpTransportContract,
   captureMcpTransportSnapshot,
@@ -89,7 +89,48 @@ async function main(): Promise<void> {
     const contract = await withTimeout(captureMcpTransportSnapshot(client), 'MCP transport contract');
     await assertMcpTransportContract(contract, { contractVersion: '6', logging: true });
     assert(stderr.length <= MAX_STDERR_CHARS, 'stdio stderr capture exceeded its bound');
-    console.error('[node-stdio-e2e] Compiled Node stdio MCP server passed public transport checks.');
+    await withTimeout(client.close(), 'legacy MCP client close');
+    client = undefined;
+
+    const modernTransport = new StdioClientTransport({
+      command: process.execPath,
+      args: [join(ROOT, 'dist', 'index.js')],
+      cwd: workspace,
+      env: {
+        NODE_ENV: 'test',
+        THEOLOGAI_DATABASE_PATH: databasePath,
+      },
+      stderr: 'pipe',
+    });
+    client = new Client(
+      { name: 'theologai-node-stdio-e2e-modern', version: '1.0.0' },
+      { versionNegotiation: { mode: { pin: '2026-07-28' } } },
+    );
+    await withTimeout(client.connect(modernTransport), 'modern MCP discovery');
+    assert.equal(client.getProtocolEra(), 'modern');
+    assert.equal(client.getNegotiatedProtocolVersion(), '2026-07-28');
+    assert.deepEqual(client.getDiscoverResult()?.capabilities, {
+      tools: {}, resources: {}, prompts: {},
+    });
+    assert.equal(client.getDiscoverResult()?.ttlMs, 0);
+    assert.equal(client.getDiscoverResult()?.cacheScope, 'private');
+    const modernContract = await withTimeout(
+      captureMcpTransportSnapshot(client),
+      'modern MCP transport contract',
+    );
+    await assertMcpTransportContract(modernContract, { contractVersion: '6', logging: false });
+    const modernDonation = await withTimeout(
+      client.callTool({ name: 'donation_config', arguments: {} }),
+      'modern tools/call',
+    );
+    assert.equal(modernDonation.isError, undefined);
+    assert.equal((modernDonation.structuredContent as { kind?: string } | undefined)?.kind, 'donation_config');
+    await assert.rejects(
+      client.setLoggingLevel('warning'),
+      /logging/i,
+      'modern clients must not be offered deprecated MCP Logging',
+    );
+    console.error('[node-stdio-e2e] Compiled Node stdio MCP server passed legacy and modern public transport checks.');
   } finally {
     if (client) await withTimeout(client.close(), 'MCP client close').catch(() => undefined);
     await rm(workspace, { recursive: true, force: true });

--- a/scripts/test-worker-production-runtime.ts
+++ b/scripts/test-worker-production-runtime.ts
@@ -113,12 +113,23 @@ class WorkerRpcContractClient implements McpContractClient {
   private serverVersion: { name?: string; version?: string } | undefined;
   private capabilities: JsonRecord | undefined;
 
-  constructor(private readonly worker: Miniflare) {}
+  constructor(
+    private readonly worker: Miniflare,
+    private readonly protocolVersion: '2025-11-25' | '2026-07-28',
+  ) {}
 
   async initialize(): Promise<void> {
+    if (this.protocolVersion === '2026-07-28') {
+      const result = await this.request('server/discover');
+      this.serverVersion = (result._meta as JsonRecord | undefined)?.['io.modelcontextprotocol/serverInfo'] as {
+        name?: string; version?: string;
+      };
+      this.capabilities = result.capabilities as JsonRecord;
+      return;
+    }
     const result = await this.request('initialize', {
-      protocolVersion: '2025-11-25', capabilities: {},
-      clientInfo: { name: 'production-runtime-contract', version: '1.0.0' },
+      protocolVersion: this.protocolVersion, capabilities: {},
+      clientInfo: { name: `production-runtime-contract-${this.protocolVersion}`, version: '1.0.0' },
     });
     this.serverVersion = result.serverInfo as { name?: string; version?: string };
     this.capabilities = result.capabilities as JsonRecord;
@@ -134,15 +145,32 @@ class WorkerRpcContractClient implements McpContractClient {
   async listResources() { return await this.request('resources/list') as { resources: JsonRecord[] }; }
 
   private async request(method: string, params?: JsonRecord): Promise<JsonRecord> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json, text/event-stream',
+      'Content-Type': 'application/json',
+      Origin: 'https://allowed.example',
+      'MCP-Protocol-Version': this.protocolVersion,
+    };
+    if (this.protocolVersion === '2026-07-28') {
+      headers['Mcp-Method'] = method;
+      if (method === 'tools/call' && typeof params?.name === 'string') headers['Mcp-Name'] = params.name;
+    }
+    const requestParams = this.protocolVersion === '2026-07-28'
+      ? {
+          ...(params ?? {}),
+          _meta: {
+            'io.modelcontextprotocol/protocolVersion': this.protocolVersion,
+            'io.modelcontextprotocol/clientInfo': {
+              name: 'production-runtime-contract-modern', version: '1.0.0',
+            },
+            'io.modelcontextprotocol/clientCapabilities': {},
+          },
+        }
+      : params;
     const response = await this.worker.dispatchFetch('https://worker.test/mcp', {
       method: 'POST',
-      headers: {
-        Accept: 'application/json, text/event-stream',
-        'Content-Type': 'application/json',
-        Origin: 'https://allowed.example',
-        'MCP-Protocol-Version': '2025-11-25',
-      },
-      body: JSON.stringify({ jsonrpc: '2.0', id: this.nextId++, method, ...(params ? { params } : {}) }),
+      headers,
+      body: JSON.stringify({ jsonrpc: '2.0', id: this.nextId++, method, ...(requestParams ? { params: requestParams } : {}) }),
     });
     const message = parseMessage(response, await response.text());
     if (response.status !== 200 || message.error || !message.result) {
@@ -153,11 +181,13 @@ class WorkerRpcContractClient implements McpContractClient {
 }
 
 try {
-  const client = new WorkerRpcContractClient(miniflare);
-  await client.initialize();
-  const contract = await captureMcpTransportSnapshot(client);
-  await assertMcpTransportContract(contract, { contractVersion: '6', logging: false });
-  console.log('Production-like Worker bundle passed the full v6 MCP transport contract.');
+  for (const era of ['2025-11-25', '2026-07-28'] as const) {
+    const client = new WorkerRpcContractClient(miniflare, era);
+    await client.initialize();
+    const contract = await captureMcpTransportSnapshot(client);
+    await assertMcpTransportContract(contract, { contractVersion: '6', logging: false });
+    console.log(`Production-like Worker bundle passed the full v6 MCP transport contract for ${era}.`);
+  }
 } finally {
   await miniflare.dispose();
 }

--- a/src/http/mcpErrors.ts
+++ b/src/http/mcpErrors.ts
@@ -1,17 +1,17 @@
 import {
-  ErrorCode,
+  ProtocolErrorCode,
   isJSONRPCErrorResponse,
   type JSONRPCMessage,
-} from '@modelcontextprotocol/sdk/types.js';
+} from '@modelcontextprotocol/server';
 
 export const INTERNAL_MCP_ERROR = {
-  code: ErrorCode.InternalError,
+  code: ProtocolErrorCode.InternalError,
   message: 'Internal server error',
 } as const;
 
 /** Remove exception text and data from unexpected MCP handler failures. */
 export function sanitizeMcpMessage(message: JSONRPCMessage): JSONRPCMessage {
-  if (!isJSONRPCErrorResponse(message) || message.error.code !== ErrorCode.InternalError) {
+  if (!isJSONRPCErrorResponse(message) || message.error.code !== ProtocolErrorCode.InternalError) {
     return message;
   }
 

--- a/src/http/nodeHttpServer.ts
+++ b/src/http/nodeHttpServer.ts
@@ -1,20 +1,16 @@
 import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { ErrorCode, type JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+import {
+  createMcpHandler as createSdkMcpHandler,
+  ProtocolErrorCode,
+  type McpHttpHandler,
+} from '@modelcontextprotocol/server';
+import { toNodeHandler } from '@modelcontextprotocol/node';
 import { STATELESS_HTTP_CAPABILITIES, type McpCompositionRoot } from '../mcp/server.js';
-import { BibleMCPServer } from '../server.js';
+import { createTheologAiMcpServer } from '../mcp/server.js';
+import { THEOLOGAI_VERSION } from '../server.js';
 import { normalizeHostname, type NodeHttpConfig } from './config.js';
-import { INTERNAL_MCP_ERROR, sanitizeMcpMessage } from './mcpErrors.js';
-
-class SanitizingNodeHttpTransport extends StreamableHTTPServerTransport {
-  override async send(
-    message: JSONRPCMessage,
-    options?: Parameters<StreamableHTTPServerTransport['send']>[1],
-  ): Promise<void> {
-    await super.send(sanitizeMcpMessage(message), options);
-  }
-}
+import { INTERNAL_MCP_ERROR } from './mcpErrors.js';
 
 export interface HttpTelemetryEvent {
   event: string;
@@ -30,27 +26,17 @@ export interface HttpTelemetryEvent {
 
 export type HttpTelemetry = (event: HttpTelemetryEvent) => void;
 
-interface McpRequestServer {
-  connect(transport: StreamableHTTPServerTransport): Promise<void>;
-  getServer(): { close(): Promise<void> };
-}
-
 export interface NodeHttpServerOptions {
   root: McpCompositionRoot;
   config: NodeHttpConfig;
   telemetry?: HttpTelemetry;
-  createMcpServer?: (root: McpCompositionRoot) => McpRequestServer;
+  createMcpHandler?: (root: McpCompositionRoot) => Pick<McpHttpHandler, 'fetch' | 'close'>;
 }
 
 export interface NodeHttpRuntime {
   readonly server: HttpServer;
   listen(): Promise<AddressInfo>;
   close(): Promise<void>;
-}
-
-interface ActiveRequest {
-  server: McpRequestServer;
-  transport: StreamableHTTPServerTransport;
 }
 
 type BodyResult =
@@ -60,10 +46,45 @@ type BodyResult =
 export function createNodeHttpServer(options: NodeHttpServerOptions): NodeHttpRuntime {
   const { root, config } = options;
   const telemetry = options.telemetry ?? defaultTelemetry;
-  const createMcpServer = options.createMcpServer ?? (
-    sharedRoot => new BibleMCPServer(sharedRoot, undefined, STATELESS_HTTP_CAPABILITIES)
-  );
-  const activeRequests = new Set<ActiveRequest>();
+  const createHandler = options.createMcpHandler ?? (sharedRoot => createSdkMcpHandler(
+    ({ era }) => createTheologAiMcpServer(
+      sharedRoot,
+      THEOLOGAI_VERSION,
+      STATELESS_HTTP_CAPABILITIES,
+      era,
+    ),
+    { legacy: 'stateless', responseMode: 'auto' },
+  ));
+  const mcpHandler = createHandler(root);
+  const reportMcpError = (error: Error) => {
+    telemetry({
+      event: 'http.request.error',
+      level: 'error',
+      timestamp: new Date().toISOString(),
+      status: 500,
+      errorName: safeErrorName(error),
+    });
+  };
+  const safeMcpHandler = {
+    async fetch(
+      request: Request,
+      requestOptions?: Parameters<McpHttpHandler['fetch']>[1],
+    ): Promise<Response> {
+      try {
+        const response = await mcpHandler.fetch(request, requestOptions);
+        return withPrivateErrorCaching(response);
+      } catch (error) {
+        reportMcpError(error instanceof Error ? error : new Error('Unknown MCP handler failure'));
+        return internalMcpErrorResponse(requestOptions?.parsedBody);
+      }
+    },
+  };
+  const nodeMcpHandler = toNodeHandler(safeMcpHandler, {
+    onerror(error) {
+      reportMcpError(error);
+    },
+  });
+  const activeRequests = new Set<Promise<void>>();
   let listening = false;
   let closing = false;
   let closePromise: Promise<void> | undefined;
@@ -118,7 +139,7 @@ export function createNodeHttpServer(options: NodeHttpServerOptions): NodeHttpRu
       res.writeHead(204, {
         Allow: 'POST, OPTIONS',
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Accept, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
+        'Access-Control-Allow-Headers': 'Content-Type, Accept, Mcp-Method, Mcp-Name, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
       });
       res.end();
       return;
@@ -148,17 +169,13 @@ export function createNodeHttpServer(options: NodeHttpServerOptions): NodeHttpRu
       return;
     }
 
-    const transport = new SanitizingNodeHttpTransport({ sessionIdGenerator: undefined });
-    const mcpServer = createMcpServer(root);
-    const active = { server: mcpServer, transport };
+    const active = nodeMcpHandler(req, res, bodyResult.body);
     activeRequests.add(active);
 
     try {
-      await mcpServer.connect(transport);
-      await transport.handleRequest(req, res, bodyResult.body);
+      await active;
     } finally {
       activeRequests.delete(active);
-      await Promise.allSettled([mcpServer.getServer().close(), transport.close()]);
     }
   }
 
@@ -192,13 +209,8 @@ export function createNodeHttpServer(options: NodeHttpServerOptions): NodeHttpRu
               server.closeIdleConnections();
             })
           : Promise.resolve();
-        const closeActive = Promise.allSettled(
-          [...activeRequests].flatMap(active => [
-            active.server.getServer().close(),
-            active.transport.close(),
-          ]),
-        );
-        await closeActive;
+        await mcpHandler.close();
+        await Promise.allSettled([...activeRequests]);
         // Active MCP transports have had a chance to finish. End any remaining
         // pre-dispatch or idle HTTP connections so shutdown cannot be held open
         // indefinitely by a slow request body.
@@ -312,6 +324,35 @@ function sendMcpInternalError(res: ServerResponse): void {
   }));
 }
 
+function internalMcpErrorResponse(parsedBody: unknown): Response {
+  const id = parsedBody && typeof parsedBody === 'object' && !Array.isArray(parsedBody)
+    && 'id' in parsedBody
+    ? (parsedBody as { id?: unknown }).id ?? null
+    : null;
+  return new Response(JSON.stringify({
+    jsonrpc: '2.0',
+    error: INTERNAL_MCP_ERROR,
+    id,
+  }), {
+    status: 500,
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  });
+}
+
+function withPrivateErrorCaching(response: Response): Response {
+  if (response.status < 500 || response.headers.has('Cache-Control')) return response;
+  const headers = new Headers(response.headers);
+  headers.set('Cache-Control', 'no-store');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 function sendMcpParseError(res: ServerResponse): void {
   if (res.writableEnded) return;
   res.writeHead(400, {
@@ -320,7 +361,7 @@ function sendMcpParseError(res: ServerResponse): void {
   });
   res.end(JSON.stringify({
     jsonrpc: '2.0',
-    error: { code: ErrorCode.ParseError, message: 'Parse error' },
+    error: { code: ProtocolErrorCode.ParseError, message: 'Parse error' },
     id: null,
   }));
 }

--- a/src/http/worker/mcpHandler.ts
+++ b/src/http/worker/mcpHandler.ts
@@ -1,22 +1,17 @@
-import { WorkerTransport } from 'agents/mcp';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
-import { INTERNAL_MCP_ERROR, sanitizeMcpMessage } from '../mcpErrors.js';
+import {
+  createMcpHandler,
+  type McpRequestContext,
+  type Server,
+} from '@modelcontextprotocol/server';
+import { INTERNAL_MCP_ERROR } from '../mcpErrors.js';
 import { safeErrorName } from './telemetry.js';
-
-class SanitizingWorkerTransport extends WorkerTransport {
-  override async send(
-    message: JSONRPCMessage,
-    options?: Parameters<WorkerTransport['send']>[1],
-  ): Promise<void> {
-    await super.send(sanitizeMcpMessage(message), options);
-  }
-}
 
 export interface WorkerMcpResult {
   response: Response;
   errorName?: string;
 }
+
+export type WorkerMcpServerFactory = (era: McpRequestContext['era']) => Server;
 
 export function createInternalMcpErrorResponse(): Response {
   return new Response(JSON.stringify({
@@ -33,18 +28,39 @@ export function createInternalMcpErrorResponse(): Response {
 }
 
 export async function handleWorkerMcpRequest(
-  server: McpServer,
+  createServer: WorkerMcpServerFactory,
   request: Request,
 ): Promise<WorkerMcpResult> {
-  const transport = new SanitizingWorkerTransport({ sessionIdGenerator: undefined });
+  let errorName: string | undefined;
+  const handler = createMcpHandler(
+    ({ era }) => createServer(era),
+    {
+      legacy: 'stateless',
+      responseMode: 'auto',
+      onerror(error) {
+        errorName = safeErrorName(error);
+      },
+    },
+  );
 
   try {
-    await server.connect(transport);
-    return { response: await transport.handleRequest(request) };
+    const response = await handler.fetch(request);
+    return { response: withPrivateErrorCaching(response), errorName };
   } catch (error) {
     return {
       response: createInternalMcpErrorResponse(),
       errorName: safeErrorName(error),
     };
   }
+}
+
+function withPrivateErrorCaching(response: Response): Response {
+  if (response.status < 500 || response.headers.has('Cache-Control')) return response;
+  const headers = new Headers(response.headers);
+  headers.set('Cache-Control', 'no-store');
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }

--- a/src/http/worker/requestPolicy.ts
+++ b/src/http/worker/requestPolicy.ts
@@ -8,7 +8,7 @@ const ALLOWED_METHODS = new Set(['POST', 'OPTIONS']);
 const ALLOWED_PATHS = new Set(['/', '/mcp']);
 const CORS_HEADERS = {
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Accept, Content-Type, Authorization, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID',
+  'Access-Control-Allow-Headers': 'Accept, Content-Type, Authorization, Mcp-Method, Mcp-Name, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID',
   'Access-Control-Expose-Headers': 'Mcp-Session-Id',
   'Access-Control-Max-Age': '86400',
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 import 'dotenv/config';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { BibleMCPServer } from './server.js';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { createTheologAiMcpServer, STDIO_CAPABILITIES } from './mcp/server.js';
+import { THEOLOGAI_VERSION } from './server.js';
 import { createCompositionRoot } from './tools/v2/index.js';
 import { readNodeHttpConfig } from './http/config.js';
 import { createNodeHttpServer } from './http/nodeHttpServer.js';
@@ -47,12 +48,25 @@ async function main() {
     process.once('SIGTERM', shutdown);
 
   } else {
-    // Stdio mode - original behavior
-    const server = new BibleMCPServer(root);
-    const transport = new StdioServerTransport();
-
     try {
-      await server.connect(transport);
+      serveStdio(
+        ({ era }) => createTheologAiMcpServer(
+          root,
+          THEOLOGAI_VERSION,
+          STDIO_CAPABILITIES,
+          era,
+        ),
+        {
+          onerror(error) {
+            console.error(JSON.stringify({
+              event: 'stdio.server.protocol_error',
+              level: 'error',
+              errorName: error.name,
+              timestamp: new Date().toISOString(),
+            }));
+          },
+        },
+      );
       console.error('TheologAI Bible MCP Server running on stdio');
     } catch (error) {
       console.error(JSON.stringify({

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -9,24 +9,25 @@
  * directory is retired; use src/kernel/index.ts only as a convenience barrel.
  */
 
-import type { CallToolResult, ContentBlock, TextContent, Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ContentBlock, TextContent, Tool } from '@modelcontextprotocol/server';
 
 // ── Tool infrastructure ──
 
 export interface ToolHandler {
   name: string;
   description: string;
-  inputSchema: Tool['inputSchema'];
-  outputSchema?: Tool['outputSchema'];
+  inputSchema: Tool['inputSchema'] & { properties?: Record<string, any> };
+  outputSchema?: Tool['outputSchema'] & { properties?: Record<string, any> };
   /** Optional cross-field validation that JSON Schema cannot fully express. */
   validateStructuredOutput?: (value: Record<string, unknown>) => boolean;
   annotations?: Tool['annotations'];
   handler: (params: Record<string, unknown>) => Promise<ToolResult>;
 }
 
-export type ToolResult = Omit<CallToolResult, 'content'> & {
+export type ToolResult = Omit<CallToolResult, 'content' | 'structuredContent'> & {
   /** A text fallback is always first; later blocks may use the native MCP union. */
   content: [TextContent, ...ContentBlock[]];
+  structuredContent?: Record<string, any>;
 };
 
 // ── Bible types ──

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -1,11 +1,15 @@
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import { ProtocolError, ProtocolErrorCode, ResourceNotFoundError } from '@modelcontextprotocol/server';
 
 const RESOURCE_NOT_FOUND = -32002;
 
-export function resourceNotFound(uri: string): McpError {
-  return new McpError(RESOURCE_NOT_FOUND, 'Resource not found', { uri });
+export function resourceNotFound(uri: string, era: 'legacy' | 'modern'): ProtocolError {
+  // Retain the legacy construction seam; the v2 encoder projects the retired
+  // -32002 value to spec-valid -32602 on the wire for both eras.
+  return era === 'modern'
+    ? new ResourceNotFoundError(uri, 'Resource not found')
+    : new ProtocolError(RESOURCE_NOT_FOUND, 'Resource not found', { uri });
 }
 
-export function internalError(message = 'Internal server error'): McpError {
-  return new McpError(ErrorCode.InternalError, message);
+export function internalError(message = 'Internal server error'): ProtocolError {
+  return new ProtocolError(ProtocolErrorCode.InternalError, message);
 }

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -1,5 +1,4 @@
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { GetPromptRequestSchema, ListPromptsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { Server } from '@modelcontextprotocol/server';
 import { z } from 'zod/v4';
 import { parseReference } from '../kernel/reference.js';
 import { parseStrongsIdentity } from '../kernel/strongs.js';
@@ -16,17 +15,10 @@ const TRANSLATIONS = new Set(['ESV', 'NET', 'KJV', 'WEB', 'BSB', 'ASV', 'YLT', '
 const CCEL_DATE_CAPABILITY_NOTICE = 'Expanded discovery does not provide reviewed composition-date filtering; any returned broader hit is not composition-date evidence.';
 const CCEL_DATED_FALLBACK_NOTICE = 'Expanded discovery deliberately omits the requested catalog composition-year bounds; any returned broader hit cannot establish membership in that requested range.';
 
-/**
- * The upstream SDK's strict string record throws an unclassified ZodError before
- * our handler can return MCP InvalidParams. Accept unknown values at the wire
- * boundary, then classify them explicitly with validatePromptArguments.
- */
-const ClassifiedGetPromptRequestSchema = GetPromptRequestSchema.extend({
-  params: GetPromptRequestSchema.shape.params.extend({
-    name: z.unknown(),
-    arguments: z.unknown().optional(),
-  }),
-});
+const classifiedPromptParams = z.object({
+  name: z.unknown(),
+  arguments: z.unknown().optional(),
+}).passthrough();
 
 function translation(value: string | undefined): string {
   const normalized = value?.trim().toUpperCase();
@@ -180,7 +172,7 @@ export function registerPromptHandlers(
   server: Server,
   descriptor: PrimarySourceSearchDescriptor = createPrimarySourceSearchDescriptor(),
 ): void {
-  server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+  server.setRequestHandler('prompts/list', async () => ({
     prompts: [
       {
         name: 'word-study',
@@ -263,8 +255,8 @@ export function registerPromptHandlers(
     ],
   }));
 
-  server.setRequestHandler(ClassifiedGetPromptRequestSchema, async (request) => {
-    const { name, arguments: args } = request.params;
+  server.setRequestHandler('prompts/get', { params: classifiedPromptParams }, async (params) => {
+    const { name, arguments: args } = params;
     validatePromptArguments(name, args);
     // validatePromptArguments narrows both values after the permissive wire boundary.
     if (typeof name !== 'string') throw new Error('Unreachable prompt-name validation state');

--- a/src/mcp/schemas/bibleLookup.ts
+++ b/src/mcp/schemas/bibleLookup.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { ProvenanceRecord } from '../../kernel/provenance.js';
 import { createProvenanceRecordSchema } from './provenance.js';
 

--- a/src/mcp/schemas/classicTexts.ts
+++ b/src/mcp/schemas/classicTexts.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 const resourceLocator = {

--- a/src/mcp/schemas/commentary.ts
+++ b/src/mcp/schemas/commentary.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type {
   CanonicalCommentator,
   CommentaryCoverageEvidence,

--- a/src/mcp/schemas/crossReferences.ts
+++ b/src/mcp/schemas/crossReferences.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { ProvenanceRecord } from '../../kernel/provenance.js';
 import {
   OPENBIBLE_CROSS_REFERENCE_PROVENANCE,

--- a/src/mcp/schemas/donationConfig.ts
+++ b/src/mcp/schemas/donationConfig.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import {
   DONATION_CONFIG_LIMITS,
   RECIPIENT_ADDRESS,

--- a/src/mcp/schemas/historicalHierarchy.ts
+++ b/src/mcp/schemas/historicalHierarchy.ts
@@ -6,7 +6,7 @@
  * by historicalHierarchyStructured.ts, not an open-ended metadata envelope.
  */
 
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { HISTORICAL_HIERARCHY_RESOURCE_URI_MAX_LENGTH } from '../../kernel/historicalHierarchyResource.js';
 
 const SAFE_SLUG = '^[A-Za-z0-9][A-Za-z0-9._-]{0,159}$';

--- a/src/mcp/schemas/originalLanguage.ts
+++ b/src/mcp/schemas/originalLanguage.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '@cfworker/json-schema';
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { ProvenanceRecord } from '../../kernel/provenance.js';
 
 export const ORIGINAL_LANGUAGE_EVIDENCE_NOTICE_MAX_LENGTH = 1000;

--- a/src/mcp/schemas/originalLanguageStudy.ts
+++ b/src/mcp/schemas/originalLanguageStudy.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { createProvenanceRecordSchema } from './provenance.js';
 import { ORIGINAL_LANGUAGE_EVIDENCE_NOTICE_MAX_LENGTH } from './originalLanguage.js';
 

--- a/src/mcp/schemas/originalLanguageStudyV2.ts
+++ b/src/mcp/schemas/originalLanguageStudyV2.ts
@@ -1,5 +1,5 @@
 import { originalLanguageStudyOutputSchema } from './originalLanguageStudy.js';
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import {
   ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_MAX_LENGTH,
   ORIGINAL_LANGUAGE_STUDY_V2_CURSOR_OPERATION,

--- a/src/mcp/schemas/parallelPassages.ts
+++ b/src/mcp/schemas/parallelPassages.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { ProvenanceRecord } from '../../kernel/provenance.js';
 import { createProvenanceRecordSchema } from './provenance.js';
 

--- a/src/mcp/schemas/primarySourceSearch.ts
+++ b/src/mcp/schemas/primarySourceSearch.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 const status = {

--- a/src/mcp/schemas/primarySourceSearchV4.ts
+++ b/src/mcp/schemas/primarySourceSearchV4.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 
 const status = {

--- a/src/mcp/schemas/verifyDonation.ts
+++ b/src/mcp/schemas/verifyDonation.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import {
   RECIPIENT_ADDRESS,
   SUPPORTED_DONATION_CHAINS,

--- a/src/mcp/schemas/verseMorphology.ts
+++ b/src/mcp/schemas/verseMorphology.ts
@@ -1,4 +1,4 @@
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { Tool } from '@modelcontextprotocol/server';
 import type { ProvenanceRecord } from '../../kernel/provenance.js';
 import { createProvenanceRecordSchema } from './provenance.js';
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,17 +1,19 @@
 /**
  * Shared MCP protocol registration for both Node.js and Cloudflare Workers.
  *
- * The high-level McpServer is the transport-facing object. Its underlying
- * low-level server is used here so the advertised JSON Schemas, dynamic
- * resource listing, and protocol error taxonomy remain under one registry.
+ * The low-level v2 Server keeps the advertised JSON Schemas, deterministic
+ * lists, and error taxonomy under one dual-era registry without implicitly
+ * advertising list-change notifications that this stateless service cannot
+ * deliver.
  */
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
-  ListResourcesRequestSchema,
-  ListResourceTemplatesRequestSchema,
-  ReadResourceRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+  ProtocolError,
+  Server,
+  type JSONRPCRequest,
+  type Result,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
 import { NotFoundError } from '../kernel/errors.js';
 import { parseStrongsIdentity } from '../kernel/strongs.js';
 import { buildLocalDocumentResourceUri, parseLocalDocumentResourceUri } from '../kernel/documentResource.js';
@@ -29,6 +31,28 @@ import { buildPrimarySourceCatalog, PRIMARY_SOURCE_CATALOG_URI } from './primary
 import { COMMENTARY_CATALOG } from '../kernel/commentaryCatalog.js';
 import type { PrimarySourceContractConfig } from '../kernel/featureFlags.js';
 import type { PrimarySourceSearchBinding } from '../tools/v2/primarySourceSearch.js';
+
+export class TheologAiMcpServer extends Server {
+  /** Temporary source-compatible view for callers that previously received McpServer. */
+  get server(): Server {
+    return this;
+  }
+
+  protected override _wrapHandler(
+    method: string,
+    handler: (request: JSONRPCRequest, ctx: ServerContext) => Promise<Result>,
+  ): (request: JSONRPCRequest, ctx: ServerContext) => Promise<Result> {
+    const wrapped = super._wrapHandler(method, handler);
+    return async (request, ctx) => {
+      try {
+        return await wrapped(request, ctx);
+      } catch (error) {
+        if (error instanceof ProtocolError) throw error;
+        throw internalError();
+      }
+    };
+  }
+}
 
 export interface McpServerServices {
   bibleService: Pick<BibleService, 'getSupportedTranslations'>;
@@ -56,28 +80,37 @@ export function createTheologAiMcpServer(
   root: McpCompositionRoot,
   version: string,
   profile: McpCapabilityProfile = STDIO_CAPABILITIES,
-): McpServer {
+  era: 'legacy' | 'modern' = 'legacy',
+): TheologAiMcpServer {
   assertPrimarySourceContractParity(root);
-  const mcpServer = new McpServer(
+  const legacyLogging = profile.logging && era === 'legacy';
+  const server = new TheologAiMcpServer(
     { name: 'theologai-bible-server', version },
     {
       capabilities: {
         tools: {},
         resources: {},
         prompts: {},
-        ...(profile.logging ? { logging: {} } : {}),
+        ...(legacyLogging ? { logging: {} } : {}),
       },
       jsonSchemaValidator,
+      cacheHints: {
+        'server/discover': { ttlMs: 0, cacheScope: 'private' },
+        'tools/list': { ttlMs: 0, cacheScope: 'private' },
+        'prompts/list': { ttlMs: 0, cacheScope: 'private' },
+        'resources/list': { ttlMs: 0, cacheScope: 'private' },
+        'resources/templates/list': { ttlMs: 0, cacheScope: 'private' },
+        'resources/read': { ttlMs: 0, cacheScope: 'private' },
+      },
     },
   );
-  const server = mcpServer.server;
 
   const { tools, services } = root;
-  registerToolHandlers(server, tools, profile.logging);
+  registerToolHandlers(server, tools, legacyLogging);
 
   // ── Resources ──
 
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  server.setRequestHandler('resources/list', async () => {
     const resources: Array<{
       uri: string;
       name: string;
@@ -122,7 +155,7 @@ export function createTheologAiMcpServer(
         });
       }
     } catch {
-      if (profile.logging) {
+      if (legacyLogging) {
         await server.sendLoggingMessage({
           level: 'warning',
           logger: 'theologai.resources',
@@ -138,7 +171,7 @@ export function createTheologAiMcpServer(
     return { resources };
   });
 
-  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({
+  server.setRequestHandler('resources/templates/list', async () => ({
     resourceTemplates: [
       {
         uriTemplate: 'theologai://documents/{slug}',
@@ -155,7 +188,7 @@ export function createTheologAiMcpServer(
     ],
   }));
 
-  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  server.setRequestHandler('resources/read', async (request) => {
     const { uri } = request.params;
 
     // theologai://translations
@@ -243,7 +276,7 @@ export function createTheologAiMcpServer(
           contents: [{ uri, mimeType: 'text/markdown', text: formatLocalDocumentResource(doc, sections) }],
         };
       } catch (error) {
-        if (error instanceof NotFoundError) throw resourceNotFound(uri);
+        if (error instanceof NotFoundError) throw resourceNotFound(uri, era);
         throw internalError('Unable to read resource');
       }
     }
@@ -291,17 +324,17 @@ export function createTheologAiMcpServer(
           contents: [{ uri, mimeType: 'text/markdown', text: lines.filter(Boolean).join('\n') }],
         };
       } catch (error) {
-        if (error instanceof NotFoundError) throw resourceNotFound(uri);
+        if (error instanceof NotFoundError) throw resourceNotFound(uri, era);
         throw internalError('Unable to read resource');
       }
     }
 
-    throw resourceNotFound(uri);
+    throw resourceNotFound(uri, era);
   });
 
   registerPromptHandlers(server, root.primarySourceSearch.descriptor);
 
-  return mcpServer;
+  return server;
 }
 
 function assertPrimarySourceContractParity(root: McpCompositionRoot): void {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,11 +1,9 @@
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
-  CallToolRequestSchema,
-  ErrorCode,
-  ListToolsRequestSchema,
-  McpError,
-} from '@modelcontextprotocol/sdk/types.js';
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+  ProtocolError,
+  ProtocolErrorCode,
+  type CallToolResult,
+  type Server,
+} from '@modelcontextprotocol/server';
 import type { ToolHandler } from '../kernel/types.js';
 import { internalError } from './errors.js';
 import { formatValidationError, type SchemaValidator, validatorFor } from './validation.js';
@@ -24,7 +22,7 @@ export function registerToolHandlers(
       .map(tool => [tool.name, validatorFor(tool.outputSchema!)]),
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  server.setRequestHandler('tools/list', async () => ({
     tools: tools.map(tool => ({
       name: tool.name,
       description: tool.description,
@@ -34,24 +32,24 @@ export function registerToolHandlers(
     })),
   }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler('tools/call', async (request) => {
     const { name, arguments: args } = request.params;
     const tool = tools.find(candidate => candidate.name === name);
     if (!tool) {
-      throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${name}`);
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown tool: ${name}`);
     }
 
     const validate = validators.get(name);
     const toolArguments = args ?? {};
     const validation = validate?.(toolArguments);
     if (!validation?.valid) {
-      return {
+      return server.projectCallToolResult({
         content: [{
           type: 'text',
           text: `Invalid arguments for ${name}: ${formatValidationError(validation?.errorMessage)}`,
         }],
         isError: true,
-      };
+      }, tool.outputSchema);
     }
 
     if (logging) {
@@ -76,7 +74,7 @@ export function registerToolHandlers(
         // Generic sanitized tool errors may omit structured output. Whenever a
         // handler does provide it (including partial/unavailable isError
         // results), it must validate against the advertised schema.
-        if (result.isError) return result as CallToolResult;
+        if (result.isError) return server.projectCallToolResult(result as CallToolResult, tool.outputSchema);
         await reportOutputValidationFailure(server, logging, name);
         throw internalError();
       }
@@ -93,7 +91,7 @@ export function registerToolHandlers(
       }
     }
 
-    return result as CallToolResult;
+    return server.projectCallToolResult(result as CallToolResult, tool.outputSchema);
   });
 }
 

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -1,6 +1,9 @@
 import { Validator, type Schema } from '@cfworker/json-schema';
-import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import type { JsonSchemaType } from '@modelcontextprotocol/sdk/validation/types.js';
+import {
+  ProtocolError,
+  ProtocolErrorCode,
+  type JsonSchemaType,
+} from '@modelcontextprotocol/server';
 import { parseReference } from '../kernel/reference.js';
 
 export type SchemaValidationResult<T> = {
@@ -36,7 +39,7 @@ export const jsonSchemaValidator = {
 const validatorCache = new Map<string, SchemaValidator<Record<string, unknown>>>();
 
 export function validatorFor(
-  schema: JsonSchemaType,
+  schema: Record<string, unknown>,
 ): SchemaValidator<Record<string, unknown>> {
   const serializedSchema = JSON.stringify(schema);
   const cached = validatorCache.get(serializedSchema);
@@ -119,26 +122,26 @@ export function validatePromptArguments(
   args: unknown,
 ): asserts args is Record<string, string> | undefined {
   if (typeof name !== 'string') {
-    throw new McpError(ErrorCode.InvalidParams, 'Prompt name must be a string');
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Prompt name must be a string');
   }
   const definition = PROMPT_ARGUMENTS[name as keyof typeof PROMPT_ARGUMENTS];
   if (!definition) {
-    throw new McpError(ErrorCode.InvalidParams, `Unknown prompt: ${name}`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown prompt: ${name}`);
   }
 
   if (args !== undefined && (args === null || typeof args !== 'object' || Array.isArray(args))) {
-    throw new McpError(ErrorCode.InvalidParams, `Arguments for prompt "${name}" must be an object`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Arguments for prompt "${name}" must be an object`);
   }
   const values = (args ?? {}) as Record<string, unknown>;
   const unknown = Object.keys(values).find(key => !(definition.allowed as readonly string[]).includes(key));
   if (unknown) {
-    throw new McpError(ErrorCode.InvalidParams, `Unknown argument "${unknown}" for prompt "${name}"`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown argument "${unknown}" for prompt "${name}"`);
   }
 
   const wrongType = Object.entries(values).find(([, value]) => typeof value !== 'string');
   if (wrongType) {
-    throw new McpError(
-      ErrorCode.InvalidParams,
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
       `Argument "${wrongType[0]}" for prompt "${name}" must be a string`,
     );
   }
@@ -147,24 +150,24 @@ export function validatePromptArguments(
 
   const missing = (definition.required as readonly string[]).find(key => !stringValues[key]?.trim());
   if (missing) {
-    throw new McpError(ErrorCode.InvalidParams, `Missing required argument "${missing}" for prompt "${name}"`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Missing required argument "${missing}" for prompt "${name}"`);
   }
 
   const oversized = Object.entries(stringValues).find(([, value]) => value.length > 500);
   if (oversized) {
-    throw new McpError(ErrorCode.InvalidParams, `Argument "${oversized[0]}" for prompt "${name}" exceeds 500 characters`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Argument "${oversized[0]}" for prompt "${name}" exceeds 500 characters`);
   }
 
   if (name === 'word-study') {
     const word = stringValues.word?.trim() ?? '';
     if (word.length < 2 || word.length > 100) {
-      throw new McpError(ErrorCode.InvalidParams, 'Argument "word" for prompt "word-study" must be between 2 and 100 characters');
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "word" for prompt "word-study" must be between 2 and 100 characters');
     }
     if (stringValues.testament && !['OT', 'NT'].includes(stringValues.testament.toUpperCase())) {
-      throw new McpError(ErrorCode.InvalidParams, 'Argument "testament" for prompt "word-study" must be OT or NT');
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "testament" for prompt "word-study" must be OT or NT');
     }
     if ((stringValues.reference?.length ?? 0) > 100) {
-      throw new McpError(ErrorCode.InvalidParams, 'Argument "reference" for prompt "word-study" exceeds 100 characters');
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "reference" for prompt "word-study" exceeds 100 characters');
     }
     const reference = stringValues.reference?.trim();
     if (reference) {
@@ -174,8 +177,8 @@ export function validatePromptArguments(
           throw new Error('not one verse');
         }
       } catch {
-        throw new McpError(
-          ErrorCode.InvalidParams,
+        throw new ProtocolError(
+          ProtocolErrorCode.InvalidParams,
           'Argument "reference" for prompt "word-study" must be exactly one valid Bible verse',
         );
       }
@@ -183,33 +186,33 @@ export function validatePromptArguments(
   }
 
   if (['passage-exegesis', 'compare-translations'].includes(name) && (stringValues.reference?.length ?? 0) > 100) {
-    throw new McpError(ErrorCode.InvalidParams, `Argument "reference" for prompt "${name}" exceeds 100 characters`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Argument "reference" for prompt "${name}" exceeds 100 characters`);
   }
 
   if (name === 'primary-source-research') {
     const topicLength = Array.from(stringValues.topic.trim()).length;
     if (topicLength < 1 || topicLength > 200) {
-      throw new McpError(ErrorCode.InvalidParams, 'Argument "topic" for prompt "primary-source-research" must be between 1 and 200 characters');
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "topic" for prompt "primary-source-research" must be between 1 and 200 characters');
     }
     if (stringValues.work !== undefined) {
       const workLength = Array.from(stringValues.work.trim()).length;
       if (workLength < 1 || workLength > 160) {
-        throw new McpError(ErrorCode.InvalidParams, 'Argument "work" for prompt "primary-source-research" must be between 1 and 160 characters');
+        throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "work" for prompt "primary-source-research" must be between 1 and 160 characters');
       }
     }
     if (stringValues.authors !== undefined) {
       const authors = stringValues.authors.split(',').map(value => value.trim()).filter(Boolean);
       if (authors.length < 1 || authors.length > 4 || authors.some(value => Array.from(value).length > 100)) {
-        throw new McpError(ErrorCode.InvalidParams, 'Argument "authors" for prompt "primary-source-research" must contain 1 to 4 comma-separated canonical creator names');
+        throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "authors" for prompt "primary-source-research" must contain 1 to 4 comma-separated canonical creator names');
       }
     }
     const startYear = promptYear(stringValues.startYear, 'startYear');
     const endYear = promptYear(stringValues.endYear, 'endYear');
     if (startYear !== undefined && endYear !== undefined && startYear > endYear) {
-      throw new McpError(ErrorCode.InvalidParams, 'Argument "startYear" for prompt "primary-source-research" must be less than or equal to endYear');
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "startYear" for prompt "primary-source-research" must be less than or equal to endYear');
     }
     if (stringValues.maxSections !== undefined && !/^[1-5]$/.test(stringValues.maxSections.trim())) {
-      throw new McpError(ErrorCode.InvalidParams, 'Argument "maxSections" for prompt "primary-source-research" must be a string integer from 1 to 5');
+      throw new ProtocolError(ProtocolErrorCode.InvalidParams, 'Argument "maxSections" for prompt "primary-source-research" must be a string integer from 1 to 5');
     }
   }
 }
@@ -218,11 +221,11 @@ function promptYear(value: string | undefined, name: string): number | undefined
   if (value === undefined) return undefined;
   const normalized = value.trim();
   if (!/^-?\d{1,4}$/.test(normalized)) {
-    throw new McpError(ErrorCode.InvalidParams, `Argument "${name}" for prompt "primary-source-research" must be an integer year`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Argument "${name}" for prompt "primary-source-research" must be an integer year`);
   }
   const year = Number(normalized);
   if (!Number.isSafeInteger(year) || year < -5000 || year > 3000) {
-    throw new McpError(ErrorCode.InvalidParams, `Argument "${name}" for prompt "primary-source-research" must be from -5000 to 3000`);
+    throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Argument "${name}" for prompt "primary-source-research" must be from -5000 to 3000`);
   }
   return year;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,33 +1,33 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Server, Transport } from '@modelcontextprotocol/server';
 import { createTheologAiMcpServer, STDIO_CAPABILITIES } from './mcp/server.js';
 import type { McpCapabilityProfile, McpCompositionRoot } from './mcp/server.js';
 import { createCompositionRoot } from './tools/v2/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as { version: string };
+export const THEOLOGAI_VERSION = pkg.version;
 
 /**
  * Node.js compatibility adapter retained for the existing stdio/HTTP entrypoint.
  * All MCP registration is owned by the shared factory in src/mcp/server.ts.
  */
 export class BibleMCPServer {
-  private readonly mcpServer: McpServer;
+  private readonly mcpServer: Server;
 
   constructor(
     root: McpCompositionRoot = createCompositionRoot(),
-    version: string = pkg.version,
+    version: string = THEOLOGAI_VERSION,
     profile: McpCapabilityProfile = STDIO_CAPABILITIES,
+    era: 'legacy' | 'modern' = 'legacy',
   ) {
-    this.mcpServer = createTheologAiMcpServer(root, version, profile);
+    this.mcpServer = createTheologAiMcpServer(root, version, profile, era);
   }
 
   getServer(): Server {
-    return this.mcpServer.server;
+    return this.mcpServer;
   }
 
   async connect(transport: Transport): Promise<void> {

--- a/src/shims/ai-stub.ts
+++ b/src/shims/ai-stub.ts
@@ -1,8 +1,0 @@
-/**
- * Empty stub for the "ai" (Vercel AI SDK) module.
- *
- * The `agents` package optionally imports "ai" in its MCP client code.
- * The server-side Agents transport does not use the AI SDK, so this stub satisfies
- * the bundler without pulling in the full Vercel AI SDK.
- */
-export {};

--- a/src/tools/v2/classicTexts.ts
+++ b/src/tools/v2/classicTexts.ts
@@ -22,7 +22,7 @@ import {
   presentClassicTextWork,
   validateClassicTextsOutputSemantics,
 } from '../../presenters/classicTextsStructured.js';
-import type { ResourceLink } from '@modelcontextprotocol/sdk/types.js';
+import type { ResourceLink } from '@modelcontextprotocol/server';
 import { CLASSIC_TEXT_LIMITS } from '../../kernel/classicTextContract.js';
 import {
   decodeHistoricalSectionedOnlyCursor,

--- a/src/tools/v2/primarySourceSearch.ts
+++ b/src/tools/v2/primarySourceSearch.ts
@@ -3,7 +3,7 @@ import { handleToolError } from '../../kernel/errors.js';
 import type { PrimarySourceSearchService } from '../../services/historical/PrimarySourceSearchService.js';
 import { formatPrimarySourceSearchFallback, PRIMARY_SOURCE_FALLBACK_MAX_BYTES } from '../../formatters/primarySourceFormatter.js';
 import { buildLocalDocumentResourceUri } from '../../kernel/documentResource.js';
-import type { ResourceLink } from '@modelcontextprotocol/sdk/types.js';
+import type { ResourceLink } from '@modelcontextprotocol/server';
 import { DEFAULT_PRIMARY_SOURCE_CONTRACT_CONFIG } from '../../kernel/featureFlags.js';
 import type { PrimarySourceContractConfig } from '../../kernel/featureFlags.js';
 import { createPrimarySourceSearchDescriptor, type PrimarySourceSearchDescriptor } from '../../mcp/primarySourceSearchDescriptor.js';

--- a/src/worker-server.ts
+++ b/src/worker-server.ts
@@ -2,10 +2,14 @@
  * Cloudflare Workers compatibility adapter for the shared MCP server factory.
  */
 
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { TheologAiMcpServer } from './mcp/server.js';
 import { createTheologAiMcpServer, STATELESS_HTTP_CAPABILITIES } from './mcp/server.js';
 import type { WorkerCompositionRoot } from './tools/worker/index.js';
 
-export function createWorkerMcpServer(root: WorkerCompositionRoot, version: string): McpServer {
-  return createTheologAiMcpServer(root, version, STATELESS_HTTP_CAPABILITIES);
+export function createWorkerMcpServer(
+  root: WorkerCompositionRoot,
+  version: string,
+  era: 'legacy' | 'modern' = 'legacy',
+): TheologAiMcpServer {
+  return createTheologAiMcpServer(root, version, STATELESS_HTTP_CAPABILITIES, era);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -107,8 +107,11 @@ export default {
       }
 
       const root = createWorkerCompositionRoot(env);
-      const mcpServer = createWorkerMcpServer(root, env.THEOLOGAI_VERSION || '0.0.0');
-      const result = await handleWorkerMcpRequest(mcpServer, boundedRequest);
+      const version = env.THEOLOGAI_VERSION || '0.0.0';
+      const result = await handleWorkerMcpRequest(
+        era => createWorkerMcpServer(root, version, era),
+        boundedRequest,
+      );
       const response = applyCors(result.response, origin);
 
       if (result.errorName) {

--- a/test/conformance/modern-expected-failures.yml
+++ b/test/conformance/modern-expected-failures.yml
@@ -1,0 +1,9 @@
+# The server-stateless scenario uses three public diagnostic tools to exercise
+# capabilities that TheologAI deliberately does not expose. Baselining only
+# those untestable checks keeps the other 24 structural checks enforceable
+# without adding conformance-only names to the eleven-tool product contract.
+server:
+  - server-stateless:sep-2575-server-rejects-undeclared-capability
+  - server-stateless:sep-2575-missing-capability-http-400
+  - server-stateless:sep-2575-http-server-no-independent-requests-on-stream
+  - server-stateless:sep-2575-server-no-log-without-loglevel

--- a/test/conformance/run-server-conformance.ts
+++ b/test/conformance/run-server-conformance.ts
@@ -8,7 +8,7 @@ import { createDeterministicMcpFixture } from '../fixtures/mcpCompositionRoot.js
 // The official runner's default server suite targets its fixture-only
 // "everything" server. These are the protocol-generic scenarios that apply to
 // TheologAI's advertised capabilities and anonymous, stateless HTTP transport.
-const APPLICABLE_SCENARIOS = [
+const LEGACY_SCENARIOS = [
   'server-initialize',
   'ping',
   'tools-list',
@@ -17,15 +17,39 @@ const APPLICABLE_SCENARIOS = [
   'dns-rebinding-protection',
 ] as const;
 
-const conformanceEntrypoint = fileURLToPath(new URL(
+const MODERN_SCENARIOS = [
+  'server-stateless',
+  'tools-list',
+  'resources-list',
+  'prompts-list',
+  'sep-2164-resource-not-found',
+  'dns-rebinding-protection',
+  'caching',
+  'http-header-validation',
+] as const;
+
+const legacyConformanceEntrypoint = fileURLToPath(new URL(
   '../../node_modules/@modelcontextprotocol/conformance/dist/index.js',
   import.meta.url,
 ));
-const outputDirectory = resolve('test-output/mcp-conformance');
+const modernConformanceEntrypoint = fileURLToPath(new URL(
+  '../../node_modules/@modelcontextprotocol/conformance-modern/dist/index.js',
+  import.meta.url,
+));
+const legacyOutputDirectory = resolve('test-output/mcp-conformance/legacy');
+const modernOutputDirectory = resolve('test-output/mcp-conformance/modern');
+const modernExpectedFailures = resolve('test/conformance/modern-expected-failures.yml');
 
-async function runScenario(url: string, scenario: string): Promise<void> {
+async function runScenario(
+  entrypoint: string,
+  url: string,
+  scenario: string,
+  outputDirectory: string,
+  specVersion?: string,
+  expectedFailures?: string,
+): Promise<void> {
   const args = [
-    conformanceEntrypoint,
+    entrypoint,
     'server',
     '--url',
     url,
@@ -34,6 +58,9 @@ async function runScenario(url: string, scenario: string): Promise<void> {
     '--output-dir',
     outputDirectory,
   ];
+  if (specVersion) args.push('--spec-version', specVersion);
+  if (expectedFailures) args.push('--expected-failures', expectedFailures);
+  if (scenario === 'http-header-validation') args.push('--force');
 
   await new Promise<void>((resolveRun, rejectRun) => {
     const child = spawn(process.execPath, args, { stdio: 'inherit' });
@@ -80,8 +107,23 @@ async function main(): Promise<void> {
     config.allowedOrigins.push(origin);
     const url = `${origin}/mcp`;
 
-    for (const scenario of APPLICABLE_SCENARIOS) {
-      await runScenario(url, scenario);
+    for (const scenario of LEGACY_SCENARIOS) {
+      await runScenario(
+        legacyConformanceEntrypoint,
+        url,
+        scenario,
+        legacyOutputDirectory,
+      );
+    }
+    for (const scenario of MODERN_SCENARIOS) {
+      await runScenario(
+        modernConformanceEntrypoint,
+        url,
+        scenario,
+        modernOutputDirectory,
+        '2026-07-28',
+        modernExpectedFailures,
+      );
     }
 
     if (biblePassageCalls.length !== 0) {

--- a/test/integration/current/mcp-protocol.test.ts
+++ b/test/integration/current/mcp-protocol.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import type { Server, Transport } from '@modelcontextprotocol/server';
 import { createTheologAiMcpServer } from '../../../src/mcp/server.js';
 import { BibleMCPServer } from '../../../src/server.js';
 import { createWorkerMcpServer } from '../../../src/worker-server.js';
@@ -142,7 +140,7 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
       const primarySourceTool = listed.tools.find(tool => tool.name === 'primary_source_search')!;
       expect(JSON.stringify(primarySourceTool.inputSchema).toLowerCase()).not.toContain('ccel');
       expect(JSON.stringify(primarySourceTool.outputSchema).toLowerCase()).not.toContain('ccel');
-      expect((primarySourceTool.outputSchema!.properties!.queries as any).items.properties.providers)
+      expect(((primarySourceTool.outputSchema as any).properties.queries as any).items.properties.providers)
         .toMatchObject({ minItems: 1, maxItems: 1 });
 
       const primarySource = await client.callTool({

--- a/test/integration/phase3-helloao-test.ts
+++ b/test/integration/phase3-helloao-test.ts
@@ -8,7 +8,7 @@
  */
 
 import { commentaryLookupHandler } from '../../src/tools/commentaryLookup.js';
-import type { TextContent } from '@modelcontextprotocol/sdk/types.js';
+import type { TextContent } from '@modelcontextprotocol/server';
 
 console.log('================================================================================');
 console.log('PHASE 3.2 INTEGRATION TESTS - HELLOAO COMMENTARY');

--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -10,8 +10,8 @@
     "conformance": 1
   },
   "current": {
-    "totalTestTypeScript": 283,
-    "activeVitest": 204,
+    "totalTestTypeScript": 284,
+    "activeVitest": 205,
     "support": 24,
     "manual": 4,
     "legacyOrphan": 50,
@@ -141,6 +141,7 @@
       "test/unit/scripts/d1WorkerdVerifierUtils.test.ts",
       "test/unit/scripts/dataIntegrity.test.ts",
       "test/unit/scripts/detectProductionCustomDomainChange.test.ts",
+      "test/unit/scripts/dualEraPreviewReleaseReceipt.test.ts",
       "test/unit/scripts/eeboTcpNorton1561.test.ts",
       "test/unit/scripts/finalizeBiblicalLanguageUnicodeManifest.test.ts",
       "test/unit/scripts/historicalCorePreviewAudit.test.ts",

--- a/test/unit/config/customDomainConfig.test.ts
+++ b/test/unit/config/customDomainConfig.test.ts
@@ -48,6 +48,7 @@ describe('custom-domain infrastructure contract', () => {
     expect(productionWorkflow).toContain('name: production');
     expect(productionWorkflow).toContain('url: https://mcp.theologai.xyz/mcp');
     const releaseContextStart = productionWorkflow.indexOf('- name: Resolve production release comparison context');
+    const releaseContextEnd = productionWorkflow.indexOf('- name: Download verified production deployment plan gate');
     const detectorStart = productionWorkflow.indexOf('- name: Detect production custom-domain declaration change');
     const prerequisiteStart = productionWorkflow.indexOf('- name: Require live website and audited preview custom domain');
     const deployStart = productionWorkflow.indexOf('- name: Deploy to Cloudflare Workers');
@@ -56,7 +57,8 @@ describe('custom-domain infrastructure contract', () => {
     expect(prerequisiteStart).toBeGreaterThan(detectorStart);
     expect(prerequisiteStart).toBeGreaterThan(0);
     expect(deployStart).toBeGreaterThan(prerequisiteStart);
-    const releaseContext = productionWorkflow.slice(releaseContextStart, detectorStart);
+    expect(releaseContextEnd).toBeGreaterThan(releaseContextStart);
+    const releaseContext = productionWorkflow.slice(releaseContextStart, releaseContextEnd);
     expect(releaseContext).toContain('PRODUCTION_RELEASE_EVENT_NAME: ${{ github.event_name }}');
     expect(releaseContext).toContain('PRODUCTION_RELEASE_REF: ${{ github.ref }}');
     expect(releaseContext).toContain('PRODUCTION_RELEASE_PUSH_BEFORE: ${{ github.event.before }}');

--- a/test/unit/config/workflowTopology.test.ts
+++ b/test/unit/config/workflowTopology.test.ts
@@ -50,6 +50,7 @@ describe('workflow topology', () => {
     const jobs = uniqueBlock(workflow, 'jobs:');
     const classifier = uniqueBlock(workflow, '  classify-deployment:');
     const verifier = uniqueBlock(workflow, '  verify-deployment-plan:');
+    const previewVerifier = uniqueBlock(workflow, '  verify-dual-era-preview:');
     const deploy = uniqueBlock(workflow, '  deploy:');
     const classifierOutputs = uniqueBlock(classifier, '    outputs:');
     const verifierOutputs = uniqueBlock(verifier, '    outputs:');
@@ -68,9 +69,10 @@ describe('workflow topology', () => {
     expect(normalized(concurrency)).toBe('concurrency: group: deploy-production cancel-in-progress: false');
     expect(occurrences(workflow, '  classify-deployment:')).toBe(1);
     expect(occurrences(workflow, '  verify-deployment-plan:')).toBe(1);
+    expect(occurrences(workflow, '  verify-dual-era-preview:')).toBe(1);
     expect(occurrences(workflow, '  deploy:')).toBe(1);
     expect([...jobs.matchAll(/^  ([a-z][a-z0-9-]+):$/gm)].map(match => match[1])).toEqual([
-      'classify-deployment', 'verify-deployment-plan', 'deploy',
+      'classify-deployment', 'verify-deployment-plan', 'verify-dual-era-preview', 'deploy',
     ]);
 
     expect(classifier).toContain('name: Classify Production Deployment');
@@ -127,12 +129,24 @@ describe('workflow topology', () => {
     expect(verifier).toContain('node scripts/production-deployment-plan.mjs verify');
     expect(verifier).toContain('value.classificationSucceeded !== true');
 
-    expect(deploy).toContain('needs: verify-deployment-plan');
+    expect(previewVerifier).toContain('needs: verify-deployment-plan');
+    expect(previewVerifier).not.toContain('environment:');
+    expect(previewVerifier).toContain('permissions:\n      actions: read\n      contents: read\n      pull-requests: read');
+    expect(previewVerifier).toContain('name: Resolve fresh protected dual-era preview evidence');
+    expect(previewVerifier).toContain("run.event === 'pull_request' && run.status === 'completed' && run.conclusion === 'success'");
+    expect(previewVerifier).toContain('Date.now() - 7 * 24 * 60 * 60 * 1000');
+    expect(previewVerifier).toContain('name: Download exact protected preview evidence with digest validation');
+    expect(previewVerifier).toContain('run-id: ${{ steps.evidence.outputs.run_id }}');
+    expect(previewVerifier).toContain('github-token: ${{ github.token }}');
+    expect(previewVerifier).toContain('digest-mismatch: error');
+    expect(previewVerifier).toContain('scripts/dual-era-preview-release-receipt.ts verify');
+
+    expect(deploy).toContain('needs: [verify-deployment-plan, verify-dual-era-preview]');
     expect(deploy).toContain("if: ${{ github.ref == 'refs/heads/main' && needs.verify-deployment-plan.outputs.deploy_required == 'true' && needs.verify-deployment-plan.outputs.decision == 'deploy' }}");
     expect(deploy.slice(0, deploy.indexOf('    runs-on:'))).not.toContain('always()');
     expect(deploy).not.toContain('needs.classify-deployment');
     expect(deploy).toContain('environment:\n      name: production\n      url: https://mcp.theologai.xyz/mcp');
-    expect(deploy).toContain('permissions:\n      contents: read');
+    expect(deploy).toContain('permissions:\n      actions: read\n      contents: read');
     for (const command of [
       'npm run typecheck:node',
       'npm run typecheck:test-node',
@@ -146,8 +160,13 @@ describe('workflow topology', () => {
     ]) expect(deploy).toContain(command);
     expect(deploy).not.toContain('typecheck:test-fixtures');
     expect(occurrences(workflow, '      name: production')).toBe(1);
-    expect(occurrences(workflow, '        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1')).toBe(2);
-    expect(workflow).not.toMatch(/checks:\s*write|github-token:|artifact-ids:|merge-multiple:\s*true|repository:|run-id:|pattern:/);
+    expect(occurrences(workflow, '        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1')).toBe(4);
+    expect(deploy).toContain('name: Download exact protected preview evidence with digest validation');
+    expect(deploy).toContain('run-id: ${{ needs.verify-dual-era-preview.outputs.run_id }}');
+    expect(deploy).toContain('github-token: ${{ github.token }}');
+    expect(deploy).toContain('digest-mismatch: error');
+    expect(deploy).toContain('scripts/dual-era-preview-release-receipt.ts verify');
+    expect(workflow).not.toMatch(/checks:\s*write|artifact-ids:|merge-multiple:\s*true|repository:|pattern:/);
   });
 
   it('keeps the five PR checks and preview authorization boundary exact', async () => {

--- a/test/unit/docs/publicContract.test.ts
+++ b/test/unit/docs/publicContract.test.ts
@@ -1,9 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import Database from 'better-sqlite3';
 import { afterAll, describe, expect, it } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import type { Server } from '@modelcontextprotocol/server';
 import { createTheologAiMcpServer } from '../../../src/mcp/server.js';
 import { createWorkerCompositionRoot } from '../../../src/tools/worker/index.js';
 import { createCompositionRoot } from '../../../src/tools/v2/index.js';

--- a/test/unit/http/legacyRedirectTransport.test.ts
+++ b/test/unit/http/legacyRedirectTransport.test.ts
@@ -1,7 +1,7 @@
 import { once } from 'node:events';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 interface ListeningServer {

--- a/test/unit/http/nodeHttpServer.test.ts
+++ b/test/unit/http/nodeHttpServer.test.ts
@@ -1,5 +1,6 @@
 import { Agent, request, type IncomingHttpHeaders } from 'node:http';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMcpHandler as createSdkMcpHandler } from '@modelcontextprotocol/server';
 import type { BibleProviderPort } from '../../../src/services/bible/BibleProviderPort.js';
 import {
   DEFAULT_ALLOWED_ORIGIN,
@@ -102,11 +103,11 @@ describe('Node stateless HTTP MCP server', () => {
       root: makeRoot(),
       config,
       telemetry: event => telemetry.push(event),
-      createMcpServer: root => {
-        const server = new BibleMCPServer(root, 'http-integration-test');
+      createMcpHandler: root => createSdkMcpHandler(({ era }) => {
+        const server = new BibleMCPServer(root, 'http-integration-test', undefined, era);
         createdServers.push(server);
-        return server;
-      },
+        return server.getServer();
+      }),
     });
     port = (await runtime.listen()).port;
   });
@@ -264,6 +265,8 @@ describe('Node stateless HTTP MCP server', () => {
     expect(response.status).toBe(204);
     expect(response.headers['access-control-allow-origin']).toBe(DEFAULT_ALLOWED_ORIGIN);
     expect(response.headers['access-control-allow-methods']).toBe('POST, OPTIONS');
+    expect(response.headers['access-control-allow-headers']).toContain('Mcp-Method');
+    expect(response.headers['access-control-allow-headers']).toContain('Mcp-Name');
     expect(createdServers).toHaveLength(0);
   });
 
@@ -281,10 +284,10 @@ describe('Node stateless HTTP MCP server', () => {
         maxBodyBytes: TEST_MAX_BODY_BYTES,
       },
       telemetry: event => telemetry.push(event),
-      createMcpServer: () => ({
-        connect: vi.fn().mockRejectedValue(new Error(privateDetail)),
-        getServer: () => ({ close: vi.fn().mockResolvedValue(undefined) }),
-      }) as never,
+      createMcpHandler: () => ({
+        fetch: vi.fn().mockRejectedValue(new Error(privateDetail)),
+        close: vi.fn().mockResolvedValue(undefined),
+      }),
     });
     port = (await runtime.listen()).port;
 
@@ -293,7 +296,7 @@ describe('Node stateless HTTP MCP server', () => {
     expect(response.json).toEqual({
       jsonrpc: '2.0',
       error: { code: -32603, message: 'Internal server error' },
-      id: null,
+      id: 1,
     });
     expect(response.headers['cache-control']).toBe('no-store');
     expect(telemetry).toContainEqual(expect.objectContaining({

--- a/test/unit/http/workerMcpHandler.test.ts
+++ b/test/unit/http/workerMcpHandler.test.ts
@@ -1,49 +1,35 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-
-const { mockHandleRequest, mockWorkerTransport } = vi.hoisted(() => {
-  const mockHandleRequest = vi.fn();
-  const mockWorkerTransport = vi.fn(function MockWorkerTransport() {
-    return { handleRequest: mockHandleRequest };
-  });
-  return { mockHandleRequest, mockWorkerTransport };
-});
-
-vi.mock('agents/mcp', () => ({ WorkerTransport: mockWorkerTransport }));
+import { describe, expect, it, vi } from 'vitest';
+import { Server } from '@modelcontextprotocol/server';
 
 import { handleWorkerMcpRequest } from '../../../src/http/worker/mcpHandler.js';
 
 describe('handleWorkerMcpRequest', () => {
-  const request = new Request('https://example.com/mcp', { method: 'POST' });
+  it('serves a legacy request with a fresh stateless v2 server', async () => {
+    const createServer = vi.fn(() => new Server(
+      { name: 'worker-test', version: '1.0.0' },
+      { capabilities: {} },
+    ));
+    const result = await handleWorkerMcpRequest(createServer, initializeRequest());
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockHandleRequest.mockResolvedValue(new Response('ok'));
-  });
-
-  it('connects a stateless WorkerTransport and returns its response', async () => {
-    const server = { connect: vi.fn().mockResolvedValue(undefined) } as unknown as McpServer;
-    const result = await handleWorkerMcpRequest(server, request);
-
-    expect(mockWorkerTransport).toHaveBeenCalledWith({ sessionIdGenerator: undefined });
-    expect(server.connect).toHaveBeenCalledWith(expect.objectContaining({
-      handleRequest: mockHandleRequest,
-    }));
-    expect(mockHandleRequest).toHaveBeenCalledWith(request);
+    expect(createServer).toHaveBeenCalledWith('legacy');
     expect(result.errorName).toBeUndefined();
-    await expect(result.response.text()).resolves.toBe('ok');
+    expect(result.response.status).toBe(200);
+    expect(await responsePayload(result.response)).toMatchObject({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        protocolVersion: '2025-11-25',
+        serverInfo: { name: 'worker-test', version: '1.0.0' },
+      },
+    });
   });
 
-  it.each(['connect', 'handle'])('sanitizes a private %s failure', async failurePoint => {
+  it('sanitizes a private handler setup failure', async () => {
     const secret = 'rpc-key=private&sql=SELECT-private';
-    const server = {
-      connect: failurePoint === 'connect'
-        ? vi.fn().mockRejectedValue(new Error(secret))
-        : vi.fn().mockResolvedValue(undefined),
-    } as unknown as McpServer;
-    if (failurePoint === 'handle') mockHandleRequest.mockRejectedValueOnce(new Error(secret));
-
-    const result = await handleWorkerMcpRequest(server, request);
+    const result = await handleWorkerMcpRequest(
+      () => { throw new Error(secret); },
+      initializeRequest(),
+    );
     expect(result.errorName).toBe('Error');
     expect(result.response.status).toBe(500);
     expect(result.response.headers.get('Cache-Control')).toBe('no-store');
@@ -53,7 +39,37 @@ describe('handleWorkerMcpRequest', () => {
     expect(JSON.parse(body)).toEqual({
       jsonrpc: '2.0',
       error: { code: -32603, message: 'Internal server error' },
-      id: null,
+      id: 1,
     });
   });
 });
+
+function initializeRequest(): Request {
+  return new Request('https://example.com/mcp', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json, text/event-stream',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 'worker-test-client', version: '1.0.0' },
+      },
+    }),
+  });
+}
+
+async function responsePayload(response: Response): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  if (response.headers.get('Content-Type')?.includes('text/event-stream')) {
+    const data = text.split('\n').find(line => line.startsWith('data: '));
+    if (!data) throw new Error('SSE response omitted a data event');
+    return JSON.parse(data.slice('data: '.length)) as Record<string, unknown>;
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import type { Server } from '@modelcontextprotocol/server';
 import type { ToolHandler } from '../../../src/kernel/types.js';
 import { createTheologAiMcpServer } from '../../../src/mcp/server.js';
 import { createBibleLookupHandler } from '../../../src/tools/v2/bibleLookup.js';
@@ -62,7 +60,7 @@ async function connect(
   const server = createTheologAiMcpServer(root, 'output-validation-test').server;
   const client = new Client({ name: 'output-validation-client', version: '1.0.0' }, { capabilities: {} });
   if (logs) {
-    client.setNotificationHandler(LoggingMessageNotificationSchema, notification => {
+    client.setNotificationHandler('notifications/message', notification => {
       logs.push(notification.params);
     });
   }
@@ -191,7 +189,7 @@ describe('MCP structured output validation', () => {
           : toolName === 'classic_text_lookup'
             ? '2'
             : '1';
-      expect(schema?.properties?.schemaVersion).toMatchObject({ const: expectedVersion });
+      expect((schema as any)?.properties?.schemaVersion).toMatchObject({ const: expectedVersion });
     }
   });
 

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import type { Server } from '@modelcontextprotocol/server';
 import type { ToolHandler, ToolResult } from '../../../src/kernel/types.js';
 import type { McpCompositionRoot } from '../../../src/mcp/server.js';
 import { createTheologAiMcpServer, STATELESS_HTTP_CAPABILITIES } from '../../../src/mcp/server.js';
@@ -282,7 +280,7 @@ describe('shared MCP registration', () => {
       { name: 'theologai-logging-client', version: '1.0.0' },
       { capabilities: {} },
     );
-    client.setNotificationHandler(LoggingMessageNotificationSchema, notification => {
+    client.setNotificationHandler('notifications/message', notification => {
       messages.push(notification.params);
     });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -452,7 +450,7 @@ describe('shared MCP registration', () => {
       { name: 'theologai-resource-client', version: '1.0.0' },
       { capabilities: {} },
     );
-    client.setNotificationHandler(LoggingMessageNotificationSchema, notification => {
+    client.setNotificationHandler('notifications/message', notification => {
       messages.push(notification.params);
     });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -493,7 +491,7 @@ describe('shared MCP registration', () => {
     const uri = 'theologai://unknown/item';
 
     await expect(client.readResource({ uri })).rejects.toMatchObject({
-      code: -32002,
+      code: -32602,
       message: expect.stringContaining('Resource not found'),
       data: { uri },
     });
@@ -514,7 +512,7 @@ describe('shared MCP registration', () => {
     }
 
     for (const uri of ['theologai://strongs/G0', 'theologai://strongs/G100000', 'theologai://strongs/H999999']) {
-      await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32002, data: { uri } });
+      await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32602, data: { uri } });
     }
     expect(lookup).toHaveBeenCalledTimes(5);
   });
@@ -588,7 +586,7 @@ describe('shared MCP registration', () => {
 
     const fuzzyUri = 'theologai://documents/nicene';
     await expect(client.readResource({ uri: fuzzyUri })).rejects.toMatchObject({
-      code: -32002,
+      code: -32602,
       data: { uri: fuzzyUri },
     });
     expect(getSections).not.toHaveBeenCalled();
@@ -708,7 +706,7 @@ describe('shared MCP registration', () => {
     }
 
     for (const uri of ['theologai://strongs/G0', 'theologai://strongs/G100000', 'theologai://strongs/H999999']) {
-      await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32002, data: { uri } });
+      await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32602, data: { uri } });
     }
     expect(lookup).toHaveBeenCalledTimes(5);
   });
@@ -742,7 +740,7 @@ describe('shared MCP registration', () => {
     'theologai://documents/Nicene-Creed#section-1',
   ])('rejects malformed exact-section resource %s', async uri => {
     const client = await connect(createTheologAiMcpServer(makeMockRoot(), '1.0.0-test').server);
-    await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32002, data: { uri } });
+    await expect(client.readResource({ uri })).rejects.toMatchObject({ code: -32602, data: { uri } });
   });
 
   it.each([
@@ -1114,7 +1112,7 @@ describe('shared MCP registration', () => {
 
     const listed = await client.listTools();
     const advertised = listed.tools.find(tool => tool.name === 'primary_source_search')!;
-    expect(advertised.outputSchema?.properties?.schemaVersion).toEqual({ const: '7' });
+    expect((advertised.outputSchema as any)?.properties?.schemaVersion).toEqual({ const: '7' });
     expect(advertised.annotations).toMatchObject({ openWorldHint: true });
     const inputItem = (advertised.inputSchema.properties?.queries as any).items;
     expect(inputItem.properties).not.toHaveProperty('providers');

--- a/test/unit/presenters/commentaryStructured.test.ts
+++ b/test/unit/presenters/commentaryStructured.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/client/validators/ajv';
 import type { CommentaryLookupResult } from '../../../src/kernel/types.js';
 import {
   CANONICAL_COMMENTATORS,

--- a/test/unit/presenters/verifyDonationStructured.test.ts
+++ b/test/unit/presenters/verifyDonationStructured.test.ts
@@ -1,4 +1,4 @@
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/client/validators/ajv';
 import Ajv2020 from 'ajv/dist/2020.js';
 import { describe, expect, it } from 'vitest';
 import {

--- a/test/unit/scripts/dualEraPreviewReleaseReceipt.test.ts
+++ b/test/unit/scripts/dualEraPreviewReleaseReceipt.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDualEraPreviewReleaseReceipt,
+  verifyDualEraPreviewReleaseReceipt,
+} from '../../../scripts/dual-era-preview-release-receipt.js';
+
+const capturedAt = '2026-08-31T12:00:00.000Z';
+const fingerprints = {
+  capabilities: '1'.repeat(64), tools: '2'.repeat(64), prompts: '3'.repeat(64),
+  resourceTemplates: '4'.repeat(64), staticResources: '5'.repeat(64),
+};
+const counts = { tools: 11, prompts: 6, resourceTemplates: 2, staticResources: 3 };
+const auditText = `${JSON.stringify({
+  schemaVersion: 'theologai-dual-era-mcp-preview-audit.v1', capturedAt,
+  endpoint: 'https://preview-mcp.theologai.xyz/mcp', productProfile: '7',
+  eras: ['2025-11-25', '2026-07-28'].map(protocolVersion => ({
+    protocolVersion, serverName: 'theologai-bible-server', serverVersion: '3.6.0', counts, fingerprints,
+  })),
+  crossEraContractSha256: '6'.repeat(64),
+})}\n`;
+const workerIdentityText = JSON.stringify({
+  schemaVersion: 2, worker: 'theologai-preview',
+  deployedVersionId: '11111111-1111-4111-8111-111111111111', deployedVersionNumber: 151,
+  deploymentId: '22222222-2222-4222-8222-222222222222',
+});
+const cutoverText = JSON.stringify({
+  worker: 'theologai-preview', candidateBindingMatches: true,
+  observedActiveVersionId: '11111111-1111-4111-8111-111111111111',
+  observedActiveDeploymentId: '22222222-2222-4222-8222-222222222222',
+  candidateD1: {
+    binding: 'THEOLOGAI_DB', databaseName: 'theologai-preview-20260811-schema0009-a',
+    databaseId: '33333333-3333-4333-8333-333333333333',
+  },
+  observedActiveD1: { binding: 'THEOLOGAI_DB', databaseId: '33333333-3333-4333-8333-333333333333' },
+});
+const readinessText = JSON.stringify({
+  schemaVersion: 'theologai-remote-d1-readiness-receipt.v1',
+  database: 'theologai-preview-20260811-schema0009-a', environment: 'preview',
+});
+
+function receipt() {
+  return createDualEraPreviewReleaseReceipt({
+    repository: 'owner/TheologAI', pullRequest: 150, sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40),
+    auditText, workerIdentityText, cutoverText, d1ReadinessText: readinessText,
+  });
+}
+
+describe('dual-era protected preview receipt', () => {
+  it('binds a fresh dual-era audit to exact source, Worker, and D1 identities', () => {
+    const value = receipt();
+    expect(verifyDualEraPreviewReleaseReceipt(value, {
+      repository: 'owner/TheologAI', sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40),
+      serverVersion: '3.6.0', now: new Date('2026-09-07T11:59:59.000Z'),
+    })).toEqual(value);
+    expect(value.protocols).toEqual(['2025-11-25', '2026-07-28']);
+    expect(value.worker.versionNumber).toBe(151);
+  });
+
+  it('fails closed when evidence is stale or belongs to another source tree', () => {
+    const value = receipt();
+    expect(() => verifyDualEraPreviewReleaseReceipt(value, {
+      repository: 'owner/TheologAI', sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40),
+      serverVersion: '3.6.0', now: new Date('2026-09-07T12:00:01.000Z'),
+    })).toThrow(/seven-day freshness/);
+    expect(() => verifyDualEraPreviewReleaseReceipt(value, {
+      repository: 'owner/TheologAI', sourceCommit: 'a'.repeat(40), sourceTree: 'c'.repeat(40),
+      serverVersion: '3.6.0', now: new Date(capturedAt),
+    })).toThrow(/identity/);
+  });
+
+  it('rejects a cutover whose observed D1 differs from the readiness-tested candidate', () => {
+    const changed = JSON.stringify({
+      ...JSON.parse(cutoverText),
+      observedActiveD1: { binding: 'THEOLOGAI_DB', databaseId: '44444444-4444-4444-8444-444444444444' },
+    });
+    expect(() => createDualEraPreviewReleaseReceipt({
+      repository: 'owner/TheologAI', pullRequest: 150, sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40),
+      auditText, workerIdentityText, cutoverText: changed, d1ReadinessText: readinessText,
+    })).toThrow(/cutover identity/);
+  });
+});

--- a/test/unit/scripts/historicalCorePreviewAudit.test.ts
+++ b/test/unit/scripts/historicalCorePreviewAudit.test.ts
@@ -3,9 +3,8 @@ import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import { Server } from '@modelcontextprotocol/server';
 import {
   AuditDeadline,
   MAX_MCP_RESPONSE_BYTES,

--- a/test/unit/scripts/originalLanguageStudyV2DraftInertness.test.ts
+++ b/test/unit/scripts/originalLanguageStudyV2DraftInertness.test.ts
@@ -203,7 +203,8 @@ describe('globally inactive original_language_study v2 fixture packet', () => {
     expect([...reachableRuntimeFiles].filter(path => hasDraftReference(readRepoFile(path)))).toEqual([]);
 
     const wiringPaths = trackedIndexEntries().map(entry => entry.path)
-      .filter(path => isRuntimeWiringPath(path) && !isDraftPacketPath(path));
+      .filter(path => isRuntimeWiringPath(path) && !isDraftPacketPath(path)
+        && existsSync(resolve(repoPath, path)));
     const offenders = wiringPaths.filter(path => hasDraftReference(readRepoFile(path))).sort();
     expect(offenders).toEqual([]);
   });

--- a/test/unit/services/historical/HistoricalHierarchyService.test.ts
+++ b/test/unit/services/historical/HistoricalHierarchyService.test.ts
@@ -1,4 +1,4 @@
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/client/validators/ajv';
 import Ajv2020 from 'ajv/dist/2020.js';
 import Database from 'better-sqlite3';
 import { readFileSync } from 'node:fs';

--- a/test/unit/tools/v2/primarySourceSearch.test.ts
+++ b/test/unit/tools/v2/primarySourceSearch.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { createPrimarySourceSearchHandler } from '../../../../src/tools/v2/primarySourceSearch.js';
 import { createPrimarySourceSearchDescriptor } from '../../../../src/mcp/primarySourceSearchDescriptor.js';
 import { validatorFor } from '../../../../src/mcp/validation.js';
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/client/validators/ajv';
 import type { PrimarySourceSearchPlanResult } from '../../../../src/services/historical/primarySourceTypes.js';
 
 function schemaTerms(value: unknown): string[] {

--- a/test/unit/worker/workerEntryPoint.test.ts
+++ b/test/unit/worker/workerEntryPoint.test.ts
@@ -262,7 +262,7 @@ describe('Worker Entry Point', () => {
       const response = await worker.fetch(request, env as never, ctx);
 
       expect(response.status).toBe(200);
-      expect(mockHandleMcp).toHaveBeenCalledWith(mockServer, request);
+      expect(mockHandleMcp).toHaveBeenCalledWith(expect.any(Function), request);
     });
 
     it.each([
@@ -283,7 +283,7 @@ describe('Worker Entry Point', () => {
       const response = await worker.fetch(request, env as never, ctx);
 
       expect(response.status).toBe(200);
-      expect(mockHandleMcp).toHaveBeenCalledWith(mockServer, request);
+      expect(mockHandleMcp).toHaveBeenCalledWith(expect.any(Function), request);
     });
   });
 
@@ -292,8 +292,10 @@ describe('Worker Entry Point', () => {
     await worker.fetch(request, env as never, ctx);
 
     expect(mockCreateRoot).toHaveBeenCalledWith(env);
-    expect(mockCreateServer).toHaveBeenCalledWith(mockRoot, '1.0.0-test');
-    expect(mockHandleMcp).toHaveBeenCalledWith(mockServer, request);
+    expect(mockHandleMcp).toHaveBeenCalledWith(expect.any(Function), request);
+    const factory = mockHandleMcp.mock.calls[0]![0] as (era: 'legacy' | 'modern') => unknown;
+    expect(factory('modern')).toBe(mockServer);
+    expect(mockCreateServer).toHaveBeenCalledWith(mockRoot, '1.0.0-test', 'modern');
   });
 
   it('allows native clients without emitting an allow-origin header', async () => {

--- a/test/worker-runtime/workerMcp.test.ts
+++ b/test/worker-runtime/workerMcp.test.ts
@@ -82,6 +82,43 @@ async function rpc(
   return { response, message: await parseMcpResponse(response) };
 }
 
+async function modernRpc(
+  method: string,
+  params: Record<string, unknown> = {},
+  id: number | string = 1,
+  nameHeader?: string,
+): Promise<{ response: Response; message: JsonRpcResponse }> {
+  const headers = new Headers({
+    Accept: 'application/json, text/event-stream',
+    'Content-Type': 'application/json',
+    Origin: ALLOWED_ORIGIN,
+    'Mcp-Method': method,
+    'Mcp-Protocol-Version': '2026-07-28',
+  });
+  if (nameHeader) headers.set('Mcp-Name', nameHeader);
+  const response = await SELF.fetch(MCP_URL, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method,
+      params: {
+        ...params,
+        _meta: {
+          'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+          'io.modelcontextprotocol/clientInfo': {
+            name: 'worker-runtime-modern-test',
+            version: '1.0.0',
+          },
+          'io.modelcontextprotocol/clientCapabilities': {},
+        },
+      },
+    }),
+  });
+  return { response, message: await parseMcpResponse(response) };
+}
+
 async function rateLimitKey(ip: string, userAgent: string): Promise<string> {
   const input = new TextEncoder().encode(`theologai-rate-limit-v1\0${ip}\0${userAgent}`);
   const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', input));
@@ -101,6 +138,8 @@ describe('Worker MCP endpoint in workerd', () => {
     expect(browserPreflight.status).toBe(204);
     expect(browserPreflight.headers.get('Location')).toBeNull();
     expect(browserPreflight.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_ORIGIN);
+    expect(browserPreflight.headers.get('Access-Control-Allow-Headers')).toContain('Mcp-Method');
+    expect(browserPreflight.headers.get('Access-Control-Allow-Headers')).toContain('Mcp-Name');
 
     const browserRequest = await SELF.fetch(LEGACY_PRODUCTION_MCP_URL, {
       method: 'POST',
@@ -314,6 +353,65 @@ describe('Worker MCP endpoint in workerd', () => {
     expect(primarySourceQuery.properties.searchDepth).toMatchObject({ enum: ['standard', 'expanded'], default: 'standard' });
     expect(primarySourceQuery.properties.expandedLimit).toMatchObject({ minimum: 1, maximum: 5, default: 3 });
     expect(primarySourceQuery.properties.page).toMatchObject({ const: 1, default: 1 });
+  });
+
+  it('discovers and serves the modern protocol with explicit private zero-TTL metadata', async () => {
+    const discovered = await modernRpc('server/discover', {}, 'modern-discover');
+    expect(discovered.response.status).toBe(200);
+    expect(discovered.message.error).toBeUndefined();
+    expect(discovered.message.result).toMatchObject({
+      supportedVersions: ['2026-07-28'],
+      capabilities: { tools: {}, resources: {}, prompts: {} },
+      resultType: 'complete',
+      ttlMs: 0,
+      cacheScope: 'private',
+      _meta: {
+        'io.modelcontextprotocol/serverInfo': {
+          name: 'theologai-bible-server',
+          version: '3.6.0-test',
+        },
+      },
+    });
+
+    const listed = await modernRpc('tools/list', {}, 'modern-tools');
+    expect(listed.response.status).toBe(200);
+    expect(listed.message.result).toMatchObject({
+      resultType: 'complete',
+      ttlMs: 0,
+      cacheScope: 'private',
+    });
+    expect((listed.message.result?.tools as Array<{ name: string }>).map(tool => tool.name)).toEqual([
+      'bible_lookup',
+      'bible_cross_references',
+      'parallel_passages',
+      'commentary_lookup',
+      'classic_text_lookup',
+      'primary_source_search',
+      'original_language_lookup',
+      'bible_verse_morphology',
+      'original_language_study',
+      'donation_config',
+      'verify_donation',
+    ]);
+
+    const mismatch = await modernRpc(
+      'tools/call',
+      { name: 'donation_config', arguments: {} },
+      'modern-mismatch',
+      'bible_lookup',
+    );
+    expect(mismatch.response.status).toBe(400);
+    expect(mismatch.message.error).toMatchObject({ code: -32020 });
+
+    const called = await modernRpc(
+      'tools/call',
+      { name: 'donation_config', arguments: {} },
+      'modern-call',
+      'donation_config',
+    );
+    expect(called.response.status).toBe(200);
+    expect(called.message.error).toBeUndefined();
+    expect(called.message.result?.structuredContent).toMatchObject({ kind: 'donation_config' });
   });
 
   it('returns structured Bible content alongside the legacy Markdown result', async () => {
@@ -1220,7 +1318,7 @@ describe('Worker MCP endpoint in workerd', () => {
     expect(result.response.status).toBe(200);
     expect(result.message.result).toBeUndefined();
     expect(result.message.error).toMatchObject({
-      code: -32002,
+      code: -32602,
       data: { uri: 'theologai://documents/not-in-the-fixture' },
     });
     expect(result.message.error?.message).toContain('Resource not found');

--- a/test/worker-runtime/wrangler.test.toml
+++ b/test/worker-runtime/wrangler.test.toml
@@ -3,9 +3,6 @@ main = "../../src/worker.ts"
 compatibility_date = "2026-07-09"
 compatibility_flags = ["nodejs_compat"]
 
-[alias]
-ai = "../../src/shims/ai-stub.ts"
-
 [vars]
 THEOLOGAI_VERSION = "3.6.0-test"
 THEOLOGAI_REQUEST_LOGS = "false"

--- a/tsconfig.release-scripts.json
+++ b/tsconfig.release-scripts.json
@@ -11,6 +11,8 @@
     "scripts/production-release-reconciliation.ts",
     "scripts/verify-preview-worker-deployment.ts",
     "scripts/verify-production-worker-deployment.ts",
+    "scripts/audit-dual-era-mcp-preview.ts",
+    "scripts/dual-era-preview-release-receipt.ts",
     "scripts/audit-original-language-v2-preview.ts",
     "scripts/audit-original-language-v2-production.ts",
     "scripts/audit-historical-core-preview.ts",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,10 +21,6 @@ head_sampling_rate = 0.05
 [version_metadata]
 binding = "CF_VERSION_METADATA"
 
-# Alias the Vercel AI SDK to an empty stub — only used by agents MCP client, not our server
-[alias]
-ai = "./src/shims/ai-stub.ts"
-
 [vars]
 THEOLOGAI_VERSION = "3.6.0"
 THEOLOGAI_ALLOWED_ORIGINS = "https://theologai.xyz,https://theologai.pages.dev"


### PR DESCRIPTION
## Summary

- migrate the Node and Worker MCP transports to the exact v2 server/node/client packages and remove the obsolete Agents SDK/AI shim path
- support both the legacy `2025-11-25` and modern `2026-07-28` MCP protocol eras while preserving the public contract: 11 tools, 6 prompts, resources, transport policy, caching, logging, and sanitized errors
- add dual-era conformance, Workerd, Node end-to-end, bundle/startup, preview-audit, and protected preview-receipt coverage
- require a source/tree/Worker/D1-matched preview receipt before production deployment can enter the approval environment, then revalidate the receipt after approval

## Verification

- `npm run typecheck`
- `npm run test:unit` — 2,585 passed, 5 skipped across 202 files
- unit coverage — 90.78% lines, 86.61% statements, 80.86% branches
- current integration contract — 3/3 passed
- real Workerd runtime — 26/26 passed, including a successful modern-era `tools/call`
- Node HTTP and stdio end-to-end checks — both eras passed
- production-like Worker runtime — both eras passed
- server conformance — legacy passed; modern public scenarios passed with exactly four documented synthetic diagnostic checks baselined as untestable
- Worker bundle — 2,404,805 bytes raw / 470,926 bytes gzip; local startup 52.2 ms (1,000 ms budget)
- `npm audit --omit=dev` — 0 vulnerabilities
- workflow YAML parsing and `git diff --check`

## Release boundary

This PR does **not** deploy a Worker or mutate D1. Preview deployment remains label-gated, and production still requires a separate approval after a protected dual-era preview receipt exists and is revalidated.

## Known compatibility note

The v2 protocol encoder normalizes the retired legacy resource-not-found code (`-32002`) to the SDK's standard invalid-params code (`-32602`); the implementation and conformance baseline document this package-level boundary rather than carrying a transport fork.
