### PR TITLE
Clarify architecture ownership and enforce preparation boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 TheologAI is an MCP server for Bible study and theological research. It runs
 locally over stdio or Streamable HTTP and on Cloudflare Workers with D1.
 
+For the current source layout and maintenance responsibilities, see
+[Architecture and ownership](docs/ARCHITECTURE.md). The earlier
+`docs/bible-mcp-architecture.md` remains historical design evidence.
+
 The checked-out local registry contains eleven tools, six guided prompts, eight
 English Bible translations, six commentary sources, 35 locally indexed
 historical works, Strong's dictionaries, and Greek/Hebrew morphology. The

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,97 @@
+# Architecture and ownership
+
+This guide describes the maintained source layout. Deployment identity belongs
+only to [CURRENT-RELEASE.md](CURRENT-RELEASE.md), and delivery sequencing belongs
+to [ROADMAP.md](ROADMAP.md). The earlier
+[architecture plan](bible-mcp-architecture.md) is historical.
+
+## Three maintenance responsibilities
+
+The application remains one modular codebase with Node and Worker transports.
+These ownership roles describe responsibility for a change, not additional
+services or a new organization. A PR names its responsible contributor and
+reviewer; an agent assignment does not grant release or source-rights authority.
+
+| Responsibility | Main locations | Owns | Verification |
+|---|---|---|---|
+| Research serving | `src/mcp`, `src/http`, `src/tools`, `src/services`, `src/adapters`, `src/presenters`, `src/formatters`, `src/kernel` | Input/output contracts, query behavior, source interpretation boundaries, request budgets, transport compatibility | Unit tests, current integration, Node/Worker typechecks, compiled process tests and Workerd tests as relevant |
+| Corpus preparation | `scripts/build-*`, source acquisition/compilation/verification scripts, `data`, `migrations` | Pinned inputs, edition provenance, deterministic transformations, canonical section identity, generated SQLite and seeds | Source reproduction, integrity and authority checks, capacity, SQLite/D1 parity, deterministic seed verification |
+| Release operations | `.github/workflows`, candidate preparation, release/audit/reconciliation scripts, `wrangler*.toml`, release runbooks | Privilege boundaries, exact source/tree/Worker/D1 evidence, compatible rollout and recovery, evidence custody | Workflow and script tests, protected preview receipts and release gates; local correctness alone does not establish a deployed assignment |
+
+Some scripts participate in both preparation and release. Assign responsibility
+according to the behavior being changed: seed bytes belong to preparation;
+permission to apply them belongs to operations. The existing TypeScript project
+and test inventories remain compiler authority; this table does not create a
+second file-by-file compiler manifest.
+
+## Request flow and dependency direction
+
+1. `src/index.ts` or `src/worker.ts` applies transport policy and creates the
+   appropriate composition root.
+2. `src/mcp/server.ts` and the shared registrars advertise and validate the
+   protocol. `src/tools` adapts calls into application services.
+3. Services own provider ports. Adapters implement those ports or the kernel's
+   persistence interfaces. SQLite and D1 use the same domain contracts.
+4. Presenters and formatters construct public structured/Markdown results.
+   The registrar validates structured output before returning it.
+
+Keep shared domain behavior in services. Keep transport policy in `src/http`
+and storage/provider details in adapters. Node and Worker composition roots
+remain explicit because their dependencies and lifetimes differ. Extract a
+shared factory only when repeated wiring produces real drift.
+
+The kernel imports only other kernel modules within `src`. Services cannot
+import adapters. Language services cannot import presenters or formatters.
+`LocalPrimarySourceSearchProvider` retains its documented historical formatter
+dependency for exact resource sizing/identity; extending that exception needs
+an explicit compatibility rationale.
+
+Serving source cannot import preparation scripts, tests, documentation, or raw
+root-level `data` modules. Generated artifacts under `src/data` are permitted.
+The Node database adapter opens the derived database read-only; builds create
+their own writable connections. Node's generated UBS loader reads the compiled
+artifact, while the Worker uses D1 and its separate bundle-exclusion check.
+
+These module boundaries are enforced in
+[`applicationBoundaries.test.ts`](../test/unit/config/applicationBoundaries.test.ts),
+including regression examples for import/export, import types, dynamic imports,
+and literal `require`. This static guard is not a filesystem-access sandbox:
+nonliteral imports and runtime file/network operations require normal review.
+See [test ownership](../test/README.md) for compiler and execution partitions.
+
+## Dormant work register
+
+Review baseline: **2026-09-05**. Next maintenance review: **2026-10-05**, or
+before a PR proposes activation, whichever comes first. Review dates trigger
+a decision to continue, narrow, or retire work; they never authorize deletion,
+source acquisition, flags, publication, or deployment. The project maintainer
+assigns the responsible contributor when scheduling each review.
+
+| Work | Responsible review role | Current boundary and retained locations | Evidence needed before activation |
+|---|---|---|---|
+| CCEL discovery | Research serving + release operations | Adapter/coordinator code is present in the serving graph; execution remains gated. It is not dead code merely because live search is disabled. See [coordinator](CCEL-UPSTREAM-COORDINATOR.md) and [canary transaction](CCEL-LIVE-PREVIEW-CANARY-TRANSACTION.md). | Demonstrated gap after adequate local search, current interface/policy review, preserved discovery-only bounds, authorized canary and separate release decision |
+| Primary-source research v8 | Research serving | Implemented contract/prompt foundation selected by otherwise absent flag; see [v8 foundation](PRIMARY-SOURCE-RESEARCH-V8-FOUNDATION.md). | Useful local research outcomes, contract/parity tests, existing external execution gates, protected release evidence |
+| Partial Aquinas Transform 10 | Corpus preparation + research serving | Source packet, hierarchy contracts and disposable materializer remain; normal corpus excludes Aquinas lineage/publication. See [Transform 10](AQUINAS-HIERARCHY-TRANSFORM10.md). | Explicit complete-edition/coverage decision, edition-specific source evidence, conservation and search quality, capacity, reviewed activation transform |
+| Complete-edition Aquinas preparation | Corpus preparation | Collection/package foundations and Gutenberg acquisition/topology scripts remain preparation-only. Their presence does not replace the partial packet or activate a catalog work. | Verified acquisition/topology and completeness, source/rights review, deterministic compiler, integration and release decisions |
+| Norton | Corpus preparation + release operations | Generic Candidate-C schema is maintained, but Norton rows are confined to disposable proof. See [inactive Transform 12](NORTON-TRANSFORM12-INACTIVE.md). | Normalized-text rights decision, reviewed canonical activation, retrieval/section identity and capacity proof, separate release preparation |
+| MACULA context | Corpus preparation + language research | Source contract and synthetic parser/capacity experiments; see [source contract](MACULA-SOURCE-CONTRACT.md) and [synthetic Gate 1](MACULA-GATE1-SYNTHETIC.md). | Product scope, real source/rights review and acquisition, alignment correctness, measured real-corpus capacity and research benefit |
+
+Keep new experiments outside the serving dependency graph until their use case,
+contract and source boundary are decided. Existing kernel foundations may be
+shared by compilers and serving code; inspect callers before moving them. Do
+not combine speculative relocation with feature activation or rewrite frozen
+evidence scripts to make the tree appear uniform.
+
+## Change handoff
+
+Each substantial assignment identifies an observable outcome, owned files,
+preserved contracts, relevant verification, and decisions that need escalation.
+Keep separate worktrees for independent changes and one owner for shared files.
+Review the resulting diff and tests against the assignment rather than relying
+only on its implementation summary.
+
+For a boundary change, record which import becomes legal or illegal and prove
+the guard detects a violating example. For a corpus change, record source and
+materialization identity. For an operations change, record the preserved
+approval and rollback conditions. Keep runtime/configuration, corpus, and
+release-state claims separate in every handoff.

