### PR TITLE
Fix protected preview receipt version gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -337,13 +337,13 @@ jobs:
           SOURCE_COMMIT: ${{ steps.evidence.outputs.source_commit }}
         run: |
           source_tree="$(git rev-parse 'HEAD^{tree}')"
-          server_version="$(node --input-type=module -e "import packageJson from './package.json' with { type: 'json' }; process.stdout.write(packageJson.version)")"
+          preview_server_version="$(node --input-type=module -e "import packageJson from './package.json' with { type: 'json' }; process.stdout.write(packageJson.version + '-preview')")"
           npx --no-install tsx scripts/dual-era-preview-release-receipt.ts verify \
             --receipt "$RUNNER_TEMP/protected-dual-era-preview/dual-era-preview-release-receipt.json" \
             --expected-repository "$GITHUB_REPOSITORY" \
             --expected-source-commit "$SOURCE_COMMIT" \
             --expected-source-tree "$source_tree" \
-            --expected-server-version "$server_version"
+            --expected-server-version "$preview_server_version"
 
   deploy:
     name: Test, Build & Deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -458,13 +458,13 @@ jobs:
           SOURCE_COMMIT: ${{ needs.verify-dual-era-preview.outputs.source_commit }}
         run: |
           source_tree="$(git rev-parse 'HEAD^{tree}')"
-          server_version="$(node --input-type=module -e "import packageJson from './package.json' with { type: 'json' }; process.stdout.write(packageJson.version)")"
+          preview_server_version="$(node --input-type=module -e "import packageJson from './package.json' with { type: 'json' }; process.stdout.write(packageJson.version + '-preview')")"
           npx --no-install tsx scripts/dual-era-preview-release-receipt.ts verify \
             --receipt "$RUNNER_TEMP/protected-dual-era-preview/dual-era-preview-release-receipt.json" \
             --expected-repository "$GITHUB_REPOSITORY" \
             --expected-source-commit "$SOURCE_COMMIT" \
             --expected-source-tree "$source_tree" \
-            --expected-server-version "$server_version"
+            --expected-server-version "$preview_server_version"
 
       - name: Detect production custom-domain declaration change
         id: production-custom-domain-change

--- a/test/unit/scripts/dualEraPreviewReleaseReceipt.test.ts
+++ b/test/unit/scripts/dualEraPreviewReleaseReceipt.test.ts
@@ -14,7 +14,7 @@ const auditText = `${JSON.stringify({
   schemaVersion: 'theologai-dual-era-mcp-preview-audit.v1', capturedAt,
   endpoint: 'https://preview-mcp.theologai.xyz/mcp', productProfile: '7',
   eras: ['2025-11-25', '2026-07-28'].map(protocolVersion => ({
-    protocolVersion, serverName: 'theologai-bible-server', serverVersion: '3.6.0', counts, fingerprints,
+    protocolVersion, serverName: 'theologai-bible-server', serverVersion: '3.6.0-preview', counts, fingerprints,
   })),
   crossEraContractSha256: '6'.repeat(64),
 })}\n`;
