### PR TITLE
Record content-free MCP tool outcomes and document operational baselines

### DIFF
--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -6,6 +6,83 @@ The [current release snapshot](CURRENT-RELEASE.md) is the designated current
 snapshot for this operations document. The dated records below retain release
 evidence and are not current identity authority.
 
+## Tool outcome observability
+
+Every dispatched `tools/call` emits one best-effort, content-free event at the
+shared MCP execution boundary. This covers MCP tool failures represented in a
+successful HTTP response as well as invalid arguments, unknown tool names,
+handler exceptions, and output-contract failures. It is not request logging.
+
+The fixed event shape is:
+
+```json
+{
+  "event": "theologai.tool.execution",
+  "tool": "bible_lookup",
+  "outcome": "success",
+  "durationMs": 12,
+  "releaseVersion": "3.6.0"
+}
+```
+
+`tool` is an allowlisted tool identifier (or `unknown`), `outcome` is one of
+`success`, `partial`, `unavailable`, `invalid`, or `error`, and an unsuccessful
+event can carry one low-cardinality `failureCategory`: `input_validation`,
+`unknown_tool`, `handler_exception`, `output_contract`, `tool_reported_error`,
+or `dependency_unavailable`. The event deliberately excludes arguments, response
+content, raw error text, URLs, IP addresses, user agents, sessions, user IDs,
+and authorization data. The observer is synchronous and exceptions from its
+sink are ignored, so telemetry cannot delay or alter a tool response.
+
+`partial` and `unavailable` are determined only from explicit, versioned
+structured fields for the tools that publish those states: Bible comparison
+passage/failure counts, parallel-passage enrichment completion, primary-source
+plan status, nested original-language-study status, and donation coverage.
+`dependency_unavailable` deliberately does not identify a provider: a local
+D1 dependency and an external provider are operationally distinct. Other
+domain results such as a valid not-found or unsupported receipt remain
+successful tool executions; they must not be counted as provider outages.
+
+The Worker writes these events as structured console records without request
+metadata. Node HTTP and stdio write the same records to stderr. Collection and
+sampling are platform operations, not application usage accounting: sampled
+logs can diagnose distributions but cannot establish exact totals. Until a
+durable metric sink is separately approved and provisioned, report rates only
+with the sample/window and do not infer request counts or user counts from
+them.
+
+Initial service indicators are separated by dependency boundary:
+
+| Indicator | Population | Initial target after baseline |
+| --- | --- | --- |
+| Local tool completion | Local-only tools and local portions of mixed tools; exclude `invalid` calls | ≥99.5% `success` or `partial` over 30 days |
+| External provider availability | Provider-dependent calls with `dependency_unavailable`; exclude valid absence, unsupported, and user-input errors | ≥99.0% over 30 days per provider-dependent tool |
+| Local tool latency | `durationMs` for local-only tools | p95 ≤1 s, p99 ≤3 s |
+| External tool latency | `durationMs` for provider-dependent tools | p95 ≤8 s, p99 ≤20 s |
+
+These are proposals, not accepted SLOs: establish a representative baseline
+before setting enforcement thresholds. While events are sampled, alert on a
+sustained sampled increase in `error`/`unavailable` (for example, five minutes
+above three times the rolling baseline) and on absence of expected synthetic
+events. Page only when a corroborating platform signal or synthetic check also
+fails; otherwise open an investigation. Revisit thresholds after the first
+30-day baseline and any provider or deadline-policy change.
+
+Keep the telemetry budget bounded: one small event per executed tool call, no
+retry by the application, no event payload growth, and no per-user dimensions.
+Release version is bounded to a short allowlisted token. Retain and export only
+according to the approved platform retention policy; this repository does not
+create a telemetry binding, account, dashboard, or deployment configuration.
+
+For a no-network synthetic check, run
+`npm test -- test/unit/mcp/toolExecutionObserver.test.ts`. It builds an
+in-process MCP server with an injected observer and proves success, invalid,
+reported-error, exception, partial, unavailable, unknown-tool, and failing-sink
+paths without a database or live provider. A future deployed synthetic must be
+explicitly authorized and should use one fixed harmless tool request, a bounded
+cadence, and the same release-version event; do not substitute ordinary traffic
+logs for that check.
+
 ## Production rollback rehearsal capability
 
 The protected `Production Rollback Rehearsal` workflow is manual, main-only,

--- a/docs/worker-operations.md
+++ b/docs/worker-operations.md
@@ -29,10 +29,10 @@ The fixed event shape is:
 `success`, `partial`, `unavailable`, `invalid`, or `error`, and an unsuccessful
 event can carry one low-cardinality `failureCategory`: `input_validation`,
 `unknown_tool`, `handler_exception`, `output_contract`, `tool_reported_error`,
-or `dependency_unavailable`. The event deliberately excludes arguments, response
+`execution_exception`, or `dependency_unavailable`. The event deliberately excludes arguments, response
 content, raw error text, URLs, IP addresses, user agents, sessions, user IDs,
-and authorization data. The observer is synchronous and exceptions from its
-sink are ignored, so telemetry cannot delay or alter a tool response.
+and authorization data. Delivery is nonawaited and not retried; exceptions from
+its sink are ignored, so telemetry cannot alter a tool response.
 
 `partial` and `unavailable` are determined only from explicit, versioned
 structured fields for the tools that publish those states: Bible comparison
@@ -42,6 +42,10 @@ plan status, nested original-language-study status, and donation coverage.
 D1 dependency and an external provider are operationally distinct. Other
 domain results such as a valid not-found or unsupported receipt remain
 successful tool executions; they must not be counted as provider outages.
+This event does not identify the local phase versus a provider phase, and it
+cannot distinguish an expected partial result (such as a budget omission or a
+disabled provider) from an unexpected degradation. Do not count every
+`partial` or `dependency_unavailable` event as a provider outage.
 
 The Worker writes these events as structured console records without request
 metadata. Node HTTP and stdio write the same records to stderr. Collection and
@@ -60,7 +64,9 @@ Initial service indicators are separated by dependency boundary:
 | Local tool latency | `durationMs` for local-only tools | p95 ≤1 s, p99 ≤3 s |
 | External tool latency | `durationMs` for provider-dependent tools | p95 ≤8 s, p99 ≤20 s |
 
-These are proposals, not accepted SLOs: establish a representative baseline
+These are proposals, not accepted SLOs: the local portions and per-provider
+populations require later, separately approved bounded instrumentation before
+they can be measured from these events. Establish a representative baseline
 before setting enforcement thresholds. While events are sampled, alert on a
 sustained sampled increase in `error`/`unavailable` (for example, five minutes
 above three times the rolling baseline) and on absence of expected synthetic