--- a/docs/bible-mcp-architecture.md
+++ b/docs/bible-mcp-architecture.md
@@ -5,6 +5,10 @@
 > status. See [README.md](../README.md) and [docs/ROADMAP.md](ROADMAP.md) for
 > the current capabilities and sequence.
 
+For current source layout and maintenance responsibilities, use
+[Architecture and ownership](ARCHITECTURE.md). The addendum below preserves
+the boundary program's historical record; the new guide links its executable guards.
+
 ### Current compiler-boundary addendum
 
 The historical plan above is not a source-layout authority. Current test

--- a/src/adapters/shared/Database.ts
+++ b/src/adapters/shared/Database.ts
@@ -1,9 +1,8 @@
 /**
  * SQLite connection manager.
  *
- * Singleton better-sqlite3 connection to data/theologai.db with:
- *   - WAL mode for concurrent reads
- *   - Prepared statement caching
+ * Read-only singleton connection to the database produced by the corpus build.
+ * Database creation and writable connections belong to preparation scripts.
  */
 
 import Database from 'better-sqlite3';
@@ -54,14 +53,4 @@ export function closeDatabase(): void {
     instance.close();
     instance = null;
   }
-}
-
-/**
- * Open a writable database connection (for build scripts only).
- */
-export function openWritableDatabase(dbPath: string): Database.Database {
-  const db = new Database(dbPath);
-  db.pragma('journal_mode = WAL');
-  db.pragma('synchronous = NORMAL');
-  return db;
 }

