### PR TITLE
Fix protected preview audits for v2 SDK

### DIFF
--- a/scripts/audit-dual-era-mcp-preview.ts
+++ b/scripts/audit-dual-era-mcp-preview.ts
@@ -13,6 +13,16 @@ const PROTOCOLS = ['2025-11-25', '2026-07-28'] as const;
 const DEFAULT_URL = 'https://preview-mcp.theologai.xyz/mcp';
 type ProtocolVersion = typeof PROTOCOLS[number];
 
+export function versionNegotiationFor(protocolVersion: ProtocolVersion) {
+  return protocolVersion === '2025-11-25'
+    ? { versionNegotiation: { mode: 'legacy' as const } }
+    : { versionNegotiation: { mode: { pin: protocolVersion } } };
+}
+
+export function expectedPreviewServerVersion(packageVersion: string): string {
+  return `${packageVersion}-preview`;
+}
+
 export interface DualEraMcpAudit {
   schemaVersion: 'theologai-dual-era-mcp-preview-audit.v1';
   capturedAt: string;
@@ -62,7 +72,7 @@ export async function auditDualEraMcpPreview(
   for (const protocolVersion of PROTOCOLS) {
     const client = new Client(
       { name: `theologai-protected-preview-${protocolVersion}`, version: '1.0.0' },
-      { versionNegotiation: { mode: { pin: protocolVersion } } },
+      versionNegotiationFor(protocolVersion),
     );
     try {
       await client.connect(new StreamableHTTPClientTransport(url));
@@ -113,7 +123,10 @@ async function main(): Promise<void> {
   if (typeof packageJson.version !== 'string') fail('package version is invalid');
   const output = option('--output');
   if (!output) fail('--output is required');
-  const audit = await auditDualEraMcpPreview(option('--url') ?? DEFAULT_URL, packageJson.version);
+  const audit = await auditDualEraMcpPreview(
+    option('--url') ?? DEFAULT_URL,
+    expectedPreviewServerVersion(packageJson.version),
+  );
   await mkdir(dirname(resolve(output)), { recursive: true });
   await writeFile(resolve(output), `${JSON.stringify(audit, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
   console.error(`[dual-era-preview] ${audit.eras.length} eras, 11 tools, 6 prompts; ${audit.crossEraContractSha256}`);

--- a/scripts/audit-historical-core-preview.ts
+++ b/scripts/audit-historical-core-preview.ts
@@ -864,9 +864,9 @@ function assertResourceNotFound(message: ObjectRecord, expectedUri: string): voi
   const error = object(message.error);
   assert(error !== undefined && JSON.stringify(Object.keys(error).sort()) === JSON.stringify(['code', 'data', 'message']),
     `${label} error envelope keys drifted`);
-  assert(error.code === -32002, `${label} must return exact resource-not-found code -32002`);
+  assert(error.code === -32602, `${label} must return exact resource-not-found code -32602`);
   const errorMessage = requireString(error.message, `${label} error message`);
-  assert(errorMessage === 'Resource not found' || errorMessage === 'MCP error -32002: Resource not found',
+  assert(errorMessage === 'Resource not found' || errorMessage === 'MCP error -32602: Resource not found',
     `${label} must return an exact safe resource-not-found message`);
   assertNoSensitiveErrorText(errorMessage, label);
   const data = object(error.data);

--- a/scripts/audit-historical-spine-preview.ts
+++ b/scripts/audit-historical-spine-preview.ts
@@ -264,7 +264,7 @@ function assertSectionRead(message: ObjectRecord, expectedUri: string, workId: s
 function assertInvalidResource(message: ObjectRecord): void {
   assert(message.result === undefined, 'historical-spine invalid resource returned a result');
   const error = object(message.error);
-  assert(error?.code === -32002 && (error.message === 'Resource not found' || error.message === 'MCP error -32002: Resource not found'),
+  assert(error?.code === -32602 && (error.message === 'Resource not found' || error.message === 'MCP error -32602: Resource not found'),
     'historical-spine invalid resource regression drifted');
 }
 

--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -10,8 +10,8 @@
     "conformance": 1
   },
   "current": {
-    "totalTestTypeScript": 284,
-    "activeVitest": 205,
+    "totalTestTypeScript": 286,
+    "activeVitest": 207,
     "support": 24,
     "manual": 4,
     "legacyOrphan": 50,
@@ -95,6 +95,7 @@
       "test/unit/kernel/transliteration.test.ts",
       "test/unit/kernel/ubsSemanticDomain.test.ts",
       "test/unit/kernel/ubsSemanticEvidenceBundle.test.ts",
+      "test/unit/mcp/errors.test.ts",
       "test/unit/mcp/originalLanguageStudyV2DraftSchema.test.ts",
       "test/unit/mcp/originalLanguageStudyV2Schema.test.ts",
       "test/unit/mcp/outputValidation.test.ts",
@@ -141,6 +142,7 @@
       "test/unit/scripts/d1WorkerdVerifierUtils.test.ts",
       "test/unit/scripts/dataIntegrity.test.ts",
       "test/unit/scripts/detectProductionCustomDomainChange.test.ts",
+      "test/unit/scripts/dualEraMcpPreviewAudit.test.ts",
       "test/unit/scripts/dualEraPreviewReleaseReceipt.test.ts",
       "test/unit/scripts/eeboTcpNorton1561.test.ts",
       "test/unit/scripts/finalizeBiblicalLanguageUnicodeManifest.test.ts",

--- a/test/unit/mcp/errors.test.ts
+++ b/test/unit/mcp/errors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { resourceNotFound } from '../../../src/mcp/errors.js';
+
+describe('MCP resource-not-found errors', () => {
+  const uri = 'theologai://documents/does-not-exist';
+
+  it('retains the legacy construction seam while using the modern SDK error', () => {
+    expect(resourceNotFound(uri, 'legacy')).toMatchObject({
+      code: -32002,
+      message: 'Resource not found',
+      data: { uri },
+    });
+    expect(resourceNotFound(uri, 'modern')).toMatchObject({
+      code: -32602,
+      message: 'Resource not found',
+      data: { uri },
+    });
+  });
+});

--- a/test/unit/scripts/dualEraMcpPreviewAudit.test.ts
+++ b/test/unit/scripts/dualEraMcpPreviewAudit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  expectedPreviewServerVersion,
+  versionNegotiationFor,
+} from '../../../scripts/audit-dual-era-mcp-preview.js';
+
+describe('dual-era preview MCP audit configuration', () => {
+  it('uses legacy negotiation for the 2025 protocol and exact pinning for the modern protocol', () => {
+    expect(versionNegotiationFor('2025-11-25')).toEqual({
+      versionNegotiation: { mode: 'legacy' },
+    });
+    expect(versionNegotiationFor('2026-07-28')).toEqual({
+      versionNegotiation: { mode: { pin: '2026-07-28' } },
+    });
+  });
+
+  it('derives the deployed preview identity from the package version', () => {
+    expect(expectedPreviewServerVersion('3.6.0')).toBe('3.6.0-preview');
+  });
+});

--- a/test/unit/scripts/historicalCorePreviewAudit.test.ts
+++ b/test/unit/scripts/historicalCorePreviewAudit.test.ts
@@ -461,11 +461,11 @@ describe('historical core preview audit contract', () => {
     const invalidResourceUri = 'theologai://documents/does-not-exist#section-not-real';
     await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: 'Resource not found' })))
       .resolves.toMatchObject({ regressions: { invalidResourceRejected: true } });
-    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceCode: -32001 })))
-      .rejects.toThrow('invalid resource regression must return exact resource-not-found code -32002');
-    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: `MCP error -32002: Resource not found: ${invalidResourceUri}` })))
+    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceCode: -32601 })))
+      .rejects.toThrow('invalid resource regression must return exact resource-not-found code -32602');
+    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: `MCP error -32602: Resource not found: ${invalidResourceUri}` })))
       .rejects.toThrow('invalid resource regression must return an exact safe resource-not-found message');
-    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: 'MCP error -32002: Resource not found: file:///private/tmp/internal' })))
+    await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: 'MCP error -32602: Resource not found: file:///private/tmp/internal' })))
       .rejects.toThrow('invalid resource regression must return an exact safe resource-not-found message');
     for (const invalidResourceExtra of [
       { stack: 'Error: not found' }, { debug: 'internal' }, { source: 'file:///private/tmp/internal' },
@@ -492,7 +492,7 @@ describe('historical core preview audit contract', () => {
     await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: 'https://private.invalid/secret' })))
       .rejects.toThrow('invalid resource regression must return an exact safe resource-not-found message');
     for (const sensitive of ['SQLite database failure', 'API Key leaked', 'SQL D1 traceback stack', 'Internal implementation detail']) {
-      await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: `MCP error -32002: Resource not found; ${sensitive}` })))
+      await expect(runPreviewAudit(parsed, fakeFetchWith(parsed, { invalidResourceError: `MCP error -32602: Resource not found; ${sensitive}` })))
         .rejects.toThrow('invalid resource regression must return an exact safe resource-not-found message');
     }
   });
@@ -701,8 +701,8 @@ function resourceResponse(body: RecordValue, fixtureValue: Audit, options: FakeO
     jsonrpc: '2.0', id: body.id,
     ...(options.invalidResourceResult === undefined ? {} : { result: options.invalidResourceResult }),
     error: {
-      code: options.invalidResourceCode ?? -32002,
-      message: options.invalidResourceError ?? 'MCP error -32002: Resource not found',
+      code: options.invalidResourceCode ?? -32602,
+      message: options.invalidResourceError ?? 'MCP error -32602: Resource not found',
       ...(options.omitInvalidResourceData ? {} : { data: options.invalidResourceData ?? { uri } }),
       ...(options.invalidResourceExtra ?? {}),
     },

--- a/test/unit/scripts/historicalSpinePreviewAudit.test.ts
+++ b/test/unit/scripts/historicalSpinePreviewAudit.test.ts
@@ -36,7 +36,7 @@ function response(body: RecordValue, fixtureValue: HistoricalSpineAuditFixture, 
   if (body.method === 'resources/list') return rpc({ resources: HISTORICAL_CORE_EXPECTED_RESOURCE_URIS.map(uri => ({ uri })) });
   if (body.method === 'resources/read') {
     const uri = (body.params as RecordValue).uri as string;
-    if (uri === 'theologai://documents/does-not-exist#section-not-real') return error({ code: -32002, message: 'Resource not found', data: { uri } });
+    if (uri === 'theologai://documents/does-not-exist#section-not-real') return error({ code: -32602, message: 'Resource not found', data: { uri } });
     if (uri === 'theologai://primary-sources/catalog') {
       const works = [...fixtureValue.probes.map((probe, index) => ({
         id: probe.workId,


### PR DESCRIPTION
## Summary

- assert the v2 SDK's exact `-32602` resource-not-found wire envelope in the protected historical audits while retaining a test for the legacy internal `-32002` construction seam
- use legacy negotiation mode for MCP `2025-11-25` and exact pinning for `2026-07-28`
- derive the expected preview server identity as the package version plus `-preview`

## Verification

- 29 targeted tests passed
- all TypeScript configurations passed
- historical core live preview audit passed (8/8)
- historical spine live preview audit passed (10/10)
- dual-era live preview audit passed (both protocol eras; 11 tools, 6 prompts)
- `git diff --check` passed

## Release safety

This changes release audits only. It does not alter application behavior, D1, secrets, or production. The existing failed preview run remains fail-closed and production remains blocked pending a fresh matched receipt.