### PR TITLE
Preserve Bible comparison options and bound remote request time

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,15 @@ attempts for the 12 scheduled lookups, preserving headroom below the
 50-subrequest Worker limit; this relationship is executable policy, not only
 documentation.
 
+Each `bible_lookup` call and the remote text-enrichment portion of
+`parallel_passages` share a 30-second deadline across provider fetches, body
+reads, and retry delays. MCP cancellation propagates through those operations.
+Bible comparisons run at most four translations concurrently, retain request
+order within successes and failures, and forward `includeFootnotes` for both
+single and multiple translations. When the budget expires, completed passages
+remain available and queued provider work does not start. This deadline does
+not preempt local database queries or synchronous formatting.
+
 For exact `original_language_lookup` calls, corpus usage is opt-in. `overview`
 returns totals plus the complete canonical-book distribution only. `study`
 adds the top 10 exact source variants and defaults to 8 raw occurrences (maximum

--- a/src/adapters/bible/EsvAdapter.ts
+++ b/src/adapters/bible/EsvAdapter.ts
@@ -27,7 +27,11 @@ export class EsvAdapter implements BibleProviderPort {
     });
   }
 
-  async getPassage(ref: BibleReference, _translation: string, options?: { includeFootnotes?: boolean }): Promise<BibleResult> {
+  async getPassage(
+    ref: BibleReference,
+    _translation: string,
+    options?: { includeFootnotes?: boolean; signal?: AbortSignal },
+  ): Promise<BibleResult> {
     if (!this.apiKey) {
       throw new APIError(401, 'ESV API key not configured. Set ESV_API_KEY environment variable.');
     }
@@ -41,7 +45,7 @@ export class EsvAdapter implements BibleProviderPort {
       'include-short-copyright': 'false',
     });
 
-    const data = await this.client.getJSON<any>(`/text/?${params}`);
+    const data = await this.client.getJSON<any>(`/text/?${params}`, { signal: options?.signal });
 
     if (!data.passages || data.passages.length === 0) {
       throw new APIError(404, `No passages found for: ${refStr}`);

--- a/src/adapters/bible/HelloAoAdapter.ts
+++ b/src/adapters/bible/HelloAoAdapter.ts
@@ -44,7 +44,11 @@ export class HelloAoAdapter implements BibleProviderPort {
     });
   }
 
