### PR TITLE
Fix four MCP black-box audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "happy-dom": "^20.0.4",
         "miniflare": "4.20260722.0",
         "nodemon": "^3.1.14",
-        "smol-toml": "^1.6.1",
+        "smol-toml": "^1.8.0",
         "tsx": "^4.20.6",
         "vite": "8.1.5",
         "vitest": "4.1.10",
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
-      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -788,13 +788,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
-      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -811,13 +811,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.1"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
-      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -825,7 +825,7 @@
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.2"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -835,9 +835,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
-      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -852,9 +852,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
-      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -869,9 +869,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
-      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -886,9 +886,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
-      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -903,9 +903,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
-      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
-      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
-      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
-      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -971,9 +971,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
-      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
-      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -1005,9 +1005,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
-      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -1024,13 +1024,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.1"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
-      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1047,13 +1047,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.1"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
-      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1070,13 +1070,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
-      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -1093,13 +1093,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
-      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -1116,13 +1116,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.1"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
-      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -1139,13 +1139,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.1"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
-      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -1162,13 +1162,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
-      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -1185,18 +1185,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
-      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1205,10 +1205,21 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
-      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
@@ -1216,7 +1227,7 @@
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.2"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1226,9 +1237,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
-      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -1246,9 +1257,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
-      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -1266,9 +1277,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
-      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -4663,15 +4674,15 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
-      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.8.4"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -4680,31 +4691,36 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.2",
-        "@img/sharp-darwin-x64": "0.35.2",
-        "@img/sharp-freebsd-wasm32": "0.35.2",
-        "@img/sharp-libvips-darwin-arm64": "1.3.1",
-        "@img/sharp-libvips-darwin-x64": "1.3.1",
-        "@img/sharp-libvips-linux-arm": "1.3.1",
-        "@img/sharp-libvips-linux-arm64": "1.3.1",
-        "@img/sharp-libvips-linux-ppc64": "1.3.1",
-        "@img/sharp-libvips-linux-riscv64": "1.3.1",
-        "@img/sharp-libvips-linux-s390x": "1.3.1",
-        "@img/sharp-libvips-linux-x64": "1.3.1",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
-        "@img/sharp-linux-arm": "0.35.2",
-        "@img/sharp-linux-arm64": "0.35.2",
-        "@img/sharp-linux-ppc64": "0.35.2",
-        "@img/sharp-linux-riscv64": "0.35.2",
-        "@img/sharp-linux-s390x": "0.35.2",
-        "@img/sharp-linux-x64": "0.35.2",
-        "@img/sharp-linuxmusl-arm64": "0.35.2",
-        "@img/sharp-linuxmusl-x64": "0.35.2",
-        "@img/sharp-webcontainers-wasm32": "0.35.2",
-        "@img/sharp-win32-arm64": "0.35.2",
-        "@img/sharp-win32-ia32": "0.35.2",
-        "@img/sharp-win32-x64": "0.35.2"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -4887,9 +4903,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.8.0.tgz",
+      "integrity": "sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,8 @@
     "postcss": {
       "nanoid": "3.3.18"
     },
-    "undici": "7.29.0"
+    "undici": "7.29.0",
+    "sharp": "0.35.4"
   },
   "dependencies": {
     "@cfworker/json-schema": "4.1.1",
@@ -148,7 +149,7 @@
     "happy-dom": "^20.0.4",
     "miniflare": "4.20260722.0",
     "nodemon": "^3.1.14",
-    "smol-toml": "^1.6.1",
+    "smol-toml": "^1.8.0",
     "tsx": "^4.20.6",
     "vite": "8.1.5",
     "vitest": "4.1.10",

--- a/src/adapters/bible/EsvAdapter.ts
+++ b/src/adapters/bible/EsvAdapter.ts
@@ -41,6 +41,7 @@ export class EsvAdapter implements BibleProviderPort {
       q: refStr,
       'include-headings': 'false',
       'include-footnotes': String(options?.includeFootnotes ?? false),
+      'include-footnote-body': String(options?.includeFootnotes ?? false),
       'include-verse-numbers': 'true',
       'include-short-copyright': 'false',
     });