@@ -50,21 +50,25 @@ describe('dual-era protected preview receipt', () => {
     const value = receipt();
     expect(verifyDualEraPreviewReleaseReceipt(value, {
       repository: 'owner/TheologAI', sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40),
-      serverVersion: '3.6.0', now: new Date('2026-09-07T11:59:59.000Z'),
+      serverVersion: '3.6.0-preview', now: new Date('2026-09-07T11:59:59.000Z'),
     })).toEqual(value);
     expect(value.protocols).toEqual(['2025-11-25', '2026-07-28']);
     expect(value.worker.versionNumber).toBe(151);
+    expect(() => verifyDualEraPreviewReleaseReceipt(value, {
+      repository: 'owner/TheologAI', sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40),
+      serverVersion: '3.6.0', now: new Date(capturedAt),
+    })).toThrow(/contract evidence/);
   });
 
   it('fails closed when evidence is stale or belongs to another source tree', () => {
     const value = receipt();
     expect(() => verifyDualEraPreviewReleaseReceipt(value, {
       repository: 'owner/TheologAI', sourceCommit: 'a'.repeat(40), sourceTree: 'b'.repeat(40),
-      serverVersion: '3.6.0', now: new Date('2026-09-07T12:00:01.000Z'),
+      serverVersion: '3.6.0-preview', now: new Date('2026-09-07T12:00:01.000Z'),
     })).toThrow(/seven-day freshness/);
     expect(() => verifyDualEraPreviewReleaseReceipt(value, {
       repository: 'owner/TheologAI', sourceCommit: 'a'.repeat(40), sourceTree: 'c'.repeat(40),
-      serverVersion: '3.6.0', now: new Date(capturedAt),
+      serverVersion: '3.6.0-preview', now: new Date(capturedAt),
     })).toThrow(/identity/);
   });
 

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -70,6 +70,17 @@ describe('production release guards', () => {
     expect(workflow).not.toContain('d1 delete');
   });
 
+  it('verifies the protected receipt against the preview-suffixed server identity', async () => {
+    const workflow = await readFile(new URL('.github/workflows/deploy.yml', root), 'utf8');
+    const verifyStart = workflow.indexOf('Verify source-bound dual-era preview release receipt');
+    const deployStart = workflow.indexOf('  deploy:', verifyStart);
+    const verifyBlock = workflow.slice(verifyStart, deployStart);
+
+    expect(verifyBlock).toContain("process.stdout.write(packageJson.version + '-preview')");
+    expect(verifyBlock).toContain('--expected-server-version "$preview_server_version"');
+    expect(verifyBlock).not.toContain('process.stdout.write(packageJson.version)');
+  });
+
   it('revalidates the exact gate artifact before dependencies, secrets, Cloudflare, or D1 and retains seven release artifacts', async () => {
     const workflow = await readFile(new URL('.github/workflows/deploy.yml', root), 'utf8');
     const deployStart = workflow.indexOf('  deploy:');

--- a/test/unit/scripts/productionReleaseGuards.test.ts
+++ b/test/unit/scripts/productionReleaseGuards.test.ts
@@ -72,13 +72,10 @@ describe('production release guards', () => {
 
   it('verifies the protected receipt against the preview-suffixed server identity', async () => {
     const workflow = await readFile(new URL('.github/workflows/deploy.yml', root), 'utf8');
-    const verifyStart = workflow.indexOf('Verify source-bound dual-era preview release receipt');
-    const deployStart = workflow.indexOf('  deploy:', verifyStart);
-    const verifyBlock = workflow.slice(verifyStart, deployStart);
-
-    expect(verifyBlock).toContain("process.stdout.write(packageJson.version + '-preview')");
-    expect(verifyBlock).toContain('--expected-server-version "$preview_server_version"');
-    expect(verifyBlock).not.toContain('process.stdout.write(packageJson.version)');
+    expect((workflow.match(/process\.stdout\.write\(packageJson\.version \+ '-preview'\)/g) ?? [])).toHaveLength(2);
+    expect((workflow.match(/--expected-server-version "\$preview_server_version"/g) ?? [])).toHaveLength(2);
+    expect(workflow).not.toContain('process.stdout.write(packageJson.version)');
+    expect(workflow).not.toContain('--expected-server-version "$server_version"');
   });
 
   it('revalidates the exact gate artifact before dependencies, secrets, Cloudflare, or D1 and retains seven release artifacts', async () => {


### PR DESCRIPTION
## Summary

- verify the source-bound protected preview receipt against the preview server identity (`<package version>-preview`)
- keep the production package/runtime expectation unchanged
- add a release-guard regression test for the exact workflow command

## Verification

- production release guards, workflow topology, and test topology: 17 tests passed
- release-script TypeScript partition passed
- `git diff --check` passed

## Release safety

This is a code-bearing release candidate solely because the production verifier must consume the exact preview identity. It does not change application behavior or D1. The prior manual run failed closed before the production environment.