### PR TITLE
Patch dependency advisories blocking PR checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3102,9 +3102,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",
@@ -4408,9 +4408,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   },
   "overrides": {
     "brace-expansion": "5.0.9",
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.6",
     "hono": "4.12.34",
     "ip-address": "10.3.1",
     "postcss": {


### PR DESCRIPTION
The existing lockfile blocks PR CI at the high-severity dependency audit. Update the fast-uri override from 3.1.5 to 3.1.6 and the qs lockfile resolution from 6.15.3 to 6.16.0; no other dependency resolutions change.

These versions address the current [fast-uri advisories](https://github.com/advisories/GHSA-f65p-4m7j-42xc) and [qs advisories](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g). This repairs the audit prerequisite for the improvement PRs, including #155, without coupling the dependency patch to those features.

Validation on Node 22 after a clean install: dependency audit reports zero vulnerabilities; build and current integration passed. This PR's CI Test & Build, Node HTTP E2E, Workerd, conformance, and source-reproduction checks passed. The combined improvement checkout also passed all 2,658 unit tests (five existing skips), three integration tests, the full typecheck matrix, build, and 26 Workerd runtime tests.

Draft for owner review. Do not merge until the owner has reviewed it. No deployment or release configuration changes.