@@ -67,6 +68,12 @@ export class EsvAdapter implements BibleProviderPort {
       reference: data.canonical || refStr,
       translation: 'ESV',
       text: data.passages[0].trim(),
+      ...(options?.includeFootnotes ? {
+        footnoteDelivery: {
+          status: 'inline' as const,
+          reason: 'The ESV passage-text API embeds available footnote callouts and bodies in the passage text.',
+        },
+      } : {}),
       citation: {
         source: 'English Standard Version',
         copyright: COPYRIGHT,

--- a/src/adapters/bible/HelloAoAdapter.ts
+++ b/src/adapters/bible/HelloAoAdapter.ts
@@ -80,8 +80,19 @@ export class HelloAoAdapter implements BibleProviderPort {
     const text = verses.map(v => this.extractVerseText(v.content)).join(' ');
 
     let footnotes: Footnote[] | undefined;
-    if (options?.includeFootnotes && data.chapter.footnotes) {
-      footnotes = this.extractFootnotes(data.chapter.footnotes, hao.verse, hao.endVerse);
+    let footnoteDelivery: BibleResult['footnoteDelivery'];
+    if (options?.includeFootnotes) {
+      if (Array.isArray(data.chapter.footnotes)) {
+        footnotes = this.extractFootnotes(data.chapter.footnotes, hao.verse, hao.endVerse);
+        footnoteDelivery = footnotes.length > 0
+          ? { status: 'structured', noteCount: footnotes.length }
+          : { status: 'none', noteCount: 0 };
+      } else {
+        footnoteDelivery = {
+          status: 'unavailable',
+          reason: 'The translation provider response did not include footnote data.',
+        };
+      }
     }
 
     return {
@@ -89,6 +100,7 @@ export class HelloAoAdapter implements BibleProviderPort {
       translation: key,
       text,
       footnotes,
+      footnoteDelivery,
       citation: { source: meta.name, copyright: meta.copyright, url: meta.url },
     };
   }

--- a/src/adapters/bible/NetBibleAdapter.ts
+++ b/src/adapters/bible/NetBibleAdapter.ts
@@ -48,11 +48,23 @@ export class NetBibleAdapter implements BibleProviderPort {
     // Combine verses
     const html = data.map((v: any) => v.text || '').join(' ');
     const text = stripHtml(html);
+    const markerCount = options?.includeFootnotes
+      ? [...html.matchAll(/<n\b[^>]*\bid=["']\d+["'][^>]*\/?\s*>/gi)].length
+      : 0;
 
     return {
       reference: refStr,
       translation: 'NET',
       text,
+      ...(options?.includeFootnotes ? {
+        footnoteDelivery: markerCount > 0
+          ? {
+            status: 'unavailable' as const,
+            markerCount,
+            reason: 'The configured NET Bible public API returns note markers but not translator or study note bodies.',
+          }
+          : { status: 'none' as const, noteCount: 0, markerCount: 0 },
+      } : {}),
       citation: {
         source: 'New English Translation',
         copyright: COPYRIGHT,

--- a/src/formatters/bibleFormatter.ts
+++ b/src/formatters/bibleFormatter.ts
@@ -22,6 +22,8 @@ export function formatBibleResponse(data: BibleResult): string {
     }
   }
 
+  s += formatFootnoteDelivery(data, '\n');
+
   s += `\n*Source: ${data.citation.source}*`;
   if (data.citation.copyright) s += ` - ${data.citation.copyright}`;
   return s.trim();
@@ -49,6 +51,7 @@ export function formatMultiBibleResponse(data: BibleLookupMultipleResult | Bible
       }
       s += '\n';
     }
+    s += formatFootnoteDelivery(r, '', '\n\n');
   }
 
   if (failures.length > 0) {
@@ -64,6 +67,29 @@ export function formatMultiBibleResponse(data: BibleLookupMultipleResult | Bible
     s += `*Sources: ${sources.join(', ')}*`;
   }
   return s.trim();
+}
+
+function formatFootnoteDelivery(data: BibleResult, prefix: string, suffix = '\n'): string {
+  const delivery = data.footnoteDelivery;
+  if (!delivery || delivery.status === 'structured') return '';
+
+  let message: string;
+  switch (delivery.status) {
+    case 'inline':
+      message = delivery.reason ?? 'Available footnotes are embedded in the passage text.';
+      break;
+    case 'none':
+      message = 'No footnotes were returned for this passage.';
+      break;
+    case 'unavailable': {
+      const markers = delivery.markerCount == null
+        ? ''
+        : ` ${delivery.markerCount} note marker${delivery.markerCount === 1 ? '' : 's'} observed.`;
+      message = `Requested footnote text is unavailable.${markers}${delivery.reason ? ` ${delivery.reason}` : ''}`;
+      break;
+    }
+  }
+  return `${prefix}*Footnote status: ${message}*${suffix}`;
 }
 
 /** Format cross-reference results */

--- a/src/kernel/index.ts
+++ b/src/kernel/index.ts
@@ -159,6 +159,7 @@ export type {
   Citation,
   Reference,
   Footnote,
+  FootnoteDelivery,
   BibleResult,
   BibleTranslationFailure,
   BibleLookupMultipleResult,

--- a/src/kernel/reference.ts
+++ b/src/kernel/reference.ts
@@ -86,7 +86,8 @@ export function parseReference(input: string): BibleReference {
       validateReferenceBounds(ref);
       return ref;
     }
-    throw new Error(
+    throw new ValidationError(
+      'reference',
       `Invalid Bible reference: "${input}". Expected format like "John 3:16", "Genesis 1:1-5", or "Ps 23"`
     );
   }
@@ -121,7 +122,8 @@ function resolveBook(raw: string): BibleBook {
   const byAbbrev = findBookByAbbreviation(cleaned);
   if (byAbbrev) return byAbbrev;
 
-  throw new Error(
+  throw new ValidationError(
+    'reference',
     `Unknown Bible book: "${raw}". Try a full name (e.g. "Genesis") or common abbreviation (e.g. "Gen").`
   );
 }

--- a/src/kernel/sourceAttestedReference.ts
+++ b/src/kernel/sourceAttestedReference.ts
@@ -20,25 +20,116 @@ export interface SourceAttestedLookupReference {
 export const SOURCE_ATTESTED_OPEN_ENDED_VERSE = Number.MAX_SAFE_INTEGER;
 
 /**
- * Chapter maxima that differ in the source-owned Hebrew versification used by
- * the pinned UBS parallel-passage corpus. Keep this list explicit: accepting an
- * arbitrary positive verse would turn malformed English references into
- * authoritative-looking source searches.
+ * Complete set of chapter maxima where the source-owned Hebrew versification
+ * exceeds the English bounds. Derived from every `nativeCoordinateKeys` entry
+ * in the pinned TAHOT coordinate bridge (identity
+ * a7d103edbf0b29214634f25ce54feb72979e8a732c6c5caf62c3ecc23a12a790),
+ * not merely from verses observed in the parallel-passage corpus. Keeping the
+ * finite divergence set explicit prevents arbitrary positive verses from
+ * becoming authoritative-looking source searches.
  */
 const SOURCE_ATTESTED_MAX_VERSE_OVERRIDES: Readonly<Record<string, number>> = {
+  '1:32': 33,
+  '2:7': 29,
+  '2:21': 37,
+  '3:5': 26,
+  '4:17': 28,
+  '4:25': 19,
+  '4:30': 17,
+  '5:13': 19,
+  '5:23': 26,
+  '5:28': 69,
+  '9:21': 16,
+  '9:24': 23,
+  '10:19': 44,
   '11:5': 32,
+  '11:22': 54,
+  '12:12': 22,
+  '13:5': 41,
+  '13:12': 41,
+  '14:1': 18,
   '14:13': 23,
+  '16:3': 38,
+  '16:10': 40,
+  '18:40': 32,
+  '19:3': 9,
+  '19:4': 9,
+  '19:5': 13,
+  '19:6': 11,
+  '19:7': 18,
+  '19:8': 10,
+  '19:9': 21,
+  '19:12': 9,
   '19:18': 51,
+  '19:19': 15,
+  '19:20': 10,
+  '19:21': 14,
+  '19:22': 32,
+  '19:30': 13,
+  '19:31': 25,
+  '19:34': 23,
+  '19:36': 13,
+  '19:38': 23,
+  '19:39': 14,
   '19:40': 18,
+  '19:41': 14,
   '19:42': 12,
+  '19:44': 27,
+  '19:45': 18,
   '19:46': 12,
+  '19:47': 10,
+  '19:48': 15,
+  '19:49': 21,
+  '19:51': 21,
+  '19:52': 11,
   '19:53': 7,
+  '19:54': 9,
+  '19:55': 24,
+  '19:56': 14,
   '19:57': 12,
+  '19:58': 12,
+  '19:59': 18,
   '19:60': 14,
+  '19:61': 9,
+  '19:62': 13,
+  '19:63': 12,
+  '19:64': 11,
+  '19:65': 14,
+  '19:67': 8,
+  '19:68': 36,
+  '19:69': 37,
   '19:70': 6,
+  '19:75': 11,
+  '19:76': 13,
+  '19:77': 21,
+  '19:80': 20,
+  '19:81': 17,
+  '19:83': 19,
+  '19:84': 13,
+  '19:85': 14,
+  '19:88': 19,
+  '19:89': 53,
+  '19:92': 16,
+  '19:102': 29,
   '19:108': 14,
+  '19:140': 14,
+  '19:142': 8,
+  '21:4': 17,
+  '22:7': 14,
   '23:8': 23,
+  '24:8': 23,
+  '26:21': 37,
+  '27:3': 33,
+  '27:6': 29,
   '28:2': 25,
+  '28:12': 15,
+  '28:14': 10,
+  '29:4': 21,
+  '32:2': 11,
+  '33:4': 14,
+  '34:2': 14,
+  '38:2': 17,
+  '39:3': 24,
 };
 
 export function parseSourceAttestedLookupReference(input: string): SourceAttestedLookupReference {
@@ -60,6 +151,23 @@ export function parseSourceAttestedLookupReference(input: string): SourceAtteste
       // English verse maxima. Parse that narrow case below while retaining
       // canonical book/chapter validation.
     }
+
+    const sourceOnlyChapter = /^(.+?)\s+(\d+)$/.exec(raw);
+    if (sourceOnlyChapter) {
+      const book = findBook(sourceOnlyChapter[1]);
+      const chapter = safePositive(sourceOnlyChapter[2], input);
+      if (book && SOURCE_ATTESTED_MAX_VERSE_OVERRIDES[`${book.number}:${chapter}`] !== undefined) {
+        return {
+          normalizedReference: `${book.name} ${chapter}`,
+          segments: [{
+            bookNumber: book.number,
+            chapter,
+            startVerse: 1,
+            endVerse: SOURCE_ATTESTED_OPEN_ENDED_VERSE,
+          }],
+        };
+      }
+    }
   }
 
   const match = /^(.+?)\s+(\d+):(\d+(?:-\d+)?(?:,(?:\d+:)?\d+(?:-\d+)?)*)$/.exec(raw);
@@ -72,14 +180,17 @@ export function parseSourceAttestedLookupReference(input: string): SourceAtteste
     const full = /^(\d+):(\d+(?:-\d+)?)$/.exec(part);
     const chapter = full ? safePositive(full[1], input) : firstChapter;
     const canonicalBounds = getBibleBookBounds(book).maxVerseByChapter;
-    if (chapter > canonicalBounds.length) throw new Error(`Invalid source-attested reference: ${input}`);
+    const canonicalMaxVerse = canonicalBounds[chapter - 1];
+    const sourceMaxVerse = SOURCE_ATTESTED_MAX_VERSE_OVERRIDES[`${book.number}:${chapter}`];
+    if (canonicalMaxVerse === undefined && sourceMaxVerse === undefined) {
+      throw new Error(`Invalid source-attested reference: ${input}`);
+    }
     const versePart = full ? full[2] : part;
     const verse = /^(\d+)(?:-(\d+))?$/.exec(versePart);
     if (!verse) throw new Error(`Invalid source-attested reference: ${input}`);
     const startVerse = safePositive(verse[1], input);
     const endVerse = verse[2] ? safePositive(verse[2], input) : startVerse;
-    const maxVerse = SOURCE_ATTESTED_MAX_VERSE_OVERRIDES[`${book.number}:${chapter}`]
-      ?? canonicalBounds[chapter - 1];
+    const maxVerse = Math.max(canonicalMaxVerse ?? 0, sourceMaxVerse ?? 0);
     if (endVerse < startVerse || startVerse > maxVerse || endVerse > maxVerse) {
       throw new Error(`Invalid source-attested reference: ${input}`);
     }

--- a/src/kernel/sourceAttestedReference.ts
+++ b/src/kernel/sourceAttestedReference.ts
@@ -19,6 +19,28 @@ export interface SourceAttestedLookupReference {
  */
 export const SOURCE_ATTESTED_OPEN_ENDED_VERSE = Number.MAX_SAFE_INTEGER;
 
+/**
+ * Chapter maxima that differ in the source-owned Hebrew versification used by
+ * the pinned UBS parallel-passage corpus. Keep this list explicit: accepting an
+ * arbitrary positive verse would turn malformed English references into
+ * authoritative-looking source searches.
+ */
+const SOURCE_ATTESTED_MAX_VERSE_OVERRIDES: Readonly<Record<string, number>> = {
+  '11:5': 32,
+  '14:13': 23,
+  '19:18': 51,
+  '19:40': 18,
+  '19:42': 12,
+  '19:46': 12,
+  '19:53': 7,
+  '19:57': 12,
+  '19:60': 14,
+  '19:70': 6,
+  '19:108': 14,
+  '23:8': 23,
+  '28:2': 25,
+};
+
 export function parseSourceAttestedLookupReference(input: string): SourceAttestedLookupReference {
   const raw = input.trim();
   if (!raw.includes(',')) {
@@ -49,13 +71,18 @@ export function parseSourceAttestedLookupReference(input: string): SourceAtteste
   const segments = parts.map((part, index) => {
     const full = /^(\d+):(\d+(?:-\d+)?)$/.exec(part);
     const chapter = full ? safePositive(full[1], input) : firstChapter;
-    if (chapter > getBibleBookBounds(book).maxVerseByChapter.length) throw new Error(`Invalid source-attested reference: ${input}`);
+    const canonicalBounds = getBibleBookBounds(book).maxVerseByChapter;
+    if (chapter > canonicalBounds.length) throw new Error(`Invalid source-attested reference: ${input}`);
     const versePart = full ? full[2] : part;
     const verse = /^(\d+)(?:-(\d+))?$/.exec(versePart);
     if (!verse) throw new Error(`Invalid source-attested reference: ${input}`);
     const startVerse = safePositive(verse[1], input);
     const endVerse = verse[2] ? safePositive(verse[2], input) : startVerse;
-    if (endVerse < startVerse) throw new Error(`Invalid source-attested reference: ${input}`);
+    const maxVerse = SOURCE_ATTESTED_MAX_VERSE_OVERRIDES[`${book.number}:${chapter}`]
+      ?? canonicalBounds[chapter - 1];
+    if (endVerse < startVerse || startVerse > maxVerse || endVerse > maxVerse) {
+      throw new Error(`Invalid source-attested reference: ${input}`);
+    }
     return { bookNumber: book.number, chapter, startVerse, endVerse, index };
   });
   const normalized = segments.map((segment, index) => {

--- a/src/kernel/types.ts
+++ b/src/kernel/types.ts
@@ -64,12 +64,21 @@ export interface Footnote {
   };
 }
 
+/** How a provider fulfilled an explicit includeFootnotes request. */
+export interface FootnoteDelivery {
+  status: 'structured' | 'inline' | 'none' | 'unavailable';
+  noteCount?: number;
+  markerCount?: number;
+  reason?: string;
+}
+
 export interface BibleResult {
   reference: string;
   translation: string;
   text: string;
   crossReferences?: Reference[];
   footnotes?: Footnote[];
+  footnoteDelivery?: FootnoteDelivery;
   citation: Citation;
 }
 

--- a/src/mcp/prompts.ts
+++ b/src/mcp/prompts.ts
@@ -3,7 +3,7 @@ import { z } from 'zod/v4';
 import { parseReference } from '../kernel/reference.js';
 import { parseStrongsIdentity } from '../kernel/strongs.js';
 import { PUBLIC_DONATION_URL } from '../kernel/publicUrls.js';
-import { validatePromptArguments } from './validation.js';
+import { resolveComparisonTranslations, SUPPORTED_BIBLE_TRANSLATIONS, validatePromptArguments } from './validation.js';
 import { createPrimarySourceSearchDescriptor, type PrimarySourceSearchDescriptor } from './primarySourceSearchDescriptor.js';
 import { initialPrimarySourceLocalQuery } from './primarySourceQueryPlanning.js';
 
@@ -12,7 +12,7 @@ export interface RecommendedToolCall {
   arguments: Record<string, unknown>;
 }
 
-const TRANSLATIONS = new Set(['ESV', 'NET', 'KJV', 'WEB', 'BSB', 'ASV', 'YLT', 'DBY']);
+const TRANSLATIONS = new Set<string>(SUPPORTED_BIBLE_TRANSLATIONS);
 const CCEL_DATE_CAPABILITY_NOTICE = 'Expanded discovery does not provide reviewed composition-date filtering; any returned broader hit is not composition-date evidence.';
 const CCEL_DATED_FALLBACK_NOTICE = 'Expanded discovery deliberately omits the requested catalog composition-year bounds; any returned broader hit cannot establish membership in that requested range.';
 
@@ -95,12 +95,7 @@ export function recommendedToolCallsForPrompt(
     case 'compare-translations': {
       const reference = args?.reference ?? '';
       const singleVerse = isSingleVerseReference(reference);
-      const requested = (args?.translations || 'ESV,KJV,NET,BSB')
-        .split(',')
-        .map(item => item.trim().toUpperCase())
-        .filter(item => TRANSLATIONS.has(item));
-      const translations = [...new Set(requested)].slice(0, 8);
-      const selected = translations.length > 0 ? translations : ['ESV', 'KJV', 'NET', 'BSB'];
+      const selected = resolveComparisonTranslations(args?.translations);
       return [
         ...selected.map(item => ({ tool: 'bible_lookup', arguments: { reference, translation: item } })),
         ...(singleVerse ? [{ tool: 'bible_verse_morphology', arguments: { reference, expand_morphology: true } }] : []),
@@ -203,7 +198,7 @@ export function registerPromptHandlers(
         description: 'Compare a passage across multiple Bible translations to highlight differences in rendering',
         arguments: [
           { name: 'reference', description: 'Bible reference (e.g. "Philippians 2:6-8")', required: true },
-          { name: 'translations', description: 'Comma-separated list of translations. Default: ESV,KJV,NET,BSB.', required: false },
+          { name: 'translations', description: 'Comma-separated list using ESV, NET, KJV, WEB, BSB, ASV, YLT, or DBY. Default when omitted: ESV,KJV,NET,BSB.', required: false },
         ],
       },
       {

--- a/src/mcp/schemas/bibleLookup.ts
+++ b/src/mcp/schemas/bibleLookup.ts
@@ -18,6 +18,12 @@ export interface BibleLookupOutputV1 {
       chapter: number;
       verse: number;
     }>;
+    footnoteDelivery?: {
+      status: 'structured' | 'inline' | 'none' | 'unavailable';
+      noteCount?: number;
+      markerCount?: number;
+      reason?: string;
+    };
     provenanceIds: string[];
   }>;
   failures: Array<{ translation: string; reason: string }>;
@@ -57,6 +63,17 @@ export const bibleLookupOutputSchema = {
               required: ['caller', 'text', 'chapter', 'verse'],
               additionalProperties: false,
             },
+          },
+          footnoteDelivery: {
+            type: 'object',
+            properties: {
+              status: { type: 'string', enum: ['structured', 'inline', 'none', 'unavailable'] },
+              noteCount: { type: 'integer', minimum: 0, maximum: 1000 },
+              markerCount: { type: 'integer', minimum: 0, maximum: 1000 },
+              reason: { type: 'string', minLength: 1, maxLength: 500 },
+            },
+            required: ['status'],
+            additionalProperties: false,
           },
           provenanceIds: {
             type: 'array', minItems: 1, maxItems: 16, uniqueItems: true,

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -6,6 +6,10 @@ import {
 } from '@modelcontextprotocol/server';
 import { parseReference } from '../kernel/reference.js';
 
+export const SUPPORTED_BIBLE_TRANSLATIONS = ['ESV', 'NET', 'KJV', 'WEB', 'BSB', 'ASV', 'YLT', 'DBY'] as const;
+const SUPPORTED_BIBLE_TRANSLATION_SET = new Set<string>(SUPPORTED_BIBLE_TRANSLATIONS);
+const DEFAULT_COMPARISON_TRANSLATIONS = ['ESV', 'KJV', 'NET', 'BSB'] as const;
+
 export type SchemaValidationResult<T> = {
   valid: true;
   data: T;
@@ -117,6 +121,29 @@ const PROMPT_ARGUMENTS = {
   donate: { required: [], allowed: [] },
 } as const;
 
+export function resolveComparisonTranslations(value: string | undefined): string[] {
+  if (value === undefined) return [...DEFAULT_COMPARISON_TRANSLATIONS];
+
+  const requested = value.split(',').map(item => item.trim().toUpperCase());
+  const supportedList = SUPPORTED_BIBLE_TRANSLATIONS.join(', ');
+  if (requested.some(item => item.length === 0)) {
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      `Argument "translations" for prompt "compare-translations" must contain only non-empty comma-separated translation codes. Supported translations: ${supportedList}`,
+    );
+  }
+
+  const unsupported = [...new Set(requested.filter(item => !SUPPORTED_BIBLE_TRANSLATION_SET.has(item)))];
+  if (unsupported.length > 0) {
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      `Argument "translations" for prompt "compare-translations" contains unsupported translation${unsupported.length === 1 ? '' : 's'}: ${unsupported.join(', ')}. Supported translations: ${supportedList}`,
+    );
+  }
+
+  return [...new Set(requested)];
+}
+
 export function validatePromptArguments(
   name: unknown,
   args: unknown,
@@ -187,6 +214,10 @@ export function validatePromptArguments(
 
   if (['passage-exegesis', 'compare-translations'].includes(name) && (stringValues.reference?.length ?? 0) > 100) {
     throw new ProtocolError(ProtocolErrorCode.InvalidParams, `Argument "reference" for prompt "${name}" exceeds 100 characters`);
+  }
+
+  if (name === 'compare-translations') {
+    resolveComparisonTranslations(stringValues.translations);
   }
 
   if (name === 'primary-source-research') {

--- a/src/presenters/bibleStructured.ts
+++ b/src/presenters/bibleStructured.ts
@@ -36,6 +36,9 @@ export function presentBibleLookupStructured(
         verse: footnote.reference.verse,
       })),
     } : {}),
+    ...(result.footnoteDelivery ? {
+      footnoteDelivery: { ...result.footnoteDelivery },
+    } : {}),
     provenanceIds: [getProvenanceId(result, provenance, provenanceByKey)],
   }));
 

--- a/src/tools/v2/bibleLookup.ts
+++ b/src/tools/v2/bibleLookup.ts
@@ -28,7 +28,11 @@ export function createBibleLookupHandler(bibleService: BibleService): ToolHandle
           default: 'ESV',
           description: 'Translation(s). Single: "ESV". Compare: ["ESV","KJV","WEB"].',
         },
-        includeFootnotes: { type: 'boolean', default: false, description: 'Include footnotes and translation notes' },
+        includeFootnotes: {
+          type: 'boolean',
+          default: false,
+          description: 'Request available footnotes and translation notes. Each returned passage reports footnoteDelivery when enabled; provider support and delivery format vary.',
+        },
       },
       required: ['reference'],
       additionalProperties: false,

--- a/test/helpers/mcpTransportContract.ts
+++ b/test/helpers/mcpTransportContract.ts
@@ -69,15 +69,15 @@ const STATIC_RESOURCE_ORDER = [
 export const EXPECTED_MCP_CONTRACT_FINGERPRINTS: Record<'6' | '7', McpContractFingerprints> = {
   '6': {
     capabilities: '',
-    tools: '013cfd1b41e3ed8a30b0d7aa7dd6fa241d7481611af7c81c0805de478ab118b1',
-    prompts: 'a4b74048b785049c539bcc4868102e6143d4053a79e9da6cf0b41cc2fbf0fc60',
+    tools: '5a294c67a5faf01f8a91562f06ad55497a281fe52606ccb0f4c15abe7bf9b117',
+    prompts: '7e6ab1c22d32a9f520a4a2e2cc917df17827610462ef524b791ad0c06ff3133d',
     resourceTemplates: 'f67c92aa2f3f64ce0a55e0973b61346962edd1533c86024347b63483a04d6ca3',
     staticResources: '1a07ddfb5b7954de0f37d1bec03c0886e6235f63ef5611a557a8cde4424e201b',
   },
   '7': {
     capabilities: '',
-    tools: '21ad4813fa053e04065aca7028bbe97c288d58935c65e113ddc1d061ae9eded4',
-    prompts: 'a18ccf15c9a9bc3fd588aebe5ac8a5dc5cf9dec9ef67013c1494b5d2239b7a0f',
+    tools: '3db01fdd22ed671ff16a4749768b04a099154a7485c83469184a9c21c2a4e982',
+    prompts: 'ce77959ede84ac3e4910e253282c831e7cfaa07976771cc02b88a57a21764df4',
     resourceTemplates: 'f67c92aa2f3f64ce0a55e0973b61346962edd1533c86024347b63483a04d6ca3',
     staticResources: '1a07ddfb5b7954de0f37d1bec03c0886e6235f63ef5611a557a8cde4424e201b',
   },
@@ -189,6 +189,29 @@ export async function assertMcpTransportContract(
   invariant(
     (primary.annotations as JsonRecord | undefined)?.openWorldHint === (profile.contractVersion === '7'),
     `primary_source_search openWorldHint drifted for v${profile.contractVersion}`,
+  );
+
+  const bibleLookup = snapshot.tools.find(tool => tool.name === 'bible_lookup');
+  invariant(bibleLookup, 'bible_lookup is missing');
+  const bibleOutputProperties = (bibleLookup.outputSchema as JsonRecord | undefined)?.properties as JsonRecord | undefined;
+  const passages = bibleOutputProperties?.passages as JsonRecord | undefined;
+  const passageProperties = (passages?.items as JsonRecord | undefined)?.properties as JsonRecord | undefined;
+  const footnoteDelivery = passageProperties?.footnoteDelivery as JsonRecord | undefined;
+  const deliveryProperties = footnoteDelivery?.properties as JsonRecord | undefined;
+  invariant(
+    canonicalize((deliveryProperties?.status as JsonRecord | undefined)?.enum)
+      === canonicalize(['structured', 'inline', 'none', 'unavailable']),
+    'bible_lookup footnoteDelivery status contract drifted',
+  );
+
+  const comparePrompt = snapshot.prompts.find(prompt => prompt.name === 'compare-translations');
+  invariant(comparePrompt, 'compare-translations is missing');
+  const comparisonArguments = comparePrompt.arguments as JsonRecord[] | undefined;
+  const translationsArgument = comparisonArguments?.find(argument => argument.name === 'translations');
+  invariant(
+    typeof translationsArgument?.description === 'string'
+      && translationsArgument.description.includes('ESV, NET, KJV, WEB, BSB, ASV, YLT, or DBY'),
+    'compare-translations supported-translation contract drifted',
   );
 
   const fingerprints = await fingerprintMcpTransportSnapshot(snapshot);

--- a/test/unit/adapters/bible/EsvAdapter.test.ts
+++ b/test/unit/adapters/bible/EsvAdapter.test.ts
@@ -55,6 +55,10 @@ describe('EsvAdapter', () => {
         copyright: adapter.getCopyright(),
         url: 'https://www.esv.org/',
       },
+      footnoteDelivery: {
+        status: 'inline',
+        reason: 'The ESV passage-text API embeds available footnote callouts and bodies in the passage text.',
+      },
     });
 
     expect(adapter.isConfigured()).toBe(true);
@@ -63,6 +67,7 @@ describe('EsvAdapter', () => {
     expect(String(url)).toContain('https://api.esv.org/v3/passage/text/?');
     expect(String(url)).toContain('q=John+3%3A16-17');
     expect(String(url)).toContain('include-footnotes=true');
+    expect(String(url)).toContain('include-footnote-body=true');
     expect(init?.headers).toMatchObject({ Authorization: 'Token secret-key' });
   });
 
@@ -72,6 +77,8 @@ describe('EsvAdapter', () => {
 
     expect(result.reference).toBe('Psalms 23');
     expect(String(vi.mocked(globalThis.fetch).mock.calls[0][0])).toContain('include-footnotes=false');
+    expect(String(vi.mocked(globalThis.fetch).mock.calls[0][0])).toContain('include-footnote-body=false');
+    expect(result).not.toHaveProperty('footnoteDelivery');
   });
 
   it('accepts a common single-chapter canonical form from the provider', async () => {

--- a/test/unit/adapters/bible/HelloAoAdapter.test.ts
+++ b/test/unit/adapters/bible/HelloAoAdapter.test.ts
@@ -60,6 +60,7 @@ describe('HelloAoAdapter', () => {
         text: 'Or uniquely gave',
         reference: { chapter: 3, verse: 16 },
       }],
+      footnoteDelivery: { status: 'structured', noteCount: 1 },
       citation: {
         source: 'World English Bible',
         copyright: 'Public Domain',
@@ -114,6 +115,30 @@ describe('HelloAoAdapter', () => {
 
     const result = await new HelloAoAdapter().getPassage(parseReference('Genesis 1'), 'BSB', { includeFootnotes: true });
     expect(result.footnotes).toHaveLength(1);
+    expect(result.footnoteDelivery).toEqual({ status: 'structured', noteCount: 1 });
+  });
+
+  it('distinguishes no matching notes from unavailable provider note data', async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(response({
+        chapter: {
+          content: [{ type: 'verse', number: 1, content: ['First.'] }],
+          footnotes: [],
+        },
+      }))
+      .mockResolvedValueOnce(response({
+        chapter: { content: [{ type: 'verse', number: 1, content: ['First.'] }] },
+      }));
+
+    const adapter = new HelloAoAdapter();
+    const none = await adapter.getPassage(parseReference('Genesis 1:1'), 'KJV', { includeFootnotes: true });
+    const unavailable = await adapter.getPassage(parseReference('Genesis 1:1'), 'WEB', { includeFootnotes: true });
+
+    expect(none.footnoteDelivery).toEqual({ status: 'none', noteCount: 0 });
+    expect(unavailable.footnoteDelivery).toEqual({
+      status: 'unavailable',
+      reason: 'The translation provider response did not include footnote data.',
+    });
   });
 
   it('rejects an unsupported translation before making a request', async () => {

--- a/test/unit/adapters/bible/NetBibleAdapter.test.ts
+++ b/test/unit/adapters/bible/NetBibleAdapter.test.ts
@@ -19,8 +19,8 @@ describe('NetBibleAdapter', () => {
 
   it('maps a range request and combines sanitized verse text', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue(response([
-      { bookname: 'John', chapter: 1, verse: 1, text: '<b>In</b> the beginning&nbsp;' },
-      { bookname: 'John', chapter: 1, verse: 2, text: '<span>was the Word.</span>' },
+      { bookname: 'John', chapter: 1, verse: 1, text: '<b>In</b> the beginning<n id="1" />&nbsp;' },
+      { bookname: 'John', chapter: 1, verse: 2, text: '<span>was the Word.</span><n id="2" />' },
     ]));
     const adapter = new NetBibleAdapter();
 
@@ -39,6 +39,56 @@ describe('NetBibleAdapter', () => {
     expect(adapter.supportedTranslations).toEqual(['NET']);
     const url = String(vi.mocked(globalThis.fetch).mock.calls[0][0]);
     expect(url).toBe('https://labs.bible.org/api/?passage=John+1%3A1-2&formatting=full&type=json');
+  });
+
+  it('discloses that requested NET note bodies are unavailable while preserving the passage', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(response([
+      {
+        bookname: 'John', chapter: 1, verse: 1,
+        text: '<st data-num="1722">In</st> the beginning<n id="1" /> was the Word<n id="2" />.',
+      },
+    ]));
+
+    const result = await new NetBibleAdapter().getPassage(
+      parseReference('John 1:1'),
+      'NET',
+      { includeFootnotes: true },
+    );
+
+    expect(result.text).toBe('In the beginning was the Word.');
+    expect(result.footnotes).toBeUndefined();
+    expect(result.footnoteDelivery).toEqual({
+      status: 'unavailable',
+      markerCount: 2,
+      reason: 'The configured NET Bible public API returns note markers but not translator or study note bodies.',
+    });
+  });
+
+  it('keeps omitted and false footnote behavior compatible', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(response([
+      { bookname: 'John', chapter: 1, verse: 1, text: 'In the beginning<n id="1" />.' },
+    ]));
+
+    const adapter = new NetBibleAdapter();
+    const omitted = await adapter.getPassage(parseReference('John 1:1'), 'NET');
+    const disabled = await adapter.getPassage(parseReference('John 1:1'), 'NET', { includeFootnotes: false });
+
+    expect(omitted).toEqual(disabled);
+    expect(omitted).not.toHaveProperty('footnoteDelivery');
+  });
+
+  it('reports no notes when a notes-enabled NET response has no markers', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(response([
+      { bookname: 'John', chapter: 11, verse: 35, text: 'Jesus wept.' },
+    ]));
+
+    const result = await new NetBibleAdapter().getPassage(
+      parseReference('John 11:35'),
+      'NET',
+      { includeFootnotes: true },
+    );
+
+    expect(result.footnoteDelivery).toEqual({ status: 'none', noteCount: 0, markerCount: 0 });
   });
 
   it.each([

--- a/test/unit/formatters/bibleFormatter.test.ts
+++ b/test/unit/formatters/bibleFormatter.test.ts
@@ -70,6 +70,30 @@ describe('formatBibleResponse', () => {
     expect(out).not.toContain('**Footnotes:**');
   });
 
+  it('discloses unavailable requested notes without presenting passage retrieval as a failure', () => {
+    const out = formatBibleResponse(makeBibleResult({
+      translation: 'NET',
+      footnoteDelivery: {
+        status: 'unavailable',
+        markerCount: 3,
+        reason: 'The configured provider returns markers but not note bodies.',
+      },
+    }));
+
+    expect(out).toContain('Requested footnote text is unavailable. 3 note markers observed.');
+    expect(out).toContain('The configured provider returns markers but not note bodies.');
+    expect(out).toContain('*Source: ESV API*');
+  });
+
+  it('discloses inline and empty provider note delivery', () => {
+    expect(formatBibleResponse(makeBibleResult({
+      footnoteDelivery: { status: 'inline' },
+    }))).toContain('Available footnotes are embedded in the passage text.');
+    expect(formatBibleResponse(makeBibleResult({
+      footnoteDelivery: { status: 'none', noteCount: 0 },
+    }))).toContain('No footnotes were returned for this passage.');
+  });
+
   it('returns trimmed output', () => {
     const out = formatBibleResponse(makeBibleResult());
     expect(out).toBe(out.trim());
@@ -227,6 +251,21 @@ describe('formatMultiBibleResponse', () => {
     ]);
     expect(out).toContain('*Footnotes:*');
     expect(out).toContain('[1] (v16): tn: note');
+  });
+
+  it('preserves per-translation footnote delivery status in comparisons', () => {
+    const out = formatMultiBibleResponse([
+      makeBibleResult({ translation: 'ESV', footnoteDelivery: { status: 'inline' } }),
+      makeBibleResult({
+        translation: 'NET',
+        footnoteDelivery: { status: 'unavailable', markerCount: 1, reason: 'Note bodies are unavailable.' },
+      }),
+    ]);
+
+    expect(out).toContain('**ESV:**');
+    expect(out).toContain('Available footnotes are embedded in the passage text.');
+    expect(out).toContain('**NET:**');
+    expect(out).toContain('Requested footnote text is unavailable. 1 note marker observed. Note bodies are unavailable.');
   });
 
   it('deduplicates source citations', () => {

--- a/test/unit/helpers/mcpTransportContract.test.ts
+++ b/test/unit/helpers/mcpTransportContract.test.ts
@@ -23,6 +23,27 @@ function snapshot(version: '6' | '7', logging = false): McpTransportSnapshot {
     'bible_verse_morphology', 'original_language_study', 'donation_config', 'verify_donation',
   ];
   const tools = toolNames.map(name => descriptor(name, name === 'primary_source_search' ? version : '1'));
+  (tools[0] as any).outputSchema = {
+    type: 'object',
+    properties: {
+      schemaVersion: { const: '1' },
+      passages: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            footnoteDelivery: {
+              type: 'object',
+              properties: {
+                status: { type: 'string', enum: ['structured', 'inline', 'none', 'unavailable'] },
+              },
+            },
+          },
+        },
+      },
+    },
+    additionalProperties: false,
+  };
   tools[5]!.annotations.openWorldHint = version === '7';
   return {
     server: {
@@ -31,7 +52,16 @@ function snapshot(version: '6' | '7', logging = false): McpTransportSnapshot {
     },
     tools,
     prompts: ['word-study', 'passage-exegesis', 'compare-translations', 'confession-study', 'primary-source-research', 'donate']
-      .map(name => ({ name, description: `${name} prompt` })),
+      .map(name => ({
+        name,
+        description: `${name} prompt`,
+        ...(name === 'compare-translations' ? {
+          arguments: [{
+            name: 'translations',
+            description: 'Comma-separated list using ESV, NET, KJV, WEB, BSB, ASV, YLT, or DBY.',
+          }],
+        } : {}),
+      })),
     resourceTemplates: [
       { uriTemplate: 'theologai://documents/{slug}', name: 'Historical Document' },
       { uriTemplate: 'theologai://strongs/{number}', name: "Strong's Dictionary Entry" },
@@ -68,6 +98,13 @@ describe('MCP transport contract oracle', () => {
     ['template addition', (value: McpTransportSnapshot) => value.resourceTemplates.push({ uriTemplate: 'extra://{id}' })],
     ['primary v6/v7 drift', (value: McpTransportSnapshot) => {
       ((value.tools[5]!.outputSchema as any).properties.schemaVersion as any).const = '7';
+    }],
+    ['footnote-delivery status drift', (value: McpTransportSnapshot) => {
+      (((value.tools[0]!.outputSchema as any).properties.passages.items.properties.footnoteDelivery.properties.status as any).enum)
+        .pop();
+    }],
+    ['comparison-translation metadata drift', (value: McpTransportSnapshot) => {
+      (value.prompts[2]!.arguments as any)[0].description = 'Translations are silently filtered.';
     }],
   ])('rejects %s drift', async (_name, mutate) => {
     const actual = snapshot('6');

--- a/test/unit/kernel/reference.test.ts
+++ b/test/unit/kernel/reference.test.ts
@@ -11,6 +11,7 @@ import {
   toRomanNumeral,
 } from '../../../src/kernel/reference.js';
 import { BIBLE_BOOKS, getBibleBookBounds } from '../../../src/kernel/books.js';
+import { ValidationError } from '../../../src/kernel/errors.js';
 
 describe('parseReference', () => {
   it('parses "John 3:16"', () => {
@@ -92,10 +93,12 @@ describe('parseReference', () => {
   });
 
   it('throws on invalid format', () => {
-    expect(() => parseReference('just some text')).toThrow();
+    expect(() => parseReference('just some text')).toThrow(ValidationError);
+    expect(() => parseReference('just some text')).toThrow(/Expected format like/);
   });
 
   it('throws on unknown book', () => {
+    expect(() => parseReference('Hezekiah 1:1')).toThrow(ValidationError);
     expect(() => parseReference('Hezekiah 1:1')).toThrow('Unknown Bible book');
   });
 

--- a/test/unit/mcp/promptContracts.test.ts
+++ b/test/unit/mcp/promptContracts.test.ts
@@ -45,7 +45,7 @@ describe('prompt-recommended tool-call contracts', () => {
     ['passage-exegesis', { reference: 'John 3:16', translation: 'unsupported' }],
     ['passage-exegesis', { reference: 'Romans 8:28-30', translation: 'ESV' }],
     ['compare-translations', { reference: 'Philippians 2:6-8', translations: 'ESV,KJV,NET,BSB' }],
-    ['compare-translations', { reference: 'John 1:1', translations: 'unknown' }],
+    ['compare-translations', { reference: 'John 1:1', translations: 'kjv,web,KJV' }],
     ['confession-study', { topic: 'justification', traditions: 'Reformed, Lutheran' }],
     ['primary-source-research', { topic: "Lord's Supper", work: 'westminster-confession', maxSections: '2' }],
     ['primary-source-research', { topic: "Lord's Supper", authors: 'Philip Melanchthon,Westminster Assembly', startYear: '1500', endYear: '1700', maxSections: '2' }],
@@ -96,6 +96,15 @@ describe('prompt-recommended tool-call contracts', () => {
       tool: 'bible_verse_morphology',
       arguments: { reference: 'John 1:1', expand_morphology: true },
     });
+  });
+
+  it('normalizes and deduplicates explicitly selected comparison translations', () => {
+    expect(recommendedToolCallsForPrompt('compare-translations', {
+      reference: 'John 3:16', translations: ' kjv,web,KJV ',
+    }).filter(call => call.tool === 'bible_lookup')).toEqual([
+      { tool: 'bible_lookup', arguments: { reference: 'John 3:16', translation: 'KJV' } },
+      { tool: 'bible_lookup', arguments: { reference: 'John 3:16', translation: 'WEB' } },
+    ]);
   });
 
   it('never recommends a chapter to verse-only morphology or cross-reference tools', () => {

--- a/test/unit/mcp/server.test.ts
+++ b/test/unit/mcp/server.test.ts
@@ -1219,6 +1219,44 @@ describe('shared MCP registration', () => {
     });
   });
 
+  it.each([
+    ['Node', () => new BibleMCPServer(makeMockRoot(), 'comparison-validation-test').getServer()],
+    ['Worker', () => createWorkerMcpServer(makeMockRoot() as WorkerCompositionRoot, 'comparison-validation-test').server],
+  ])('rejects unsupported comparison translations with actionable errors on %s', async (_runtime, makeServer) => {
+    const client = await connect(makeServer());
+
+    await expect(client.getPrompt({
+      name: 'compare-translations',
+      arguments: { reference: 'John 3:16', translations: 'KJV,NIV,BOGUS' },
+    })).rejects.toMatchObject({
+      code: -32602,
+      message: expect.stringContaining('unsupported translations: NIV, BOGUS'),
+    });
+  });
+
+  it.each([
+    ['Node', () => new BibleMCPServer(makeMockRoot(), 'comparison-normalization-test').getServer()],
+    ['Worker', () => createWorkerMcpServer(makeMockRoot() as WorkerCompositionRoot, 'comparison-normalization-test').server],
+  ])('preserves defaults and supported normalization on %s', async (_runtime, makeServer) => {
+    const client = await connect(makeServer());
+    const defaults = await client.getPrompt({
+      name: 'compare-translations', arguments: { reference: 'John 3:16' },
+    });
+    const selected = await client.getPrompt({
+      name: 'compare-translations',
+      arguments: { reference: 'John 3:16', translations: 'kjv,web,KJV' },
+    });
+    const defaultText = textContent(defaults.messages[0]?.content);
+    const selectedText = textContent(selected.messages[0]?.content);
+
+    for (const translation of ['ESV', 'KJV', 'NET', 'BSB']) {
+      expect(defaultText).toContain(`"translation":"${translation}"`);
+    }
+    expect(selectedText.match(/`bible_lookup`/g)).toHaveLength(2);
+    expect(selectedText).toContain('"translation":"KJV"');
+    expect(selectedText).toContain('"translation":"WEB"');
+  });
+
   it('keeps tool/resource/prompt registrations identical while profiling logging by transport', async () => {
     const shared = await registrationSnapshot(
       createTheologAiMcpServer(makeMockRoot(), 'parity-test').server,

--- a/test/unit/mcp/validation.test.ts
+++ b/test/unit/mcp/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatValidationError, validatePromptArguments, validatorFor } from '../../../src/mcp/validation.js';
+import { formatValidationError, resolveComparisonTranslations, validatePromptArguments, validatorFor } from '../../../src/mcp/validation.js';
 import { createBibleLookupHandler } from '../../../src/tools/v2/bibleLookup.js';
 import { createClassicTextsHandler } from '../../../src/tools/v2/classicTexts.js';
 import { createCommentaryHandler } from '../../../src/tools/v2/commentary.js';
@@ -69,6 +69,27 @@ describe('Worker-safe JSON Schema validation', () => {
       word: 'love', reference: 'John 3:16',
     })).not.toThrow();
   });
+
+  it('defaults, normalizes, and deduplicates comparison translations', () => {
+    expect(resolveComparisonTranslations(undefined)).toEqual(['ESV', 'KJV', 'NET', 'BSB']);
+    expect(resolveComparisonTranslations(' kjv,web,KJV ')).toEqual(['KJV', 'WEB']);
+  });
+
+  it.each([
+    ['', 'non-empty comma-separated translation codes'],
+    ['   ', 'non-empty comma-separated translation codes'],
+    ['KJV,,WEB', 'non-empty comma-separated translation codes'],
+    ['NIV', 'unsupported translation: NIV'],
+    ['KJV,NIV,BOGUS', 'unsupported translations: NIV, BOGUS'],
+  ])('rejects invalid explicitly supplied comparison translations (%j)', (translations, message) => {
+    expect(() => validatePromptArguments('compare-translations', {
+      reference: 'John 3:16', translations,
+    })).toThrow(expect.objectContaining({
+      code: -32602,
+      message: expect.stringContaining(message),
+    }));
+  });
+
   it('validates the two advertised output schemas with the same Worker-safe validator', () => {
     const bible = validatorFor(bibleLookupOutputSchema);
     const language = validatorFor(originalLanguageOutputSchema);

--- a/test/unit/presenters/bibleStructured.test.ts
+++ b/test/unit/presenters/bibleStructured.test.ts
@@ -19,6 +19,7 @@ describe('Bible structured presenter', () => {
         text: 'A translation note.',
         reference: { chapter: 3, verse: 16 },
       }],
+      footnoteDelivery: { status: 'structured', noteCount: 1 },
       citation,
     }, 'John 3:16', ['ESV']);
 
@@ -32,6 +33,7 @@ describe('Bible structured presenter', () => {
         translation: 'ESV',
         text: 'For God so loved the world.',
         footnotes: [{ caller: 'a', text: 'A translation note.', chapter: 3, verse: 16 }],
+        footnoteDelivery: { status: 'structured', noteCount: 1 },
         provenanceIds: ['src-1'],
       }],
     });
@@ -45,6 +47,27 @@ describe('Bible structured presenter', () => {
       status: 'provider_attributed',
     })]);
     expect(result.provenance[0]).not.toHaveProperty('license');
+  });
+
+  it('preserves an unavailable note-body disclosure for one translation without adding a failure', () => {
+    const result = presentBibleLookupStructured({
+      reference: 'John 1:1',
+      translation: 'NET',
+      text: 'In the beginning was the Word.',
+      footnoteDelivery: {
+        status: 'unavailable',
+        markerCount: 3,
+        reason: 'The configured NET Bible public API returns note markers but not note bodies.',
+      },
+      citation: { source: 'New English Translation' },
+    }, 'John 1:1', ['NET']);
+
+    expect(result.passages[0].footnoteDelivery).toEqual({
+      status: 'unavailable',
+      markerCount: 3,
+      reason: 'The configured NET Bible public API returns note markers but not note bodies.',
+    });
+    expect(result.failures).toEqual([]);
   });
 
   it('adds authoritative ESV and NET source metadata without inventing licenses', () => {

--- a/test/unit/services/bible/ParallelPassageHardCutover.test.ts
+++ b/test/unit/services/bible/ParallelPassageHardCutover.test.ts
@@ -34,6 +34,19 @@ function legacyFixture() {
 
 describe('ParallelPassageService hard-cutover contract', () => {
   it.each([
+    'Matthew 26:999',
+    'Matthew 26:75-999',
+  ])('rejects an impossible canonical endpoint before UBS lookup: %s', async reference => {
+    const source = sourceService();
+    const service = new ParallelPassageService(
+      crossReferences(), undefined, undefined, legacyFixture(), source as any,
+    );
+
+    await expect(service.lookup({ reference })).rejects.toThrow(/out of range for Matthew 26/);
+    expect(source.lookup).not.toHaveBeenCalled();
+  });
+
+  it.each([
     { corpora: ['theologai_legacy'] as const },
     { corpora: ['ubs_source_attested', 'theologai_legacy'] as const },
     { mode: 'auto' as const },

--- a/test/unit/services/bible/SourceAttestedParallelService.test.ts
+++ b/test/unit/services/bible/SourceAttestedParallelService.test.ts
@@ -4,7 +4,9 @@ import { UbsParallelPassageRepository } from '../../../../src/adapters/shared/Ub
 import { SourceAttestedParallelService } from '../../../../src/services/bible/SourceAttestedParallelService.js';
 import { encodeParallelGroupCursor } from '../../../../src/kernel/parallelGroupCursor.js';
 import { parseSourceAttestedLookupReference } from '../../../../src/kernel/sourceAttestedReference.js';
+import { findBookByNumber, getBibleBookBounds } from '../../../../src/kernel/books.js';
 import { ubsFixture } from '../../../fixtures/ubsParallelCorpus.js';
+import { readFileSync } from 'node:fs';
 
 describe('SourceAttestedParallelService', () => {
   const fixtureRepository = (): UbsParallelPassageRepository => {
@@ -190,9 +192,68 @@ describe('SourceAttestedParallelService', () => {
     ['Psalms 60:13-14', 19, 60, 13],
     ['Isaiah 8:23', 23, 8, 23],
     ['Hosea 2:25', 28, 2, 25],
+    ['Joel 4:1-21', 29, 4, 1],
   ] as const)('preserves the bounded source-versification coordinate %s', (reference, bookNumber, chapter, startVerse) => {
     const parsed = parseSourceAttestedLookupReference(reference);
     expect(parsed.segments[0]).toMatchObject({ bookNumber, chapter, startVerse });
+  });
+
+  it('supports an open-ended query for a source-only chapter', () => {
+    expect(parseSourceAttestedLookupReference('Joel 4')).toEqual({
+      normalizedReference: 'Joel 4',
+      segments: [{
+        bookNumber: 29,
+        chapter: 4,
+        startVerse: 1,
+        endVerse: Number.MAX_SAFE_INTEGER,
+      }],
+    });
+  });
+
+  it('accepts a complete Hebrew Psalm range and retrieves its stored UBS member', async () => {
+    const artifact = JSON.parse(readFileSync(
+      new URL('../../../../src/data/ubs-parallel-passages.generated.json', import.meta.url),
+      'utf8',
+    )) as { artifactIdentity: string };
+    const repository = new UbsParallelPassageRepository(artifact, artifact.artifactIdentity);
+
+    const result = await new SourceAttestedParallelService(repository).lookup({
+      reference: 'Psalms 51:1-21',
+      maxGroups: 10,
+    });
+
+    expect(result.groups.some(group => group.members.some(member => (
+      member.sourceReference === 'PSA 51:6'
+    )))).toBe(true);
+    await expect(new SourceAttestedParallelService(repository).lookup({
+      reference: 'Psalms 51:1-22',
+    })).rejects.toThrow('reference must identify one canonical or source-versification Bible passage');
+  });
+
+  it('covers every chapter maximum in the pinned TAHOT native-coordinate inventory', () => {
+    const bridge = JSON.parse(readFileSync(
+      new URL('../../../../data/biblical-languages/ubs-open-license/v0.9.2/NATIVE-TO-NORMALIZED-BRIDGE.json', import.meta.url),
+      'utf8',
+    )) as { nativeCoordinateKeys: string[] };
+    const sourceMaxima = new Map<string, number>();
+    for (const key of bridge.nativeCoordinateKeys) {
+      const [bookNumber, chapter, verse] = key.split(':').map(Number);
+      const chapterKey = `${bookNumber}:${chapter}`;
+      sourceMaxima.set(chapterKey, Math.max(sourceMaxima.get(chapterKey) ?? 0, verse));
+    }
+
+    for (const [chapterKey, sourceMaxVerse] of sourceMaxima) {
+      const [bookNumber, chapter] = chapterKey.split(':').map(Number);
+      const book = findBookByNumber(bookNumber)!;
+      const canonicalMaxVerse = getBibleBookBounds(book).maxVerseByChapter[chapter - 1] ?? 0;
+      const acceptedMaxVerse = Math.max(sourceMaxVerse, canonicalMaxVerse);
+      expect(() => parseSourceAttestedLookupReference(
+        `${book.name} ${chapter}:1-${acceptedMaxVerse}`,
+      ), chapterKey).not.toThrow();
+      expect(() => parseSourceAttestedLookupReference(
+        `${book.name} ${chapter}:1-${acceptedMaxVerse + 1}`,
+      ), chapterKey).toThrow();
+    }
   });
 
   it('rejects oversized and over-segmented references before repository lookup', async () => {

--- a/test/unit/services/bible/SourceAttestedParallelService.test.ts
+++ b/test/unit/services/bible/SourceAttestedParallelService.test.ts
@@ -168,6 +168,33 @@ describe('SourceAttestedParallelService', () => {
     expect(repository.findGroups).not.toHaveBeenCalled();
   });
 
+  it.each([
+    'Matthew 26:999',
+    'Matthew 26:75-999',
+    'Matthew 26:75,999',
+  ])('rejects an upper-bound violation before repository lookup: %s', async reference => {
+    const repository: ISourceAttestedParallelRepository = {
+      findGroups: vi.fn(),
+      hasValidGroupCursorBoundary: vi.fn().mockResolvedValue(true),
+      getProvenance: vi.fn(),
+    };
+
+    await expect(new SourceAttestedParallelService(repository).lookup({ reference }))
+      .rejects.toThrow('reference must identify one canonical or source-versification Bible passage');
+    expect(repository.findGroups).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['Psalms 18:51', 19, 18, 51],
+    ['1 Kings 5:32', 11, 5, 32],
+    ['Psalms 60:13-14', 19, 60, 13],
+    ['Isaiah 8:23', 23, 8, 23],
+    ['Hosea 2:25', 28, 2, 25],
+  ] as const)('preserves the bounded source-versification coordinate %s', (reference, bookNumber, chapter, startVerse) => {
+    const parsed = parseSourceAttestedLookupReference(reference);
+    expect(parsed.segments[0]).toMatchObject({ bookNumber, chapter, startVerse });
+  });
+
   it('rejects oversized and over-segmented references before repository lookup', async () => {
     const repository: ISourceAttestedParallelRepository = {
       findGroups: vi.fn(), hasValidGroupCursorBoundary: vi.fn().mockResolvedValue(true), getProvenance: vi.fn(),

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -37,6 +37,7 @@ import { validatorFor } from '../../../../src/mcp/validation.js';
 import { validateClassicTextsOutputSemantics } from '../../../../src/presenters/classicTextsStructured.js';
 import { encodeHistoricalSectionedOnlyCursor } from '../../../../src/kernel/historicalSectionedDelivery.js';
 import { Buffer } from 'node:buffer';
+import { parseReference } from '../../../../src/kernel/reference.js';
 
 function serviceDouble<T>(methods: Partial<{ [K in keyof T]: T[K] }>): T {
   return methods as unknown as T;
@@ -120,6 +121,35 @@ describe('v2 tool handler schemas', () => {
     expect(commentary.properties?.reference).toMatchObject({
       description: expect.stringContaining('verse ranges are not supported'),
     });
+  });
+});
+
+describe('shared malformed-reference guidance', () => {
+  const rejectMalformedReference = (reference: string): never => {
+    parseReference(reference);
+    throw new Error('expected malformed reference');
+  };
+  const handlers = [
+    createBibleLookupHandler(serviceDouble<BibleService>({
+      lookup: vi.fn(async params => rejectMalformedReference(params.reference)),
+      lookupMultiple: vi.fn(),
+    })),
+    createVerseMorphologyHandler(serviceDouble<MorphologyService>({
+      getVerseMorphology: vi.fn(async reference => rejectMalformedReference(reference)),
+    })),
+    createCommentaryHandler(serviceDouble<CommentaryService>({
+      lookup: vi.fn(async params => rejectMalformedReference(params.reference)),
+    })),
+    createParallelPassagesHandler(serviceDouble<ParallelPassageService>({
+      lookup: vi.fn(async params => rejectMalformedReference(params.reference)),
+    })),
+  ];
+
+  it.each(handlers)('returns actionable validation guidance from $name', async handler => {
+    const result = await handler.handler({ reference: 'not a reference' });
+    expect(result).toMatchObject({ isError: true });
+    expect(textOf(result)).toContain('Invalid input: Invalid Bible reference');
+    expect(textOf(result)).not.toContain('Please try again');
   });
 });
 

--- a/test/unit/tools/v2/handlers.test.ts
+++ b/test/unit/tools/v2/handlers.test.ts
@@ -185,6 +185,36 @@ describe('bible_lookup handler', () => {
     });
   });
 
+  it('returns NET note unavailability in both Markdown and structured content without a translation failure', async () => {
+    const lookup = vi.fn<BibleService['lookup']>().mockResolvedValue({
+      reference: 'John 1:1',
+      translation: 'NET',
+      text: 'In the beginning was the Word.',
+      footnoteDelivery: {
+        status: 'unavailable',
+        markerCount: 3,
+        reason: 'The configured provider returns markers but not note bodies.',
+      },
+      citation,
+    });
+    const handler = createBibleLookupHandler(serviceDouble<BibleService>({
+      lookup,
+      lookupMultiple: vi.fn<BibleService['lookupMultiple']>(),
+    }));
+
+    const result = await handler.handler({ reference: 'John 1:1', translation: 'NET', includeFootnotes: true });
+
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain('Requested footnote text is unavailable. 3 note markers observed.');
+    expect(result.structuredContent).toMatchObject({
+      passages: [{
+        translation: 'NET',
+        footnoteDelivery: { status: 'unavailable', markerCount: 3 },
+      }],
+      failures: [],
+    });
+  });
+
   it('dispatches an array to multi-translation lookup', async () => {
     const lookup = vi.fn<BibleService['lookup']>();
     const lookupMultiple = vi.fn<BibleService['lookupMultiple']>().mockResolvedValue({


### PR DESCRIPTION
Addresses four black-box audit findings: invalid parallel-passage endpoints now receive validation errors, malformed references receive actionable input errors, comparison prompts reject unsupported translations instead of silently substituting them, and requested footnotes disclose their delivery status when upstream note bodies are unavailable.

Includes the review correction that preserves valid Hebrew source-coordinate ranges using complete pinned corpus bounds, with boundary and real UBS retrieval regression tests. NET note bodies remain unavailable from the configured API; the response now makes that explicit. Donation-provider availability is outside this change and remains unresolved.

Validation: combined branch passed 2,699 unit tests (5 skipped), all 3 MCP integration tests, Node and Worker typechecks, and git diff --check. The targeted reference regression suite also passed 129 tests. No deployment is included.

CI follow-up: patch smol-toml to 1.8.0 and override sharp to 0.35.4 to clear the existing high-severity dependency gate without upgrading the Cloudflare runtime. The high-severity audit passes; moderate advisories remain. Updated v6/v7 transport fingerprints for the intentional schema and prompt metadata changes, with explicit regression assertions; all 13 contract-helper tests pass.