@@ -75,7 +81,7 @@ according to the approved platform retention policy; this repository does not
 create a telemetry binding, account, dashboard, or deployment configuration.
 
 For a no-network synthetic check, run
-`npm test -- test/unit/mcp/toolExecutionObserver.test.ts`. It builds an
+`npx --no-install vitest run test/unit/mcp/toolExecutionObserver.test.ts`. It builds an
 in-process MCP server with an injected observer and proves success, invalid,
 reported-error, exception, partial, unavailable, unknown-tool, and failing-sink
 paths without a database or live provider. A future deployed synthetic must be

--- a/src/http/nodeHttpServer.ts
+++ b/src/http/nodeHttpServer.ts
@@ -8,6 +8,7 @@ import {
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import { STATELESS_HTTP_CAPABILITIES, type McpCompositionRoot } from '../mcp/server.js';
 import { createTheologAiMcpServer } from '../mcp/server.js';
+import type { ToolExecutionObserver } from '../mcp/toolExecutionObserver.js';
 import { THEOLOGAI_VERSION } from '../server.js';
 import { normalizeHostname, type NodeHttpConfig } from './config.js';
 import { INTERNAL_MCP_ERROR } from './mcpErrors.js';
@@ -30,6 +31,8 @@ export interface NodeHttpServerOptions {
   root: McpCompositionRoot;
   config: NodeHttpConfig;
   telemetry?: HttpTelemetry;
+  /** Content-free tool outcome telemetry; the caller owns its sink. */
+  toolExecutionObserver?: ToolExecutionObserver;
   createMcpHandler?: (root: McpCompositionRoot) => Pick<McpHttpHandler, 'fetch' | 'close'>;
 }
 
@@ -44,7 +47,7 @@ type BodyResult =
   | { ok: false; status: 400 | 413; message: string };
 
 export function createNodeHttpServer(options: NodeHttpServerOptions): NodeHttpRuntime {
-  const { root, config } = options;
+  const { root, config, toolExecutionObserver } = options;
   const telemetry = options.telemetry ?? defaultTelemetry;
   const createHandler = options.createMcpHandler ?? (sharedRoot => createSdkMcpHandler(
     ({ era }) => createTheologAiMcpServer(
@@ -52,6 +55,7 @@ export function createNodeHttpServer(options: NodeHttpServerOptions): NodeHttpRu
       THEOLOGAI_VERSION,
       STATELESS_HTTP_CAPABILITIES,
       era,
+      toolExecutionObserver,
     ),
     { legacy: 'stateless', responseMode: 'auto' },
   ));

--- a/src/http/worker/telemetry.ts
+++ b/src/http/worker/telemetry.ts
@@ -1,4 +1,5 @@
 import type { Env } from '../../worker-env.js';
+import type { ToolExecutionEvent, ToolExecutionObserver } from '../../mcp/toolExecutionObserver.js';
 
 export interface WorkerRequestMetadata {
   method: string;
@@ -100,4 +101,14 @@ export function logWorkerRuntimeError(
     errorName,
     durationMs,
   }));
+}
+
+/**
+ * Tool events intentionally use no request metadata. Unlike sampled request
+ * diagnostics, their schema contains no caller-controlled identifiers.
+ */
+export function createWorkerToolExecutionObserver(): ToolExecutionObserver {
+  return (event: ToolExecutionEvent) => {
+    console.info(JSON.stringify(event));
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,15 @@
 import 'dotenv/config';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 import { createTheologAiMcpServer, STDIO_CAPABILITIES } from './mcp/server.js';
+import type { ToolExecutionObserver } from './mcp/toolExecutionObserver.js';
 import { THEOLOGAI_VERSION } from './server.js';
 import { createCompositionRoot } from './tools/v2/index.js';
 import { readNodeHttpConfig } from './http/config.js';
 import { createNodeHttpServer } from './http/nodeHttpServer.js';
+
+const stderrToolExecutionObserver: ToolExecutionObserver = event => {
+  console.error(JSON.stringify(event));
+};
 
 async function main() {
   // The composition root owns the long-lived local database and caches. HTTP
@@ -16,7 +21,7 @@ async function main() {
 
   if (port) {
     const config = readNodeHttpConfig(process.env);
-    const runtime = createNodeHttpServer({ root, config });
+    const runtime = createNodeHttpServer({ root, config, toolExecutionObserver: stderrToolExecutionObserver });
     const address = await runtime.listen();
 
     console.error(`TheologAI Bible MCP Server running at http://${config.host}:${address.port}/mcp`);
@@ -55,6 +60,7 @@ async function main() {
           THEOLOGAI_VERSION,
           STDIO_CAPABILITIES,
           era,
+          stderrToolExecutionObserver,
         ),
         {
           onerror(error) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -26,6 +26,7 @@ import type { StrongsService } from '../services/languages/StrongsService.js';
 import { internalError, resourceNotFound } from './errors.js';
 import { registerPromptHandlers } from './prompts.js';
 import { registerToolHandlers } from './tools.js';
+import type { ToolExecutionObserver } from './toolExecutionObserver.js';
 import { jsonSchemaValidator } from './validation.js';
 import { buildPrimarySourceCatalog, PRIMARY_SOURCE_CATALOG_URI } from './primarySourceCatalog.js';
 import { COMMENTARY_CATALOG } from '../kernel/commentaryCatalog.js';
@@ -81,6 +82,7 @@ export function createTheologAiMcpServer(
   version: string,
   profile: McpCapabilityProfile = STDIO_CAPABILITIES,
   era: 'legacy' | 'modern' = 'legacy',
+  toolExecutionObserver?: ToolExecutionObserver,
 ): TheologAiMcpServer {
   assertPrimarySourceContractParity(root);
   const legacyLogging = profile.logging && era === 'legacy';
@@ -106,7 +108,7 @@ export function createTheologAiMcpServer(
   );
 
   const { tools, services } = root;
-  registerToolHandlers(server, tools, legacyLogging);
+  registerToolHandlers(server, tools, legacyLogging, toolExecutionObserver, version);
 
   // ── Resources ──
 

--- a/src/mcp/toolExecutionObserver.ts
+++ b/src/mcp/toolExecutionObserver.ts
@@ -14,6 +14,7 @@ export type ToolExecutionFailureCategory =
   | 'unknown_tool'
   | 'handler_exception'
   | 'output_contract'
+  | 'execution_exception'
   | 'tool_reported_error'
   | 'dependency_unavailable';
 
@@ -50,7 +51,7 @@ export function safeToolName(value: unknown): string {
 }
 
 export function safeReleaseVersion(value: unknown): string {
-  return typeof value === 'string' && RELEASE_VERSION.test(value) ? value : 'unknown';
+  return typeof value === 'string' && value.length <= 64 && RELEASE_VERSION.test(value) ? value : 'unknown';
 }
 
 export function observeToolExecution(

--- a/src/mcp/toolExecutionObserver.ts
+++ b/src/mcp/toolExecutionObserver.ts
@@ -30,7 +30,7 @@ export interface ToolExecutionEvent {
 export type ToolExecutionObserver = (event: ToolExecutionEvent) => void;
 
 export const UNKNOWN_TOOL_NAME = 'unknown';
-export const OBSERVABLE_TOOL_NAMES = new Set([
+const OBSERVABLE_TOOL_NAMES = [
   'bible_lookup',
   'bible_cross_references',
   'parallel_passages',
@@ -42,11 +42,11 @@ export const OBSERVABLE_TOOL_NAMES = new Set([
   'original_language_study',
   'donation_config',
   'verify_donation',
-] as const);
+] as const;
 const RELEASE_VERSION = /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]{1,32})?(?:\+[0-9A-Za-z.-]{1,32})?$/;
 
 export function safeToolName(value: unknown): string {
-  return typeof value === 'string' && OBSERVABLE_TOOL_NAMES.has(value as never) ? value : UNKNOWN_TOOL_NAME;
+  return typeof value === 'string' && OBSERVABLE_TOOL_NAMES.includes(value as never) ? value : UNKNOWN_TOOL_NAME;
 }
 
 export function safeReleaseVersion(value: unknown): string {

--- a/src/mcp/toolExecutionObserver.ts
+++ b/src/mcp/toolExecutionObserver.ts
@@ -1,0 +1,141 @@
+import type { ToolResult } from '../kernel/types.js';
+
+/**
+ * A deliberately small, content-free event for operational tool outcomes.
+ *
+ * This is an application telemetry contract, not an MCP response field. It
+ * must never contain request arguments, result content, raw errors, client
+ * identifiers, or provider URLs.
+ */
+export type ToolExecutionOutcome = 'success' | 'partial' | 'unavailable' | 'invalid' | 'error';
+
+export type ToolExecutionFailureCategory =
+  | 'input_validation'
+  | 'unknown_tool'
+  | 'handler_exception'
+  | 'output_contract'
+  | 'tool_reported_error'
+  | 'dependency_unavailable';
+
+export interface ToolExecutionEvent {
+  readonly event: 'theologai.tool.execution';
+  readonly tool: string;
+  readonly outcome: ToolExecutionOutcome;
+  readonly durationMs: number;
+  readonly releaseVersion: string;
+  readonly failureCategory?: ToolExecutionFailureCategory;
+}
+
+/** A synchronous, best-effort sink. Callers must not await or depend on it. */
+export type ToolExecutionObserver = (event: ToolExecutionEvent) => void;
+
+export const UNKNOWN_TOOL_NAME = 'unknown';
+export const OBSERVABLE_TOOL_NAMES = new Set([
+  'bible_lookup',
+  'bible_cross_references',
+  'parallel_passages',
+  'commentary_lookup',
+  'classic_text_lookup',
+  'primary_source_search',
+  'original_language_lookup',
+  'bible_verse_morphology',
+  'original_language_study',
+  'donation_config',
+  'verify_donation',
+] as const);
+const RELEASE_VERSION = /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]{1,32})?(?:\+[0-9A-Za-z.-]{1,32})?$/;
+
+export function safeToolName(value: unknown): string {
+  return typeof value === 'string' && OBSERVABLE_TOOL_NAMES.has(value as never) ? value : UNKNOWN_TOOL_NAME;
+}
+
+export function safeReleaseVersion(value: unknown): string {
+  return typeof value === 'string' && RELEASE_VERSION.test(value) ? value : 'unknown';
+}
+
+export function observeToolExecution(
+  observer: ToolExecutionObserver | undefined,
+  event: ToolExecutionEvent,
+): void {
+  try {
+    // A function typed `() => void` may still accidentally return a Promise.
+    // Attach a rejection handler without awaiting so an optional sink cannot
+    // create an unhandled rejection or add call latency.
+    const delivered = (observer as ((value: ToolExecutionEvent) => unknown) | undefined)?.(event);
+    if (isPromiseLike(delivered)) void Promise.resolve(delivered).catch(() => undefined);
+  } catch {
+    // Observability is best-effort and must never delay or change a tool call.
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === 'object' && value !== null && 'then' in value
+    && typeof (value as { then?: unknown }).then === 'function';
+}
+
+/**
+ * Classify only the public, versioned structured fields documented by each
+ * tool. Unknown shapes intentionally fall back to the MCP `isError` signal;
+ * this avoids parsing prose or guessing meaning from arbitrary payload data.
+ */
+export function classifyToolResult(tool: string, result: ToolResult): Pick<ToolExecutionEvent, 'outcome' | 'failureCategory'> {
+  const structured = asRecord(result.structuredContent);
+  const structuredOutcome = classifyKnownStructuredOutcome(tool, structured);
+  if (structuredOutcome) return structuredOutcome;
+  return result.isError
+    ? { outcome: 'error', failureCategory: 'tool_reported_error' }
+    : { outcome: 'success' };
+}
+
+function classifyKnownStructuredOutcome(
+  tool: string,
+  structured: Record<string, unknown> | undefined,
+): Pick<ToolExecutionEvent, 'outcome' | 'failureCategory'> | undefined {
+  if (!structured) return undefined;
+
+  switch (tool) {
+    case 'bible_lookup': {
+      const passages = asArray(structured.passages);
+      const failures = asArray(structured.failures);
+      if (passages.length > 0 && failures.length > 0) return { outcome: 'partial' };
+      if (passages.length === 0 && failures.length > 0) {
+        return { outcome: 'unavailable', failureCategory: 'dependency_unavailable' };
+      }
+      return undefined;
+    }
+    case 'parallel_passages':
+      return asRecord(structured.textEnrichment)?.completionStatus === 'incomplete'
+        ? { outcome: 'partial' }
+        : undefined;
+    case 'primary_source_search':
+      return classifyPlanStatus(structured.planStatus);
+    case 'original_language_study':
+      return asRecord(structured.study)?.status === 'partial' ? { outcome: 'partial' } : undefined;
+    case 'verify_donation': {
+      const coverage = asRecord(structured.coverage);
+      if (coverage?.availability === 'partial') return { outcome: 'partial' };
+      if (coverage?.availability === 'unavailable' || asRecord(structured.classification)?.status === 'unavailable') {
+        return { outcome: 'unavailable', failureCategory: 'dependency_unavailable' };
+      }
+      return undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function classifyPlanStatus(value: unknown): Pick<ToolExecutionEvent, 'outcome' | 'failureCategory'> | undefined {
+  if (value === 'partial') return { outcome: 'partial' };
+  if (value === 'unavailable') return { outcome: 'unavailable', failureCategory: 'dependency_unavailable' };
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -68,49 +68,50 @@ export function registerToolHandlers(
         emit(outcome);
         return projected;
       } catch {
-        emit({ outcome: 'error', failureCategory: 'output_contract' });
+        emit({ outcome: 'error', failureCategory: 'execution_exception' });
         throw internalError();
       }
     };
-    const tool = tools.find(candidate => candidate.name === name);
-    if (!tool) {
-      emit({ outcome: 'invalid', failureCategory: 'unknown_tool' });
-      throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown tool: ${name}`);
-    }
-
-    const validate = validators.get(name);
-    const toolArguments = args ?? {};
-    const validation = validate?.(toolArguments);
-    if (!validation?.valid) {
-      return project({
-        content: [{
-          type: 'text',
-          text: `Invalid arguments for ${name}: ${formatValidationError(validation?.errorMessage)}`,
-        }],
-        isError: true,
-      }, tool.outputSchema, { outcome: 'invalid', failureCategory: 'input_validation' });
-    }
-
-    if (logging) {
-      await server.sendLoggingMessage({
-        level: 'info',
-        logger: 'theologai.tools',
-        data: { event: 'tool_execution', tool: name },
-      }).catch(() => {
-        // Logging is observational and must not make an otherwise valid tool call fail.
-      });
-    }
-
-    let result;
     try {
-      result = await tool.handler(toolArguments);
-    } catch {
-      emit({ outcome: 'error', failureCategory: 'handler_exception' });
-      throw internalError();
-    }
+      const tool = tools.find(candidate => candidate.name === name);
+      if (!tool) {
+        emit({ outcome: 'invalid', failureCategory: 'unknown_tool' });
+        throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown tool: ${name}`);
+      }
 
-    if (tool.outputSchema) {
-      if (result.structuredContent === undefined) {
+      const validate = validators.get(name);
+      const toolArguments = args ?? {};
+      const validation = validate?.(toolArguments);
+      if (!validation?.valid) {
+        return project({
+          content: [{
+            type: 'text',
+            text: `Invalid arguments for ${name}: ${formatValidationError(validation?.errorMessage)}`,
+          }],
+          isError: true,
+        }, tool.outputSchema, { outcome: 'invalid', failureCategory: 'input_validation' });
+      }
+
+      if (logging) {
+        await server.sendLoggingMessage({
+          level: 'info',
+          logger: 'theologai.tools',
+          data: { event: 'tool_execution', tool: name },
+        }).catch(() => {
+          // Logging is observational and must not make an otherwise valid tool call fail.
+        });
+      }
+
+      let result;
+      try {
+        result = await tool.handler(toolArguments);
+      } catch {
+        emit({ outcome: 'error', failureCategory: 'handler_exception' });
+        throw internalError();
+      }
+
+      if (tool.outputSchema) {
+        if (result.structuredContent === undefined) {
         // Generic sanitized tool errors may omit structured output. Whenever a
         // handler does provide it (including partial/unavailable isError
         // results), it must validate against the advertised schema.
@@ -120,22 +121,29 @@ export function registerToolHandlers(
         await reportOutputValidationFailure(server, logging, name);
         emit({ outcome: 'error', failureCategory: 'output_contract' });
         throw internalError();
+        }
+        const validation = outputValidators.get(name)?.(result.structuredContent);
+        const semanticValidation = validation?.valid && tool.validateStructuredOutput
+          ? safelyValidateStructuredOutput(
+            tool.validateStructuredOutput,
+            result.structuredContent as Record<string, unknown>,
+          )
+          : true;
+        if (!validation?.valid || !semanticValidation) {
+          await reportOutputValidationFailure(server, logging, name);
+          emit({ outcome: 'error', failureCategory: 'output_contract' });
+          throw internalError();
+        }
       }
-      const validation = outputValidators.get(name)?.(result.structuredContent);
-      const semanticValidation = validation?.valid && tool.validateStructuredOutput
-        ? safelyValidateStructuredOutput(
-          tool.validateStructuredOutput,
-          result.structuredContent as Record<string, unknown>,
-        )
-        : true;
-      if (!validation?.valid || !semanticValidation) {
-        await reportOutputValidationFailure(server, logging, name);
-        emit({ outcome: 'error', failureCategory: 'output_contract' });
-        throw internalError();
-      }
-    }
 
-    return project(result as CallToolResult, tool.outputSchema, classifyToolResult(observedTool, result));
+      return project(result as CallToolResult, tool.outputSchema, classifyToolResult(observedTool, result));
+    } catch (error) {
+      // Do not expose an unexpected validator/projection error. The server's
+      // existing wrapper retains its established sanitized protocol behavior.
+      if (!emitted) emit({ outcome: 'error', failureCategory: 'execution_exception' });
+      if (error instanceof ProtocolError) throw error;
+      throw internalError();
+    }
   });
 }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -7,11 +7,21 @@ import {
 import type { ToolHandler } from '../kernel/types.js';
 import { internalError } from './errors.js';
 import { formatValidationError, type SchemaValidator, validatorFor } from './validation.js';
+import {
+  classifyToolResult,
+  observeToolExecution,
+  safeReleaseVersion,
+  safeToolName,
+  type ToolExecutionEvent,
+  type ToolExecutionObserver,
+} from './toolExecutionObserver.js';
 
 export function registerToolHandlers(
   server: Server,
   tools: ToolHandler[],
   logging: boolean,
+  toolExecutionObserver?: ToolExecutionObserver,
+  releaseVersion?: string,
 ): void {
   const validators = new Map<string, SchemaValidator<Record<string, unknown>>>(
     tools.map(tool => [tool.name, validatorFor(tool.inputSchema)]),
@@ -34,8 +44,37 @@ export function registerToolHandlers(
 
   server.setRequestHandler('tools/call', async (request) => {
     const { name, arguments: args } = request.params;
+    const startedAt = Date.now();
+    const observedTool = safeToolName(name);
+    let emitted = false;
+    const emit = (event: Omit<ToolExecutionEvent, 'event' | 'tool' | 'durationMs' | 'releaseVersion'>) => {
+      if (emitted) return;
+      emitted = true;
+      observeToolExecution(toolExecutionObserver, {
+        event: 'theologai.tool.execution',
+        tool: observedTool,
+        durationMs: Math.max(0, Date.now() - startedAt),
+        releaseVersion: safeReleaseVersion(releaseVersion),
+        ...event,
+      });
+    };
+    const project = (
+      result: CallToolResult,
+      outputSchema: ToolHandler['outputSchema'],
+      outcome: Omit<ToolExecutionEvent, 'event' | 'tool' | 'durationMs' | 'releaseVersion'>,
+    ) => {
+      try {
+        const projected = server.projectCallToolResult(result, outputSchema);
+        emit(outcome);
+        return projected;
+      } catch {
+        emit({ outcome: 'error', failureCategory: 'output_contract' });
+        throw internalError();
+      }
+    };
     const tool = tools.find(candidate => candidate.name === name);
     if (!tool) {
+      emit({ outcome: 'invalid', failureCategory: 'unknown_tool' });
       throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown tool: ${name}`);
     }
 
@@ -43,13 +82,13 @@ export function registerToolHandlers(
     const toolArguments = args ?? {};
     const validation = validate?.(toolArguments);
     if (!validation?.valid) {
-      return server.projectCallToolResult({
+      return project({
         content: [{
           type: 'text',
           text: `Invalid arguments for ${name}: ${formatValidationError(validation?.errorMessage)}`,
         }],
         isError: true,
-      }, tool.outputSchema);
+      }, tool.outputSchema, { outcome: 'invalid', failureCategory: 'input_validation' });
     }
 
     if (logging) {
@@ -66,6 +105,7 @@ export function registerToolHandlers(
     try {
       result = await tool.handler(toolArguments);
     } catch {
+      emit({ outcome: 'error', failureCategory: 'handler_exception' });
       throw internalError();
     }
 
@@ -74,8 +114,11 @@ export function registerToolHandlers(
         // Generic sanitized tool errors may omit structured output. Whenever a
         // handler does provide it (including partial/unavailable isError
         // results), it must validate against the advertised schema.
-        if (result.isError) return server.projectCallToolResult(result as CallToolResult, tool.outputSchema);
+        if (result.isError) {
+          return project(result as CallToolResult, tool.outputSchema, classifyToolResult(observedTool, result));
+        }
         await reportOutputValidationFailure(server, logging, name);
+        emit({ outcome: 'error', failureCategory: 'output_contract' });
         throw internalError();
       }
       const validation = outputValidators.get(name)?.(result.structuredContent);
@@ -87,11 +130,12 @@ export function registerToolHandlers(
         : true;
       if (!validation?.valid || !semanticValidation) {
         await reportOutputValidationFailure(server, logging, name);
+        emit({ outcome: 'error', failureCategory: 'output_contract' });
         throw internalError();
       }
     }
 
-    return server.projectCallToolResult(result as CallToolResult, tool.outputSchema);
+    return project(result as CallToolResult, tool.outputSchema, classifyToolResult(observedTool, result));
   });
 }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -112,15 +112,15 @@ export function registerToolHandlers(
 
       if (tool.outputSchema) {
         if (result.structuredContent === undefined) {
-        // Generic sanitized tool errors may omit structured output. Whenever a
-        // handler does provide it (including partial/unavailable isError
-        // results), it must validate against the advertised schema.
-        if (result.isError) {
-          return project(result as CallToolResult, tool.outputSchema, classifyToolResult(observedTool, result));
-        }
-        await reportOutputValidationFailure(server, logging, name);
-        emit({ outcome: 'error', failureCategory: 'output_contract' });
-        throw internalError();
+          // Generic sanitized tool errors may omit structured output. Whenever a
+          // handler does provide it (including partial/unavailable isError
+          // results), it must validate against the advertised schema.
+          if (result.isError) {
+            return project(result as CallToolResult, tool.outputSchema, classifyToolResult(observedTool, result));
+          }
+          await reportOutputValidationFailure(server, logging, name);
+          emit({ outcome: 'error', failureCategory: 'output_contract' });
+          throw internalError();
         }
         const validation = outputValidators.get(name)?.(result.structuredContent);
         const semanticValidation = validation?.valid && tool.validateStructuredOutput

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import type { Server, Transport } from '@modelcontextprotocol/server';
 import { createTheologAiMcpServer, STDIO_CAPABILITIES } from './mcp/server.js';
+import type { ToolExecutionObserver } from './mcp/toolExecutionObserver.js';
 import type { McpCapabilityProfile, McpCompositionRoot } from './mcp/server.js';
 import { createCompositionRoot } from './tools/v2/index.js';
 
@@ -22,8 +23,9 @@ export class BibleMCPServer {
     version: string = THEOLOGAI_VERSION,
     profile: McpCapabilityProfile = STDIO_CAPABILITIES,
     era: 'legacy' | 'modern' = 'legacy',
+    toolExecutionObserver?: ToolExecutionObserver,
   ) {
-    this.mcpServer = createTheologAiMcpServer(root, version, profile, era);
+    this.mcpServer = createTheologAiMcpServer(root, version, profile, era, toolExecutionObserver);
   }
 
   getServer(): Server {

--- a/src/worker-server.ts
+++ b/src/worker-server.ts
@@ -4,12 +4,14 @@
 
 import type { TheologAiMcpServer } from './mcp/server.js';
 import { createTheologAiMcpServer, STATELESS_HTTP_CAPABILITIES } from './mcp/server.js';
+import type { ToolExecutionObserver } from './mcp/toolExecutionObserver.js';
 import type { WorkerCompositionRoot } from './tools/worker/index.js';
 
 export function createWorkerMcpServer(
   root: WorkerCompositionRoot,
   version: string,
   era: 'legacy' | 'modern' = 'legacy',
+  toolExecutionObserver?: ToolExecutionObserver,
 ): TheologAiMcpServer {
-  return createTheologAiMcpServer(root, version, STATELESS_HTTP_CAPABILITIES, era);
+  return createTheologAiMcpServer(root, version, STATELESS_HTTP_CAPABILITIES, era, toolExecutionObserver);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,6 +19,7 @@ import { getLegacyEndpointResponse } from './http/worker/legacyEndpoint.js';
 import { getRateLimitResponse } from './http/worker/rateLimit.js';
 import {
   getWorkerRequestMetadata,
+  createWorkerToolExecutionObserver,
   logWorkerRuntimeError,
   logWorkerRequestEvent,
   safeErrorName,
@@ -109,7 +110,7 @@ export default {
       const root = createWorkerCompositionRoot(env);
       const version = env.THEOLOGAI_VERSION || '0.0.0';
       const result = await handleWorkerMcpRequest(
-        era => createWorkerMcpServer(root, version, era),
+        era => createWorkerMcpServer(root, version, era, createWorkerToolExecutionObserver()),
         boundedRequest,
       );
       const response = applyCors(result.response, origin);

--- a/test/test-topology.json
+++ b/test/test-topology.json
@@ -10,8 +10,8 @@
     "conformance": 1
   },
   "current": {
-    "totalTestTypeScript": 286,
-    "activeVitest": 207,
+    "totalTestTypeScript": 287,
+    "activeVitest": 208,
     "support": 24,
     "manual": 4,
     "legacyOrphan": 50,
@@ -104,6 +104,7 @@
       "test/unit/mcp/primarySourceSearchDescriptor.test.ts",
       "test/unit/mcp/promptContracts.test.ts",
       "test/unit/mcp/server.test.ts",
+      "test/unit/mcp/toolExecutionObserver.test.ts",
       "test/unit/mcp/validation.test.ts",
       "test/unit/presenters/bibleStructured.test.ts",
       "test/unit/presenters/classicTextsStructured.test.ts",

--- a/test/unit/mcp/toolExecutionObserver.test.ts
+++ b/test/unit/mcp/toolExecutionObserver.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
+import type { Server } from '@modelcontextprotocol/server';
+import type { ToolHandler, ToolResult } from '../../../src/kernel/types.js';
+import { createTheologAiMcpServer } from '../../../src/mcp/server.js';
+import {
+  classifyToolResult,
+  safeReleaseVersion,
+  safeToolName,
+  type ToolExecutionEvent,
+} from '../../../src/mcp/toolExecutionObserver.js';
+import { createDeterministicMcpFixture } from '../../fixtures/mcpCompositionRoot.js';
+
+const connected: Array<{ client: Client; server: Server }> = [];
+
+async function connect(tools: ToolHandler[], events: ToolExecutionEvent[], version = '3.6.0-test'): Promise<Client> {
+  const fixture = createDeterministicMcpFixture();
+  const primarySourceSearch = tools.find(tool => tool.name === 'primary_source_search')
+    ?? fixture.root.primarySourceSearch.tool;
+  const root = {
+    ...fixture.root,
+    tools: tools.some(tool => tool.name === 'primary_source_search') ? tools : [...tools, primarySourceSearch],
+    primarySourceSearch: { ...fixture.root.primarySourceSearch, tool: primarySourceSearch },
+  };
+  const server = createTheologAiMcpServer(root, version, undefined, undefined, event => events.push(event)).server;
+  const client = new Client({ name: 'tool-observer-test', version: '1.0.0' }, { capabilities: {} });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  connected.push({ client, server });
+  return client;
+}
+
+function handler(overrides: Partial<ToolHandler> = {}): ToolHandler {
+  return {
+    name: 'bible_lookup',
+    description: 'Synthetic observability fixture',
+    inputSchema: {
+      type: 'object', properties: { reference: { type: 'string' } }, required: ['reference'], additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    handler: async () => ({ content: [{ type: 'text', text: 'safe' }] }),
+    ...overrides,
+  };
+}
+
+function textResult(text: string, isError = false): ToolResult {
+  return {
+    content: [{ type: 'text', text }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+afterEach(async () => {
+  await Promise.allSettled(connected.splice(0).flatMap(({ client, server }) => [client.close(), server.close()]));
+});
+
+describe('tool execution observer', () => {
+  it('emits exactly one content-free event for successful, invalid, reported-error, and thrown calls', async () => {
+    const events: ToolExecutionEvent[] = [];
+    const privateValue = 'PRIVATE_ARGUMENT_OR_ERROR';
+    const client = await connect([
+      handler({
+        handler: vi.fn(async (params): Promise<ToolResult> => {
+          if (params.reference === 'reported') return textResult(privateValue, true);
+          if (params.reference === 'throw') throw new Error(privateValue);
+          return textResult(privateValue);
+        }),
+      }),
+    ], events);
+
+    await client.callTool({ name: 'bible_lookup', arguments: { reference: 'success' } });
+    await client.callTool({ name: 'bible_lookup', arguments: {} });
+    await client.callTool({ name: 'bible_lookup', arguments: { reference: 'reported' } });
+    await expect(client.callTool({ name: 'bible_lookup', arguments: { reference: 'throw' } })).rejects.toMatchObject({ code: -32603 });
+
+    expect(events).toEqual([
+      expect.objectContaining({ tool: 'bible_lookup', outcome: 'success', releaseVersion: '3.6.0-test' }),
+      expect.objectContaining({ tool: 'bible_lookup', outcome: 'invalid', failureCategory: 'input_validation' }),
+      expect.objectContaining({ tool: 'bible_lookup', outcome: 'error', failureCategory: 'tool_reported_error' }),
+      expect.objectContaining({ tool: 'bible_lookup', outcome: 'error', failureCategory: 'handler_exception' }),
+    ]);
+    expect(events.every(event => Number.isInteger(event.durationMs) && event.durationMs >= 0)).toBe(true);
+    expect(JSON.stringify(events)).not.toContain(privateValue);
+    expect(JSON.stringify(events)).not.toContain('arguments');
+  });
+
+  it('emits one invalid event for an unknown name without retaining the caller-provided name', async () => {
+    const events: ToolExecutionEvent[] = [];
+    const unknown = 'private_unknown_tool';
+    const client = await connect([handler()], events);
+    await expect(client.callTool({ name: unknown, arguments: {} })).rejects.toMatchObject({ code: -32602 });
+    expect(events).toEqual([expect.objectContaining({
+      tool: 'unknown', outcome: 'invalid', failureCategory: 'unknown_tool',
+    })]);
+    expect(JSON.stringify(events)).not.toContain(unknown);
+  });
+
+  it('does not let a synchronous sink failure change a successful tool result', async () => {
+    const fixture = createDeterministicMcpFixture();
+    const observer = vi.fn(() => { throw new Error('telemetry sink failure'); });
+    const server = createTheologAiMcpServer(
+      fixture.root,
+      '3.6.0-test',
+      undefined,
+      undefined,
+      observer,
+    ).server;
+    const client = new Client({ name: 'tool-observer-failure-test', version: '1.0.0' }, { capabilities: {} });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    connected.push({ client, server });
+
+    await expect(client.callTool({ name: 'bible_lookup', arguments: { reference: 'John 3:16' } }))
+      .resolves.toMatchObject({ structuredContent: { kind: 'bible_lookup' } });
+    expect(observer).toHaveBeenCalledOnce();
+  });
+
+  it('records an output-contract projection failure once', async () => {
+    const events: ToolExecutionEvent[] = [];
+    const client = await connect([handler({
+      outputSchema: {
+        type: 'object', properties: { value: { type: 'string' } }, required: ['value'], additionalProperties: false,
+      },
+      handler: async () => ({
+        content: [{ type: 'text', text: 'private malformed output' }],
+        structuredContent: { value: 42 },
+      }),
+    })], events);
+
+    await expect(client.callTool({ name: 'bible_lookup', arguments: { reference: 'John 3:16' } }))
+      .rejects.toMatchObject({ code: -32603 });
+    expect(events).toEqual([expect.objectContaining({
+      outcome: 'error', failureCategory: 'output_contract',
+    })]);
+    expect(JSON.stringify(events)).not.toContain('private malformed output');
+  });
+
+  it('uses explicit structured contracts for partial and unavailable outcomes', () => {
+    expect(classifyToolResult('bible_lookup', {
+      content: [{ type: 'text', text: 'ignored' }],
+      structuredContent: { passages: [{}], failures: [{}] },
+    })).toEqual({ outcome: 'partial' });
+    expect(classifyToolResult('primary_source_search', {
+      content: [{ type: 'text', text: 'ignored' }], isError: true,
+      structuredContent: { planStatus: 'unavailable' },
+    })).toEqual({ outcome: 'unavailable', failureCategory: 'dependency_unavailable' });
+    expect(classifyToolResult('original_language_study', {
+      content: [{ type: 'text', text: 'ignored' }], structuredContent: { study: { status: 'partial' } },
+    })).toEqual({ outcome: 'partial' });
+  });
+
+  it('bounds potentially caller-controlled identifiers before observation', () => {
+    expect(safeToolName('bible_lookup')).toBe('bible_lookup');
+    expect(safeToolName('private_tool_name')).toBe('unknown');
+    expect(safeReleaseVersion('3.6.0+abc')).toBe('3.6.0+abc');
+    expect(safeReleaseVersion('private version with spaces')).toBe('unknown');
+  });
+});

--- a/test/unit/mcp/toolExecutionObserver.test.ts
+++ b/test/unit/mcp/toolExecutionObserver.test.ts
@@ -3,6 +3,10 @@ import { Client, InMemoryTransport } from '@modelcontextprotocol/client';
 import type { Server } from '@modelcontextprotocol/server';
 import type { ToolHandler, ToolResult } from '../../../src/kernel/types.js';
 import { createTheologAiMcpServer } from '../../../src/mcp/server.js';
+import { presentBibleLookupStructured } from '../../../src/presenters/bibleStructured.js';
+import { presentParallelPassagesStructured } from '../../../src/presenters/parallelPassagesStructured.js';
+import { presentPrimarySourceSearchV6 } from '../../../src/presenters/primarySourceSearchV4Structured.js';
+import { presentOriginalLanguageStudyV2 } from '../../../src/presenters/originalLanguageStudyV2Presentation.js';
 import {
   classifyToolResult,
   safeReleaseVersion,
@@ -10,6 +14,8 @@ import {
   type ToolExecutionEvent,
 } from '../../../src/mcp/toolExecutionObserver.js';
 import { createDeterministicMcpFixture } from '../../fixtures/mcpCompositionRoot.js';
+import { productionCandidate, productionContext, productionCoordinator, productionRequest } from '../../helpers/originalLanguageStudyV2ProductionFixtures.js';
+import type { PrimarySourceSearchPlanResult } from '../../../src/services/historical/primarySourceTypes.js';
 
 const connected: Array<{ client: Client; server: Server }> = [];
 
@@ -137,18 +143,87 @@ describe('tool execution observer', () => {
     expect(JSON.stringify(events)).not.toContain('private malformed output');
   });
 
-  it('uses explicit structured contracts for partial and unavailable outcomes', () => {
-    expect(classifyToolResult('bible_lookup', {
-      content: [{ type: 'text', text: 'ignored' }],
-      structuredContent: { passages: [{}], failures: [{}] },
-    })).toEqual({ outcome: 'partial' });
+  it('records a validator exception once with a generic category', async () => {
+    const events: ToolExecutionEvent[] = [];
+    const client = await connect([handler({
+      outputSchema: { type: 'object', additionalProperties: false },
+      handler: async () => ({
+        content: [{ type: 'text', text: 'safe fallback' }],
+        structuredContent: new Proxy({}, { ownKeys: () => { throw new Error('private validator failure'); } }),
+      }),
+    })], events);
+
+    await expect(client.callTool({ name: 'bible_lookup', arguments: { reference: 'John 3:16' } }))
+      .rejects.toMatchObject({ code: -32603 });
+    expect(events).toEqual([expect.objectContaining({
+      outcome: 'error', failureCategory: 'execution_exception',
+    })]);
+    expect(JSON.stringify(events)).not.toContain('private validator failure');
+  });
+
+  it('records a projection exception once with a generic category', async () => {
+    const events: ToolExecutionEvent[] = [];
+    const fixture = createDeterministicMcpFixture();
+    const server = createTheologAiMcpServer(
+      fixture.root,
+      '3.6.0-test',
+      undefined,
+      undefined,
+      event => events.push(event),
+    ).server;
+    vi.spyOn(server, 'projectCallToolResult').mockImplementationOnce(() => {
+      throw new Error('private projection failure');
+    });
+    const client = new Client({ name: 'tool-observer-projection-test', version: '1.0.0' }, { capabilities: {} });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    connected.push({ client, server });
+
+    await expect(client.callTool({ name: 'bible_lookup', arguments: { reference: 'John 3:16' } }))
+      .rejects.toMatchObject({ code: -32603 });
+    expect(events).toEqual([expect.objectContaining({
+      outcome: 'error', failureCategory: 'execution_exception',
+    })]);
+    expect(JSON.stringify(events)).not.toContain('private projection failure');
+  });
+
+  it('uses presenter-produced structured contracts for partial and unavailable outcomes', async () => {
+    const bible = presentBibleLookupStructured({
+      reference: 'John 3:16',
+      results: [{ reference: 'John 3:16', translation: 'ESV', text: 'For God so loved the world.', citation: { source: 'Fixture' } }],
+      failures: [{ translation: 'NET', reason: 'intentionally unavailable fixture' }],
+    }, 'John 3:16', ['ESV', 'NET']);
+    expect(classifyToolResult('bible_lookup', { content: [{ type: 'text', text: 'ignored' }], structuredContent: bible }))
+      .toEqual({ outcome: 'partial' });
+
+    const parallel = presentParallelPassagesStructured({
+      requestedReference: 'John 3:16', corpora: [], sourceAttestedGroups: [],
+      sourceAttestedResultWindow: { requestedLimit: 1, returnedGroupCount: 0, additionalMatchStatus: 'not_evaluated' },
+      legacyParallels: [], openBibleCrossReferences: [], provenance: [],
+      textEnrichment: {
+        requested: true, translation: 'ESV', budget: { unit: 'unique_canonical_passage_lookups', maximum: 12 },
+        uniqueTargetCount: 2, scheduledLookupCount: 2, succeededLookupCount: 1, failedLookupCount: 1, omittedLookupCount: 0,
+        completionStatus: 'incomplete',
+      },
+    });
+    expect(classifyToolResult('parallel_passages', { content: [{ type: 'text', text: 'ignored' }], structuredContent: parallel }))
+      .toEqual({ outcome: 'partial' });
+
+    const primary = presentPrimarySourceSearchV6(primarySourcePartialPlan());
+    expect(classifyToolResult('primary_source_search', { content: [{ type: 'text', text: 'ignored' }], structuredContent: primary }))
+      .toEqual({ outcome: 'partial' });
+
+    const context = productionContext();
+    context.v1Result = { ...context.v1Result, status: 'partial' };
+    const language = presentOriginalLanguageStudyV2(await productionCoordinator([productionCandidate(1)], context).coordinator.study(productionRequest())).output;
+    expect(classifyToolResult('original_language_study', { content: [{ type: 'text', text: 'ignored' }], structuredContent: language }))
+      .toEqual({ outcome: 'partial' });
+
     expect(classifyToolResult('primary_source_search', {
       content: [{ type: 'text', text: 'ignored' }], isError: true,
-      structuredContent: { planStatus: 'unavailable' },
+      structuredContent: { ...primary, planStatus: 'unavailable' },
     })).toEqual({ outcome: 'unavailable', failureCategory: 'dependency_unavailable' });
-    expect(classifyToolResult('original_language_study', {
-      content: [{ type: 'text', text: 'ignored' }], structuredContent: { study: { status: 'partial' } },
-    })).toEqual({ outcome: 'partial' });
   });
 
   it('bounds potentially caller-controlled identifiers before observation', () => {
@@ -156,5 +231,21 @@ describe('tool execution observer', () => {
     expect(safeToolName('private_tool_name')).toBe('unknown');
     expect(safeReleaseVersion('3.6.0+abc')).toBe('3.6.0+abc');
     expect(safeReleaseVersion('private version with spaces')).toBe('unknown');
+    expect(safeReleaseVersion(`3.6.0+${'a'.repeat(60)}`)).toBe('unknown');
   });
 });
+
+function primarySourcePartialPlan(): PrimarySourceSearchPlanResult {
+  return {
+    planStatus: 'partial',
+    queries: [{
+      id: 'q', normalizedMode: 'all_terms', normalizedSelection: 'relevance', providers: [{
+        provider: 'local', status: 'no_results', searched: true, page: 1, hitCount: 0,
+        resultWindow: { returnedHitCount: 0, additionalMatchStatus: 'no_additional_match_observed' },
+        hits: [], notices: [],
+        scope: { status: 'matched', requested: {}, eligibleDocumentCount: 0, eligibleDocuments: [], eligibleDocumentsTruncated: false },
+      }],
+    }],
+    coverage: { localAttempted: true, localStatus: 'no_results', localHitCount: 0, ccelAttempted: false, ccelHitCount: 0, notices: [] },
+  };
+}

--- a/test/unit/worker/workerEntryPoint.test.ts
+++ b/test/unit/worker/workerEntryPoint.test.ts
@@ -294,8 +294,20 @@ describe('Worker Entry Point', () => {
     expect(mockCreateRoot).toHaveBeenCalledWith(env);
     expect(mockHandleMcp).toHaveBeenCalledWith(expect.any(Function), request);
     const factory = mockHandleMcp.mock.calls[0]![0] as (era: 'legacy' | 'modern') => unknown;
-    expect(factory('modern')).toBe(mockServer);
-    expect(mockCreateServer).toHaveBeenCalledWith(mockRoot, '1.0.0-test', 'modern');
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      expect(factory('modern')).toBe(mockServer);
+      expect(mockCreateServer).toHaveBeenCalledWith(mockRoot, '1.0.0-test', 'modern', expect.any(Function));
+      const observer = mockCreateServer.mock.calls[0]![3] as (event: unknown) => void;
+      observer({
+        event: 'theologai.tool.execution', tool: 'bible_lookup', outcome: 'success', durationMs: 12, releaseVersion: '1.0.0-test',
+      });
+      expect(infoSpy.mock.calls.map(call => JSON.parse(call[0] as string))).toEqual([{
+        event: 'theologai.tool.execution', tool: 'bible_lookup', outcome: 'success', durationMs: 12, releaseVersion: '1.0.0-test',
+      }]);
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 
   it('allows native clients without emitting an allow-origin header', async () => {


### PR DESCRIPTION
HTTP success can hide MCP tool failures and incomplete provider results. Add one content-free outcome event at the shared tool execution boundary, with Node stderr and Worker structured-console sinks. Events contain only an allowlisted tool name, outcome, elapsed milliseconds, bounded release version, and optional fixed failure category. Arguments, source text, error messages, URLs, and client identifiers are excluded.

The observer covers input errors, handler exceptions, output validation/projection failures, and explicit partial/unavailable structured results. Sink failures do not change protocol outcomes. The operations guide explains sampling limits, proposed baseline indicators, and a local synthetic check. This does not provision dashboards, alerts, or a production metric sink; expected partials and provider-specific phases need further bounded instrumentation before corresponding SLOs can be measured.

Validation: Node, Worker, and Node-test typechecks passed; 178 MCP, topology, presenter, and current integration checks passed, plus Worker observer wiring coverage. Privacy and exceptional-path tests include actual presenter output, unknown tool names, bounded versions, and throwing/rejecting sinks. A clean combined checkout of #155–#159 passed 2,658 unit tests (five existing skips), three integration tests, 26 Workerd tests, the full typecheck matrix, build, and the full-corpus benchmark.

The existing dependency audit blocker is addressed separately by #156. This branch is based on main. When integrating #158, preserve both the observer wrapper and `(request, context)` / `tool.handler(toolArguments, { signal: context.mcpReq.signal })`. With #159, retain both new test inventory entries and use combined totals of 289 TypeScript test files / 210 active Vitest files. These resolutions were validated together in the disposable combined checkout.

Draft for owner review. Do not merge until the owner has reviewed it. No deployment, secrets, or production configuration changes.