-  async getPassage(ref: BibleReference, translation: string, options?: { includeFootnotes?: boolean }): Promise<BibleResult> {
+  async getPassage(
+    ref: BibleReference,
+    translation: string,
+    options?: { includeFootnotes?: boolean; signal?: AbortSignal },
+  ): Promise<BibleResult> {
     const key = translation.toUpperCase();
     const meta = TRANSLATIONS[key];
     if (!meta) {
@@ -52,7 +56,10 @@ export class HelloAoAdapter implements BibleProviderPort {
     }
 
     const hao = toHelloAO(ref);
-    const data = await this.client.getJSON<any>(`/${meta.id}/${hao.bookCode}/${hao.chapter}.json`);
+    const data = await this.client.getJSON<any>(
+      `/${meta.id}/${hao.bookCode}/${hao.chapter}.json`,
+      { signal: options?.signal },
+    );
     this.assertResponseMatchesRequest(data, ref, hao.bookCode, meta.id);
 
     // Extract verses

--- a/src/adapters/bible/NetBibleAdapter.ts
+++ b/src/adapters/bible/NetBibleAdapter.ts
@@ -25,7 +25,11 @@ export class NetBibleAdapter implements BibleProviderPort {
     });
   }
 
-  async getPassage(ref: BibleReference, _translation: string): Promise<BibleResult> {
+  async getPassage(
+    ref: BibleReference,
+    _translation: string,
+    options?: { includeFootnotes?: boolean; signal?: AbortSignal },
+  ): Promise<BibleResult> {
     const refStr = formatReference(ref);
     const params = new URLSearchParams({
       passage: refStr,
@@ -33,7 +37,7 @@ export class NetBibleAdapter implements BibleProviderPort {
       type: 'json',
     });
 
-    const data = await this.client.getJSON<any[]>(`?${params}`);
+    const data = await this.client.getJSON<any[]>(`?${params}`, { signal: options?.signal });
 
     if (!Array.isArray(data) || data.length === 0) {
       throw new APIError(404, `No passage found for: ${refStr}`);

--- a/src/adapters/shared/HttpClient.ts
+++ b/src/adapters/shared/HttpClient.ts
@@ -6,6 +6,7 @@
 
 import { AdapterError } from '../../kernel/errors.js';
 import { DEFAULT_HTTP_MAX_RETRIES } from '../../kernel/requestLimits.js';
+import { RequestDeadlineExceededError } from '../../kernel/requestDeadline.js';
 
 const DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const DEFAULT_MAX_CACHE_BYTES = 8 * 1024 * 1024;
@@ -29,6 +30,11 @@ export interface HttpClientOptions {
   maxResponseBytes?: number;
   /** Maximum aggregate UTF-8 cache weight. Default: 8 MiB. */
   maxCacheBytes?: number;
+}
+
+export interface HttpRequestOptions {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
 }
 
 export class HttpClient {
@@ -62,16 +68,17 @@ export class HttpClient {
   }
 
   /** GET request, returning parsed JSON */
-  async getJSON<T = unknown>(path: string, options?: { headers?: Record<string, string> }): Promise<T> {
+  async getJSON<T = unknown>(path: string, options: HttpRequestOptions = {}): Promise<T> {
     const url = this.baseUrl + path;
     const cacheKey = url;
+    this.throwIfCallerCancelled(options.signal);
 
     if (this.cache) {
       const cached = this.cache.get(cacheKey);
       if (cached !== undefined) return JSON.parse(cached) as T;
     }
 
-    const body = await this.fetchWithRetry(url, options?.headers);
+    const body = await this.fetchWithRetry(url, options);
 
     if (this.cache) {
       this.cache.set(cacheKey, body);
@@ -81,16 +88,17 @@ export class HttpClient {
   }
 
   /** GET request, returning raw text */
-  async getText(path: string, options?: { headers?: Record<string, string> }): Promise<string> {
+  async getText(path: string, options: HttpRequestOptions = {}): Promise<string> {
     const url = this.baseUrl + path;
     const cacheKey = `text:${url}`;
+    this.throwIfCallerCancelled(options.signal);
 
     if (this.cache) {
       const cached = this.cache.get(cacheKey);
       if (cached !== undefined) return cached;
     }
 
-    const body = await this.fetchWithRetry(url, options?.headers);
+    const body = await this.fetchWithRetry(url, options);
 
     if (this.cache) {
       this.cache.set(cacheKey, body);
@@ -107,21 +115,28 @@ export class HttpClient {
     this.cache?.dispose();
   }
 
-  private async fetchWithRetry(url: string, extraHeaders?: Record<string, string>): Promise<string> {
+  private async fetchWithRetry(url: string, options: HttpRequestOptions): Promise<string> {
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      this.throwIfCallerCancelled(options.signal);
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+      const abortFromCaller = () => controller.abort(options.signal?.reason);
+      options.signal?.addEventListener('abort', abortFromCaller, { once: true });
+      if (options.signal?.aborted) abortFromCaller();
+      const timeout = setTimeout(() => {
+        controller.abort(new DOMException('Upstream request timed out.', 'TimeoutError'));
+      }, this.timeoutMs);
       let shouldRetry = false;
 
       try {
         const response = await fetch(url, {
-          headers: { ...this.headers, ...extraHeaders },
+          headers: { ...this.headers, ...options.headers },
           signal: controller.signal,
         });
 
         if (!response.ok) {
+          cancelResponseBody(response, `HTTP ${response.status}`);
           if (response.status >= 500 && attempt < this.maxRetries) {
             shouldRetry = true;
           } else {
@@ -131,21 +146,34 @@ export class HttpClient {
             );
           }
         } else {
-          return await readBoundedResponseText(response, this.maxResponseBytes, this.source);
+          return await readBoundedResponseText(
+            response,
+            this.maxResponseBytes,
+            this.source,
+            controller.signal,
+          );
         }
       } catch (error) {
+        if (options.signal?.aborted) {
+          throw this.callerCancellationError(options.signal, error);
+        }
         if (error instanceof AdapterError) throw error;
 
-        lastError = error as Error;
+        lastError = error instanceof Error ? error : new Error(String(error));
         if (attempt < this.maxRetries) {
           shouldRetry = true;
         }
       } finally {
         clearTimeout(timeout);
+        options.signal?.removeEventListener('abort', abortFromCaller);
       }
 
       if (shouldRetry) {
-        await this.backoff(attempt);
+        try {
+          await this.backoff(attempt, options.signal);
+        } catch (error) {
+          throw this.callerCancellationError(options.signal, error);
+        }
       }
     }
 
@@ -156,9 +184,26 @@ export class HttpClient {
     );
   }
 
-  private backoff(attempt: number): Promise<void> {
+  private backoff(attempt: number, signal?: AbortSignal): Promise<void> {
     const delay = Math.min(1000 * 2 ** attempt, 10000);
-    return new Promise(resolve => setTimeout(resolve, delay));
+    return waitForDelay(delay, signal);
+  }
+
+  private throwIfCallerCancelled(signal?: AbortSignal): void {
+    if (signal?.aborted) throw this.callerCancellationError(signal);
+  }
+
+  private callerCancellationError(signal?: AbortSignal, cause?: unknown): AdapterError {
+    const reason = signal?.reason;
+    const message = reason instanceof RequestDeadlineExceededError
+      ? 'Request deadline exceeded.'
+      : 'Request was cancelled.';
+    const errorCause = cause instanceof Error
+      ? cause
+      : reason instanceof Error
+        ? reason
+        : undefined;
+    return new AdapterError(this.source, message, errorCause);
   }
 }
 
@@ -167,30 +212,40 @@ export async function readBoundedResponseText(
   response: Response,
   maxBytes: number,
   source: string,
+  signal?: AbortSignal,
 ): Promise<string> {
   const declared = response.headers?.get('Content-Length');
   if (declared && /^\d+$/.test(declared) && Number(declared) > maxBytes) {
-    await response.body?.cancel();
+    cancelResponseBody(response, 'Upstream response exceeds configured limit');
     throw new AdapterError(source, `Upstream response exceeds ${maxBytes} bytes`);
   }
-  if (!response.body) return response.text();
+  if (!response.body) return awaitWithAbort(response.text(), signal);
 
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const { done, value } = await awaitWithAbort(reader.read(), signal);
       if (done) break;
       total += value.byteLength;
       if (total > maxBytes) {
-        await reader.cancel('Upstream response exceeds configured limit');
+        cancelReader(reader, 'Upstream response exceeds configured limit');
         throw new AdapterError(source, `Upstream response exceeds ${maxBytes} bytes`);
       }
       chunks.push(value);
     }
+  } catch (error) {
+    if (signal?.aborted) {
+      cancelReader(reader, signal.reason);
+    }
+    throw error;
   } finally {
-    reader.releaseLock();
+    try {
+      reader.releaseLock();
+    } catch {
+      // A hostile or detached stream must not replace the bounded read failure.
+    }
   }
 
   const body = new Uint8Array(total);
@@ -200,6 +255,78 @@ export async function readBoundedResponseText(
     offset += chunk.byteLength;
   }
   return new TextDecoder().decode(body);
+}
+
+function waitForDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(abortReason(signal));
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      cleanup();
+      reject(abortReason(signal));
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', onAbort);
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+}
+
+function awaitWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(abortReason(signal));
+    };
+    const cleanup = () => signal.removeEventListener('abort', onAbort);
+    signal.addEventListener('abort', onAbort, { once: true });
+    if (signal.aborted) onAbort();
+    promise.then(
+      value => {
+        cleanup();
+        resolve(value);
+      },
+      error => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function cancelResponseBody(response: Response, reason: string): void {
+  try {
+    void response.body?.cancel(reason).catch(() => {
+      // Body cleanup must never replace or delay the request failure.
+    });
+  } catch {
+    // Preserve the request failure when a nonconforming stream throws synchronously.
+  }
+}
+
+function cancelReader(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reason: unknown,
+): void {
+  try {
+    void reader.cancel(reason).catch(() => {
+      // Preserve the bounded read or cancellation failure.
+    });
+  } catch {
+    // Preserve the bounded read or cancellation failure.
+  }
+}
+
+function abortReason(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The request was aborted.', 'AbortError');
 }
 
 class ResponseCache {

--- a/src/kernel/requestDeadline.ts
+++ b/src/kernel/requestDeadline.ts
@@ -1,0 +1,49 @@
+/** Request-local deadline composition shared by Node and Worker handlers. */
+
+export class RequestDeadlineExceededError extends Error {
+  constructor() {
+    super('Request deadline exceeded.');
+    this.name = 'RequestDeadlineExceededError';
+  }
+}
+
+export interface RequestDeadline {
+  signal: AbortSignal;
+  dispose(): void;
+}
+
+export function createRequestDeadline(
+  timeoutMs: number,
+  parentSignal?: AbortSignal,
+): RequestDeadline {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1) {
+    throw new Error('timeoutMs must be a positive safe integer');
+  }
+
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort(abortReason(parentSignal));
+  parentSignal?.addEventListener('abort', abortFromParent, { once: true });
+  if (parentSignal?.aborted) abortFromParent();
+
+  const timeout = setTimeout(() => {
+    controller.abort(new RequestDeadlineExceededError());
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    dispose() {
+      clearTimeout(timeout);
+      parentSignal?.removeEventListener('abort', abortFromParent);
+    },
+  };
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw abortReason(signal);
+}
+
+function abortReason(signal?: AbortSignal): Error {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The request was aborted.', 'AbortError');
+}

--- a/src/kernel/requestLimits.ts
+++ b/src/kernel/requestLimits.ts
@@ -2,6 +2,10 @@
 export const DEFAULT_HTTP_MAX_RETRIES = 2 as const;
 /** Remote Bible adapters are pinned so generic-client changes cannot consume enrichment headroom. */
 export const BIBLE_TEXT_HTTP_MAX_RETRIES = 2 as const;
+/** One MCP Bible-tool invocation, including all retries and text enrichment. */
+export const BIBLE_TOOL_CALL_DEADLINE_MS = 30_000 as const;
+/** Bound provider fan-out without serializing an eight-translation comparison. */
+export const BIBLE_TRANSLATION_LOOKUP_CONCURRENCY = 4 as const;
 export const PARALLEL_TEXT_LOOKUP_BUDGET = 12 as const;
 
 /**

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -13,6 +13,11 @@ import type { CallToolResult, ContentBlock, TextContent, Tool } from '@modelcont
 
 // ── Tool infrastructure ──
 
+export interface RequestContext {
+  /** Cancellation from the active request. */
+  signal?: AbortSignal;
+}
+
 export interface ToolHandler {
   name: string;
   description: string;
@@ -21,7 +26,7 @@ export interface ToolHandler {
   /** Optional cross-field validation that JSON Schema cannot fully express. */
   validateStructuredOutput?: (value: Record<string, unknown>) => boolean;
   annotations?: Tool['annotations'];
-  handler: (params: Record<string, unknown>) => Promise<ToolResult>;
+  handler: (params: Record<string, unknown>, context?: RequestContext) => Promise<ToolResult>;
 }
 
 export type ToolResult = Omit<CallToolResult, 'content' | 'structuredContent'> & {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -32,7 +32,7 @@ export function registerToolHandlers(
     })),
   }));
 
-  server.setRequestHandler('tools/call', async (request) => {
+  server.setRequestHandler('tools/call', async (request, context) => {
     const { name, arguments: args } = request.params;
     const tool = tools.find(candidate => candidate.name === name);
     if (!tool) {
@@ -64,7 +64,7 @@ export function registerToolHandlers(
 
     let result;
     try {
-      result = await tool.handler(toolArguments);
+      result = await tool.handler(toolArguments, { signal: context.mcpReq.signal });
     } catch {
       throw internalError();
     }

--- a/src/services/bible/BibleProviderPort.ts
+++ b/src/services/bible/BibleProviderPort.ts
@@ -7,7 +7,10 @@ export interface BibleProviderPort {
   getPassage(
     ref: BibleReference,
     translation: string,
-    options?: { readonly includeFootnotes?: boolean },
+    options?: {
+      readonly includeFootnotes?: boolean;
+      readonly signal?: AbortSignal;
+    },
   ): Promise<BibleResult>;
   isConfigured(): boolean;
 }

--- a/src/services/bible/BibleService.ts
+++ b/src/services/bible/BibleService.ts
@@ -5,9 +5,16 @@
  */
 
 import type { BibleProviderPort } from './BibleProviderPort.js';
-import type { BibleResult, BibleLookupMultipleResult, BibleLookupParams } from '../../kernel/types.js';
+import type {
+  BibleResult,
+  BibleLookupMultipleResult,
+  BibleLookupParams,
+  RequestContext,
+} from '../../kernel/types.js';
 import { parseReference, formatReference, referencesEqual } from '../../kernel/reference.js';
 import { APIError, ValidationError, NotFoundError } from '../../kernel/errors.js';
+import { BIBLE_TRANSLATION_LOOKUP_CONCURRENCY } from '../../kernel/requestLimits.js';
+import { throwIfAborted } from '../../kernel/requestDeadline.js';
 
 export class BibleService {
   private providersByTranslation = new Map<string, BibleProviderPort>();
@@ -20,7 +27,8 @@ export class BibleService {
     }
   }
 
-  async lookup(params: BibleLookupParams): Promise<BibleResult> {
+  async lookup(params: BibleLookupParams, context: RequestContext = {}): Promise<BibleResult> {
+    throwIfAborted(context.signal);
     const translation = this.resolveTranslation(params.translation);
     const ref = parseReference(params.reference);
 
@@ -38,36 +46,51 @@ export class BibleService {
 
     const result = await provider.getPassage(ref, translation, {
       includeFootnotes: params.includeFootnotes,
+      signal: context.signal,
     });
+    throwIfAborted(context.signal);
     this.assertResultConsistency(ref, translation, result);
     return result;
   }
 
   /** Look up the same reference in multiple translations */
-  async lookupMultiple(reference: string, translations: string[]): Promise<BibleLookupMultipleResult> {
+  async lookupMultiple(
+    reference: string,
+    translations: string[],
+    options: Pick<BibleLookupParams, 'includeFootnotes'> = {},
+    context: RequestContext = {},
+  ): Promise<BibleLookupMultipleResult> {
     const ref = parseReference(reference);
-    const results: BibleResult[] = [];
-    const failures: BibleLookupMultipleResult['failures'] = [];
+    type Outcome = { result: BibleResult } | { failure: BibleLookupMultipleResult['failures'][number] };
+    const outcomes = new Array<Outcome>(translations.length);
 
-    for (const t of translations) {
+    await mapWithConcurrency(translations, BIBLE_TRANSLATION_LOOKUP_CONCURRENCY, async (t, index) => {
       const upper = t.toUpperCase();
       const provider = this.providersByTranslation.get(upper);
       if (!provider) {
-        failures.push({ translation: upper, reason: 'Translation is not supported by this server.' });
-        continue;
+        outcomes[index] = { failure: { translation: upper, reason: 'Translation is not supported by this server.' } };
+        return;
       }
       if (!provider.isConfigured()) {
-        failures.push({ translation: upper, reason: 'Translation provider is not configured.' });
-        continue;
+        outcomes[index] = { failure: { translation: upper, reason: 'Translation provider is not configured.' } };
+        return;
       }
       try {
-        const result = await provider.getPassage(ref, upper);
+        throwIfAborted(context.signal);
+        const result = await provider.getPassage(ref, upper, {
+          includeFootnotes: options.includeFootnotes,
+          signal: context.signal,
+        });
+        throwIfAborted(context.signal);
         this.assertResultConsistency(ref, upper, result);
-        results.push(result);
+        outcomes[index] = { result };
       } catch {
-        failures.push({ translation: upper, reason: 'Translation could not be retrieved.' });
+        outcomes[index] = { failure: { translation: upper, reason: 'Translation could not be retrieved.' } };
       }
-    }
+    });
+
+    const results = outcomes.flatMap(outcome => outcome && 'result' in outcome ? [outcome.result] : []);
+    const failures = outcomes.flatMap(outcome => outcome && 'failure' in outcome ? [outcome.failure] : []);
 
     return { reference: formatReference(ref), results, failures };
   }
@@ -104,4 +127,19 @@ export class BibleService {
       throw new APIError(502, 'Bible provider returned an empty passage.');
     }
   }
+}
+
+async function mapWithConcurrency<T>(
+  values: readonly T[],
+  concurrency: number,
+  mapper: (value: T, index: number) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  const workers = Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+    while (next < values.length) {
+      const index = next++;
+      await mapper(values[index], index);
+    }
+  });
+  await Promise.all(workers);
 }

--- a/src/services/bible/ParallelPassageService.ts
+++ b/src/services/bible/ParallelPassageService.ts
@@ -12,6 +12,7 @@ import type {
   ParallelTextEnrichment,
   ParallelTextEnrichmentStatus,
   ParallelTextTranslation,
+  RequestContext,
   ResearchLegacyParallel,
   SourceAttestedParallelGroupResult,
   SourceAttestedResultWindow,
@@ -79,7 +80,10 @@ export class ParallelPassageService {
     this.indexDatabase(raw);
   }
 
-  async lookup(params: ParallelPassageLookupParams): Promise<ParallelPassageResearchResult> {
+  async lookup(
+    params: ParallelPassageLookupParams,
+    context: RequestContext = {},
+  ): Promise<ParallelPassageResearchResult> {
     validateCursorIsolation(params);
     const corpora = normalizeCorpora(params);
     const primaryReference = normalizeResearchReference(params.reference);
@@ -117,6 +121,7 @@ export class ParallelPassageService {
         params.translation || 'ESV',
         warnings,
         provenance,
+        context,
       )
       : notRequestedTextEnrichment(
         orderedUniqueParallelTextTargets(sourceAttestedGroups, legacyParallels).length,
@@ -263,6 +268,7 @@ export class ParallelPassageService {
     translation: ParallelTextTranslation,
     warnings: string[],
     provenance: ProvenanceRecord[],
+    context: RequestContext,
   ): Promise<ParallelTextEnrichment> {
     const targets: Array<{
       reference: string;
@@ -310,7 +316,10 @@ export class ParallelPassageService {
         try {
           outcomes.set(plan.reference, {
             status: 'succeeded',
-            result: await this.bibleService!.lookup({ reference: plan.reference, translation }),
+            result: await this.bibleService!.lookup(
+              { reference: plan.reference, translation },
+              context,
+            ),
           });
         } catch {
           outcomes.set(plan.reference, { status: 'failed' });

--- a/src/tools/v2/bibleLookup.ts
+++ b/src/tools/v2/bibleLookup.ts
@@ -9,6 +9,8 @@ import { formatBibleResponse, formatMultiBibleResponse } from '../../formatters/
 import { handleToolError } from '../../kernel/errors.js';
 import { bibleLookupOutputSchema } from '../../mcp/schemas/bibleLookup.js';
 import { presentBibleLookupStructured } from '../../presenters/bibleStructured.js';
+import { BIBLE_TOOL_CALL_DEADLINE_MS } from '../../kernel/requestLimits.js';
+import { createRequestDeadline } from '../../kernel/requestDeadline.js';
 
 export function createBibleLookupHandler(bibleService: BibleService): ToolHandler {
   return {
@@ -34,7 +36,8 @@ export function createBibleLookupHandler(bibleService: BibleService): ToolHandle
     outputSchema: bibleLookupOutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
 
-    handler: async (params) => {
+    handler: async (params, context) => {
+      const deadline = createRequestDeadline(BIBLE_TOOL_CALL_DEADLINE_MS, context?.signal);
       try {
         const translations = resolveTranslations(params.translation);
 
@@ -43,7 +46,7 @@ export function createBibleLookupHandler(bibleService: BibleService): ToolHandle
             reference: params.reference as string,
             translation: translations[0],
             includeFootnotes: params.includeFootnotes as boolean,
-          });
+          }, { signal: deadline.signal });
           return {
             content: [{ type: 'text', text: formatBibleResponse(result) }],
             structuredContent: presentBibleLookupStructured(
@@ -54,7 +57,12 @@ export function createBibleLookupHandler(bibleService: BibleService): ToolHandle
           };
         }
 
-        const results = await bibleService.lookupMultiple(params.reference as string, translations);
+        const results = await bibleService.lookupMultiple(
+          params.reference as string,
+          translations,
+          { includeFootnotes: params.includeFootnotes as boolean },
+          { signal: deadline.signal },
+        );
         return {
           content: [{ type: 'text', text: formatMultiBibleResponse(results) }],
           structuredContent: presentBibleLookupStructured(
@@ -65,6 +73,8 @@ export function createBibleLookupHandler(bibleService: BibleService): ToolHandle
         };
       } catch (error) {
         return handleToolError(error as Error);
+      } finally {
+        deadline.dispose();
       }
     },
   };

--- a/src/tools/v2/parallelPassages.ts
+++ b/src/tools/v2/parallelPassages.ts
@@ -9,6 +9,8 @@ import { handleToolError } from '../../kernel/errors.js';
 import { parallelPassagesOutputSchema } from '../../mcp/schemas/parallelPassages.js';
 import { presentParallelPassagesStructured } from '../../presenters/parallelPassagesStructured.js';
 import { validateParallelPassagesOutputSemantics } from '../../mcp/parallelPassagesOutputValidation.js';
+import { BIBLE_TOOL_CALL_DEADLINE_MS } from '../../kernel/requestLimits.js';
+import { createRequestDeadline } from '../../kernel/requestDeadline.js';
 
 export function createParallelPassagesHandler(service: ParallelPassageService): ToolHandler {
   return {
@@ -56,7 +58,8 @@ export function createParallelPassagesHandler(service: ParallelPassageService): 
     validateStructuredOutput: validateParallelPassagesOutputSemantics,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
 
-    handler: async (params) => {
+    handler: async (params, context) => {
+      const deadline = createRequestDeadline(BIBLE_TOOL_CALL_DEADLINE_MS, context?.signal);
       try {
         const result = await service.lookup({
           reference: params.reference as string,
@@ -70,13 +73,15 @@ export function createParallelPassagesHandler(service: ParallelPassageService): 
           includeAlignment: params.includeAlignment as boolean,
           includeOpenBibleCrossReferences: params.includeOpenBibleCrossReferences as boolean,
           useCrossReferences: params.useCrossReferences as boolean,
-        });
+        }, { signal: deadline.signal });
         return {
           content: [{ type: 'text', text: formatParallelPassageResearch(result) }],
           structuredContent: presentParallelPassagesStructured(result),
         };
       } catch (error) {
         return handleToolError(error as Error);
+      } finally {
+        deadline.dispose();
       }
     },
   };

--- a/test/integration/current/mcp-protocol.test.ts
+++ b/test/integration/current/mcp-protocol.test.ts
@@ -335,7 +335,10 @@ describe.each(SERVER_FACTORIES)('$name protocol contract', ({ create, logging })
             startVerse: 16,
           }),
           translation: 'ESV',
-          options: { includeFootnotes: undefined },
+          options: {
+            includeFootnotes: undefined,
+            signal: expect.any(AbortSignal),
+          },
         },
       ]);
       expect(result.content).toEqual([

--- a/test/unit/adapters/shared/HttpClient.test.ts
+++ b/test/unit/adapters/shared/HttpClient.test.ts
@@ -2,13 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HttpClient } from '../../../../src/adapters/shared/HttpClient.js';
 import {
   DEFAULT_HTTP_MAX_RETRIES,
+  BIBLE_TOOL_CALL_DEADLINE_MS,
   BIBLE_TEXT_HTTP_MAX_RETRIES,
+  BIBLE_TRANSLATION_LOOKUP_CONCURRENCY,
   CLOUDFLARE_FREE_EXTERNAL_SUBREQUEST_LIMIT,
   PARALLEL_TEXT_LOOKUP_BUDGET,
   PARALLEL_TEXT_RESERVED_SUBREQUEST_HEADROOM,
 } from '../../../../src/kernel/requestLimits.js';
 import { createBibleHttpClient } from '../../../../src/adapters/bible/createBibleHttpClient.js';
 import { AdapterError } from '../../../../src/kernel/errors.js';
+import { RequestDeadlineExceededError } from '../../../../src/kernel/requestDeadline.js';
 
 describe('HttpClient timeouts', () => {
   let originalFetch: typeof globalThis.fetch;
@@ -93,6 +96,85 @@ describe('HttpClient timeouts', () => {
     expect(vi.getTimerCount()).toBe(0);
     client.dispose();
   });
+
+  it('propagates caller cancellation through fetch without retrying', async () => {
+    const controller = new AbortController();
+    globalThis.fetch = vi.fn().mockImplementation((_url, init) => new Promise((_resolve, reject) => {
+      const signal = init?.signal as AbortSignal;
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }));
+    const client = new HttpClient({
+      source: 'Test', cacheTtlMs: 0, maxRetries: 2, timeoutMs: 15_000,
+    });
+
+    const request = client.getText('https://example.test/cancelled', { signal: controller.signal });
+    controller.abort(new DOMException('client cancelled', 'AbortError'));
+
+    await expect(request).rejects.toMatchObject({
+      name: 'AdapterError',
+      message: '[Test] Request was cancelled.',
+    });
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    client.dispose();
+  });
+
+  it('interrupts a stalled body read and starts best-effort stream cancellation', async () => {
+    const controller = new AbortController();
+    const reader = {
+      read: vi.fn(() => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {})),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      releaseLock: vi.fn(),
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      body: { getReader: () => reader },
+    } as unknown as Response);
+    const client = new HttpClient({
+      source: 'Test', cacheTtlMs: 0, maxRetries: 0, timeoutMs: 15_000,
+    });
+
+    const request = client.getText('https://example.test/stalled-body', { signal: controller.signal });
+    await Promise.resolve();
+    controller.abort(new DOMException('client cancelled', 'AbortError'));
+
+    await expect(request).rejects.toMatchObject({ message: '[Test] Request was cancelled.' });
+    expect(reader.cancel).toHaveBeenCalledOnce();
+    expect(reader.releaseLock).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    client.dispose();
+  });
+
+  it('interrupts retry backoff and prevents the next provider attempt', async () => {
+    const controller = new AbortController();
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network failure'));
+    const client = new HttpClient({
+      source: 'Test', cacheTtlMs: 0, maxRetries: 2, timeoutMs: 15_000,
+    });
+
+    const request = client.getText('https://example.test/backoff', { signal: controller.signal });
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort(new DOMException('client cancelled', 'AbortError'));
+
+    await expect(request).rejects.toMatchObject({ message: '[Test] Request was cancelled.' });
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    client.dispose();
+  });
+
+  it('distinguishes the enclosing deadline from direct caller cancellation internally', async () => {
+    const controller = new AbortController();
+    controller.abort(new RequestDeadlineExceededError());
+    globalThis.fetch = vi.fn();
+    const client = new HttpClient({ source: 'Test', cacheTtlMs: 0 });
+
+    await expect(client.getText('https://example.test/deadline', { signal: controller.signal }))
+      .rejects.toMatchObject({ message: '[Test] Request deadline exceeded.' });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+    client.dispose();
+  });
 });
 
 describe('HttpClient requests, caching, and errors', () => {
@@ -111,6 +193,8 @@ describe('HttpClient requests, caching, and errors', () => {
   it('keeps parallel text enrichment below the reviewed upstream-attempt headroom', () => {
     expect(DEFAULT_HTTP_MAX_RETRIES).toBe(2);
     expect(BIBLE_TEXT_HTTP_MAX_RETRIES).toBe(2);
+    expect(BIBLE_TOOL_CALL_DEADLINE_MS).toBe(30_000);
+    expect(BIBLE_TRANSLATION_LOOKUP_CONCURRENCY).toBe(4);
     expect((1 + BIBLE_TEXT_HTTP_MAX_RETRIES) * PARALLEL_TEXT_LOOKUP_BUDGET)
       .toBeLessThanOrEqual(
         CLOUDFLARE_FREE_EXTERNAL_SUBREQUEST_LIMIT - PARALLEL_TEXT_RESERVED_SUBREQUEST_HEADROOM,
@@ -170,6 +254,19 @@ describe('HttpClient requests, caching, and errors', () => {
       .resolves.toEqual({ kind: 'json' });
 
     expect(globalThis.fetch).toHaveBeenCalledTimes(3);
+    client.dispose();
+  });
+
+  it('does not serve a cache hit after its caller has been cancelled', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response('cached'));
+    const client = new HttpClient({ source: 'Test', cacheTtlMs: 60_000 });
+    await client.getText('https://example.test/cached');
+    const controller = new AbortController();
+    controller.abort(new DOMException('client cancelled', 'AbortError'));
+
+    await expect(client.getText('https://example.test/cached', { signal: controller.signal }))
+      .rejects.toMatchObject({ message: '[Test] Request was cancelled.' });
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
     client.dispose();
   });
 
@@ -243,6 +340,23 @@ describe('HttpClient requests, caching, and errors', () => {
       message: expect.stringContaining('HTTP 404: Not Found'),
     });
     expect(globalThis.fetch).toHaveBeenCalledOnce();
+    client.dispose();
+  });
+
+  it('does not wait for non-OK response-body cleanup before failing', async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      body: { cancel },
+    } as unknown as Response);
+    const client = new HttpClient({ source: 'Test', maxRetries: 0, cacheTtlMs: 0 });
+
+    await expect(client.getText('https://example.test/missing')).rejects.toMatchObject({
+      message: expect.stringContaining('HTTP 404: Not Found'),
+    });
+    expect(cancel).toHaveBeenCalledOnce();
     client.dispose();
   });
 

--- a/test/unit/mcp/outputValidation.test.ts
+++ b/test/unit/mcp/outputValidation.test.ts
@@ -220,6 +220,7 @@ describe('MCP structured output validation', () => {
     await expect(client.callTool({ name: 'structured_test', arguments: {} }))
       .rejects.toMatchObject({ code: -32603, message: expect.stringContaining('Internal server error') });
     expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][1]).toEqual({ signal: expect.any(AbortSignal) });
   });
 
   it('rejects malformed successful structured results without disclosing payloads', async () => {

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -251,7 +251,10 @@ describe('shared MCP registration', () => {
       arguments: { reference: 'John 3:16' },
     });
     expect(result.content).toEqual([{ type: 'text', text: 'Result from bible_lookup' }]);
-    expect(root.tools[0].handler).toHaveBeenCalledWith({ reference: 'John 3:16' });
+    expect(root.tools[0].handler).toHaveBeenCalledWith(
+      { reference: 'John 3:16' },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it('preserves bounded UBS survey navigation in the parallel_passages tools/list contract', async () => {

--- a/test/unit/services/bible/BibleService.test.ts
+++ b/test/unit/services/bible/BibleService.test.ts
@@ -100,7 +100,7 @@ describe('BibleService', () => {
       expect(esvAdapter.getPassage).toHaveBeenCalledWith(
         expect.anything(),
         'ESV',
-        { includeFootnotes: true }
+        { includeFootnotes: true, signal: undefined }
       );
     });
   });
@@ -137,6 +137,28 @@ describe('BibleService', () => {
       expect(kjvAdapter.getPassage).toHaveBeenCalled();
     });
 
+    it('forwards footnotes and one cancellation signal to every translation provider', async () => {
+      const controller = new AbortController();
+
+      await service.lookupMultiple(
+        'John 3:16',
+        ['ESV', 'KJV'],
+        { includeFootnotes: true },
+        { signal: controller.signal },
+      );
+
+      expect(esvAdapter.getPassage).toHaveBeenCalledWith(
+        expect.anything(),
+        'ESV',
+        { includeFootnotes: true, signal: controller.signal },
+      );
+      expect(kjvAdapter.getPassage).toHaveBeenCalledWith(
+        expect.anything(),
+        'KJV',
+        { includeFootnotes: true, signal: controller.signal },
+      );
+    });
+
     it('reports unconfigured adapters without discarding successful translations', async () => {
       (kjvAdapter.isConfigured as ReturnType<typeof vi.fn>).mockReturnValue(false);
       const response = await service.lookupMultiple('John 3:16', ['ESV', 'KJV']);
@@ -163,6 +185,62 @@ describe('BibleService', () => {
       const response = await service.lookupMultiple('John 3:16', ['ESV', 'KJV']);
       expect(response.results[0].translation).toBe('ESV');
       expect(response.results[1].translation).toBe('KJV');
+    });
+
+    it('bounds concurrency while preserving requested order across partial failures', async () => {
+      let active = 0;
+      let maximumActive = 0;
+      const translations = ['ESV', 'KJV', 'WEB', 'BSB', 'ASV'];
+      const adapter = makeAdapter({
+        supportedTranslations: translations,
+        getPassage: vi.fn().mockImplementation(async (_ref, translation) => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
+          await new Promise(resolve => setTimeout(resolve, translation === 'ESV' ? 10 : 1));
+          active -= 1;
+          if (translation === 'KJV') throw new Error('unavailable');
+          return {
+            reference: 'John 3:16', translation, text: `${translation} text`,
+            citation: { source: 'Fixture' },
+          };
+        }),
+      });
+
+      const response = await new BibleService([adapter]).lookupMultiple('John 3:16', translations);
+
+      expect(maximumActive).toBe(4);
+      expect(response.results.map(result => result.translation)).toEqual(['ESV', 'WEB', 'BSB', 'ASV']);
+      expect(response.failures).toEqual([{
+        translation: 'KJV',
+        reason: 'Translation could not be retrieved.',
+      }]);
+    });
+
+    it('stops starting provider calls after cancellation and fills stable failure outcomes', async () => {
+      const controller = new AbortController();
+      const translations = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8'];
+      const getPassage = vi.fn().mockImplementation(async (
+        _ref: unknown,
+        _translation: string,
+        options?: { signal?: AbortSignal },
+      ) => new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+      }));
+      const runtime = new BibleService([makeAdapter({ supportedTranslations: translations, getPassage })]);
+
+      const pending = runtime.lookupMultiple(
+        'John 3:16',
+        translations,
+        {},
+        { signal: controller.signal },
+      );
+      expect(getPassage).toHaveBeenCalledTimes(4);
+      controller.abort(new DOMException('cancelled', 'AbortError'));
+
+      const response = await pending;
+      expect(getPassage).toHaveBeenCalledTimes(4);
+      expect(response.results).toEqual([]);
+      expect(response.failures.map(failure => failure.translation)).toEqual(translations);
     });
 
     it('reports unknown translations instead of omitting them', async () => {

--- a/test/unit/services/bible/ParallelPassageTextBudget.test.ts
+++ b/test/unit/services/bible/ParallelPassageTextBudget.test.ts
@@ -156,6 +156,19 @@ describe('ParallelPassageService fixed text-enrichment budget', () => {
     ]);
   });
 
+  it('shares one caller cancellation signal across the fixed enrichment budget', async () => {
+    const controller = new AbortController();
+    const lookup = successfulLookup();
+
+    await service(lookup).lookup({
+      reference: 'Matthew 1:1', corpora: ['ubs_source_attested', 'theologai_legacy'],
+      includeText: true, translation: 'WEB',
+    }, { signal: controller.signal });
+
+    expect(lookup).toHaveBeenCalledTimes(12);
+    expect(lookup.mock.calls.every((call) => call[1]?.signal === controller.signal)).toBe(true);
+  });
+
   it('does not backfill after failures and bounds deterministic failure examples', async () => {
     const lookup = vi.fn().mockImplementation(async ({ reference }) => {
       throw new Error(`Unavailable ${reference}`);

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -17,7 +17,8 @@ import {
   DonationService as DonationServiceClass,
   type DonationService,
 } from '../../../../src/services/donation/DonationService.js';
-import type { BibleService } from '../../../../src/services/bible/BibleService.js';
+import { BibleService } from '../../../../src/services/bible/BibleService.js';
+import type { BibleProviderPort } from '../../../../src/services/bible/BibleProviderPort.js';
 import type { CrossReferenceService } from '../../../../src/services/bible/CrossReferenceService.js';
 import type { ParallelPassageService } from '../../../../src/services/bible/ParallelPassageService.js';
 import type { CommentaryService } from '../../../../src/services/commentary/CommentaryService.js';
@@ -135,11 +136,14 @@ describe('bible_lookup handler', () => {
 
     const result = await handler.handler({ reference: 'John 3:16', includeFootnotes: true });
 
-    expect(lookup).toHaveBeenCalledWith({
-      reference: 'John 3:16',
-      translation: 'ESV',
-      includeFootnotes: true,
-    });
+    expect(lookup).toHaveBeenCalledWith(
+      {
+        reference: 'John 3:16',
+        translation: 'ESV',
+        includeFootnotes: true,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
     expect(lookupMultiple).not.toHaveBeenCalled();
     expect(textOf(result)).toContain('John 3:16 (ESV)');
     expect(textOf(result)).toContain('For God so loved the world.');
@@ -166,12 +170,57 @@ describe('bible_lookup handler', () => {
     const result = await handler.handler({
       reference: 'John 3:16',
       translation: ['ESV', 'KJV'],
+      includeFootnotes: true,
     });
 
-    expect(lookupMultiple).toHaveBeenCalledWith('John 3:16', ['ESV', 'KJV']);
+    expect(lookupMultiple).toHaveBeenCalledWith(
+      'John 3:16',
+      ['ESV', 'KJV'],
+      { includeFootnotes: true },
+      { signal: expect.any(AbortSignal) },
+    );
     expect(lookup).not.toHaveBeenCalled();
     expect(textOf(result)).toContain('(2 translations)');
     expect(textOf(result)).toContain('**KJV:**');
+  });
+
+  it('uses one overall deadline to stop queued translation work and cleans up its timer', async () => {
+    vi.useFakeTimers();
+    const translations = ['ESV', 'NET', 'KJV', 'WEB', 'BSB', 'ASV', 'YLT', 'DBY'];
+    const getPassage = vi.fn<BibleProviderPort['getPassage']>().mockImplementation(
+      async (_reference, _translation, options) => new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), { once: true });
+      }),
+    );
+    const service = new BibleService([{
+      supportedTranslations: translations,
+      getPassage,
+      isConfigured: () => true,
+    }]);
+    const handler = createBibleLookupHandler(service);
+
+    try {
+      const pending = handler.handler({ reference: 'John 3:16', translation: translations });
+      expect(getPassage).toHaveBeenCalledTimes(4);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await pending;
+
+      expect(result.isError).not.toBe(true);
+      expect(getPassage).toHaveBeenCalledTimes(4);
+      expect(result.structuredContent).toMatchObject({
+        passages: [],
+        failures: translations.map(translation => ({
+          translation,
+          reason: 'Translation could not be retrieved.',
+        })),
+      });
+      const sharedSignal = getPassage.mock.calls[0][2]?.signal;
+      expect(sharedSignal?.aborted).toBe(true);
+      expect(sharedSignal?.reason).toMatchObject({ name: 'RequestDeadlineExceededError' });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('accepts legacy JSON-encoded translation arrays and preserves partial results', async () => {
@@ -190,7 +239,12 @@ describe('bible_lookup handler', () => {
       translation: '["WEB","DBY"]',
     });
 
-    expect(lookupMultiple).toHaveBeenCalledWith('Psalm 23:1', ['WEB', 'DBY']);
+    expect(lookupMultiple).toHaveBeenCalledWith(
+      'Psalm 23:1',
+      ['WEB', 'DBY'],
+      { includeFootnotes: undefined },
+      { signal: expect.any(AbortSignal) },
+    );
     expect(textOf(result)).toContain('(2 translations requested; 1 available)');
     expect(textOf(result)).toContain('**WEB:**');
     expect(textOf(result)).toContain('**DBY:** unavailable');
@@ -237,7 +291,10 @@ describe('bible_lookup handler', () => {
 
     await handler.handler({ reference: 'John 3:16', translation: '[ESV' });
 
-    expect(lookup).toHaveBeenCalledWith(expect.objectContaining({ translation: '[ESV' }));
+    expect(lookup).toHaveBeenCalledWith(
+      expect.objectContaining({ translation: '[ESV' }),
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it('returns a tool error when lookup fails', async () => {
@@ -427,10 +484,13 @@ describe('parallel_passages handler', () => {
     const result = await handler.handler({ reference: 'John 3:16', ...materialized });
 
     expect(result.isError).not.toBe(true);
-    expect(lookup).toHaveBeenCalledWith(expect.objectContaining({
-      corpora: ['ubs_source_attested'], maxGroups: 5, includeAlignment: false,
-      includeOpenBibleCrossReferences: undefined, mode: undefined, maxParallels: undefined, useCrossReferences: undefined,
-    }));
+    expect(lookup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        corpora: ['ubs_source_attested'], maxGroups: 5, includeAlignment: false,
+        includeOpenBibleCrossReferences: undefined, mode: undefined, maxParallels: undefined, useCrossReferences: undefined,
+      }),
+      { signal: expect.any(AbortSignal) },
+    );
   });
   it('forwards all lookup controls and formats text-bearing parallels', async () => {
     const lookup = vi.fn<ParallelPassageService['lookup']>().mockResolvedValue({
@@ -474,18 +534,22 @@ describe('parallel_passages handler', () => {
       sourceAttestedResultWindow: { requestedLimit: 5, returnedGroupCount: 0, additionalMatchStatus: 'not_evaluated' },
     });
 
-    expect(lookup).toHaveBeenCalledWith({
-      reference: 'Matthew 26:26-28',
-      corpora: ['theologai_legacy'],
-      mode: 'synoptic',
-      includeText: true,
-      translation: 'KJV',
-      maxParallels: 4,
-      maxGroups: undefined,
-      includeAlignment: undefined,
-      includeOpenBibleCrossReferences: undefined,
-      useCrossReferences: false,
-    });
+    expect(lookup).toHaveBeenCalledWith(
+      {
+        reference: 'Matthew 26:26-28',
+        corpora: ['theologai_legacy'],
+        mode: 'synoptic',
+        includeText: true,
+        translation: 'KJV',
+        maxParallels: 4,
+        maxGroups: undefined,
+        groupCursor: undefined,
+        includeAlignment: undefined,
+        includeOpenBibleCrossReferences: undefined,
+        useCrossReferences: false,
+      },
+      { signal: expect.any(AbortSignal) },
+    );
     expect(textOf(result)).toContain('[synoptic] (95% confidence)');
     expect(textOf(result)).toContain('And as they were eating');
   });


### PR DESCRIPTION
Multi-translation Bible calls dropped `includeFootnotes` and awaited providers sequentially, with independent retries able to extend request latency. Forward the option to every translation, run at most four concurrently, and share a 30-second deadline across each Bible tool call and parallel-passage remote text enrichment. MCP cancellation reaches provider fetches, streamed body reads, and retry delays.

Preserve ordered successes/failures and completed passages. Queued provider work stops after cancellation/deadline, while parallel enrichment retains its existing 12-target budget and four-way concurrency. Cleanup never waits on an uncooperative response body. This is a remote-work deadline; local database queries and synchronous formatting cannot be preempted by it.

Validation: full typecheck matrix and build passed; Workerd runtime 26/26; focused checks 215/215; current integration 3/3; documentation contracts 14/14. Tests exercise the shared deadline, queued work, stable ordering, option forwarding, caller cancellation, stalled body reads, backoff interruption, cache cancellation, and timer cleanup. A clean combined checkout of #155–#159 passed all 2,658 unit tests (five existing skips), three integration tests, 26 Workerd tests, the full typecheck matrix, build, and full-corpus benchmark.

The existing dependency audit blocker is addressed separately by #156. This branch is based on main. Preserve its `context.mcpReq.signal` forwarding when integrating the #157 tool-observability registrar edit; both behaviors were verified together in the combined checkout.

Draft for owner review. Do not merge until the owner has reviewed it. No deployment or production configuration changes.