--- a/test/README.md
+++ b/test/README.md
@@ -86,6 +86,14 @@ to the V2 service/presentation edge; the historical
 `LocalPrimarySourceSearchProvider` resource-sizing formatter exception remains
 outside this claim.
 
+The guard also rejects serving-source module dependencies on preparation
+scripts, tests, documentation, and root-level raw data. Compiled `src/data`
+modules remain permitted. Synthetic import/export, import-type, dynamic-import,
+and literal CommonJS cases prove this check without executing preparation code.
+It does not inspect nonliteral imports or runtime filesystem access. See
+[architecture and ownership](../docs/ARCHITECTURE.md) for responsibility and
+dormant-work review boundaries.
+
 ## Retired legacy commands
 
 The following former package commands have been removed. They are not runnable

--- a/test/unit/config/applicationBoundaries.test.ts
+++ b/test/unit/config/applicationBoundaries.test.ts
@@ -16,6 +16,7 @@ const compilerOptions: ts.CompilerOptions = {
   allowJs: false,
   module: ts.ModuleKind.ESNext,
   moduleResolution: ts.ModuleResolutionKind.Bundler,
+  resolveJsonModule: true,
 };
 const resolutionHost = ts.createCompilerHost(compilerOptions);
 
@@ -102,6 +103,34 @@ function resolvedReferences(fileName: string, forbiddenRoot: string): string[] {
 }
 
 describe('application-owned service boundaries', () => {
+  it('keeps serving source independent of preparation, tests, documentation and raw source modules', () => {
+    const forbiddenRoots = ['scripts', 'test', 'docs', 'data'].map(directory => join(repoRoot, directory));
+    const references = walk(srcRoot).flatMap(fileName => forbiddenRoots.flatMap(forbiddenRoot =>
+      resolvedReferences(fileName, forbiddenRoot).map(specifier => ({
+        file: relative(repoRoot, fileName).replaceAll('\\', '/'),
+        specifier,
+      }))));
+    expect(references).toEqual([]);
+  });
+
+  it('detects preparation and raw-source imports without executing their modules', () => {
+    const fileName = join(srcRoot, 'preparation-boundary-regression.ts');
+    const script = '../scripts/build-database.js';
+    const source = '../data/data-manifest.json';
+    for (const statement of [
+      `import '${script}';`,
+      `export * from '${script}';`,
+      `type Build = import('${script}');`,
+      `void import('${script}');`,
+      `import build = require('${script}');`,
+      `const build = require('${script}');`,
+    ]) {
+      expect(resolvedReferencesInSource(fileName, statement, join(repoRoot, 'scripts'))).toEqual([script]);
+    }
+    expect(resolvedReferencesInSource(fileName, `import manifest from '${source}';`, join(repoRoot, 'data'))).toEqual([source]);
+    expect(resolvedReferencesInSource(fileName, "import compiled from './data/parallel-passages.json';", join(repoRoot, 'data'))).toEqual([]);
+  });
+
   it('keeps service ports application-owned and retired adapter ports absent', () => {
     expect(existsSync(join(repoRoot, 'src/adapters/bible/BibleAdapter.ts'))).toBe(false);
     expect(existsSync(join(repoRoot, 'src/adapters/commentary/CommentaryAdapter.ts'))).toBe(false);


### PR DESCRIPTION
Serving code had no general guard against importing preparation scripts or raw source modules, and the architecture entrypoint still led readers through a historical design. Add a current ownership guide, a dormant-work review register, and compiler-API boundary checks. Remove the unused writable database helper from the serving adapter; runtime database access stays read-only.

The guide separates research serving, corpus preparation, and release operations without introducing new services or changing public contracts. It records activation criteria and a maintenance review date while preserving the existing release authority.

Validation: 27 targeted tests passed, Node/Worker and Node-test typechecks passed, Node build passed, and `git diff --check` passed. This PR's fresh-checkout data, Node HTTP E2E, Workerd, and conformance CI checks passed. A clean combined checkout of #155–#159 passed 2,658 unit tests (five existing skips), three integration tests, 26 Workerd tests, the full typecheck matrix, build, and the full-corpus benchmark. No source corpus, migrations, runtime configuration, or deployed environment changed.

The existing high-severity dependency audit blocker is addressed separately in #156. Review that prerequisite before integrating the improvement PRs; no merges have been performed.

Part 4 of the approved repository improvements. Open for owner review; do not merge until the owner has reviewed it.
